### PR TITLE
Fix Maybe<T> scalar properties inside Maybe<CompositeVO> owned types in EF Core conventions

### DIFF
--- a/Trellis.EntityFrameworkCore/src/MaybeConvention.cs
+++ b/Trellis.EntityFrameworkCore/src/MaybeConvention.cs
@@ -63,53 +63,69 @@ internal sealed class MaybeConvention : IModelFinalizingConvention
     {
         foreach (var entityType in modelBuilder.Metadata.GetEntityTypes().ToList())
         {
-            if (entityType.ClrType is null)
-                continue;
+            ProcessEntityType(modelBuilder, entityType);
+        }
+    }
 
-            foreach (var maybeProperty in MaybePropertyResolver.GetMaybeProperties(entityType.ClrType))
+    /// <summary>
+    /// Processes all <see cref="Maybe{T}"/> CLR properties on a single entity type,
+    /// ignoring the struct property and mapping the generated backing field instead.
+    /// </summary>
+    private void ProcessEntityType(
+        IConventionModelBuilder modelBuilder,
+        IConventionEntityType entityType)
+    {
+        if (entityType.ClrType is null)
+            return;
+
+        foreach (var maybeProperty in MaybePropertyResolver.GetMaybeProperties(entityType.ClrType))
+        {
+            // Verify the generated storage member exists (source generator should have created it)
+            var storageMember = MaybePropertyResolver.FindStorageMember(entityType.ClrType, maybeProperty);
+
+            if (storageMember is null)
+                throw new InvalidOperationException(
+                    $"Cannot map Maybe<T> property '{maybeProperty.PropertyName}' on entity '{entityType.ClrType.Name}'. " +
+                    $"Expected generated storage member '{maybeProperty.StorageMemberName}' was not found. " +
+                    "Declare the property as partial so the Trellis.EntityFrameworkCore.Generator can emit the storage member, or configure the storage-member property explicitly before model finalization.");
+
+            // Owned types (e.g., Money) need ownership navigations, not scalar columns.
+            if (modelBuilder.Metadata.IsOwned(maybeProperty.InnerType))
             {
-                // Verify the generated storage member exists (source generator should have created it)
-                var storageMember = MaybePropertyResolver.FindStorageMember(entityType.ClrType, maybeProperty);
-
-                if (storageMember is null)
-                    throw new InvalidOperationException(
-                        $"Cannot map Maybe<T> property '{maybeProperty.PropertyName}' on entity '{entityType.ClrType.Name}'. " +
-                        $"Expected generated storage member '{maybeProperty.StorageMemberName}' was not found. " +
-                        "Declare the property as partial so the Trellis.EntityFrameworkCore.Generator can emit the storage member, or configure the storage-member property explicitly before model finalization.");
-
-                // Owned types (e.g., Money) need ownership navigations, not scalar columns.
-                if (modelBuilder.Metadata.IsOwned(maybeProperty.InnerType))
-                {
-                    ConfigureOwnedMaybe(entityType, maybeProperty, storageMember);
-                    continue;
-                }
-
-                // Always ignore the Maybe<T> CLR property — EF Core cannot map structs as nullable
-                entityType.Builder.Ignore(maybeProperty.PropertyName);
-
-                // Reuse an existing property if earlier model-building steps created it (for example via HasIndex).
-                var existingBackingProp = entityType.FindProperty(maybeProperty.StorageMemberName);
-
-                // Map or fetch the storage member as a nullable property.
-                var propertyBuilder = existingBackingProp?.Builder
-                    ?? entityType.Builder.Property(maybeProperty.StoreType, maybeProperty.StorageMemberName);
-                if (propertyBuilder is null)
-                    throw new InvalidOperationException(
-                        $"Cannot map Maybe<T> property '{maybeProperty.PropertyName}' on entity '{entityType.ClrType.Name}'. " +
-                        $"Storage member '{maybeProperty.StorageMemberName}' exists but EF Core could not map it as store type '{maybeProperty.StoreType.Name}'.");
-
-                propertyBuilder.UsePropertyAccessMode(PropertyAccessMode.Field);
-                propertyBuilder.IsRequired(false);
-                propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, maybeProperty.PropertyName);
+                ConfigureOwnedMaybe(modelBuilder, entityType, maybeProperty, storageMember);
+                continue;
             }
+
+            // Always ignore the Maybe<T> CLR property — EF Core cannot map structs as nullable
+            entityType.Builder.Ignore(maybeProperty.PropertyName);
+
+            // Reuse an existing property if earlier model-building steps created it (for example via HasIndex).
+            var existingBackingProp = entityType.FindProperty(maybeProperty.StorageMemberName);
+
+            // Map or fetch the storage member as a nullable property.
+            var propertyBuilder = existingBackingProp?.Builder
+                ?? entityType.Builder.Property(maybeProperty.StoreType, maybeProperty.StorageMemberName);
+            if (propertyBuilder is null)
+                throw new InvalidOperationException(
+                    $"Cannot map Maybe<T> property '{maybeProperty.PropertyName}' on entity '{entityType.ClrType.Name}'. " +
+                    $"Storage member '{maybeProperty.StorageMemberName}' exists but EF Core could not map it as store type '{maybeProperty.StoreType.Name}'.");
+
+            propertyBuilder.UsePropertyAccessMode(PropertyAccessMode.Field);
+            propertyBuilder.IsRequired(false);
+            propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, maybeProperty.PropertyName);
         }
     }
 
     /// <summary>
     /// Configures a <c>Maybe&lt;T&gt;</c> property where <c>T</c> is an owned type.
     /// Creates an optional ownership navigation via the source-generated backing field.
+    /// After creating the owned entity type, recursively processes any <c>Maybe&lt;T&gt;</c>
+    /// scalar properties on the owned type — these would otherwise be missed because the
+    /// owned entity type was not in the <c>.ToList()</c> snapshot taken at the start of
+    /// <see cref="ProcessModelFinalizing"/>.
     /// </summary>
-    private static void ConfigureOwnedMaybe(
+    private void ConfigureOwnedMaybe(
+        IConventionModelBuilder modelBuilder,
         IConventionEntityType entityType,
         MaybePropertyDescriptor maybeProperty,
         FieldInfo storageMember)
@@ -127,6 +143,11 @@ internal sealed class MaybeConvention : IModelFinalizingConvention
         // Store the original property name so MoneyConvention can use it for column naming
         var navigation = entityType.FindNavigation(storageMember.Name);
         navigation?.Builder.HasAnnotation(MaybeOwnedPropertyNameAnnotation, maybeProperty.PropertyName);
+
+        // The owned entity type was just created and is not in the outer .ToList() snapshot.
+        // Process its Maybe<T> properties now so they don't get missed.
+        if (navigation?.TargetEntityType is { } ownedEntityType)
+            ProcessEntityType(modelBuilder, ownedEntityType);
     }
 
     /// <summary>

--- a/Trellis.EntityFrameworkCore/tests/CompositeValueObjectConventionTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/CompositeValueObjectConventionTests.cs
@@ -706,4 +706,203 @@ public partial class CompositeValueObjectConventionTests : IDisposable
     }
 
     #endregion
+
+    #region Maybe<scalar> inside required composite VO
+
+    [Fact]
+    public void MaybeScalarInsideRequiredCompositeVo_ModelBuildsSuccessfully()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<RequiredContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new RequiredContactInfoDbContext(options);
+        context.Database.EnsureCreated();
+    }
+
+    [Fact]
+    public async Task MaybeScalarInsideRequiredCompositeVo_WithValue_RoundTripWorks()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<RequiredContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new RequiredContactInfoDbContext(options);
+        context.Database.EnsureCreated();
+
+        var ct = TestContext.Current.CancellationToken;
+        var phone = PhoneNumber.Create("+15551234567");
+        var entity = new RequiredContactInfoEntity
+        {
+            Id = 1,
+            Contact = TestContactInfo.Create("Alice", Maybe.From(phone))
+        };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(ct);
+        context.ChangeTracker.Clear();
+
+        var loaded = await context.Entities.FindAsync([1], ct);
+        loaded.Should().NotBeNull();
+        loaded!.Contact.Name.Should().Be("Alice");
+        loaded.Contact.Phone.HasValue.Should().BeTrue();
+        ((string)loaded.Contact.Phone.Value).Should().Be("+15551234567");
+    }
+
+    [Fact]
+    public async Task MaybeScalarInsideRequiredCompositeVo_WithNone_RoundTripWorks()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<RequiredContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new RequiredContactInfoDbContext(options);
+        context.Database.EnsureCreated();
+
+        var ct = TestContext.Current.CancellationToken;
+        var entity = new RequiredContactInfoEntity
+        {
+            Id = 2,
+            Contact = TestContactInfo.Create("Bob", Maybe<PhoneNumber>.None)
+        };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(ct);
+        context.ChangeTracker.Clear();
+
+        var loaded = await context.Entities.FindAsync([2], ct);
+        loaded.Should().NotBeNull();
+        loaded!.Contact.Name.Should().Be("Bob");
+        loaded.Contact.Phone.HasValue.Should().BeFalse();
+    }
+
+    private class RequiredContactInfoEntity
+    {
+        public int Id { get; set; }
+        public TestContactInfo Contact { get; set; } = null!;
+    }
+
+    private class RequiredContactInfoDbContext : DbContext
+    {
+        public DbSet<RequiredContactInfoEntity> Entities => Set<RequiredContactInfoEntity>();
+
+        public RequiredContactInfoDbContext(DbContextOptions<RequiredContactInfoDbContext> options) : base(options) { }
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
+            configurationBuilder.ApplyTrellisConventions(typeof(TestContactInfo).Assembly);
+    }
+
+    #endregion
+
+    #region Maybe<scalar> inside Maybe<composite VO>
+
+    /// <summary>
+    /// Model building must succeed when a <c>Maybe&lt;CompositeVO&gt;</c> contains
+    /// <c>partial Maybe&lt;T&gt;</c> scalar properties. <see cref="MaybeConvention"/> creates
+    /// the owned entity type for the composite VO during its finalization loop — but
+    /// the owned type's <c>Maybe&lt;T&gt;</c> scalar properties must also be processed.
+    /// The <c>.ToList()</c> snapshot taken at the start of the loop misses entity types
+    /// created mid-loop by <c>ConfigureOwnedMaybe</c>.
+    /// </summary>
+    [Fact]
+    public void MaybeScalarInsideMaybeCompositeVo_ModelBuildsSuccessfully()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MaybeContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new MaybeContactInfoDbContext(options);
+        context.Database.EnsureCreated(); // Must not throw
+    }
+
+    [Fact]
+    public async Task MaybeScalarInsideMaybeCompositeVo_WithValue_RoundTripWorks()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MaybeContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new MaybeContactInfoDbContext(options);
+        context.Database.EnsureCreated();
+
+        var ct = TestContext.Current.CancellationToken;
+        var phone = PhoneNumber.Create("+15551234567");
+        var entity = new MaybeContactInfoEntity
+        {
+            Id = 1,
+            Contact = Maybe.From(TestContactInfo.Create("Alice", Maybe.From(phone)))
+        };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(ct);
+        context.ChangeTracker.Clear();
+
+        var loaded = await context.Entities.FindAsync([1], ct);
+        loaded.Should().NotBeNull();
+        loaded!.Contact.HasValue.Should().BeTrue();
+        loaded.Contact.Value.Name.Should().Be("Alice");
+        loaded.Contact.Value.Phone.HasValue.Should().BeTrue();
+        ((string)loaded.Contact.Value.Phone.Value).Should().Be("+15551234567");
+    }
+
+    [Fact]
+    public async Task MaybeScalarInsideMaybeCompositeVo_WithNone_RoundTripWorks()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MaybeContactInfoDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = new MaybeContactInfoDbContext(options);
+        context.Database.EnsureCreated();
+
+        var ct = TestContext.Current.CancellationToken;
+        var entity = new MaybeContactInfoEntity
+        {
+            Id = 2
+        };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(ct);
+        context.ChangeTracker.Clear();
+
+        var loaded = await context.Entities.FindAsync([2], ct);
+        loaded.Should().NotBeNull();
+        loaded!.Contact.HasValue.Should().BeFalse();
+    }
+
+    private partial class MaybeContactInfoEntity
+    {
+        public int Id { get; set; }
+        public partial Maybe<TestContactInfo> Contact { get; set; }
+    }
+
+    private class MaybeContactInfoDbContext : DbContext
+    {
+        public DbSet<MaybeContactInfoEntity> Entities => Set<MaybeContactInfoEntity>();
+
+        public MaybeContactInfoDbContext(DbContextOptions<MaybeContactInfoDbContext> options) : base(options) { }
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
+            configurationBuilder.ApplyTrellisConventions(typeof(TestContactInfo).Assembly);
+    }
+
+    #endregion
 }

--- a/Trellis.EntityFrameworkCore/tests/Helpers/TestContactInfo.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/TestContactInfo.cs
@@ -1,0 +1,37 @@
+namespace Trellis.EntityFrameworkCore.Tests.Helpers;
+
+using Trellis.Primitives;
+
+/// <summary>
+/// Test composite value object that contains a <c>partial Maybe&lt;T&gt;</c> scalar property.
+/// Used to validate that <see cref="MaybeConvention"/> correctly maps <c>Maybe&lt;T&gt;</c>
+/// scalar properties inside owned <see cref="ValueObject"/> types — not just on entity types.
+/// </summary>
+[OwnedEntity]
+public partial class TestContactInfo : ValueObject
+{
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Optional scalar VO inside a composite VO — the scenario under test.
+    /// The source generator emits a <c>private PhoneNumber? _phone</c> backing field.
+    /// <see cref="MaybeConvention"/> must discover and map this backing field even though
+    /// the owning type is an owned <see cref="ValueObject"/>, not a root entity.
+    /// </summary>
+    public partial Maybe<PhoneNumber> Phone { get; private set; }
+
+    public TestContactInfo(string name, Maybe<PhoneNumber> phone)
+    {
+        Name = name;
+        Phone = phone;
+    }
+
+    public static TestContactInfo Create(string name, Maybe<PhoneNumber> phone) =>
+        new(name, phone);
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Name;
+        yield return Phone.HasValue ? (string)Phone.Value : null;
+    }
+}


### PR DESCRIPTION
## Problem

`MaybeConvention` failed to map `partial Maybe<T>` scalar properties inside composite `ValueObject` types when the composite VO was itself accessed via `Maybe<CompositeVO>`.

System.InvalidOperationException: The property 'TestContactInfo.Phone' could not be mapped because it is of type 'Maybe<PhoneNumber>', which is not a supported primitive type or a valid entity type.


### Root Cause
`ProcessModelFinalizing` takes a `.ToList()` snapshot of entity types at the start of its loop. When `ConfigureOwnedMaybe` creates a new owned entity type for `Maybe<CompositeVO>` mid-loop via `HasOwnership`, the newly-created owned type is not in the snapshot. Its `Maybe<T>` scalar properties are never processed — EF Core then fails because it encounters unmapped `Maybe<T>` struct properties.

Required composite VOs (not wrapped in `Maybe<>`) were unaffected because EF Core discovers them during normal convention processing before finalization, so they were always in the snapshot.

## Fix

- Extracted `ProcessEntityType` from the `ProcessModelFinalizing` loop body so it can be called independently.
- After `ConfigureOwnedMaybe` creates the owned entity type, it now recursively calls `ProcessEntityType` on the new type, immediately mapping any `Maybe<T>` scalar properties before the outer loop continues.

## Tests

6 new tests in `CompositeValueObjectConventionTests`:

| Test | Scenario |
|------|----------|
| `MaybeScalarInsideRequiredCompositeVo_ModelBuildsSuccessfully` | Required composite VO with `Maybe<Scalar>` — model builds |
| `MaybeScalarInsideRequiredCompositeVo_WithValue_RoundTripWorks` | Round-trip with phone present |
| `MaybeScalarInsideRequiredCompositeVo_WithNone_RoundTripWorks` | Round-trip with phone absent |
| `MaybeScalarInsideMaybeCompositeVo_ModelBuildsSuccessfully` | **Bug repro** — `Maybe<CompositeVO>` with `Maybe<Scalar>` inside |
| `MaybeScalarInsideMaybeCompositeVo_WithValue_RoundTripWorks` | Round-trip with both present |
| `MaybeScalarInsideMaybeCompositeVo_WithNone_RoundTripWorks` | Round-trip with outer `Maybe` = None |

New test helper `TestContactInfo` — a composite `ValueObject` with `partial Maybe<PhoneNumber> Phone`.

## Files Changed

| File | Change |
|------|--------|
| `Trellis.EntityFrameworkCore/src/MaybeConvention.cs` | Extract `ProcessEntityType`; recursive call from `ConfigureOwnedMaybe` |
| `Trellis.EntityFrameworkCore/tests/Helpers/TestContactInfo.cs` | New test composite VO with `Maybe<Scalar>` |
| `Trellis.EntityFrameworkCore/tests/CompositeValueObjectConventionTests.cs` | 6 new tests |
