### PR TITLE
Refactor CommonValueObjectTrace and Maybe<T> class

### DIFF
--- a/CommonValueObjects/src/CommonValueObjectTrace.cs
+++ b/CommonValueObjects/src/CommonValueObjectTrace.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 public static class CommonValueObjectTrace
 {
-    internal static readonly AssemblyName AssemblyName = typeof(Trace).Assembly.GetName();
+    internal static readonly AssemblyName AssemblyName = typeof(CommonValueObjectTrace).Assembly.GetName();
     internal static readonly string ActivitySourceName = "Functional DDD CVO";
     internal static readonly Version Version = AssemblyName.Version!;
     public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());

--- a/RailwayOrientedProgramming/src/Maybe/Maybe{T}.cs
+++ b/RailwayOrientedProgramming/src/Maybe/Maybe{T}.cs
@@ -55,9 +55,9 @@ public readonly struct Maybe<T> :
 
     public static bool operator !=(Maybe<T> maybe, T value) => !maybe.Equals(value);
 
-    public static bool operator ==(Maybe<T> maybe, object other) => maybe.Equals(other);
+    public static bool operator ==(Maybe<T> maybe, object? other) => maybe.Equals(other);
 
-    public static bool operator !=(Maybe<T> maybe, object other) => !maybe.Equals(other);
+    public static bool operator !=(Maybe<T> maybe, object? other) => !maybe.Equals(other);
 
     public static bool operator ==(Maybe<T> first, Maybe<T> second) => first.Equals(second);
 
@@ -73,15 +73,16 @@ public readonly struct Maybe<T> :
 
     public bool Equals(Maybe<T> other) =>
         _isValueSet && other._isValueSet
-        ? EqualityComparer<T>.Default.Equals(_value, other._value)
-        : !_isValueSet && !other._isValueSet;
+            ? EqualityComparer<T>.Default.Equals(_value, other._value)
+            : !_isValueSet && !other._isValueSet;
 
-    public bool Equals(T? other) =>
-        _isValueSet
-        ? EqualityComparer<T>.Default.Equals(_value, other)
-        : !_isValueSet;
+    public bool Equals(T? other) => 
+        (_isValueSet && EqualityComparer<T>.Default.Equals(_value, other))
+        || (!_isValueSet && other is null);
 
-    public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+    public override int GetHashCode() => _isValueSet
+        ? (_value?.GetHashCode() ?? 0)
+        : 0;
 
     public override string ToString() => _value?.ToString() ?? string.Empty;
 }

--- a/RailwayOrientedProgramming/tests/Maybes/EqualityTests.cs
+++ b/RailwayOrientedProgramming/tests/Maybes/EqualityTests.cs
@@ -133,6 +133,36 @@ public class EqualityTests
     }
 
     [Fact]
+    public void None_is_not_equal_to_any_concrete_value()
+    {
+        Maybe<int> none = Maybe.None<int>();
+
+        (none == 0).Should().BeFalse();
+        (none == 5).Should().BeFalse();
+        none.Equals(0).Should().BeFalse();
+        none.Equals(5).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Some_is_equal_to_underlying_value()
+    {
+        Maybe<int> some = 42;
+
+        (some == 42).Should().BeTrue();
+        some.Equals(42).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Two_nones_are_equal()
+    {
+        Maybe<int> a = Maybe.None<int>();
+        Maybe<int> b = Maybe.None<int>();
+
+        (a == b).Should().BeTrue();
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
     public void Compare_with_null_value()
     {
         Maybe<MyClass> maybe = null;


### PR DESCRIPTION
- Updated `CommonValueObjectTrace` to use its own type for assembly name.
- Enhanced `Maybe<T>` equality operator overloads to support nullable objects.
- Refactored `Equals` method for improved readability and null handling.
- Updated `GetHashCode` method to align with new equality logic.
- Added unit tests for `Maybe<T>` to ensure correct behavior for None and Some instances.