### PR TITLE
Enhance Result<TValue> with new features and validation

### DIFF
--- a/Asp/src/ActionResultExtensions.cs
+++ b/Asp/src/ActionResultExtensions.cs
@@ -153,7 +153,7 @@ public static class ActionResultExtensions
         ModelStateDictionary modelState = new();
         foreach (var error in validation.Errors)
             foreach (var detailError in error.Details)
-                modelState.AddModelError(error.Name, detailError);
+                modelState.AddModelError(error.FieldName, detailError);
 
         return controllerBase.ValidationProblem(detail, instance, modelStateDictionary: modelState);
     }

--- a/Asp/src/HttpResultExtensions.cs
+++ b/Asp/src/HttpResultExtensions.cs
@@ -29,7 +29,7 @@ public static class HttpResultExtensions
         if (error is ValidationError validationError)
         {
             Dictionary<string, string[]> errors = validationError.Errors
-                .GroupBy(x => x.Name)
+                .GroupBy(x => x.FieldName)
                 .ToDictionary(x => x.Key, x => x.SelectMany(y => y.Details).ToArray());
 
             return Results.ValidationProblem(errors, validationError.Detail, validationError.Instance);

--- a/CommonValueObjects/tests/RequiredGuidTests.cs
+++ b/CommonValueObjects/tests/RequiredGuidTests.cs
@@ -17,7 +17,7 @@ public class RequiredGuidTests
         guidId1.IsFailure.Should().BeTrue();
         guidId1.Error.Should().BeOfType<ValidationError>();
         var validation = (ValidationError)guidId1.Error;
-        validation.Errors[0].Name.Should().Be("employeeId");
+        validation.Errors[0].FieldName.Should().Be("employeeId");
         validation.Errors[0].Details[0].Should().Be("Employee Id cannot be empty.");
         validation.Code.Should().Be("validation.error");
     }
@@ -144,7 +144,7 @@ public class RequiredGuidTests
         myGuidResult.IsFailure.Should().BeTrue();
         myGuidResult.Error.Should().BeOfType<ValidationError>();
         ValidationError ve = (ValidationError)myGuidResult.Error;
-        ve.Errors[0].Name.Should().Be("employeeId");
+        ve.Errors[0].FieldName.Should().Be("employeeId");
         ve.Errors[0].Details[0].Should().Be("Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)");
 
     }
@@ -161,7 +161,7 @@ public class RequiredGuidTests
         myGuidResult.IsFailure.Should().BeTrue();
         myGuidResult.Error.Should().BeOfType<ValidationError>();
         ValidationError ve = (ValidationError)myGuidResult.Error;
-        ve.Errors[0].Name.Should().Be("employeeId");
+        ve.Errors[0].FieldName.Should().Be("employeeId");
         ve.Errors[0].Details[0].Should().Be("Employee Id cannot be empty.");
     }
 

--- a/CommonValueObjects/tests/RequiredStringTests.cs
+++ b/CommonValueObjects/tests/RequiredStringTests.cs
@@ -20,7 +20,7 @@ public class RequiredStringTests
         trackingId1.IsFailure.Should().BeTrue();
         trackingId1.Error.Should().BeOfType<ValidationError>();
         var validation = (ValidationError)trackingId1.Error;
-        validation.Errors[0].Name.Should().Be("trackingId");
+        validation.Errors[0].FieldName.Should().Be("trackingId");
         validation.Errors[0].Details[0].Should().Be("Tracking Id cannot be empty.");
         validation.Code.Should().Be("validation.error");
     }

--- a/FluentValidation/tests/FluentTests.cs
+++ b/FluentValidation/tests/FluentTests.cs
@@ -96,7 +96,7 @@ public class FluentTests
             result.Error.Should().BeOfType<ValidationError>();
             var validationError = (ValidationError)result.Error;
             validationError.Errors.Should().HaveCount(1);
-            validationError.Errors[0].Name.Should().Be("zipCode");
+            validationError.Errors[0].FieldName.Should().Be("zipCode");
             validationError.Errors[0].Details[0].Should().Be(errorMessage);
         }
 

--- a/RailwayOrientedProgramming/README.md
+++ b/RailwayOrientedProgramming/README.md
@@ -84,3 +84,35 @@ Tap calls the given function if the result is in success state and returns the s
 - HasValue - returns true if it has a value.
 - HasNoValue - returns true if it does not have a value.
 - Value - returns the value if it has a value. Otherwise `InvalidOperationException`
+
+## LINQ Query Syntax
+
+You can use C# query expressions with `Result` via `Select`, `SelectMany`, and `Where`:
+
+```csharp
+var total = from a in Result.Success(2) from b in Result.Success(3) from c in Result.Success(5) select a + b + c;          // Success(10)
+var filtered = from x in Result.Success(5) where x > 10               // predicate false -> failure (UnexpectedError) select x;
+```
+
+`where` uses an `Unexpected` error if the predicate fails. For domain-specific errors prefer `Ensure`.
+
+## Error Transformation (MapError)
+
+```csharp
+Result<int> r = GetUserPoints(userId);
+var apiResult = r.MapError(err => Error.NotFound("User not found")); // Success passes through unchanged; failure error replaced.
+```
+
+## Pattern Matching (Match / Switch)
+```csharp
+var description = r.Match( ok  => $"Points: {ok}", err => $"Error: {err.Code}");
+await r.MatchAsync( async ok  => { await LogAsync(ok); return Unit.Value; }, async err => { await LogErrorAsync(err); return Unit.Value; });
+```
+
+## Exception Capture (Try / TryAsync)
+Add these patterns to keep chains free from explicit try/catch and error plumbing.
+
+```csharp
+var loaded = Result.Try(() => LoadFromDisk(path));          // captures exceptions
+var loadedAsync = await Result.TryAsync(() => FetchAsync()); // async variant
+```

--- a/RailwayOrientedProgramming/src/Errors/Types/ValidationError.cs
+++ b/RailwayOrientedProgramming/src/Errors/Types/ValidationError.cs
@@ -2,7 +2,7 @@
 
 public sealed class ValidationError : Error
 {
-    public record FieldDetails(string Name, string[] Details);
+    public record FieldDetails(string FieldName, string[] Details);
 
     public ValidationError(string fieldDetail, string fieldName, string code, string? detail = null, string? instance = null)
         : base(detail ?? fieldDetail, code, instance)
@@ -15,5 +15,5 @@ public sealed class ValidationError : Error
     public IList<FieldDetails> Errors { get; set; }
 
     public override string ToString()
-        => base.ToString() + "\r\n" + string.Join("\r\n", Errors.Select(e => $"{e.Name}: {string.Join(", ", e.Details)}"));
+        => base.ToString() + "\r\n" + string.Join("\r\n", Errors.Select(e => $"{e.FieldName}: {string.Join(", ", e.Details)}"));
 }

--- a/RailwayOrientedProgramming/src/Result/Extensions/Linq.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/Linq.cs
@@ -1,0 +1,23 @@
+namespace FunctionalDdd;
+
+/// <summary>
+/// LINQ query expression support (Select, SelectMany, Where).
+/// </summary>
+public static class ResultLinqExtensions
+{
+    // Select -> Map
+    public static Result<TOut> Select<TIn, TOut>(this Result<TIn> result, Func<TIn, TOut> selector) =>
+        result.Map(selector);
+
+    // SelectMany (monadic bind with projection)
+    public static Result<TResult> SelectMany<TSource, TCollection, TResult>(
+        this Result<TSource> source,
+        Func<TSource, Result<TCollection>> collectionSelector,
+        Func<TSource, TCollection, TResult> resultSelector)
+        => source.Bind(s => collectionSelector(s).Map(c => resultSelector(s, c)));
+
+    // Where (filter). If predicate fails, convert to failure with a generic error.
+    // NOTE: For richer errors prefer Ensure().
+    public static Result<TSource> Where<TSource>(this Result<TSource> source, Func<TSource, bool> predicate)
+        => source.Ensure(predicate, Error.Unexpected("Result filtered out by predicate."));
+}

--- a/RailwayOrientedProgramming/src/Result/Extensions/MapError.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/MapError.cs
@@ -1,0 +1,34 @@
+namespace FunctionalDdd;
+
+using System.Threading.Tasks;
+
+/// <summary>
+/// Transforms the Error of a failed Result while leaving successful Results unchanged.
+/// </summary>
+public static class MapErrorExtensions
+{
+    public static Result<T> MapError<T>(this Result<T> result, Func<Error, Error> map)
+    {
+        if (result.IsSuccess) return result;
+        return Result.Failure<T>(map(result.Error));
+    }
+
+    public static async Task<Result<T>> MapErrorAsync<T>(this Task<Result<T>> resultTask, Func<Error, Error> map)
+    {
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.MapError(map);
+    }
+
+    public static async Task<Result<T>> MapErrorAsync<T>(this Result<T> result, Func<Error, Task<Error>> mapAsync)
+    {
+        if (result.IsSuccess) return result;
+        Error newError = await mapAsync(result.Error).ConfigureAwait(false);
+        return Result.Failure<T>(newError);
+    }
+
+    public static async Task<Result<T>> MapErrorAsync<T>(this Task<Result<T>> resultTask, Func<Error, Task<Error>> mapAsync)
+    {
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return await result.MapErrorAsync(mapAsync).ConfigureAwait(false);
+    }
+}

--- a/RailwayOrientedProgramming/src/Result/Extensions/Match.cs
+++ b/RailwayOrientedProgramming/src/Result/Extensions/Match.cs
@@ -1,0 +1,45 @@
+namespace FunctionalDdd;
+
+using System.Threading.Tasks;
+
+/// <summary>
+/// Pattern matching helpers (Match / Switch) for Result.
+/// </summary>
+public static class MatchExtensions
+{
+    public static TOut Match<TIn, TOut>(this Result<TIn> result, Func<TIn, TOut> onSuccess, Func<Error, TOut> onFailure) =>
+        result.IsSuccess ? onSuccess(result.Value) : onFailure(result.Error);
+
+    public static void Switch<TIn>(this Result<TIn> result, Action<TIn> onSuccess, Action<Error> onFailure)
+    {
+        if (result.IsSuccess) onSuccess(result.Value);
+        else onFailure(result.Error);
+    }
+}
+
+public static class MatchExtensionsAsync
+{
+    public static async Task<TOut> MatchAsync<TIn, TOut>(this Task<Result<TIn>> resultTask, Func<TIn, TOut> onSuccess, Func<Error, TOut> onFailure)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Match(onSuccess, onFailure);
+    }
+
+    public static async Task<TOut> MatchAsync<TIn, TOut>(this Result<TIn> result, Func<TIn, Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure) =>
+        result.IsSuccess
+            ? await onSuccess(result.Value).ConfigureAwait(false)
+            : await onFailure(result.Error).ConfigureAwait(false);
+
+    public static async Task<TOut> MatchAsync<TIn, TOut>(this Task<Result<TIn>> resultTask, Func<TIn, Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
+    }
+
+    public static async Task SwitchAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Task> onSuccess, Func<Error, Task> onFailure)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess) await onSuccess(result.Value).ConfigureAwait(false);
+        else await onFailure(result.Error).ConfigureAwait(false);
+    }
+}

--- a/RailwayOrientedProgramming/src/Result/Result.cs
+++ b/RailwayOrientedProgramming/src/Result/Result.cs
@@ -2,9 +2,10 @@
 using System.Threading.Tasks;
 
 /// <summary>
-/// Static methods to create the <see cref="Result{TValue}"/> object.
+/// Non-generic Result utility host.
+/// NOTE: This struct is not intended to be instantiated.
 /// </summary>
-public static class Result
+public readonly struct Result
 {
     /// <summary>
     ///     Creates a success result containing the given value.
@@ -13,7 +14,7 @@ public static class Result
         new(false, value, default);
 
     /// <summary>
-    ///     Creates a success result containing the given value.
+    ///     Creates a success result containing the given value via deferred factory.
     /// </summary>
     public static Result<TValue> Success<TValue>(Func<TValue> funcOk)
     {
@@ -28,7 +29,7 @@ public static class Result
         new(true, default, error);
 
     /// <summary>
-    ///     Creates a failure result with the given error.
+    ///     Creates a failure result with the given error via deferred factory.
     /// </summary>
     public static Result<TValue> Failure<TValue>(Func<Error> error)
     {
@@ -61,7 +62,7 @@ public static class Result
         => SuccessIf(!failurePredicate(), value, error);
 
     /// <summary>
-    ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+    ///     Creates a result whose success/failure depends on the supplied async predicate. Opposite of FailureIf().
     /// </summary>
     public static async Task<Result<TValue>> SuccessIfAsync<TValue>(Func<Task<bool>> predicate, TValue value, Error error)
     {
@@ -70,7 +71,7 @@ public static class Result
     }
 
     /// <summary>
-    ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+    ///     Creates a result whose success/failure depends on the supplied async predicate. Opposite of SuccessIf().
     /// </summary>
     public static async Task<Result<TValue>> FailureIfAsync<TValue>(Func<Task<bool>> failurePredicate, TValue value, Error error)
     {

--- a/RailwayOrientedProgramming/src/Result/Result.cs
+++ b/RailwayOrientedProgramming/src/Result/Result.cs
@@ -1,4 +1,5 @@
 ﻿namespace FunctionalDdd;
+using System;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -7,87 +8,98 @@ using System.Threading.Tasks;
 /// </summary>
 public readonly struct Result
 {
-    /// <summary>
-    ///     Creates a success result containing the given value.
-    /// </summary>
     public static Result<TValue> Success<TValue>(TValue value) =>
         new(false, value, default);
 
-    /// <summary>
-    ///     Creates a success result containing the given value via deferred factory.
-    /// </summary>
     public static Result<TValue> Success<TValue>(Func<TValue> funcOk)
     {
         TValue value = funcOk();
         return new(false, value, default);
     }
 
-    /// <summary>
-    ///     Creates a failure result with the given error.
-    /// </summary>
     public static Result<TValue> Failure<TValue>(Error error) =>
         new(true, default, error);
 
-    /// <summary>
-    ///     Creates a failure result with the given error via deferred factory.
-    /// </summary>
     public static Result<TValue> Failure<TValue>(Func<Error> error)
     {
         Error err = error();
         return new(true, default, err);
     }
 
-    /// <summary>
-    ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
-    /// </summary>
     public static Result<TValue> SuccessIf<TValue>(bool isSuccess, in TValue value, Error error)
         => isSuccess ? Success(value) : Failure<TValue>(error);
 
-    /// <summary>
-    ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
-    /// </summary>
     public static Result<(T1, T2)> SuccessIf<T1, T2>(bool isSuccess, in T1 t1, in T2 t2, Error error)
         => isSuccess ? Success((t1, t2)) : Failure<(T1, T2)>(error);
 
-    /// <summary>
-    ///     Creates a result whose success/failure reflects the supplied condition. Opposite of SuccessIf().
-    /// </summary>
     public static Result<TValue> FailureIf<TValue>(bool isFailure, TValue value, Error error)
         => SuccessIf(!isFailure, value, error);
 
-    /// <summary>
-    ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
-    /// </summary>
     public static Result<TValue> FailureIf<TValue>(Func<bool> failurePredicate, in TValue value, Error error)
         => SuccessIf(!failurePredicate(), value, error);
 
-    /// <summary>
-    ///     Creates a result whose success/failure depends on the supplied async predicate. Opposite of FailureIf().
-    /// </summary>
     public static async Task<Result<TValue>> SuccessIfAsync<TValue>(Func<Task<bool>> predicate, TValue value, Error error)
     {
         bool isSuccess = await predicate().ConfigureAwait(false);
         return SuccessIf(isSuccess, value, error);
     }
 
-    /// <summary>
-    ///     Creates a result whose success/failure depends on the supplied async predicate. Opposite of SuccessIf().
-    /// </summary>
     public static async Task<Result<TValue>> FailureIfAsync<TValue>(Func<Task<bool>> failurePredicate, TValue value, Error error)
     {
         bool isFailure = await failurePredicate().ConfigureAwait(false);
         return SuccessIf(!isFailure, value, error);
     }
 
-    /// <summary>
-    ///     Creates a success unit result.
-    /// </summary>
     public static Result<Unit> Success() =>
         new(false, default, default);
 
-    /// <summary>
-    ///     Creates a failed unit result with the given error.
-    /// </summary>
     public static Result<Unit> Failure(Error error) =>
         new(true, default, error);
+
+    // --- New: exception capture helpers --------------------------------------------------
+
+    /// <summary>
+    /// Executes the function and converts exceptions to a failed Result using the optional mapper (default Unexpected).
+    /// </summary>
+    public static Result<T> Try<T>(Func<T> func, Func<Exception, Error>? map = null)
+    {
+        try
+        {
+            return Success(func());
+        }
+        catch (Exception ex)
+        {
+            return Failure<T>((map ?? DefaultExceptionMapper)(ex));
+        }
+    }
+
+    /// <summary>
+    /// Executes the async function and converts exceptions to a failed Result using the optional mapper (default Unexpected).
+    /// </summary>
+    public static async Task<Result<T>> TryAsync<T>(Func<Task<T>> func, Func<Exception, Error>? map = null)
+    {
+        try
+        {
+            return Success(await func().ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return Failure<T>((map ?? DefaultExceptionMapper)(ex));
+        }
+    }
+
+    /// <summary>
+    /// Converts an exception to a failed unit Result using the optional mapper (default Unexpected).
+    /// </summary>
+    public static Result<Unit> FromException(Exception ex, Func<Exception, Error>? map = null) =>
+        Failure((map ?? DefaultExceptionMapper)(ex));
+
+    /// <summary>
+    /// Converts an exception to a failed generic Result using the optional mapper (default Unexpected).
+    /// </summary>
+    public static Result<T> FromException<T>(Exception ex, Func<Exception, Error>? map = null) =>
+        Failure<T>((map ?? DefaultExceptionMapper)(ex));
+
+    private static UnexpectedError DefaultExceptionMapper(Exception ex) =>
+        Error.Unexpected(ex.Message);
 }

--- a/RailwayOrientedProgramming/src/Result/Result.cs
+++ b/RailwayOrientedProgramming/src/Result/Result.cs
@@ -3,64 +3,152 @@ using System;
 using System.Threading.Tasks;
 
 /// <summary>
-/// Non-generic Result utility host.
-/// NOTE: This struct is not intended to be instantiated.
+/// Non-generic Result utility host containing factory and helper methods to construct <see cref="Result{TValue}"/> instances.
+/// NOTE: This struct is not intended to be instantiated; all members are static.
 /// </summary>
 public readonly struct Result
 {
+    /// <summary>
+    /// Creates a successful result wrapping the provided <paramref name="value"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value.</typeparam>
+    /// <param name="value">Value to wrap in a successful result (may be null for reference types).</param>
+    /// <returns>A successful <see cref="Result{TValue}"/> containing <paramref name="value"/>.</returns>
     public static Result<TValue> Success<TValue>(TValue value) =>
         new(false, value, default);
 
+    /// <summary>
+    /// Creates a successful result by invoking the supplied factory function.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value.</typeparam>
+    /// <param name="funcOk">Factory function producing the value. Must not be null.</param>
+    /// <returns>A successful <see cref="Result{TValue}"/> containing the produced value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="funcOk"/> is null.</exception>
     public static Result<TValue> Success<TValue>(Func<TValue> funcOk)
     {
         TValue value = funcOk();
         return new(false, value, default);
     }
 
+    /// <summary>
+    /// Creates a failed result with the specified <paramref name="error"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the (missing) success value.</typeparam>
+    /// <param name="error">Error describing the failure.</param>
+    /// <returns>A failed <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> Failure<TValue>(Error error) =>
         new(true, default, error);
 
+    /// <summary>
+    /// Creates a failed result using a deferred error factory.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the (missing) success value.</typeparam>
+    /// <param name="error">Factory function producing an <see cref="Error"/>.</param>
+    /// <returns>A failed <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> Failure<TValue>(Func<Error> error)
     {
         Error err = error();
         return new(true, default, err);
     }
 
+    /// <summary>
+    /// Returns a success or failure result based on <paramref name="isSuccess"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value.</typeparam>
+    /// <param name="isSuccess">If true returns success; otherwise failure.</param>
+    /// <param name="value">Value for the success case.</param>
+    /// <param name="error">Error for the failure case.</param>
+    /// <returns>A success or failure <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> SuccessIf<TValue>(bool isSuccess, in TValue value, Error error)
         => isSuccess ? Success(value) : Failure<TValue>(error);
 
+    /// <summary>
+    /// Returns a success (tuple) or failure result based on <paramref name="isSuccess"/>.
+    /// </summary>
+    /// <typeparam name="T1">Type of first value.</typeparam>
+    /// <typeparam name="T2">Type of second value.</typeparam>
+    /// <param name="isSuccess">If true returns success; otherwise failure.</param>
+    /// <param name="t1">First value for the success case.</param>
+    /// <param name="t2">Second value for the success case.</param>
+    /// <param name="error">Error for the failure case.</param>
+    /// <returns>A success or failure <see cref="Result{TValue}"/> with a tuple payload.</returns>
     public static Result<(T1, T2)> SuccessIf<T1, T2>(bool isSuccess, in T1 t1, in T2 t2, Error error)
         => isSuccess ? Success((t1, t2)) : Failure<(T1, T2)>(error);
 
+    /// <summary>
+    /// Returns failure if <paramref name="isFailure"/> is true; otherwise success with <paramref name="value"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the value.</typeparam>
+    /// <param name="isFailure">If true produce a failure result.</param>
+    /// <param name="value">Success value when not failing.</param>
+    /// <param name="error">Error when failing.</param>
+    /// <returns>A success or failure <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> FailureIf<TValue>(bool isFailure, TValue value, Error error)
         => SuccessIf(!isFailure, value, error);
 
+    /// <summary>
+    /// Returns failure if the provided predicate returns true; otherwise success with <paramref name="value"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the value.</typeparam>
+    /// <param name="failurePredicate">Predicate indicating a failure condition.</param>
+    /// <param name="value">Success value when predicate is false.</param>
+    /// <param name="error">Error when predicate is true.</param>
+    /// <returns>A success or failure <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> FailureIf<TValue>(Func<bool> failurePredicate, in TValue value, Error error)
         => SuccessIf(!failurePredicate(), value, error);
 
+    /// <summary>
+    /// Asynchronously determines success/failure using <paramref name="predicate"/>.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value.</typeparam>
+    /// <param name="predicate">Async predicate producing true for success.</param>
+    /// <param name="value">Success value if predicate is true.</param>
+    /// <param name="error">Error if predicate is false.</param>
+    /// <returns>A task producing a success or failure <see cref="Result{TValue}"/>.</returns>
     public static async Task<Result<TValue>> SuccessIfAsync<TValue>(Func<Task<bool>> predicate, TValue value, Error error)
     {
         bool isSuccess = await predicate().ConfigureAwait(false);
         return SuccessIf(isSuccess, value, error);
     }
 
+    /// <summary>
+    /// Asynchronously determines failure/success using <paramref name="failurePredicate"/> (inverse semantics of <see cref="SuccessIfAsync{TValue}"/>).
+    /// </summary>
+    /// <typeparam name="TValue">Type of the value.</typeparam>
+    /// <param name="failurePredicate">Async predicate producing true for failure.</param>
+    /// <param name="value">Success value if predicate is false.</param>
+    /// <param name="error">Error if predicate is true.</param>
+    /// <returns>A task producing a success or failure <see cref="Result{TValue}"/>.</returns>
     public static async Task<Result<TValue>> FailureIfAsync<TValue>(Func<Task<bool>> failurePredicate, TValue value, Error error)
     {
         bool isFailure = await failurePredicate().ConfigureAwait(false);
         return SuccessIf(!isFailure, value, error);
     }
 
+    /// <summary>
+    /// Creates a successful unit result (no payload).
+    /// </summary>
+    /// <returns>A successful <see cref="Result{TValue}"/> of <see cref="Unit"/>.</returns>
     public static Result<Unit> Success() =>
         new(false, default, default);
 
+    /// <summary>
+    /// Creates a failed unit result with the specified <paramref name="error"/>.
+    /// </summary>
+    /// <param name="error">Error describing the failure.</param>
+    /// <returns>A failed <see cref="Result{TValue}"/> of <see cref="Unit"/>.</returns>
     public static Result<Unit> Failure(Error error) =>
         new(true, default, error);
 
-    // --- New: exception capture helpers --------------------------------------------------
+    // --- Exception capture helpers --------------------------------------------------
 
     /// <summary>
-    /// Executes the function and converts exceptions to a failed Result using the optional mapper (default Unexpected).
+    /// Executes the function and converts exceptions to a failed result using the optional mapper (default maps to <see cref="Error.Unexpected(string, string?, string?)"/>).
     /// </summary>
+    /// <typeparam name="T">Type of the produced value.</typeparam>
+    /// <param name="func">Function to execute.</param>
+    /// <param name="map">Optional exception-to-error mapper. If null, a default Unexpected error is used.</param>
+    /// <returns>A success result with the value or a failure result if an exception was thrown.</returns>
     public static Result<T> Try<T>(Func<T> func, Func<Exception, Error>? map = null)
     {
         try
@@ -74,8 +162,12 @@ public readonly struct Result
     }
 
     /// <summary>
-    /// Executes the async function and converts exceptions to a failed Result using the optional mapper (default Unexpected).
+    /// Executes the asynchronous function and converts exceptions to a failed result using the optional mapper (default maps to Unexpected).
     /// </summary>
+    /// <typeparam name="T">Type of the produced value.</typeparam>
+    /// <param name="func">Asynchronous function to execute.</param>
+    /// <param name="map">Optional exception-to-error mapper. If null, a default Unexpected error is used.</param>
+    /// <returns>A task producing either a success or failure result.</returns>
     public static async Task<Result<T>> TryAsync<T>(Func<Task<T>> func, Func<Exception, Error>? map = null)
     {
         try
@@ -89,17 +181,29 @@ public readonly struct Result
     }
 
     /// <summary>
-    /// Converts an exception to a failed unit Result using the optional mapper (default Unexpected).
+    /// Converts an exception to a failed unit result using the optional mapper (default Unexpected).
     /// </summary>
+    /// <param name="ex">Exception to convert.</param>
+    /// <param name="map">Optional exception-to-error mapper.</param>
+    /// <returns>A failed unit result.</returns>
     public static Result<Unit> FromException(Exception ex, Func<Exception, Error>? map = null) =>
         Failure((map ?? DefaultExceptionMapper)(ex));
 
     /// <summary>
-    /// Converts an exception to a failed generic Result using the optional mapper (default Unexpected).
+    /// Converts an exception to a failed result of type <typeparamref name="T"/> using the optional mapper (default Unexpected).
     /// </summary>
+    /// <typeparam name="T">Type parameter of the target result.</typeparam>
+    /// <param name="ex">Exception to convert.</param>
+    /// <param name="map">Optional exception-to-error mapper.</param>
+    /// <returns>A failed result.</returns>
     public static Result<T> FromException<T>(Exception ex, Func<Exception, Error>? map = null) =>
         Failure<T>((map ?? DefaultExceptionMapper)(ex));
 
+    /// <summary>
+    /// Default mapper converting an exception into an <see cref="UnexpectedError"/>.
+    /// </summary>
+    /// <param name="ex">Exception that occurred.</param>
+    /// <returns>An <see cref="UnexpectedError"/> containing the exception message.</returns>
     private static UnexpectedError DefaultExceptionMapper(Exception ex) =>
         Error.Unexpected(ex.Message);
 }

--- a/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
+++ b/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
@@ -62,7 +62,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
 
         IsFailure = isFailure;
         _error = error;
-        _value = isFailure ? default : ok;
+        _value = ok;
 
         Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
 
@@ -124,7 +124,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     {
         if (IsFailure != other.IsFailure) return false;
         if (IsFailure) return _error!.Equals(other._error);
-        return EqualityComparer<TValue>.Default.Equals(_value!, other._value);
+        return EqualityComparer<TValue>.Default.Equals(_value, other._value);
     }
 
     public override bool Equals(object? obj) => obj is Result<TValue> other && Equals(other);

--- a/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
+++ b/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
@@ -131,12 +131,9 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
 
     public override int GetHashCode()
     {
-        unchecked
-        {
-            return IsFailure
-                ? HashCode.Combine(true, _error)
-                : HashCode.Combine(false, _value);
-        }
+        return IsFailure
+            ? HashCode.Combine(true, _error)
+            : HashCode.Combine(false, _value);
     }
 
     public static bool operator ==(Result<TValue> left, Result<TValue> right) => left.Equals(right);

--- a/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
+++ b/RailwayOrientedProgramming/src/Result/Result{TValue}.cs
@@ -1,58 +1,149 @@
 ﻿namespace FunctionalDdd;
 
+using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
+[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Value = {(_value is null ? \"<null>\" : _value)}, Error = {(_error is null ? \"<none>\" : _error.Code)}")]
 /// <summary>
-/// The Result type used in functional programming languages to represent a success value or an error.
+/// Represents either a successful computation (with a value) or a failure (with an <see cref="Error"/>).
 /// </summary>
-/// <typeparam name="TValue"></typeparam>
-public readonly struct Result<TValue> : IResult<TValue>
+/// <typeparam name="TValue">Success value type.</typeparam>
+public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>
 {
     /// <summary>
-    /// Gets the underlying Value if Result is in success state.
+    /// Gets the underlying value if the result is successful; otherwise throws.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Attempted to access the Value for a failed result.</exception>
-    public TValue Value => IsSuccess ? _value! : throw new InvalidOperationException("Attempted to access the Value for a failed result. A failed result has no Value.");
+    public TValue Value =>
+        IsSuccess
+            ? _value!
+            : throw new InvalidOperationException("Attempted to access the Value for a failed result. A failed result has no Value.");
 
     /// <summary>
-    /// Gets the Error object if Result is in failed state.
+    /// Gets the error if the result is a failure; otherwise throws.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Attempted to access the Error property for a successful result.</exception>
-    public Error Error => IsFailure ? _error! : throw new InvalidOperationException("Attempted to access the Error property for a successful result.A successful result has no Error.");
+    public Error Error =>
+        IsFailure
+            ? _error!
+            : throw new InvalidOperationException("Attempted to access the Error property for a successful result. A successful result has no Error.");
 
     /// <summary>
-    /// Check if result is in success state.
+    /// True when the result represents success.
     /// </summary>
     public bool IsSuccess => !IsFailure;
 
     /// <summary>
-    /// Check if result is in failure state.
+    /// True when the result represents failure.
     /// </summary>
     public bool IsFailure { get; }
 
     /// <summary>
-    /// Implicit operator to convert a value to a success <see cref="Result{TValue}"/>
+    /// Implicitly converts a value to a successful result.
     /// </summary>
-    /// <param name="value"></param>
     public static implicit operator Result<TValue>(TValue value) => Result.Success(value);
 
     /// <summary>
-    /// Implicit operator to convert an error to a failed <see cref="Result{TValue}"/>
+    /// Implicitly converts an error to a failed result.
     /// </summary>
-    /// <param name="error"></param>
     public static implicit operator Result<TValue>(Error error) => Result.Failure<TValue>(error);
 
     internal Result(bool isFailure, TValue? ok, Error? error)
     {
-        if (isFailure && error is null)
-            throw new ArgumentException("If 'isFailure' is true, 'error' must not be null.");
+        if (isFailure)
+        {
+            if (error is null)
+                throw new ArgumentException("If 'isFailure' is true, 'error' must not be null.", nameof(error));
+        }
+        else
+        {
+            if (error is not null)
+                throw new ArgumentException("If 'isFailure' is false, 'error' must be null.", nameof(error));
+        }
 
         IsFailure = isFailure;
         _error = error;
-        _value = ok;
+        _value = isFailure ? default : ok;
+
         Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+
+        // Optional enrichment (safe no-op if no activity)
+        if (IsFailure && Activity.Current is { } act && error is not null)
+        {
+            act.SetTag("result.error.code", error.Code);
+        }
     }
 
     private readonly TValue? _value;
     private readonly Error? _error;
+
+    // ------------- Convenience / ergonomic APIs -------------
+
+    /// <summary>
+    /// Attempts to get the success value without throwing.
+    /// </summary>
+    public bool TryGetValue(out TValue value)
+    {
+        if (IsSuccess)
+        {
+            value = _value!;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to get the error without throwing.
+    /// </summary>
+    public bool TryGetError(out Error error)
+    {
+        if (IsFailure)
+        {
+            error = _error!;
+            return true;
+        }
+
+        error = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Deconstructs into success flag, value (may be default if failure) and error (may be null if success).
+    /// </summary>
+    public void Deconstruct(out bool isSuccess, out TValue? value, out Error? error)
+    {
+        isSuccess = IsSuccess;
+        value = _value;
+        error = _error;
+    }
+
+    // ------------- Equality & hashing -------------
+
+    public bool Equals(Result<TValue> other)
+    {
+        if (IsFailure != other.IsFailure) return false;
+        if (IsFailure) return _error!.Equals(other._error);
+        return EqualityComparer<TValue>.Default.Equals(_value!, other._value);
+    }
+
+    public override bool Equals(object? obj) => obj is Result<TValue> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return IsFailure
+                ? HashCode.Combine(true, _error)
+                : HashCode.Combine(false, _value);
+        }
+    }
+
+    public static bool operator ==(Result<TValue> left, Result<TValue> right) => left.Equals(right);
+    public static bool operator !=(Result<TValue> left, Result<TValue> right) => !left.Equals(right);
+
+    public override string ToString() =>
+        IsFailure
+            ? $"Failure({Error.Code}: {Error.Detail})"
+            : $"Success({(_value is null ? "<null>" : _value)})";
 }

--- a/RailwayOrientedProgramming/tests/ErrorTests.cs
+++ b/RailwayOrientedProgramming/tests/ErrorTests.cs
@@ -125,7 +125,7 @@ public class ErrorTests
         error.Instance.Should().BeNull();
         var validationError = (ValidationError)error;
         validationError.Errors.Should().HaveCount(1);
-        validationError.Errors[0].Name.Should().Be("field name");
+        validationError.Errors[0].FieldName.Should().Be("field name");
         validationError.Errors[0].Details.Should().HaveCount(1);
         validationError.Errors[0].Details[0].Should().Be("field detail.");
         validationError.ToString().Should().Be("Type: ValidationError, Code: validation.error, Detail: field detail., Instance: N/A\r\nfield name: field detail.");
@@ -149,11 +149,11 @@ public class ErrorTests
         combinedError.Instance.Should().BeNull();
         var validationError = (ValidationError)combinedError;
         validationError.Errors.Should().HaveCount(2);
-        validationError.Errors[0].Name.Should().Be("password");
+        validationError.Errors[0].FieldName.Should().Be("password");
         validationError.Errors[0].Details.Should().HaveCount(1);
         validationError.Errors[0].Details[0].Should().Be("Too short.");
 
-        validationError.Errors[1].Name.Should().Be("password");
+        validationError.Errors[1].FieldName.Should().Be("password");
         validationError.Errors[1].Details.Should().HaveCount(2);
         validationError.Errors[1].Details.Should().Equal("Not complex.", "Make it complex.");
 

--- a/RailwayOrientedProgramming/tests/Results/Extensions/LinqTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/LinqTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Xunit;
+using FunctionalDdd;
+
+namespace RailwayOrientedProgramming.Tests.Results.Extensions.Linq;
+
+public class LinqTests : TestBase
+{
+    [Fact]
+    public void Select_projects_success_value()
+    {
+        var r = Result.Success(5);
+
+        var projected = r.Select(x => x * 2); // query Select extension
+
+        projected.IsSuccess.Should().BeTrue();
+        projected.Value.Should().Be(10);
+    }
+
+    [Fact]
+    public void Select_propagates_failure()
+    {
+        var r = Result.Failure<int>(Error1);
+
+        var projected = r.Select(x => x * 2);
+
+        projected.IsFailure.Should().BeTrue();
+        projected.Error.Should().Be(Error1);
+    }
+
+    [Fact]
+    public void SelectMany_combines_two_success_results()
+    {
+        var a = Result.Success(2);
+        var b = Result.Success(3);
+
+        var combined =
+            a.SelectMany(_ => b, (x, y) => x + y);
+
+        combined.IsSuccess.Should().BeTrue();
+        combined.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void SelectMany_propagates_first_failure()
+    {
+        var a = Result.Failure<int>(Error1);
+        var b = Result.Success(3);
+
+        var combined =
+            a.SelectMany(_ => b, (x, y) => x + y);
+
+        combined.IsFailure.Should().BeTrue();
+        combined.Error.Should().Be(Error1);
+    }
+
+    [Fact]
+    public void Where_filters_out_value_and_returns_failure_when_predicate_false()
+    {
+        var r =
+            Result.Success(5)
+                  .Where(v => v > 10); // predicate false
+
+        r.IsFailure.Should().BeTrue();
+        r.Error.Should().Be(Error.Unexpected("Result filtered out by predicate."));
+    }
+
+    [Fact]
+    public void Where_keeps_success_when_predicate_true()
+    {
+        var r =
+            Result.Success(15)
+                  .Where(v => v > 10);
+
+        r.IsSuccess.Should().BeTrue();
+        r.Value.Should().Be(15);
+    }
+}

--- a/RailwayOrientedProgramming/tests/Results/Extensions/LinqTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/LinqTests.cs
@@ -68,11 +68,31 @@ public class LinqTests : TestBase
     [Fact]
     public void Where_keeps_success_when_predicate_true()
     {
-        var r =
+        Result<int> r =
             Result.Success(15)
                   .Where(v => v > 10);
 
         r.IsSuccess.Should().BeTrue();
         r.Value.Should().Be(15);
+    }
+
+    [Fact]
+    public void SelectMany_combines_four_success_results()
+    {
+        var a = Result.Success(1);
+        var b = Result.Success(2);
+        var c = Result.Success(3);
+        var d = Result.Success(4);
+
+        // LINQ query syntax exercises chained SelectMany calls for 4 Results
+        Result<int> combined =
+            from av in a
+            from bv in b
+            from cv in c
+            from dv in d
+            select av + bv + cv + dv;
+
+        combined.IsSuccess.Should().BeTrue();
+        combined.Value.Should().Be(1 + 2 + 3 + 4);
     }
 }

--- a/RailwayOrientedProgramming/tests/Results/Extensions/MapErrorTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/MapErrorTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Xunit;
+using FunctionalDdd;
+
+namespace RailwayOrientedProgramming.Tests.Results.Extensions;
+
+public class MapErrorTests : TestBase
+{
+    [Fact]
+    public void MapError_transforms_failure_error()
+    {
+        var original = Result.Failure<int>(Error1);
+
+        var mapped = original.MapError(e => Error.Conflict($"Wrapped: {e.Detail}"));
+
+        mapped.IsFailure.Should().BeTrue();
+        mapped.Error.Should().Be(Error.Conflict($"Wrapped: {Error1.Detail}"));
+    }
+
+    [Fact]
+    public void MapError_does_not_touch_success()
+    {
+        var success = Result.Success(42);
+
+        var mapped = success.MapError(e => Error.Unexpected("ShouldNotHappen"));
+
+        mapped.IsSuccess.Should().BeTrue();
+        mapped.Value.Should().Be(42);
+    }
+}

--- a/RailwayOrientedProgramming/tests/Results/Extensions/QueryExpressionTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/QueryExpressionTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Xunit;
+using FunctionalDdd;
+
+namespace RailwayOrientedProgramming.Tests.Results.Extensions.Linq;
+
+public class QueryExpressionTests : TestBase
+{
+    [Fact]
+    public void Query_expression_success_chain()
+    {
+        var query =
+            from a in Result.Success(2)
+            from b in Result.Success(3)
+            from c in Result.Success(5)
+            select a + b + c;
+
+        query.IsSuccess.Should().BeTrue();
+        query.Value.Should().Be(10);
+    }
+
+    [Fact]
+    public void Query_expression_short_circuits_on_first_failure()
+    {
+        var query =
+            from a in Result.Failure<int>(Error1)
+            from b in Result.Success(3)
+            select a + b;
+
+        query.IsFailure.Should().BeTrue();
+        query.Error.Should().Be(Error1);
+    }
+
+    [Fact]
+    public void Query_expression_where_clause_filters()
+    {
+        var query =
+            from a in Result.Success(4)
+            where a % 2 == 1   // false
+            select a;
+
+        query.IsFailure.Should().BeTrue();
+        query.Error.Detail.Should().Be("Result filtered out by predicate.");
+    }
+
+    [Fact]
+    public void Query_expression_where_clause_passes()
+    {
+        var query =
+            from a in Result.Success(9)
+            where a > 3
+            select a * 2;
+
+        query.IsSuccess.Should().BeTrue();
+        query.Value.Should().Be(18);
+    }
+}

--- a/RailwayOrientedProgramming/tests/Results/Extensions/TryTests.cs
+++ b/RailwayOrientedProgramming/tests/Results/Extensions/TryTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Xunit;
+using FunctionalDdd;
+
+namespace RailwayOrientedProgramming.Tests.Results.Extensions;
+
+public class TryTests
+{
+    [Fact]
+    public void Try_wraps_exception_into_failure()
+    {
+        var r = Result.Try<int>(() => throw new InvalidOperationException("Boom"));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error.Detail.Should().Be("Boom");
+    }
+
+    [Fact]
+    public void Try_returns_success_on_normal_execution()
+    {
+        var r = Result.Try(() => 123);
+
+        r.IsSuccess.Should().BeTrue();
+        r.Value.Should().Be(123);
+    }
+
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types")]
+    public async Task TryAsync_wraps_exception()
+    {
+        var r = await Result.TryAsync<int>(async () =>
+        {
+            await Task.Delay(5);
+            throw new Exception("AsyncBoom");
+        });
+
+        r.IsFailure.Should().BeTrue();
+        r.Error.Detail.Should().Be("AsyncBoom");
+    }
+
+    [Fact]
+    public async Task TryAsync_success()
+    {
+        var r = await Result.TryAsync(async () =>
+        {
+            await Task.Delay(5);
+            return 7;
+        });
+
+        r.IsSuccess.Should().BeTrue();
+        r.Value.Should().Be(7);
+    }
+
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types")]
+    public void FromException_converts_exception()
+    {
+        var ex = new ApplicationException("Custom");
+        var r = Result.FromException<int>(ex);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error.Detail.Should().Be("Custom");
+    }
+
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types")]
+    public void Custom_exception_mapper()
+    {
+        var r = Result.Try<int>(() => throw new Exception("HideMe"), ex => Error.BadRequest("Mapped"));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error.Should().Be(Error.BadRequest("Mapped"));
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.405",
+    "version": "8.0.414",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Improved the `Result<TValue>` struct by adding the `IEquatable<Result<TValue>>` interface for better equality comparison. Introduced new methods: `TryGetValue`, `TryGetError`, and `Deconstruct` for easier access to values and errors. Reformatted `Value` and `Error` properties for clarity, and enhanced constructor validation. Overridden `GetHashCode` and `ToString` for meaningful representations. Added `DebuggerDisplay` for improved debugging information.