### PR TITLE
Ship API reference markdown files inside NuGet packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Auto-pack API reference markdown and shared .targets for any Trellis package
+    that sets TrellisApiRefName (e.g., <TrellisApiRefName>asp</TrellisApiRefName>).
+  -->
+  <ItemGroup Condition="'$(TrellisApiRefName)' != ''">
+    <None Include="$(MSBuildThisFileDirectory)docs\api_reference\trellis-api-$(TrellisApiRefName).md"
+          Pack="true" PackagePath="trellis\" />
+    <None Include="$(MSBuildThisFileDirectory)build\Trellis.ApiReference.targets"
+          Pack="true" PackagePath="build\$(PackageId).targets" />
+    <None Include="$(MSBuildThisFileDirectory)build\Trellis.ApiReference.targets"
+          Pack="true" PackagePath="buildTransitive\$(PackageId).targets" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
     Auto-pack API reference markdown and shared .targets for any Trellis package

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -3,8 +3,8 @@
   <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
   <Description>Roslyn analyzers for Trellis library. Enforces proper Result and Maybe handling patterns at compile time.</Description>
   <PackageTags>trellis;roslyn;analyzers;functional;ddd;result;maybe;railway-oriented-programming</PackageTags>
-    <TrellisApiRefName>analyzers</TrellisApiRefName>
-  </PropertyGroup>
+  <TrellisApiRefName>analyzers</TrellisApiRefName>
+</PropertyGroup>
 
   <PropertyGroup>
     <!-- Analyzers must target netstandard 2.0 -->

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -3,7 +3,8 @@
   <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
   <Description>Roslyn analyzers for Trellis library. Enforces proper Result and Maybe handling patterns at compile time.</Description>
   <PackageTags>trellis;roslyn;analyzers;functional;ddd;result;maybe;railway-oriented-programming</PackageTags>
-</PropertyGroup>
+    <TrellisApiRefName>analyzers</TrellisApiRefName>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- Analyzers must target netstandard 2.0 -->

--- a/Trellis.Asp/src/Trellis.Asp.csproj
+++ b/Trellis.Asp/src/Trellis.Asp.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;aspnetcore;mvc;minimal-api;web-api;railway-oriented;result;http;error-handling</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>asp</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.Authorization/src/Trellis.Authorization.csproj
+++ b/Trellis.Authorization/src/Trellis.Authorization.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;authorization;actor;permissions;result;railway-oriented;functional-programming</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>authorization</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.DomainDrivenDesign/src/Trellis.DomainDrivenDesign.csproj
+++ b/Trellis.DomainDrivenDesign/src/Trellis.DomainDrivenDesign.csproj
@@ -7,6 +7,7 @@
     <PackageTags>trellis;ddd;domain-driven-design;aggregate;entity;value-object;domain-events;tactical-patterns</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>ddd</TrellisApiRefName>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
+++ b/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
@@ -4,6 +4,7 @@
     <Description>EF Core integration for Trellis. Convention-based value converter registration for Trellis primitives, Result-returning SaveChanges wrappers, Maybe/Result query extensions, and provider-agnostic database exception classification.</Description>
     <PackageTags>trellis;efcore;entity-framework-core;value-converters;railway-oriented;result;maybe;ddd;domain-driven-design</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>efcore</TrellisApiRefName>
     <!-- EF Core is inherently reflection-based; AOT/Trim not applicable -->
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>

--- a/Trellis.FluentValidation/src/Trellis.FluentValidation.csproj
+++ b/Trellis.FluentValidation/src/Trellis.FluentValidation.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;validation;fluentvalidation;railway-oriented;result;error-handling;ddd</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>fluentvalidation</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\"/>

--- a/Trellis.Http/src/Trellis.Http.csproj
+++ b/Trellis.Http/src/Trellis.Http.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;http;httpclient;railway-oriented;result;maybe;functional-programming;error-handling;json</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>http</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.Mediator/src/Trellis.Mediator.csproj
+++ b/Trellis.Mediator/src/Trellis.Mediator.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;mediator;cqrs;pipeline;result;railway-oriented;validation;authorization;functional-programming</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>mediator</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.Primitives/src/Trellis.Primitives.csproj
+++ b/Trellis.Primitives/src/Trellis.Primitives.csproj
@@ -7,6 +7,7 @@
     <PackageTags>trellis;value-objects;source-generation;required-string;required-guid;email;ddd;strongly-typed;domain-primitives;primitive-obsession</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>primitives</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\"/>

--- a/Trellis.Results/src/Trellis.Results.csproj
+++ b/Trellis.Results/src/Trellis.Results.csproj
@@ -8,6 +8,7 @@
     <PackageTags>trellis;functional-programming;railway-oriented;result;monad;error-handling;maybe;csharp;dotnet;rop</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>results</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.Stateless/src/Trellis.Stateless.csproj
+++ b/Trellis.Stateless/src/Trellis.Stateless.csproj
@@ -5,6 +5,7 @@
     <PackageTags>trellis;stateless;state-machine;railway-oriented;result;functional-programming;error-handling</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>stateless</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />

--- a/Trellis.Testing/src/Trellis.Testing.csproj
+++ b/Trellis.Testing/src/Trellis.Testing.csproj
@@ -15,6 +15,7 @@
     <Description>FluentAssertions extensions and test doubles for Trellis - assert Result, Maybe, and Error types with readable fluent syntax</Description>
     <PackageTags>trellis;functional-programming;testing;assertions;fluent-assertions;ddd;railway-oriented-programming;result;maybe;test-utilities</PackageTags>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+    <TrellisApiRefName>testing-reference</TrellisApiRefName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Shared targets file packed into each Trellis NuGet package.
     Declares TrellisApiReference items pointing to the API reference markdown

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -1,0 +1,10 @@
+<Project>
+  <!--
+    Shared targets file packed into each Trellis NuGet package.
+    Declares TrellisApiReference items pointing to the API reference markdown
+    shipped in the package's trellis/ folder.
+  -->
+  <ItemGroup>
+    <TrellisApiReference Include="$(MSBuildThisFileDirectory)..\trellis\*.md" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
 ## Summary
 
 Each Trellis NuGet package now ships its `trellis-api-*.md` API reference file so that downstream projects receive 
updated documentation automatically when upgrading packages.
 
 ## Problem
 
 After creating a project from the Trellis template, the `.github/trellis-api-*.md` files were static snapshots. 
When users upgraded their Trellis NuGet packages, the API references became stale — AI agents worked against 
outdated documentation.
 
 ## Solution
 
 ### Package-level changes
 
 Each of the 12 packable libraries now sets a `TrellisApiRefName` property in its `.csproj`. A new 
`Directory.Build.targets` at the repo root uses this to automatically pack:
 
 - The corresponding `docs/api_reference/trellis-api-*.md` into a `trellis/` folder in the NuGet package
 - A shared `build/Trellis.ApiReference.targets` into both `build/` and `buildTransitive/` folders (named 
`{PackageId}.targets`)
 
 The shared `.targets` file declares `TrellisApiReference` MSBuild items pointing to the markdown file in the 
package. Consuming projects can use these items to copy the docs to a well-known location.
 
 ### Package → API reference mapping
 
 | Package | `TrellisApiRefName` | Packed file |
 |---|---|---|
 | Trellis.Results | `results` | `trellis-api-results.md` |
 | Trellis.DomainDrivenDesign | `ddd` | `trellis-api-ddd.md` |
 | Trellis.Primitives | `primitives` | `trellis-api-primitives.md` |
 | Trellis.Asp | `asp` | `trellis-api-asp.md` |
 | Trellis.EntityFrameworkCore | `efcore` | `trellis-api-efcore.md` |
 | Trellis.Authorization | `authorization` | `trellis-api-authorization.md` |
 | Trellis.Mediator | `mediator` | `trellis-api-mediator.md` |
 | Trellis.Http | `http` | `trellis-api-http.md` |
 | Trellis.Stateless | `stateless` | `trellis-api-stateless.md` |
 | Trellis.FluentValidation | `fluentvalidation` | `trellis-api-fluentvalidation.md` |
 | Trellis.Analyzers | `analyzers` | `trellis-api-analyzers.md` |
 | Trellis.Testing | `testing-reference` | `trellis-api-testing-reference.md` |
 
 ### New files
 
 - `build/Trellis.ApiReference.targets` — shared targets declaring `TrellisApiReference` items from the package's 
`trellis/` folder
 - `Directory.Build.targets` — auto-packs the API reference and shared targets for any project that sets 
`TrellisApiRefName`
 
 ### Verified
 
 - `dotnet pack` on `Trellis.Results` produces a NuGet containing `build/Trellis.Results.targets`, 
`buildTransitive/Trellis.Results.targets`, and `trellis/trellis-api-results.md`
 - Build: 0 errors, 0 warnings
 - Tests: 4803 passed, 0 failed
 ```