### PR TITLE
Remove IComparable from ValueObject. Support only IComparable<ValueObject>, IEquatable<ValueObject>

### DIFF
--- a/DomainDrivenDesign/src/ValueObject.cs
+++ b/DomainDrivenDesign/src/ValueObject.cs
@@ -1,5 +1,5 @@
 ﻿namespace FunctionalDDD;
-public abstract class ValueObject : IComparable, IComparable<ValueObject>, IEquatable<ValueObject>
+public abstract class ValueObject : IComparable<ValueObject>, IEquatable<ValueObject>
 {
     private int? _cachedHashCode;
 
@@ -34,19 +34,17 @@ public abstract class ValueObject : IComparable, IComparable<ValueObject>, IEqua
         return _cachedHashCode.Value;
     }
 
-    public virtual int CompareTo(object? obj)
-    {
-        if (obj == null)
-            throw new ArgumentNullException(nameof(obj));
 
+    public virtual int CompareTo(ValueObject? other)
+    {
+        if (other == null)
+            throw new ArgumentNullException(nameof(other));
         var thisType = GetType();
-        var otherType = obj.GetType();
+        var otherType = other.GetType();
 
         if (thisType != otherType)
             throw new ArgumentException($"Cannot compare objects of different types: {thisType} and {otherType}");
 
-
-        var other = (ValueObject)obj;
 
         object[] components = GetEqualityComponents().ToArray();
         object[] otherComponents = other.GetEqualityComponents().ToArray();
@@ -59,11 +57,6 @@ public abstract class ValueObject : IComparable, IComparable<ValueObject>, IEqua
         }
 
         return 0;
-    }
-
-    public virtual int CompareTo(ValueObject? other)
-    {
-        return CompareTo(other as object);
     }
 
     private static int CompareComponents(object? object1, object? object2)

--- a/DomainDrivenDesign/src/ValueObject.cs
+++ b/DomainDrivenDesign/src/ValueObject.cs
@@ -5,13 +5,7 @@ public abstract class ValueObject : IComparable<ValueObject>, IEquatable<ValueOb
 
     protected abstract IEnumerable<IComparable> GetEqualityComponents();
 
-    public override bool Equals(object? obj)
-    {
-        if (obj is ValueObject valueObject)
-            return Equals(valueObject);
-        else
-            return false;
-    }
+    public override bool Equals(object? obj) => Equals(obj as ValueObject);
 
     public bool Equals(ValueObject? other)
     {

--- a/DomainDrivenDesign/tests/ValueObjects/ValueObjectTests.cs
+++ b/DomainDrivenDesign/tests/ValueObjects/ValueObjectTests.cs
@@ -38,7 +38,22 @@ public class ValueObjectTests
 
         // Assert
         moneys.Should().Equal(new List<Money> { one, two, three });
+    }
 
+    [Fact]
+    public void VO_supports_orderby()
+    {
+        // Arrange
+        var one = new Money(1);
+        var two = new Money(2);
+        var three = new Money(3);
+        var moneys = new[] { two, one, three };
+
+        // Act
+        var orderedMoney = moneys.OrderBy(r => r);
+
+        // Assert
+        orderedMoney.Should().Equal(new List<Money> { one, two, three });
     }
 
     [Fact]


### PR DESCRIPTION
Remove IComparable from ValueObject and only support IComparable<T>