### PR TITLE
BindAsync to support parallel tasks.

### DIFF
--- a/Asp/src/ActionResultExtention.cs
+++ b/Asp/src/ActionResultExtention.cs
@@ -46,6 +46,8 @@ public static class ActionResultExtention
             Conflict => (ActionResult<T>)controllerBase.Conflict(error),
             Unauthorized => (ActionResult<T>)controllerBase.Unauthorized(error),
             Forbidden => (ActionResult<T>)controllerBase.Forbid(error.Description),
+            Unexpected => (ActionResult<T>)controllerBase.StatusCode(500, error),
+            Transient => (ActionResult<T>)controllerBase.StatusCode(500, error),
             _ => throw new NotImplementedException($"Unknown error {error.Code}"),
         };
     }

--- a/RailwayOrientedProgramming/src/Errors/Error.cs
+++ b/RailwayOrientedProgramming/src/Errors/Error.cs
@@ -32,7 +32,7 @@ public class Error : IEquatable<Error>
     public override int GetHashCode() => Code.GetHashCode();
 
     public static Error Validation(string description, string fieldName = "", string code = "validation.error") =>
-    new Validation(description, fieldName, code);
+        new Validation(description, fieldName, code);
 
     public static Error Conflict(string description, string code = "conflict.error") =>
         new Conflict(description, code);
@@ -44,9 +44,12 @@ public class Error : IEquatable<Error>
         new Unauthorized(description, code);
 
     public static Error Forbidden(string description, string code = "forbidden.error") =>
-     new Forbidden(description, code);
+        new Forbidden(description, code);
 
     public static Error Unexpected(string description, string code = "unexpected.error") =>
-    new Unexpected(description, code);
+        new Unexpected(description, code);
+
+    internal static Error Transient(string description, string code = "transient.error") =>
+        new Transient(description, code);
 }
 

--- a/RailwayOrientedProgramming/src/Errors/Types/Transient.cs
+++ b/RailwayOrientedProgramming/src/Errors/Types/Transient.cs
@@ -1,0 +1,8 @@
+﻿namespace FunctionalDDD;
+
+public sealed class Transient : Error
+{
+    public Transient(string description, string code) : base(description, code)
+    {
+    }
+}

--- a/RailwayOrientedProgramming/src/RailwayOrientedProgramming.csproj
+++ b/RailwayOrientedProgramming/src/RailwayOrientedProgramming.csproj
@@ -18,6 +18,12 @@
       </Compile>
 
       <Compile Update="Result\Extensions\Ensure.Task.cs" DependentUpon="Ensure.cs" />
+
+      <Compile Update="Result\Extensions\ParallelAsyncs.cs">
+        <DesignTime>True</DesignTime>
+        <AutoGen>True</AutoGen>
+        <DependentUpon>ParallelAsyncs.tt</DependentUpon>
+      </Compile>
       <Compile Update="Result\Extensions\Ensure.Task.*.cs" DependentUpon="Ensure.Task.cs" />
    </ItemGroup>
 
@@ -36,6 +42,10 @@
          <Generator>TextTemplatingFileGenerator</Generator>
          <LastGenOutput>MapTs.cs</LastGenOutput>
          <DependentUpon>Map.cs</DependentUpon>
+      </None>
+      <None Update="Result\Extensions\ParallelAsyncs.tt">
+        <Generator>TextTemplatingFileGenerator</Generator>
+        <LastGenOutput>ParallelAsyncs.cs</LastGenOutput>
       </None>
    </ItemGroup>
 

--- a/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.cs
@@ -20,6 +20,20 @@ public static partial class ResultExtensions
         return Result.Success((t1.Value.Item1, t1.Value.Item2, tc.Value));
     }
 
+    public static Result<(T1, T2, T3)> Combine<T1, T2, T3>(this Result<T1> t1, Result<T2> t2, Result<T3> t3)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            return Result.Failure<(T1, T2, T3)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value));
+    }
+
     public static Result<(T1, T2, T3, T4)> Combine<T1, T2, T3, T4>(this Result<(T1, T2, T3)> t1, Result<T4> tc)
     {
         if (t1.IsFailure || tc.IsFailure)
@@ -33,6 +47,21 @@ public static partial class ResultExtensions
         }
 
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, tc.Value));
+    }
+
+    public static Result<(T1, T2, T3, T4)> Combine<T1, T2, T3, T4>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            return Result.Failure<(T1, T2, T3, T4)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value));
     }
 
     public static Result<(T1, T2, T3, T4, T5)> Combine<T1, T2, T3, T4, T5>(this Result<(T1, T2, T3, T4)> t1, Result<T5> tc)
@@ -50,6 +79,22 @@ public static partial class ResultExtensions
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, t1.Value.Item4, tc.Value));
     }
 
+    public static Result<(T1, T2, T3, T4, T5)> Combine<T1, T2, T3, T4, T5>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4, Result<T5> t5)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure || t5.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            if (t5.IsFailure) errors.AddRange(t5.Errors);
+            return Result.Failure<(T1, T2, T3, T4, T5)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value, t5.Value));
+    }
+
     public static Result<(T1, T2, T3, T4, T5, T6)> Combine<T1, T2, T3, T4, T5, T6>(this Result<(T1, T2, T3, T4, T5)> t1, Result<T6> tc)
     {
         if (t1.IsFailure || tc.IsFailure)
@@ -63,6 +108,23 @@ public static partial class ResultExtensions
         }
 
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, t1.Value.Item4, t1.Value.Item5, tc.Value));
+    }
+
+    public static Result<(T1, T2, T3, T4, T5, T6)> Combine<T1, T2, T3, T4, T5, T6>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4, Result<T5> t5, Result<T6> t6)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure || t5.IsFailure || t6.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            if (t5.IsFailure) errors.AddRange(t5.Errors);
+            if (t6.IsFailure) errors.AddRange(t6.Errors);
+            return Result.Failure<(T1, T2, T3, T4, T5, T6)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value, t5.Value, t6.Value));
     }
 
     public static Result<(T1, T2, T3, T4, T5, T6, T7)> Combine<T1, T2, T3, T4, T5, T6, T7>(this Result<(T1, T2, T3, T4, T5, T6)> t1, Result<T7> tc)
@@ -80,6 +142,24 @@ public static partial class ResultExtensions
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, t1.Value.Item4, t1.Value.Item5, t1.Value.Item6, tc.Value));
     }
 
+    public static Result<(T1, T2, T3, T4, T5, T6, T7)> Combine<T1, T2, T3, T4, T5, T6, T7>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4, Result<T5> t5, Result<T6> t6, Result<T7> t7)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure || t5.IsFailure || t6.IsFailure || t7.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            if (t5.IsFailure) errors.AddRange(t5.Errors);
+            if (t6.IsFailure) errors.AddRange(t6.Errors);
+            if (t7.IsFailure) errors.AddRange(t7.Errors);
+            return Result.Failure<(T1, T2, T3, T4, T5, T6, T7)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value, t5.Value, t6.Value, t7.Value));
+    }
+
     public static Result<(T1, T2, T3, T4, T5, T6, T7, T8)> Combine<T1, T2, T3, T4, T5, T6, T7, T8>(this Result<(T1, T2, T3, T4, T5, T6, T7)> t1, Result<T8> tc)
     {
         if (t1.IsFailure || tc.IsFailure)
@@ -95,6 +175,25 @@ public static partial class ResultExtensions
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, t1.Value.Item4, t1.Value.Item5, t1.Value.Item6, t1.Value.Item7, tc.Value));
     }
 
+    public static Result<(T1, T2, T3, T4, T5, T6, T7, T8)> Combine<T1, T2, T3, T4, T5, T6, T7, T8>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4, Result<T5> t5, Result<T6> t6, Result<T7> t7, Result<T8> t8)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure || t5.IsFailure || t6.IsFailure || t7.IsFailure || t8.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            if (t5.IsFailure) errors.AddRange(t5.Errors);
+            if (t6.IsFailure) errors.AddRange(t6.Errors);
+            if (t7.IsFailure) errors.AddRange(t7.Errors);
+            if (t8.IsFailure) errors.AddRange(t8.Errors);
+            return Result.Failure<(T1, T2, T3, T4, T5, T6, T7, T8)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value, t5.Value, t6.Value, t7.Value, t8.Value));
+    }
+
     public static Result<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> Combine<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Result<(T1, T2, T3, T4, T5, T6, T7, T8)> t1, Result<T9> tc)
     {
         if (t1.IsFailure || tc.IsFailure)
@@ -108,6 +207,26 @@ public static partial class ResultExtensions
         }
 
         return Result.Success((t1.Value.Item1, t1.Value.Item2, t1.Value.Item3, t1.Value.Item4, t1.Value.Item5, t1.Value.Item6, t1.Value.Item7, t1.Value.Item8, tc.Value));
+    }
+
+    public static Result<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> Combine<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Result<T1> t1, Result<T2> t2, Result<T3> t3, Result<T4> t4, Result<T5> t5, Result<T6> t6, Result<T7> t7, Result<T8> t8, Result<T9> t9)
+    {
+        if (t1.IsFailure || t2.IsFailure || t3.IsFailure || t4.IsFailure || t5.IsFailure || t6.IsFailure || t7.IsFailure || t8.IsFailure || t9.IsFailure)
+        {
+            var errors = new ErrorList();
+            if (t1.IsFailure) errors.AddRange(t1.Errors);
+            if (t2.IsFailure) errors.AddRange(t2.Errors);
+            if (t3.IsFailure) errors.AddRange(t3.Errors);
+            if (t4.IsFailure) errors.AddRange(t4.Errors);
+            if (t5.IsFailure) errors.AddRange(t5.Errors);
+            if (t6.IsFailure) errors.AddRange(t6.Errors);
+            if (t7.IsFailure) errors.AddRange(t7.Errors);
+            if (t8.IsFailure) errors.AddRange(t8.Errors);
+            if (t9.IsFailure) errors.AddRange(t9.Errors);
+            return Result.Failure<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>(errors);
+        }
+
+        return Result.Success((t1.Value, t2.Value, t3.Value, t4.Value, t5.Value, t6.Value, t7.Value, t8.Value, t9.Value));
     }
 
 

--- a/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.tt
+++ b/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.tt
@@ -13,7 +13,25 @@ public static partial class ResultExtensions
 
 <#
   void WriteT1Values(int n) {
-     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => "t1.Value.Item" + i)));
+     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => $"t1.Value.Item{i}")));
+  }
+  
+  void WriteIsFailure(int n) {
+    Write(String.Join(" || ", Enumerable.Range(1, n).Select(i => $"t{i}.IsFailure")));
+  }
+
+  void WriteResultT(int n) {
+     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => $"Result<T{i}> t{i}")));
+  }
+
+  void WriteAddFailure(int n) {
+    WriteLine("if (t1.IsFailure) errors.AddRange(t1.Errors);");
+    for(var i=2; i <= n; i++)
+        WriteLine($"            if (t{i}.IsFailure) errors.AddRange(t{i}.Errors);");
+  }
+
+  void WriteTValues(int n) {
+     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => $"t{i}.Value")));
   }
 
   for(var i = 3; i <=9; i++) { 
@@ -31,6 +49,18 @@ public static partial class ResultExtensions
         }
 
         return Result.Success((<# WriteT1Values(i - 1); #>, tc.Value));
+    }
+
+    public static Result<(<# WriteTs(i); #>)> Combine<<# WriteTs(i); #>>(this <# WriteResultT(i); #>)
+    {
+        if (<# WriteIsFailure(i); #>)
+        {
+            var errors = new ErrorList();
+            <# WriteAddFailure(i); #>
+            return Result.Failure<(<# WriteTs(i); #>)>(errors);
+        }
+
+        return Result.Success((<# WriteTValues(i); #>));
     }
 
 <#

--- a/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsync.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsync.cs
@@ -5,9 +5,11 @@ public static partial class ResultExtensions
     public static (Task<Result<T1>>, Task<Result<T2>>) ParallelAsync<T1, T2>(this Task<Result<T1>> resultTask1, Task<Result<T2>> resultTask2)
         => (resultTask1, resultTask2);
 
-    public static async Task<Result<(T1, T2)>> ParallelWhenAllAsync<T1, T2>(this (Task<Result<T1>>, Task<Result<T2>>) tasks)
+    public static async Task<Result<TResult>> BindAsync<T1, T2, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>) tasks,
+        Func<T1, T2, Result<TResult>> func)
     {
         await Task.WhenAll(tasks.Item1, tasks.Item2);
-        return tasks.Item1.Result.Combine(tasks.Item2.Result);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result).Bind(func);
     }
 }

--- a/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsyncs.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsyncs.cs
@@ -1,0 +1,99 @@
+﻿
+// Generated code
+namespace FunctionalDDD;
+
+public static partial class ResultExtensions
+{
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>) ParallelAsync<T1, T2, T3>(
+        this (Task<Result<T1>>, Task<Result<T2>>) tasks,
+        Task<Result<T3>> task
+        ) => (tasks.Item1, tasks.Item2, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>) tasks,
+        Func<T1, T2, T3, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>) ParallelAsync<T1, T2, T3, T4>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>) tasks,
+        Task<Result<T4>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>) tasks,
+        Func<T1, T2, T3, T4, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>) ParallelAsync<T1, T2, T3, T4, T5>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>) tasks,
+        Task<Result<T5>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, T5, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>) tasks,
+        Func<T1, T2, T3, T4, T5, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>) ParallelAsync<T1, T2, T3, T4, T5, T6>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>) tasks,
+        Task<Result<T6>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, T5, T6, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>) tasks,
+        Func<T1, T2, T3, T4, T5, T6, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>) ParallelAsync<T1, T2, T3, T4, T5, T6, T7>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>) tasks,
+        Task<Result<T7>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, T5, T6, T7, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>) tasks,
+        Func<T1, T2, T3, T4, T5, T6, T7, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result, tasks.Item7.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>, Task<Result<T8>>) ParallelAsync<T1, T2, T3, T4, T5, T6, T7, T8>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>) tasks,
+        Task<Result<T8>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>, Task<Result<T8>>) tasks,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result).Bind(func);
+    }
+
+    public static (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>, Task<Result<T8>>, Task<Result<T9>>) ParallelAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>, Task<Result<T8>>) tasks,
+        Task<Result<T9>> task
+        ) => (tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, task);
+
+    public static async Task<Result<TResult>> BindAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
+        this (Task<Result<T1>>, Task<Result<T2>>, Task<Result<T3>>, Task<Result<T4>>, Task<Result<T5>>, Task<Result<T6>>, Task<Result<T7>>, Task<Result<T8>>, Task<Result<T9>>) tasks,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Result<TResult>> func)
+    {
+        await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9);
+        return tasks.Item1.Result.Combine(tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result).Bind(func);
+    }
+
+}

--- a/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsyncs.tt
+++ b/RailwayOrientedProgramming/src/Result/Extensions/ParallelAsyncs.tt
@@ -1,0 +1,45 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#@ include file="CommonFunction.t4" #>
+// Generated code
+namespace FunctionalDDD;
+
+public static partial class ResultExtensions
+{
+
+<#
+  void WriteTaskResult(int n) {
+     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => $"Task<Result<T{i}>>")));
+  }
+  
+  void WriteTaskItem(int n) {
+     Write(String.Join(", ", Enumerable.Range(1, n).Select(i => $"tasks.Item{i}")));
+  }
+  
+  void WriteTaskItemResult(int n) {
+     Write(String.Join(", ", Enumerable.Range(2, n - 1).Select(i => $"tasks.Item{i}.Result")));
+  }
+
+  for(var i = 3; i <= 9; i++) { 
+#>
+    public static (<# WriteTaskResult(i); #>) ParallelAsync<<# WriteTs(i); #>>(
+        this (<# WriteTaskResult(i - 1); #>) tasks,
+        Task<Result<T<#=i#>>> task
+        ) => (<# WriteTaskItem(i - 1); #>, task);
+
+    public static async Task<Result<TResult>> BindAsync<<# WriteTs(i); #>, TResult>(
+        this (<# WriteTaskResult(i); #>) tasks,
+        Func<<# WriteTs(i); #>, Result<TResult>> func)
+    {
+        await Task.WhenAll(<# WriteTaskItem(i); #>);
+        return tasks.Item1.Result.Combine(<# WriteTaskItemResult(i); #>).Bind(func);
+    }
+
+<#
+ }
+#>
+}

--- a/RailwayOrientedProgramming/tests/Results/Extensions/ParallelTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/ParallelTests.cs
@@ -9,12 +9,27 @@ public class ParallelTests
         // Act
         var r = await Task.FromResult(Result.Success("Hi"))
             .ParallelAsync(Task.FromResult(Result.Success("Bye")))
-            .ParallelWhenAllAsync()
             .BindAsync((a, b) => Result.Success(a + b));
 
         // Assert
         r.IsSuccess.Should().BeTrue();
         r.Value.Should().Be("HiBye");
+    }
 
+    [Fact]
+    public async Task Run_five_parallel_tasks()
+    {
+        // Arrange
+        // Act
+        var r = await Task.FromResult(Result.Success("1"))
+            .ParallelAsync(Task.FromResult(Result.Success("2")))
+            .ParallelAsync(Task.FromResult(Result.Success("3")))
+            .ParallelAsync(Task.FromResult(Result.Success("4")))
+            .ParallelAsync(Task.FromResult(Result.Success("5")))
+            .BindAsync((a, b, c, d, e) => Result.Success(a + b + c + d + e));
+
+        // Assert
+        r.IsSuccess.Should().BeTrue();
+        r.Value.Should().Be("12345");
     }
 }


### PR DESCRIPTION
Ability to write
```csharp
await Task.FromResult(Result.Success("1"))
            .ParallelAsync(Task.FromResult(Result.Success("2")))
            .ParallelAsync(Task.FromResult(Result.Success("3")))
            .ParallelAsync(Task.FromResult(Result.Success("4")))
            .ParallelAsync(Task.FromResult(Result.Success("5")))
            .BindAsync((a, b, c, d, e) => Result.Success(a + b + c + d + e));
```

Removed `ParallelWhenAllAsync`