### PR TITLE
Enable the option to specify a custom message for null properties

### DIFF
--- a/FluentValidation/src/FluentValidationExtension.cs
+++ b/FluentValidation/src/FluentValidationExtension.cs
@@ -1,5 +1,6 @@
 ﻿namespace FunctionalDdd;
 
+using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using FluentValidation;
@@ -57,11 +58,11 @@ public static class FunctionalDDDValidationExtension
     public static Result<T> ToResult<T>(this ValidationResult validationResult, T value)
     {
         if (validationResult.IsValid)
-            return Result.Success<T>(value);
+            return Result.Success(value);
 
         ValidationError.FieldDetails[] errors = validationResult.Errors
             .GroupBy(e => e.PropertyName)
-            .Select( g => new ValidationError.FieldDetails(g.Key, g.Select(e => e.ErrorMessage).ToArray()))
+            .Select(g => new ValidationError.FieldDetails(g.Key, g.Select(e => e.ErrorMessage).ToArray()))
             .ToArray();
 
         return Result.Failure<T>(Error.Validation(errors));
@@ -77,10 +78,11 @@ public static class FunctionalDDDValidationExtension
     public static Result<T> ValidateToResult<T>(
         this IValidator<T> validator,
         T value,
-        [CallerArgumentExpression(nameof(value))] string paramName = "value")
+        [CallerArgumentExpression(nameof(value))] string paramName = "value",
+        string? message = null)
     {
         ValidationResult result = value is null
-        ? new ValidationResult([new ValidationFailure(paramName, $"{paramName} must not be empty.")])
+        ? new ValidationResult([new ValidationFailure(paramName, message ?? $"'{paramName}' must not be empty.")])
         : validator.Validate(value);
 
         return result.ToResult(value);

--- a/FluentValidation/src/FluentValidationExtension.cs
+++ b/FluentValidation/src/FluentValidationExtension.cs
@@ -1,6 +1,5 @@
 ﻿namespace FunctionalDdd;
 
-using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using FluentValidation;

--- a/FluentValidation/tests/FluentTests.cs
+++ b/FluentValidation/tests/FluentTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace FluentValidationExt.Tests;
 
+using FluentValidation;
+using Xunit;
+
 public class FluentTests
 {
     private const string StrongPassword = "P@ssw0rd";
@@ -75,7 +78,7 @@ public class FluentTests
     [InlineData("98052-12345", false, "'zip Code' is not in the correct format.")]
     [InlineData("98052-123", false, "'zip Code' is not in the correct format.")]
     [InlineData("98052-1234-1234", false, "'zip Code' is not in the correct format.")]
-    [InlineData(null, false, "zipCode must not be empty.")]
+    [InlineData(null, false, "'zipCode' must not be empty.")]
     public void Validate_zipcode(string? strZip, bool success, string? errorMessage)
     {
         // Arrange
@@ -97,5 +100,57 @@ public class FluentTests
             validationError.Errors[0].Details[0].Should().Be(errorMessage);
         }
 
+    }
+
+    [Fact]
+    public void Validate_null_value()
+    {
+        // Arrange
+        string? alias = null;
+       InlineValidator<string?> validator = new()
+       {
+          v => v.RuleFor(x => x)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+       };
+
+        ValidationError.FieldDetails[] expectedValidationErrors = [
+            new("alias", ["'alias' must not be empty."]),
+        ];
+
+        // Act
+        var result = validator.ValidateToResult(alias);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ValidationError>();
+        ValidationError error = (ValidationError)result.Error;
+        error.Errors.Should().BeEquivalentTo(expectedValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_null_value_custom_message()
+    {
+        // Arrange
+        string? alias = null;
+        InlineValidator<string?> validator = new()
+       {
+          v => v.RuleFor(x => x)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+       };
+
+        ValidationError.FieldDetails[] expectedValidationErrors = [
+            new("Alias", ["Hello There"]),
+        ];
+
+        // Act
+        var result = validator.ValidateToResult(alias, "Alias", "Hello There");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ValidationError>();
+        ValidationError error = (ValidationError)result.Error;
+        error.Errors.Should().BeEquivalentTo(expectedValidationErrors);
     }
 }


### PR DESCRIPTION
Enable the option to specify a custom message for null properties when invoking FluentValidation.