### PR TITLE
When merging validation errors, if the details differ, set the detail…

### DIFF
--- a/RailwayOrientedProgramming/src/Result/Extensions/CombineError.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/CombineError.cs
@@ -22,8 +22,9 @@ public static class CombineErrorExtensions
         ArgumentNullException.ThrowIfNull(otherError);
         if (thisError is ValidationError thisValidation && otherError is ValidationError otherValidation)
         {
-            var validationErrors = thisValidation.Errors.Concat(otherValidation.Errors).ToArray();
-            return Error.Validation(validationErrors, thisValidation.Detail, thisValidation.Instance, thisValidation.Code);
+            ValidationError.FieldDetails[] validationErrors = [.. thisValidation.Errors, .. otherValidation.Errors];
+            var detail = thisValidation.Detail == otherValidation.Detail ? thisValidation.Detail : string.Empty;
+            return Error.Validation(validationErrors, detail, thisValidation.Instance, thisValidation.Code);
         }
 
         List<Error> errors = [];

--- a/RailwayOrientedProgramming/tests/ErrorTests.cs
+++ b/RailwayOrientedProgramming/tests/ErrorTests.cs
@@ -131,7 +131,7 @@ public class ErrorTests
         var combinedError = error1.Combine(error2);
 
         // Assert
-        combinedError.Detail.Should().Be("Too short.");
+        combinedError.Detail.Should().Be(string.Empty);
         combinedError.Code.Should().Be("validation.error");
         combinedError.Should().BeOfType<ValidationError>();
         combinedError.Instance.Should().BeNull();


### PR DESCRIPTION
When merging validation errors, if the details differ, set the details to an empty string.