### PR TITLE
Ability to combine Result<Unit>

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,27 +1,27 @@
 <Project>
   <!-- Runtime -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
-    <PackageVersion Include="FluentValidation" Version="11.9.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
+    <PackageVersion Include="FluentValidation" Version="11.10.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageVersion Include="T4.Build" Version="0.2.4" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="Xunit.DependencyInjection" Version="8.6.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/RailwayOrientedProgramming/src/Result/Extensions/Combine.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/Combine.cs
@@ -6,6 +6,22 @@
 public static partial class CombineExtensions
 {
     /// <summary>
+    /// Combine a <see cref="Result{TValue}"/> with <see cref="Result{Unit}"/> return <see cref="Result{TValue}"/>.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <param name="t1"></param>
+    /// <param name="t2"></param>
+    /// <returns>Tuple containing both the results.</returns>
+    public static Result<T1> Combine<T1>(this Result<T1> t1, Result<Unit> t2)
+    {
+        Error? error = null;
+        if (t1.IsFailure) error = error.Combine(t1.Error);
+        if (t2.IsFailure) error = error.Combine(t2.Error);
+        if (error is not null) return Result.Failure<T1>(error);
+        return Result.Success(t1.Value);
+    }
+
+    /// <summary>
     /// Combine two <see cref="Result{TValue}"/> into one <see cref="Tuple"/> containing all the Results.
     /// </summary>
     /// <typeparam name="T1"></typeparam>

--- a/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.g.tt
+++ b/RailwayOrientedProgramming/src/Result/Extensions/CombineTs.g.tt
@@ -32,6 +32,16 @@ public static partial class CombineExtensions
 
   for(var i = 3; i <=9; i++) { 
 #>
+    public static Result<(<# WriteTs(i - 1); #>)> Combine<<# WriteTs(i - 1); #>>(
+      this Result<(<# WriteTs(i - 1); #>)> t1, Result<Unit> tc)
+    {
+        Error? error = null;
+        if (t1.IsFailure) error = error.Combine(t1.Error);
+        if (tc.IsFailure) error = error.Combine(tc.Error);
+        if (error is not null) return Result.Failure<(<# WriteTs(i - 1); #>)>(error);
+        return Result.Success((<# WriteT1Values(i - 1); #>));
+    }
+
     public static Result<(<# WriteTs(i); #>)> Combine<<# WriteTs(i); #>>(
       this Result<(<# WriteTs(i - 1); #>)> t1, Result<<# Write("T" + i); #>> tc)
     {

--- a/RailwayOrientedProgramming/src/Result/Extensions/Ensure.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/Ensure.cs
@@ -1,7 +1,6 @@
 ﻿namespace FunctionalDdd;
 
 using System;
-using System.Diagnostics;
 
 /// <summary>
 ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
@@ -74,4 +73,6 @@ public static class EnsureExtensions
 
     public static Result<string> EnsureNotNullOrWhiteSpace(this string? str, Error error)
         => string.IsNullOrWhiteSpace(str) ? Result.Failure<string>(error) : Result.Success(str);
+
+    public static Result<Unit> Ensure(bool flag, Error error) => flag ? Result.Success() : Result.Failure(error);
 }

--- a/RailwayOrientedProgramming/tests/Results/Extensions/CombineTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/CombineTests.cs
@@ -3,6 +3,40 @@
 public class CombineTests
 {
     [Fact]
+    public void Combine_one_result_and_Unit_where_both_are_success()
+    {
+        // Arrange
+        var rHello = Result.Success("Hello")
+            .Combine(Result.Success())
+            .Bind(hello => Result.Success($"{hello}"));
+
+        // Act
+
+        // Assert
+        rHello.IsSuccess.Should().BeTrue();
+        var helloWorld = rHello.Value;
+        helloWorld.Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Combine_one_result_and_Unit_where_one_is_success()
+    {
+        // Arrange
+        var rHelloWorld = Result.Success("Hello")
+            .Combine(Result.Failure(Error.Validation("Bad World", "key")))
+            .Bind(hello => Result.Success($"{hello}"));
+
+        // Act
+
+        // Assert
+        rHelloWorld.IsFailure.Should().BeTrue();
+        rHelloWorld.Error.Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)rHelloWorld.Error;
+        validation.Errors.Should().ContainSingle();
+        validation.Errors[0].Should().BeEquivalentTo(new ValidationError.FieldDetails("key", ["Bad World"]));
+    }
+
+    [Fact]
     public void Combine_two_results_where_both_are_success()
     {
         // Arrange
@@ -42,6 +76,42 @@ public class CombineTests
         // Arrange
         var rHelloWorld = Result.Failure<string>(Error.Validation("Bad World", "key"))
             .Combine(Result.Success("World"))
+            .Bind((hello, world) => Result.Success($"{hello} {world}"));
+
+        // Act
+
+        // Assert
+        rHelloWorld.IsFailure.Should().BeTrue();
+        rHelloWorld.Error.Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)rHelloWorld.Error;
+        validation.Errors.Should().ContainSingle();
+        validation.Errors[0].Should().BeEquivalentTo(new ValidationError.FieldDetails("key", ["Bad World"]));
+    }
+
+    [Fact]
+    public void Combine_two_result_and_Unit_where_both_are_success()
+    {
+        // Arrange
+        var rHelloWorld = Result.Success("Hello")
+            .Combine(Result.Success("World"))
+            .Combine(Result.Success())
+            .Bind((hello, world) => Result.Success($"{hello} {world}"));
+
+        // Act
+
+        // Assert
+        rHelloWorld.IsSuccess.Should().BeTrue();
+        var helloWorld = rHelloWorld.Value;
+        helloWorld.Should().Be("Hello World");
+    }
+
+    [Fact]
+    public void Combine_two_result_and_Unit_where_one_is_success()
+    {
+        // Arrange
+        var rHelloWorld = Result.Success("Hello")
+            .Combine(Result.Success("World"))
+            .Combine(Result.Failure(Error.Validation("Bad World", "key")))
             .Bind((hello, world) => Result.Success($"{hello} {world}"));
 
         // Act
@@ -105,7 +175,6 @@ public class CombineTests
             .Combine(Result.Success("8"))
             .Combine(Result.Success("9"))
             .Bind((one, two, three, four, five, six, seven, eight, nine) => Result.Success($"{one}{two}{three}{four}{five}{six}{seven}{eight}{nine}"));
-
 
         // Act
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.303",
+    "version": "8.0.403",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Ability to combine `Result<Unit>`.
Added Ensure method that can help with validation.

```
  var actual = EmailAddress.TryCreate("xavier@somewhere.com")
      .Combine(FirstName.TryCreate("Xavier"))
      .Combine(LastName.TryCreate("John"))
      .Combine(EmailAddress.TryCreate("xavier@somewhereelse.com"))
      .Combine(Ensure(createdAt <= updatedAt, Error.Validation("updateAt cannot be less than createdAt")))
      .Bind((email, firstName, lastName, anotherEmail) => Result.Success(string.Join(" ", firstName, lastName, email, anotherEmail)));
```