### PR TITLE
Implement IConvertible on ScalarValueObject

### DIFF
--- a/Benchmark/BenchmarkROP.cs
+++ b/Benchmark/BenchmarkROP.cs
@@ -1,7 +1,6 @@
 ﻿namespace Benchmark;
 using BenchmarkDotNet.Attributes;
 using FunctionalDdd;
-using System.Globalization;
 
 /// <summary>
 /// Benchmark ROP vs If.
@@ -36,7 +35,7 @@ public class BenchmarkROP
         FirstName.TryCreate("Xavier")
             .Combine(EmailAddress.TryCreate("xavier@somewhere.com"))
             .Finally(
-                ok => ok.Item1.ToString(CultureInfo.InvariantCulture) + " " + ok.Item2.ToString(CultureInfo.InvariantCulture),
+                ok => ok.Item1 + " " + ok.Item2,
                 error => error.Detail
             );
 
@@ -46,7 +45,7 @@ public class BenchmarkROP
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("xavier@somewhere.com");
         if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value.ToString(CultureInfo.InvariantCulture) + " " + rEmailAddress.Value.ToString(CultureInfo.InvariantCulture);
+            return rFirstName.Value + " " + rEmailAddress.Value;
 
         var error = rFirstName.IsFailure ? rFirstName.Error : rEmailAddress.Error;
         if (rEmailAddress.IsFailure)
@@ -60,7 +59,7 @@ public class BenchmarkROP
     FirstName.TryCreate("Xavier")
         .Combine(EmailAddress.TryCreate("bad email"))
         .Finally(
-            ok => ok.Item1.ToString(CultureInfo.InvariantCulture) + " " + ok.Item2.ToString(CultureInfo.InvariantCulture),
+            ok => ok.Item1 + " " + ok.Item2,
             error => error.Detail
         );
 
@@ -70,7 +69,7 @@ public class BenchmarkROP
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("bad email");
         if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value.ToString(CultureInfo.InvariantCulture) + " " + rEmailAddress.Value.ToString(CultureInfo.InvariantCulture);
+            return rFirstName.Value + " " + rEmailAddress.Value;
 
         var error = rFirstName.IsFailure ? rFirstName.Error : rEmailAddress.Error;
         if (rFirstName.IsFailure && rEmailAddress.IsFailure)

--- a/Benchmark/BenchmarkROP.cs
+++ b/Benchmark/BenchmarkROP.cs
@@ -1,6 +1,7 @@
 ﻿namespace Benchmark;
 using BenchmarkDotNet.Attributes;
 using FunctionalDdd;
+using System.Globalization;
 
 /// <summary>
 /// Benchmark ROP vs If.
@@ -35,7 +36,7 @@ public class BenchmarkROP
         FirstName.TryCreate("Xavier")
             .Combine(EmailAddress.TryCreate("xavier@somewhere.com"))
             .Finally(
-                ok => ok.Item1.ToString() + " " + ok.Item2.ToString(),
+                ok => ok.Item1.ToString(CultureInfo.InvariantCulture) + " " + ok.Item2.ToString(CultureInfo.InvariantCulture),
                 error => error.Detail
             );
 
@@ -45,7 +46,7 @@ public class BenchmarkROP
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("xavier@somewhere.com");
         if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value.ToString() + " " + rEmailAddress.Value.ToString();
+            return rFirstName.Value.ToString(CultureInfo.InvariantCulture) + " " + rEmailAddress.Value.ToString(CultureInfo.InvariantCulture);
 
         var error = rFirstName.IsFailure ? rFirstName.Error : rEmailAddress.Error;
         if (rEmailAddress.IsFailure)
@@ -59,7 +60,7 @@ public class BenchmarkROP
     FirstName.TryCreate("Xavier")
         .Combine(EmailAddress.TryCreate("bad email"))
         .Finally(
-            ok => ok.Item1.ToString() + " " + ok.Item2.ToString(),
+            ok => ok.Item1.ToString(CultureInfo.InvariantCulture) + " " + ok.Item2.ToString(CultureInfo.InvariantCulture),
             error => error.Detail
         );
 
@@ -69,7 +70,7 @@ public class BenchmarkROP
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("bad email");
         if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value.ToString() + " " + rEmailAddress.Value.ToString();
+            return rFirstName.Value.ToString(CultureInfo.InvariantCulture) + " " + rEmailAddress.Value.ToString(CultureInfo.InvariantCulture);
 
         var error = rFirstName.IsFailure ? rFirstName.Error : rEmailAddress.Error;
         if (rFirstName.IsFailure && rEmailAddress.IsFailure)

--- a/CommonValueObjects/tests/EmailAddressTests.cs
+++ b/CommonValueObjects/tests/EmailAddressTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace CommonValueObjects.Tests;
 
+using System.Globalization;
+
 public class EmailAddressTests
 {
     [Theory]
@@ -36,7 +38,7 @@ public class EmailAddressTests
         // Assert
         .Should().BeTrue();
         email.Should().BeOfType<EmailAddress>();
-        email!.ToString().Should().Be(strEmail);
+        email!.ToString(CultureInfo.InvariantCulture).Should().Be(strEmail);
     }
 
     [Theory]
@@ -60,7 +62,7 @@ public class EmailAddressTests
 
         // Assert
         email.Should().BeOfType<EmailAddress>();
-        email.ToString().Should().Be(strEmail);
+        email.ToString(CultureInfo.InvariantCulture).Should().Be(strEmail);
     }
 
     [Theory]

--- a/CommonValueObjects/tests/RequiredGuidTests.cs
+++ b/CommonValueObjects/tests/RequiredGuidTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace CommonValueObjects.Tests;
 using System;
+using System.Globalization;
 using Xunit;
 
 public partial class EmployeeId : RequiredGuid
@@ -44,7 +45,7 @@ public class RequiredGuidTests
             .Tap(empId =>
             {
                 empId.Should().BeOfType<EmployeeId>();
-                empId.ToString().Should().Be(strGuid);
+                empId.ToString(CultureInfo.InvariantCulture).Should().Be(strGuid);
             })
             .IsSuccess.Should().BeTrue();
     }
@@ -82,7 +83,7 @@ public class RequiredGuidTests
         var myGuid = EmployeeId.TryCreate(guid).Value;
 
         // Act
-        var actual = myGuid.ToString();
+        var actual = myGuid.ToString(CultureInfo.InvariantCulture);
 
         // Assert
         actual.Should().Be(guid.ToString());
@@ -175,7 +176,7 @@ public class RequiredGuidTests
 
         // Assert
         myGuid.Should().BeOfType<EmployeeId>();
-        myGuid!.ToString().Should().Be(strGuid);
+        myGuid!.ToString(CultureInfo.InvariantCulture).Should().Be(strGuid);
     }
 
     [Fact]
@@ -203,7 +204,7 @@ public class RequiredGuidTests
 
         // Assert
         myGuid.Should().BeOfType<EmployeeId>();
-        myGuid.ToString().Should().Be(strGuid);
+        myGuid.ToString(CultureInfo.InvariantCulture).Should().Be(strGuid);
     }
 
     [Fact]

--- a/CommonValueObjects/tests/RequiredStringTests.cs
+++ b/CommonValueObjects/tests/RequiredStringTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace CommonValueObjects.Tests;
 
+using System.Globalization;
+
 public partial class TrackingId : RequiredString
 {
 }
@@ -9,178 +11,178 @@ internal partial class InternalTrackingId : RequiredString
 
 public class RequiredStringTests
 {
-    [Theory]
-    [MemberData(nameof(GetBadString))]
-    public void Cannot_create_empty_RequiredString(string? input)
-    {
-        var trackingId1 = TrackingId.TryCreate(input);
-        trackingId1.IsFailure.Should().BeTrue();
-        trackingId1.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)trackingId1.Error;
-        validation.Errors[0].Name.Should().Be("trackingId");
-        validation.Errors[0].Details[0].Should().Be("Tracking Id cannot be empty.");
-        validation.Code.Should().Be("validation.error");
-    }
+  [Theory]
+  [MemberData(nameof(GetBadString))]
+  public void Cannot_create_empty_RequiredString(string? input)
+  {
+    var trackingId1 = TrackingId.TryCreate(input);
+    trackingId1.IsFailure.Should().BeTrue();
+    trackingId1.Error.Should().BeOfType<ValidationError>();
+    var validation = (ValidationError)trackingId1.Error;
+    validation.Errors[0].Name.Should().Be("trackingId");
+    validation.Errors[0].Details[0].Should().Be("Tracking Id cannot be empty.");
+    validation.Code.Should().Be("validation.error");
+  }
 
-    [Fact]
-    public void Can_create_RequiredString() =>
-        InternalTrackingId.TryCreate("32141sd")
-            .Tap(trackingId =>
-            {
-                trackingId.Should().BeOfType<InternalTrackingId>();
-                trackingId.ToString().Should().Be("32141sd");
-            })
-            .IsSuccess.Should().BeTrue();
+  [Fact]
+  public void Can_create_RequiredString() =>
+      InternalTrackingId.TryCreate("32141sd")
+          .Tap(trackingId =>
+          {
+            trackingId.Should().BeOfType<InternalTrackingId>();
+            trackingId.ToString(CultureInfo.InvariantCulture).Should().Be("32141sd");
+          })
+          .IsSuccess.Should().BeTrue();
 
-    [Fact]
-    public void Two_RequiredString_with_same_value_should_be_equal() =>
-        TrackingId.TryCreate("SameValue")
-            .Combine(TrackingId.TryCreate("SameValue"))
-            .Tap((tr1, tr2) =>
-            {
-                (tr1 == tr2).Should().BeTrue();
-                tr1.Equals(tr2).Should().BeTrue();
-            })
-            .IsSuccess.Should().BeTrue();
+  [Fact]
+  public void Two_RequiredString_with_same_value_should_be_equal() =>
+      TrackingId.TryCreate("SameValue")
+          .Combine(TrackingId.TryCreate("SameValue"))
+          .Tap((tr1, tr2) =>
+          {
+            (tr1 == tr2).Should().BeTrue();
+            tr1.Equals(tr2).Should().BeTrue();
+          })
+          .IsSuccess.Should().BeTrue();
 
-    [Fact]
-    public void Two_RequiredString_with_different_value_should_be_not_equal() =>
-        TrackingId.TryCreate("Value1")
-            .Combine(TrackingId.TryCreate("Value2"))
-            .Tap((tr1, tr2) =>
-             {
-                 (tr1 != tr2).Should().BeTrue();
-                 tr1.Equals(tr2).Should().BeFalse();
-             })
-            .IsSuccess.Should().BeTrue();
+  [Fact]
+  public void Two_RequiredString_with_different_value_should_be_not_equal() =>
+      TrackingId.TryCreate("Value1")
+          .Combine(TrackingId.TryCreate("Value2"))
+          .Tap((tr1, tr2) =>
+           {
+             (tr1 != tr2).Should().BeTrue();
+             tr1.Equals(tr2).Should().BeFalse();
+           })
+          .IsSuccess.Should().BeTrue();
 
-    [Fact]
-    public void Can_implicitly_cast_to_string()
-    {
-        // Arrange
-        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
+  [Fact]
+  public void Can_implicitly_cast_to_string()
+  {
+    // Arrange
+    TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
 
-        // Act
-        string strTracking = trackingId1;
+    // Act
+    string strTracking = trackingId1;
 
-        // Assert
-        strTracking.Should().Be("32141sd");
-    }
+    // Assert
+    strTracking.Should().Be("32141sd");
+  }
 
-    [Fact]
-    public void Can_explicitly_cast_to_RequiredString()
-    {
-        // Arrange
+  [Fact]
+  public void Can_explicitly_cast_to_RequiredString()
+  {
+    // Arrange
 
-        // Act
-        TrackingId trackingId1 = (TrackingId)"32141sd";
+    // Act
+    TrackingId trackingId1 = (TrackingId)"32141sd";
 
-        // Assert
-        trackingId1.Should().Be(TrackingId.TryCreate("32141sd").Value);
-    }
+    // Assert
+    trackingId1.Should().Be(TrackingId.TryCreate("32141sd").Value);
+  }
 
-    [Fact]
-    public void Can_use_ToString()
-    {
-        // Arrange
-        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
+  [Fact]
+  public void Can_use_ToString()
+  {
+    // Arrange
+    TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
 
-        // Act
-        var strTracking = trackingId1.ToString();
+    // Act
+    var strTracking = trackingId1.ToString(CultureInfo.InvariantCulture);
 
-        // Assert
-        strTracking.Should().Be("32141sd");
-    }
+    // Assert
+    strTracking.Should().Be("32141sd");
+  }
 
-    [Fact]
-    public void Cannot_cast_empty_to_RequiredString()
-    {
-        // Arrange
-        TrackingId trackingId;
-        // Act
-        Action act = () => trackingId = (TrackingId)string.Empty;
+  [Fact]
+  public void Cannot_cast_empty_to_RequiredString()
+  {
+    // Arrange
+    TrackingId trackingId;
+    // Act
+    Action act = () => trackingId = (TrackingId)string.Empty;
 
-        // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("Attempted to access the Value for a failed result. A failed result has no Value.");
-    }
+    // Assert
+    act.Should().Throw<InvalidOperationException>()
+        .WithMessage("Attempted to access the Value for a failed result. A failed result has no Value.");
+  }
 
-    [Fact]
-    public void Can_create_RequiredString_from_try_parsing_valid_string()
-    {
-        // Arrange
-        var strTrackingId = "32141sd";
+  [Fact]
+  public void Can_create_RequiredString_from_try_parsing_valid_string()
+  {
+    // Arrange
+    var strTrackingId = "32141sd";
 
-        // Act
-        TrackingId.TryParse(strTrackingId, null, out var trackingId)
-            .Should().BeTrue();
+    // Act
+    TrackingId.TryParse(strTrackingId, null, out var trackingId)
+        .Should().BeTrue();
 
-        // Assert
-        trackingId.Should().BeOfType<TrackingId>();
-        trackingId!.ToString().Should().Be(strTrackingId);
-    }
+    // Assert
+    trackingId.Should().BeOfType<TrackingId>();
+    trackingId!.ToString(CultureInfo.InvariantCulture).Should().Be(strTrackingId);
+  }
 
-    [Theory]
-    [MemberData(nameof(GetBadString))]
-    public void Cannot_create_RequiredString_from_try_parsing_invalid_string(string? input)
-    {
-        // Arrange
+  [Theory]
+  [MemberData(nameof(GetBadString))]
+  public void Cannot_create_RequiredString_from_try_parsing_invalid_string(string? input)
+  {
+    // Arrange
 
-        // Act
-        TrackingId.TryParse(input, null, out var myId)
-            .Should().BeFalse();
+    // Act
+    TrackingId.TryParse(input, null, out var myId)
+        .Should().BeFalse();
 
-        // Assert
-        myId.Should().BeNull();
-    }
+    // Assert
+    myId.Should().BeNull();
+  }
 
-    [Fact]
-    public void Can_create_RequiredString_from_parsing_valid_string()
-    {
-        // Arrange
-        var strTrackingId = "32141sd";
+  [Fact]
+  public void Can_create_RequiredString_from_parsing_valid_string()
+  {
+    // Arrange
+    var strTrackingId = "32141sd";
 
-        // Act
-        var trackingId = TrackingId.Parse(strTrackingId, null);
+    // Act
+    var trackingId = TrackingId.Parse(strTrackingId, null);
 
-        // Assert
-        trackingId.Should().BeOfType<TrackingId>();
-        trackingId.ToString().Should().Be(strTrackingId);
-    }
+    // Assert
+    trackingId.Should().BeOfType<TrackingId>();
+    trackingId.ToString(CultureInfo.InvariantCulture).Should().Be(strTrackingId);
+  }
 
-    [Theory]
-    [MemberData(nameof(GetBadString))]
-    public void Cannot_create_RequiredString_from_parsing_invalid_string(string? input)
-    {
-        // Arrange
+  [Theory]
+  [MemberData(nameof(GetBadString))]
+  public void Cannot_create_RequiredString_from_parsing_invalid_string(string? input)
+  {
+    // Arrange
 
-        // Act
-        Action act = () => TrackingId.Parse(input!, null);
+    // Act
+    Action act = () => TrackingId.Parse(input!, null);
 
-        // Assert
-        act.Should().Throw<FormatException>()
-            .WithMessage("Tracking Id cannot be empty.");
-    }
+    // Assert
+    act.Should().Throw<FormatException>()
+        .WithMessage("Tracking Id cannot be empty.");
+  }
 
-    [Fact]
-    public void Can_use_Contains()
-    {
-        // Arrange
-        var id1 = TrackingId.TryCreate("id1").Value;
-        var id2 = TrackingId.TryCreate("id2").Value;
-        IReadOnlyList<TrackingId> ids = [id1, id2];
+  [Fact]
+  public void Can_use_Contains()
+  {
+    // Arrange
+    var id1 = TrackingId.TryCreate("id1").Value;
+    var id2 = TrackingId.TryCreate("id2").Value;
+    IReadOnlyList<TrackingId> ids = new List<TrackingId> { id1, id2 };
 
-        // Act
-        var actual = ids.Contains(id1);
+    // Act
+    var actual = ids.Contains(id1);
 
-        // Assert
-        actual.Should().BeTrue();
-    }
+    // Assert
+    actual.Should().BeTrue();
+  }
 
-    public static TheoryData<string?> GetBadString() =>
-        new TheoryData<string?>
-        {
-            null,
-            string.Empty
-        };
+  public static TheoryData<string?> GetBadString() =>
+      new TheoryData<string?>
+      {
+              null,
+              string.Empty
+      };
 }

--- a/DomainDrivenDesign/src/ScalarValueObject.cs
+++ b/DomainDrivenDesign/src/ScalarValueObject.cs
@@ -21,7 +21,7 @@
 /// }
 /// </code>
 /// </example>
-public abstract class ScalarValueObject<T> : ValueObject
+public abstract class ScalarValueObject<T> : ValueObject, IConvertible
     where T : IComparable
 {
     public T Value { get; }
@@ -34,6 +34,23 @@ public abstract class ScalarValueObject<T> : ValueObject
     }
 
     public override string ToString() => Value?.ToString() ?? string.Empty;
+    public TypeCode GetTypeCode() => Type.GetTypeCode(typeof(T));
+    public bool ToBoolean(IFormatProvider? provider) => Convert.ToBoolean(Value, provider);
+    public byte ToByte(IFormatProvider? provider) => Convert.ToByte(Value, provider);
+    public char ToChar(IFormatProvider? provider) => Convert.ToChar(Value, provider);
+    public DateTime ToDateTime(IFormatProvider? provider) => Convert.ToDateTime(Value, provider);
+    public decimal ToDecimal(IFormatProvider? provider) => Convert.ToDecimal(Value, provider);
+    public double ToDouble(IFormatProvider? provider) => Convert.ToDouble(Value, provider);
+    public short ToInt16(IFormatProvider? provider) => Convert.ToInt16(Value, provider);
+    public int ToInt32(IFormatProvider? provider) => Convert.ToInt32(Value, provider);
+    public long ToInt64(IFormatProvider? provider) => Convert.ToInt64(Value, provider);
+    public sbyte ToSByte(IFormatProvider? provider) => Convert.ToSByte(Value, provider);
+    public float ToSingle(IFormatProvider? provider) => Convert.ToSingle(Value, provider);
+    public string ToString(IFormatProvider? provider) => Value?.ToString() ?? string.Empty;
+    public object ToType(Type conversionType, IFormatProvider? provider) => Convert.ChangeType(Value, conversionType, provider);
+    public ushort ToUInt16(IFormatProvider? provider) => Convert.ToUInt16(Value, provider);
+    public uint ToUInt32(IFormatProvider? provider) => Convert.ToUInt32(Value, provider);
+    public ulong ToUInt64(IFormatProvider? provider) => Convert.ToUInt64(Value, provider);
 
     public static implicit operator T(ScalarValueObject<T> valueObject) => valueObject.Value;
 }


### PR DESCRIPTION
Implement IConvertible on ScalarValueObject

This allows tools like mapster to map without giving any configuration.