### PR TITLE
Add MaybeInvariant helpers, RepositoryBase, and TRLS023 auth analyzer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always read the relevant API reference files in `docs/api_reference/` **before**
 | Mediator pipeline behaviors | `docs/api_reference/trellis-api-mediator.md` |
 | State machine integration | `docs/api_reference/trellis-api-stateless.md` |
 | Testing helpers | `docs/api_reference/trellis-api-testing-reference.md` |
-| Analyzer rules (TRLS001-TRLS022) | `docs/api_reference/trellis-api-analyzers.md` |
+| Analyzer rules (TRLS001-TRLS023) | `docs/api_reference/trellis-api-analyzers.md` |
 
 These files document the exact method signatures, overloads, and usage patterns. Do not assume APIs based on naming conventions — read the reference first.
 

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -326,4 +326,21 @@ public static class DiagnosticDescriptors
                  "Use the Trellis versions (namespace Trellis) instead.",
         helpLinkUri: HelpLinkBase + "TRLS022");
 
+    /// <summary>
+    /// TRLS023: Command or query has typed resource ID but missing IAuthorizeResource.
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingResourceAuthorization = new(
+        id: "TRLS023",
+        title: "Command or query has resource ID without resource authorization",
+        messageFormat: "'{0}' has typed resource ID {1} but does not implement IAuthorizeResource<T>. Consider adding resource-level authorization, or suppress this warning if authorization is intentionally omitted.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Commands and queries that carry a typed aggregate ID (a property whose type implements IScalarValue and whose name " +
+                 "ends with 'Id') should typically implement IAuthorizeResource<T> to enforce resource-level authorization. " +
+                 "Without it, the handler has no compile-time guarantee that the caller is authorized to access the referenced resource. " +
+                 "When adding IAuthorizeResource<T>, also ensure a matching IResourceLoader or IIdentifyResource implementation " +
+                 "is registered so the authorization pipeline can resolve the resource at runtime.",
+        helpLinkUri: HelpLinkBase + "TRLS023");
+
 }

--- a/Trellis.Analyzers/src/MissingResourceAuthorizationAnalyzer.cs
+++ b/Trellis.Analyzers/src/MissingResourceAuthorizationAnalyzer.cs
@@ -1,0 +1,154 @@
+﻿namespace Trellis.Analyzers;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// TRLS023: Detects commands and queries that carry a typed aggregate ID property
+/// (a property whose type implements <c>IScalarValue&lt;,&gt;</c> and whose name ends with "Id")
+/// but do not implement <c>IAuthorizeResource&lt;T&gt;</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingResourceAuthorizationAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.MissingResourceAuthorization];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var commandType = compilationContext.Compilation.GetTypeByMetadataName("Mediator.ICommand`1");
+            var queryType = compilationContext.Compilation.GetTypeByMetadataName("Mediator.IQuery`1");
+            if (commandType is null && queryType is null)
+                return;
+
+            var authorizeResourceType = compilationContext.Compilation.GetTypeByMetadataName(
+                "Trellis.Authorization.IAuthorizeResource`1");
+            if (authorizeResourceType is null)
+                return;
+
+            var scalarValueType = compilationContext.Compilation.GetTypeByMetadataName("Trellis.IScalarValue`2");
+
+            compilationContext.RegisterSymbolAction(
+                ctx => AnalyzeNamedType(ctx, commandType, queryType, authorizeResourceType, scalarValueType),
+                SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeNamedType(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol? commandType,
+        INamedTypeSymbol? queryType,
+        INamedTypeSymbol authorizeResourceType,
+        INamedTypeSymbol? scalarValueType)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!ImplementsCommandOrQuery(typeSymbol, commandType, queryType))
+            return;
+
+        if (ImplementsAuthorizeResource(typeSymbol, authorizeResourceType))
+            return;
+
+        var idProperties = FindTypedIdProperties(typeSymbol, scalarValueType);
+        if (idProperties.Count == 0)
+            return;
+
+        var propertyList = string.Join(", ", idProperties.Select(p => $"'{p}'"));
+
+        var diagnostic = Diagnostic.Create(
+            DiagnosticDescriptors.MissingResourceAuthorization,
+            typeSymbol.Locations[0],
+            additionalLocations: typeSymbol.Locations.Skip(1),
+            typeSymbol.Name,
+            propertyList);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool ImplementsCommandOrQuery(
+        INamedTypeSymbol typeSymbol,
+        INamedTypeSymbol? commandType,
+        INamedTypeSymbol? queryType)
+    {
+        foreach (var iface in typeSymbol.AllInterfaces)
+        {
+            if (iface.IsGenericType)
+            {
+                var original = iface.OriginalDefinition;
+                if ((commandType is not null && SymbolEqualityComparer.Default.Equals(original, commandType)) ||
+                    (queryType is not null && SymbolEqualityComparer.Default.Equals(original, queryType)))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ImplementsAuthorizeResource(
+        INamedTypeSymbol typeSymbol,
+        INamedTypeSymbol authorizeResourceType)
+    {
+        foreach (var iface in typeSymbol.AllInterfaces)
+        {
+            if (iface.IsGenericType &&
+                SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, authorizeResourceType))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static List<string> FindTypedIdProperties(
+        INamedTypeSymbol typeSymbol,
+        INamedTypeSymbol? scalarValueType)
+    {
+        var result = new List<string>();
+        if (scalarValueType is null)
+            return result;
+
+        // Walk the type hierarchy to include inherited properties
+        var current = typeSymbol;
+        while (current is not null)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is not IPropertySymbol property)
+                    continue;
+
+                if (!property.Name.EndsWith("Id", StringComparison.Ordinal))
+                    continue;
+
+                if (ImplementsScalarValue(property.Type, scalarValueType))
+                    result.Add(property.Name);
+            }
+
+            current = current.BaseType;
+        }
+
+        return result;
+    }
+
+    private static bool ImplementsScalarValue(ITypeSymbol propertyType, INamedTypeSymbol scalarValueType)
+    {
+        if (propertyType is INamedTypeSymbol namedType)
+        {
+            foreach (var iface in namedType.AllInterfaces)
+            {
+                if (iface.IsGenericType &&
+                    SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, scalarValueType))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Trellis.Analyzers/src/MissingResourceAuthorizationAnalyzer.cs
+++ b/Trellis.Analyzers/src/MissingResourceAuthorizationAnalyzer.cs
@@ -124,6 +124,9 @@ public sealed class MissingResourceAuthorizationAnalyzer : DiagnosticAnalyzer
                 if (member is not IPropertySymbol property)
                     continue;
 
+                if (property.IsStatic)
+                    continue;
+
                 if (!property.Name.EndsWith("Id", StringComparison.Ordinal))
                     continue;
 

--- a/Trellis.Analyzers/tests/MissingResourceAuthorizationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/MissingResourceAuthorizationAnalyzerTests.cs
@@ -303,6 +303,23 @@ public class MissingResourceAuthorizationAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task Command_with_static_id_property_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record StaticIdCommand : Mediator.ICommand<Trellis.Result<TodoItem>>
+                {
+                    public static TodoId DefaultTodoId { get; } = default;
+                }
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
     #endregion
 
     private static CSharpAnalyzerTest<MissingResourceAuthorizationAnalyzer, DefaultVerifier> CreateTest(string source)

--- a/Trellis.Analyzers/tests/MissingResourceAuthorizationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/MissingResourceAuthorizationAnalyzerTests.cs
@@ -1,0 +1,320 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+public class MissingResourceAuthorizationAnalyzerTests
+{
+    private const string AuthStubs = """
+        namespace Mediator
+        {
+            public interface ICommand<out TResponse> { }
+            public interface IQuery<out TResponse> { }
+            public interface IRequest<out TResponse> { }
+        }
+
+        namespace Trellis.Authorization
+        {
+            public interface IAuthorizeResource<in TResource>
+            {
+                Trellis.IResult Authorize(object actor, TResource resource);
+            }
+        }
+
+        namespace Trellis
+        {
+            public interface IResult { }
+
+            public interface IScalarValue<TSelf, TPrimitive>
+                where TSelf : IScalarValue<TSelf, TPrimitive>
+                where TPrimitive : System.IComparable
+            {
+                static abstract Result<TSelf> TryCreate(TPrimitive value, string? fieldName = null);
+                TPrimitive Value { get; }
+            }
+
+            public readonly struct Result<T>
+            {
+                public bool IsSuccess { get; }
+            }
+        }
+        """;
+
+    private const string SampleIdType = """
+        namespace TestNamespace
+        {
+            public readonly struct TodoId : Trellis.IScalarValue<TodoId, System.Guid>
+            {
+                public System.Guid Value { get; }
+                public static Trellis.Result<TodoId> TryCreate(System.Guid value, string? fieldName = null) => default;
+            }
+
+            public readonly struct MatchId : Trellis.IScalarValue<MatchId, System.Guid>
+            {
+                public System.Guid Value { get; }
+                public static Trellis.Result<MatchId> TryCreate(System.Guid value, string? fieldName = null) => default;
+            }
+
+            public class TodoItem { }
+        }
+        """;
+
+    #region Should Warn
+
+    [Fact]
+    public async Task Command_with_typed_id_no_authorize_warns()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record CompleteTodoCommand(TodoId TodoId)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(3, 26)
+                .WithArguments("CompleteTodoCommand", "'TodoId'"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Query_with_typed_id_no_authorize_warns()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record GetTodoByIdQuery(TodoId TodoId)
+                    : Mediator.IQuery<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(3, 26)
+                .WithArguments("GetTodoByIdQuery", "'TodoId'"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Command_with_multiple_typed_ids_no_authorize_lists_all()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record TransferCommand(TodoId TodoId, MatchId MatchId)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(3, 26)
+                .WithArguments("TransferCommand", "'TodoId', 'MatchId'"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Command_with_id_property_not_positional_warns()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record UpdateTodoCommand : Mediator.ICommand<Trellis.Result<TodoItem>>
+                {
+                    public TodoId TodoId { get; init; }
+                }
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(3, 26)
+                .WithArguments("UpdateTodoCommand", "'TodoId'"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Has_IIdentifyResource_but_no_IAuthorizeResource_still_warns()
+    {
+        const string source = """
+            namespace Trellis.Authorization
+            {
+                public interface IIdentifyResource<TResource, out TId>
+                {
+                    TId GetResourceId();
+                }
+            }
+
+            namespace TestNamespace
+            {
+                public sealed record CompleteTodoCommand(TodoId TodoId)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>,
+                      Trellis.Authorization.IIdentifyResource<TodoItem, TodoId>
+                {
+                    public TodoId GetResourceId() => TodoId;
+                }
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(11, 26)
+                .WithArguments("CompleteTodoCommand", "'TodoId'"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Inherited_typed_id_from_base_class_warns()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public abstract record ResourceCommand(TodoId TodoId);
+
+                public sealed record ArchiveTodoCommand(TodoId TodoId)
+                    : ResourceCommand(TodoId), Mediator.ICommand<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticDescriptors.MissingResourceAuthorization)
+                .WithLocation(5, 26)
+                .WithArguments("ArchiveTodoCommand", "'TodoId'"));
+
+        await test.RunAsync();
+    }
+
+    #endregion
+
+    #region Should Not Warn
+
+    [Fact]
+    public async Task Command_with_IAuthorizeResource_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record CompleteTodoCommand(TodoId TodoId)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>,
+                      Trellis.Authorization.IAuthorizeResource<TodoItem>
+                {
+                    public Trellis.IResult Authorize(object actor, TodoItem resource) => default!;
+                }
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Base_type_has_IAuthorizeResource_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public abstract record AuthorizedCommand(TodoId TodoId)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>,
+                      Trellis.Authorization.IAuthorizeResource<TodoItem>
+                {
+                    public Trellis.IResult Authorize(object actor, TodoItem resource) => default!;
+                }
+
+                public sealed record CompleteTodoCommand(TodoId TodoId)
+                    : AuthorizedCommand(TodoId);
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Command_with_primitive_id_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record GetByIdQuery(System.Guid Id)
+                    : Mediator.IQuery<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Not_a_command_or_query_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record TodoDto(TodoId TodoId);
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Command_without_id_properties_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public sealed record CreateTodoCommand(string Title)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Command_with_non_scalar_custom_type_no_warning()
+    {
+        const string source = """
+            namespace TestNamespace
+            {
+                public class MyOptions { }
+                public sealed record ProcessCommand(MyOptions Options)
+                    : Mediator.ICommand<Trellis.Result<TodoItem>>;
+            }
+            """;
+
+        var test = CreateTest(source);
+        await test.RunAsync();
+    }
+
+    #endregion
+
+    private static CSharpAnalyzerTest<MissingResourceAuthorizationAnalyzer, DefaultVerifier> CreateTest(string source)
+    {
+        var test = new CSharpAnalyzerTest<MissingResourceAuthorizationAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+        };
+
+        test.TestState.Sources.Add(("AuthStubs.cs", AuthStubs));
+        test.TestState.Sources.Add(("SampleIdType.cs", SampleIdType));
+        return test;
+    }
+}

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -1,0 +1,147 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Base class for EF Core repositories that persist <see cref="Aggregate{TId}"/> instances.
+/// Provides standard <see cref="FindByIdAsync"/>, <see cref="SaveAsync"/>, and
+/// <see cref="QueryAsync"/> implementations that compose the existing Trellis EF Core helpers.
+/// </summary>
+/// <typeparam name="TAggregate">The aggregate root type.</typeparam>
+/// <typeparam name="TId">The type of the aggregate's unique identifier.</typeparam>
+/// <remarks>
+/// <para>
+/// This base class eliminates the repetitive save/find/query boilerplate that appears in every
+/// concrete repository. Repositories with custom queries inherit and add methods.
+/// </para>
+/// <para>
+/// Override <see cref="BuildFindByIdQuery"/> or <see cref="BuildQueryBase"/> to add
+/// <c>.Include()</c> chains for eager loading.
+/// </para>
+/// <para>
+/// <see cref="SaveAsync"/> uses detached-entity detection: if the aggregate's change tracker
+/// state is <see cref="EntityState.Detached"/>, it is added to the <see cref="DbSet"/>.
+/// This means new aggregates are inserted and already-tracked aggregates are updated.
+/// If your scenario requires disconnected-update semantics (attaching a deserialized
+/// aggregate that was never tracked), override <see cref="SaveAsync"/> in the concrete
+/// repository.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class OrderRepository : RepositoryBase&lt;Order, OrderId&gt;
+/// {
+///     public OrderRepository(AppDbContext context) : base(context) { }
+///
+///     protected override IQueryable&lt;Order&gt; BuildFindByIdQuery()
+///         =&gt; base.BuildFindByIdQuery().Include(o =&gt; o.LineItems);
+/// }
+/// </code>
+/// </example>
+public abstract class RepositoryBase<TAggregate, TId>
+    where TAggregate : Aggregate<TId>
+    where TId : notnull
+{
+    private static readonly Expression<Func<TAggregate, TId>> s_idSelector =
+        entity => entity.Id;
+
+    private readonly DbContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RepositoryBase{TAggregate, TId}"/> class.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext"/> used for persistence.</param>
+    protected RepositoryBase(DbContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="DbSet{TEntity}"/> for this aggregate type.
+    /// </summary>
+    protected DbSet<TAggregate> DbSet => _context.Set<TAggregate>();
+
+    /// <summary>
+    /// Gets the underlying <see cref="DbContext"/>.
+    /// Use sparingly — prefer the repository methods for standard operations.
+    /// </summary>
+    protected DbContext Context => _context;
+
+    /// <summary>
+    /// Builds the base query used by <see cref="FindByIdAsync"/>. Override to add
+    /// <c>.Include()</c> chains for eager loading when finding by ID.
+    /// </summary>
+    /// <returns>An <see cref="IQueryable{T}"/> starting from <see cref="DbSet"/>.</returns>
+    protected virtual IQueryable<TAggregate> BuildFindByIdQuery() => DbSet;
+
+    /// <summary>
+    /// Builds the base query used by <see cref="QueryAsync"/>. Override to add
+    /// <c>.Include()</c> chains for list/search queries.
+    /// </summary>
+    /// <returns>An <see cref="IQueryable{T}"/> starting from <see cref="DbSet"/>.</returns>
+    protected virtual IQueryable<TAggregate> BuildQueryBase() => DbSet;
+
+    /// <summary>
+    /// Finds an aggregate by its unique identifier.
+    /// Returns <see cref="Maybe{T}.None"/> if not found.
+    /// </summary>
+    /// <param name="id">The aggregate identifier to search for.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Maybe{T}"/> containing the aggregate, or None if not found.</returns>
+    public virtual Task<Maybe<TAggregate>> FindByIdAsync(TId id, CancellationToken cancellationToken = default)
+    {
+        var predicate = BuildIdPredicate(id);
+        return BuildFindByIdQuery().FirstOrDefaultMaybeAsync(predicate, cancellationToken);
+    }
+
+    /// <summary>
+    /// Persists a new or modified aggregate. New (detached) aggregates are added to the
+    /// <see cref="DbSet"/>; already-tracked aggregates are updated in place.
+    /// To update an existing aggregate, first retrieve it with <see cref="FindByIdAsync"/>
+    /// (which starts change tracking), mutate it, then call this method.
+    /// Passing a detached entity that already exists in the database will attempt an insert
+    /// and fail with a duplicate-key exception.
+    /// </summary>
+    /// <param name="aggregate">The aggregate to save.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
+    public virtual Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+
+        var entry = _context.Entry(aggregate);
+        if (entry.State == EntityState.Detached)
+            DbSet.Add(aggregate);
+
+        return _context.SaveChangesResultUnitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Queries aggregates matching the given specification.
+    /// </summary>
+    /// <param name="specification">The specification to filter by.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A read-only list of matching aggregates.</returns>
+    public virtual async Task<IReadOnlyList<TAggregate>> QueryAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(specification);
+        return await BuildQueryBase().Where(specification).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds an expression predicate that compares <c>entity.Id == id</c>.
+    /// Uses expression trees to ensure EF Core can translate the comparison via value converters.
+    /// </summary>
+    private static Expression<Func<TAggregate, bool>> BuildIdPredicate(TId id)
+    {
+        var parameter = s_idSelector.Parameters[0];
+        var idAccess = s_idSelector.Body;
+        var constant = Expression.Constant(id, typeof(TId));
+        var equality = Expression.Equal(idAccess, constant);
+        return Expression.Lambda<Func<TAggregate, bool>>(equality, parameter);
+    }
+}

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -79,9 +79,10 @@ public abstract class RepositoryBase<TAggregate, TId>
     /// <summary>
     /// Builds the base query used by <see cref="QueryAsync"/>. Override to add
     /// <c>.Include()</c> chains for list/search queries.
+    /// The default query is no-tracking to avoid unnecessary change tracking for read operations.
     /// </summary>
-    /// <returns>An <see cref="IQueryable{T}"/> starting from <see cref="DbSet"/>.</returns>
-    protected virtual IQueryable<TAggregate> BuildQueryBase() => DbSet;
+    /// <returns>An <see cref="IQueryable{T}"/> starting from <see cref="DbSet"/> with no tracking.</returns>
+    protected virtual IQueryable<TAggregate> BuildQueryBase() => DbSet.AsNoTracking();
 
     /// <summary>
     /// Finds an aggregate by its unique identifier.

--- a/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
@@ -1,0 +1,237 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using Trellis.EntityFrameworkCore.Tests.Helpers;
+using Trellis.Testing;
+
+public partial class RepositoryBaseTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly RepoTestDbContext _context;
+    private readonly TestItemRepository _repository;
+
+    public RepositoryBaseTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<RepoTestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new RepoTestDbContext(options);
+        _context.Database.EnsureCreated();
+        _repository = new TestItemRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region FindByIdAsync
+
+    [Fact]
+    public async Task FindByIdAsync_existing_returns_maybe_with_value()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("Test"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        // Act
+        var result = await _repository.FindByIdAsync(id, ct);
+
+        // Assert
+        result.Should().HaveValue();
+        result.Value.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_nonexistent_returns_none()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+
+        // Act
+        var result = await _repository.FindByIdAsync(id, ct);
+
+        // Assert
+        result.Should().BeNone();
+    }
+
+    #endregion
+
+    #region SaveAsync
+
+    [Fact]
+    public async Task SaveAsync_new_aggregate_inserts_and_returns_success()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("New Item"));
+
+        // Act
+        var result = await _repository.SaveAsync(item, ct);
+
+        // Assert
+        result.Should().BeSuccess();
+
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().NotBeNull();
+        found!.Name.Should().Be(TestItemName.Create("New Item"));
+    }
+
+    [Fact]
+    public async Task SaveAsync_tracked_aggregate_updates_and_returns_success()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("Original"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+
+        item.Name = TestItemName.Create("Updated");
+
+        // Act
+        var result = await _repository.SaveAsync(item, ct);
+
+        // Assert
+        result.Should().BeSuccess();
+
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found!.Name.Should().Be(TestItemName.Create("Updated"));
+    }
+
+    [Fact]
+    public async Task SaveAsync_null_aggregate_throws()
+    {
+        // Act
+        var act = () => _repository.SaveAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("aggregate");
+    }
+
+    #endregion
+
+    #region QueryAsync
+
+    [Fact]
+    public async Task QueryAsync_with_matching_specification_returns_matches()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id1 = TestItemId.Create(Guid.NewGuid());
+        var id2 = TestItemId.Create(Guid.NewGuid());
+        _context.Items.Add(TestItem.Create(id1, TestItemName.Create("Alpha")));
+        _context.Items.Add(TestItem.Create(id2, TestItemName.Create("Beta")));
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        var spec = new TestItemNameSpec(TestItemName.Create("Alpha"));
+
+        // Act
+        var results = await _repository.QueryAsync(spec, ct);
+
+        // Assert
+        results.Should().ContainSingle();
+        results[0].Id.Should().Be(id1);
+    }
+
+    [Fact]
+    public async Task QueryAsync_no_matches_returns_empty_list()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var spec = new TestItemNameSpec(TestItemName.Create("NonExistent"));
+
+        // Act
+        var results = await _repository.QueryAsync(spec, ct);
+
+        // Assert
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryAsync_null_specification_throws()
+    {
+        // Act
+        var act = () => _repository.QueryAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("specification");
+    }
+
+    #endregion
+
+    #region Constructor
+
+    [Fact]
+    public void Constructor_null_context_throws()
+    {
+        // Act
+        var act = () => new TestItemRepository(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("context");
+    }
+
+    #endregion
+
+    #region Test Infrastructure
+
+    internal partial class TestItemId : RequiredGuid<TestItemId>;
+
+    [StringLength(200)]
+    internal partial class TestItemName : RequiredString<TestItemName>;
+
+    internal class TestItem : Aggregate<TestItemId>
+    {
+        public TestItemName Name { get; set; } = null!;
+
+        private TestItem() : base(default!) { }
+
+        public static TestItem Create(TestItemId id, TestItemName name) =>
+            new() { Id = id, Name = name };
+    }
+
+    internal class RepoTestDbContext : DbContext
+    {
+        public DbSet<TestItem> Items => Set<TestItem>();
+
+        public RepoTestDbContext(DbContextOptions<RepoTestDbContext> options) : base(options) { }
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
+            configurationBuilder.ApplyTrellisConventions(typeof(TestItemId).Assembly);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<TestItem>(b =>
+            {
+                b.HasKey(i => i.Id);
+                b.Property(i => i.Name).HasMaxLength(200).IsRequired();
+            });
+    }
+
+    internal class TestItemRepository(DbContext context) : RepositoryBase<TestItem, TestItemId>(context);
+
+    internal class TestItemNameSpec(TestItemName name) : Specification<TestItem>
+    {
+        public override Expression<Func<TestItem, bool>> ToExpression() =>
+            item => item.Name == name;
+    }
+
+    #endregion
+}

--- a/Trellis.Results/src/Maybe/MaybeInvariant.cs
+++ b/Trellis.Results/src/Maybe/MaybeInvariant.cs
@@ -486,9 +486,9 @@ public static class MaybeInvariant
 
         // None present — report all fields
         ValidationError? error = null;
+        const string message = "At least one of the related fields must be provided.";
         for (int i = 0; i < fields.Length; i++)
         {
-            string message = $"At least one of the related fields must be provided.";
             error = error is null
                 ? ValidationError.For(fields[i].fieldName, message, ValidationErrorCode)
                 : error.And(fields[i].fieldName, message);

--- a/Trellis.Results/src/Maybe/MaybeInvariant.cs
+++ b/Trellis.Results/src/Maybe/MaybeInvariant.cs
@@ -1,0 +1,501 @@
+﻿namespace Trellis;
+
+using System.Diagnostics;
+
+/// <summary>
+/// Provides static methods for validating invariants across multiple <see cref="Maybe{T}"/> values.
+/// These methods express relationships between correlated optional values — such as "all or none",
+/// "if A then B", or "exactly one" — and return <see cref="Result{T}"/> with field-level
+/// <see cref="ValidationError"/> details when the invariant is violated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use these helpers in aggregate factory methods, command validation, and domain methods where
+/// multiple optional values must satisfy a relationship constraint.
+/// </para>
+/// <para>
+/// All methods return <see cref="Result{Unit}"/>. Chain with <c>.Combine()</c> to compose
+/// multiple invariant checks, or use as a step in a result pipeline.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Winner and winner points must both be present or both absent
+/// var result = MaybeInvariant.AllOrNone(winner, winnerPoints, "winner", "winnerPoints");
+///
+/// // A discount requires a coupon code
+/// var result = MaybeInvariant.Requires(discount, couponCode, "discount", "couponCode");
+///
+/// // Payment can be by card or bank transfer, but not both
+/// var result = MaybeInvariant.MutuallyExclusive(cardPayment, bankTransfer, "cardPayment", "bankTransfer");
+/// </code>
+/// </example>
+[DebuggerStepThrough]
+public static class MaybeInvariant
+{
+    private const string ValidationErrorCode = "validation.error";
+
+    #region AllOrNone
+
+    /// <summary>
+    /// Validates that all values are present or all values are absent.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value (used in validation errors).</param>
+    /// <param name="secondFieldName">Field name for the second value (used in validation errors).</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
+    /// </returns>
+    public static Result<Unit> AllOrNone<T1, T2>(
+        Maybe<T1> first, Maybe<T2> second,
+        string firstFieldName, string secondFieldName)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+
+        return AllOrNoneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName));
+    }
+
+    /// <summary>
+    /// Validates that all three values are present or all three are absent.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <typeparam name="T3">Type of the third optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="third">The third optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <param name="thirdFieldName">Field name for the third value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
+    /// </returns>
+    public static Result<Unit> AllOrNone<T1, T2, T3>(
+        Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
+        string firstFieldName, string secondFieldName, string thirdFieldName)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+        ArgumentNullException.ThrowIfNull(thirdFieldName);
+
+        return AllOrNoneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName),
+            (third.HasValue, thirdFieldName));
+    }
+
+    /// <summary>
+    /// Validates that all four values are present or all four are absent.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <typeparam name="T3">Type of the third optional value.</typeparam>
+    /// <typeparam name="T4">Type of the fourth optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="third">The third optional value.</param>
+    /// <param name="fourth">The fourth optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <param name="thirdFieldName">Field name for the third value.</param>
+    /// <param name="fourthFieldName">Field name for the fourth value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
+    /// </returns>
+    public static Result<Unit> AllOrNone<T1, T2, T3, T4>(
+        Maybe<T1> first, Maybe<T2> second, Maybe<T3> third, Maybe<T4> fourth,
+        string firstFieldName, string secondFieldName, string thirdFieldName, string fourthFieldName)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+        ArgumentNullException.ThrowIfNull(thirdFieldName);
+        ArgumentNullException.ThrowIfNull(fourthFieldName);
+
+        return AllOrNoneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName),
+            (third.HasValue, thirdFieldName),
+            (fourth.HasValue, fourthFieldName));
+    }
+
+    #endregion
+
+    #region Requires
+
+    /// <summary>
+    /// Validates that if <paramref name="source"/> has a value, <paramref name="required"/> must also have a value.
+    /// If <paramref name="source"/> has no value, the check passes regardless of <paramref name="required"/>.
+    /// </summary>
+    /// <typeparam name="T1">Type of the source optional value.</typeparam>
+    /// <typeparam name="T2">Type of the required optional value.</typeparam>
+    /// <param name="source">The optional value that triggers the requirement.</param>
+    /// <param name="required">The optional value that must be present when source is present.</param>
+    /// <param name="sourceFieldName">Field name for the source value.</param>
+    /// <param name="requiredFieldName">Field name for the required value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if source is absent or both are present;
+    /// otherwise a <see cref="ValidationError"/> for the missing required field.
+    /// </returns>
+    public static Result<Unit> Requires<T1, T2>(
+        Maybe<T1> source, Maybe<T2> required,
+        string sourceFieldName, string requiredFieldName)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(sourceFieldName);
+        ArgumentNullException.ThrowIfNull(requiredFieldName);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Requires));
+
+        if (source.HasNoValue || required.HasValue)
+            return Result.Success();
+
+        return Result.Failure<Unit>(
+            ValidationError.For(
+                requiredFieldName,
+                $"'{requiredFieldName}' is required when '{sourceFieldName}' is provided.",
+                ValidationErrorCode));
+    }
+
+    #endregion
+
+    #region MutuallyExclusive
+
+    /// <summary>
+    /// Validates that at most one of the values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if zero or one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all present fields.
+    /// </returns>
+    public static Result<Unit> MutuallyExclusive<T1, T2>(
+        Maybe<T1> first, Maybe<T2> second,
+        string firstFieldName, string secondFieldName)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+
+        return MutuallyExclusiveCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName));
+    }
+
+    /// <summary>
+    /// Validates that at most one of the three values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <typeparam name="T3">Type of the third optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="third">The third optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <param name="thirdFieldName">Field name for the third value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if zero or one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all present fields.
+    /// </returns>
+    public static Result<Unit> MutuallyExclusive<T1, T2, T3>(
+        Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
+        string firstFieldName, string secondFieldName, string thirdFieldName)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+        ArgumentNullException.ThrowIfNull(thirdFieldName);
+
+        return MutuallyExclusiveCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName),
+            (third.HasValue, thirdFieldName));
+    }
+
+    #endregion
+
+    #region ExactlyOne
+
+    /// <summary>
+    /// Validates that exactly one of the values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if exactly one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all fields.
+    /// </returns>
+    public static Result<Unit> ExactlyOne<T1, T2>(
+        Maybe<T1> first, Maybe<T2> second,
+        string firstFieldName, string secondFieldName)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+
+        return ExactlyOneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName));
+    }
+
+    /// <summary>
+    /// Validates that exactly one of the three values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <typeparam name="T3">Type of the third optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="third">The third optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <param name="thirdFieldName">Field name for the third value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if exactly one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all fields.
+    /// </returns>
+    public static Result<Unit> ExactlyOne<T1, T2, T3>(
+        Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
+        string firstFieldName, string secondFieldName, string thirdFieldName)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+        ArgumentNullException.ThrowIfNull(thirdFieldName);
+
+        return ExactlyOneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName),
+            (third.HasValue, thirdFieldName));
+    }
+
+    #endregion
+
+    #region AtLeastOne
+
+    /// <summary>
+    /// Validates that at least one of the values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if at least one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all fields.
+    /// </returns>
+    public static Result<Unit> AtLeastOne<T1, T2>(
+        Maybe<T1> first, Maybe<T2> second,
+        string firstFieldName, string secondFieldName)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+
+        return AtLeastOneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName));
+    }
+
+    /// <summary>
+    /// Validates that at least one of the three values is present.
+    /// </summary>
+    /// <typeparam name="T1">Type of the first optional value.</typeparam>
+    /// <typeparam name="T2">Type of the second optional value.</typeparam>
+    /// <typeparam name="T3">Type of the third optional value.</typeparam>
+    /// <param name="first">The first optional value.</param>
+    /// <param name="second">The second optional value.</param>
+    /// <param name="third">The third optional value.</param>
+    /// <param name="firstFieldName">Field name for the first value.</param>
+    /// <param name="secondFieldName">Field name for the second value.</param>
+    /// <param name="thirdFieldName">Field name for the third value.</param>
+    /// <returns>
+    /// <see cref="Result{Unit}"/> success if at least one value is present;
+    /// otherwise a <see cref="ValidationError"/> listing all fields.
+    /// </returns>
+    public static Result<Unit> AtLeastOne<T1, T2, T3>(
+        Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
+        string firstFieldName, string secondFieldName, string thirdFieldName)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        ArgumentNullException.ThrowIfNull(firstFieldName);
+        ArgumentNullException.ThrowIfNull(secondFieldName);
+        ArgumentNullException.ThrowIfNull(thirdFieldName);
+
+        return AtLeastOneCore(
+            (first.HasValue, firstFieldName),
+            (second.HasValue, secondFieldName),
+            (third.HasValue, thirdFieldName));
+    }
+
+    #endregion
+
+    #region Core implementations
+
+    private static Result<Unit> AllOrNoneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    {
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(AllOrNone));
+
+        int presentCount = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].hasValue)
+                presentCount++;
+        }
+
+        if (presentCount == 0 || presentCount == fields.Length)
+            return Result.Success();
+
+        // Some present, some absent — report the missing fields as required.
+        ValidationError? error = null;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (!fields[i].hasValue)
+            {
+                string message = $"'{fields[i].fieldName}' is required when related fields are provided.";
+                error = error is null
+                    ? ValidationError.For(fields[i].fieldName, message, ValidationErrorCode)
+                    : error.And(fields[i].fieldName, message);
+            }
+        }
+
+        return Result.Failure<Unit>(error!);
+    }
+
+    private static Result<Unit> MutuallyExclusiveCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    {
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(MutuallyExclusive));
+
+        int presentCount = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].hasValue)
+                presentCount++;
+        }
+
+        if (presentCount <= 1)
+            return Result.Success();
+
+        // Multiple present — report all present fields
+        ValidationError? error = null;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].hasValue)
+            {
+                string message = $"'{fields[i].fieldName}' cannot be provided together with other mutually exclusive fields.";
+                error = error is null
+                    ? ValidationError.For(fields[i].fieldName, message, ValidationErrorCode)
+                    : error.And(fields[i].fieldName, message);
+            }
+        }
+
+        return Result.Failure<Unit>(error!);
+    }
+
+    private static Result<Unit> ExactlyOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    {
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ExactlyOne));
+
+        int presentCount = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].hasValue)
+                presentCount++;
+        }
+
+        if (presentCount == 1)
+            return Result.Success();
+
+        // Build error listing relevant fields
+        ValidationError? error = null;
+        if (presentCount == 0)
+        {
+            // None present — report all fields
+            for (int i = 0; i < fields.Length; i++)
+            {
+                error = error is null
+                    ? ValidationError.For(fields[i].fieldName, "Exactly one field must be provided.", ValidationErrorCode)
+                    : error.And(fields[i].fieldName, "Exactly one field must be provided.");
+            }
+        }
+        else
+        {
+            // Multiple present — report only the fields that were provided
+            for (int i = 0; i < fields.Length; i++)
+            {
+                if (fields[i].hasValue)
+                {
+                    error = error is null
+                        ? ValidationError.For(fields[i].fieldName, "Only one field may be provided.", ValidationErrorCode)
+                        : error.And(fields[i].fieldName, "Only one field may be provided.");
+                }
+            }
+        }
+
+        return Result.Failure<Unit>(error!);
+    }
+
+    private static Result<Unit> AtLeastOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    {
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(AtLeastOne));
+
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].hasValue)
+                return Result.Success();
+        }
+
+        // None present — report all fields
+        ValidationError? error = null;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            string message = $"At least one of the related fields must be provided.";
+            error = error is null
+                ? ValidationError.For(fields[i].fieldName, message, ValidationErrorCode)
+                : error.And(fields[i].fieldName, message);
+        }
+
+        return Result.Failure<Unit>(error!);
+    }
+
+    #endregion
+}

--- a/Trellis.Results/tests/Maybes/Extensions/MaybeInvariantTests.cs
+++ b/Trellis.Results/tests/Maybes/Extensions/MaybeInvariantTests.cs
@@ -1,0 +1,703 @@
+﻿namespace Trellis.Results.Tests.Maybes.Extensions;
+
+using Trellis;
+using Trellis.Testing;
+
+public class MaybeInvariantTests
+{
+    #region AllOrNone — 2 values
+
+    [Fact]
+    public void AllOrNone2_both_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone2_both_none_returns_success()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone2_first_present_second_none_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "second");
+    }
+
+    [Fact]
+    public void AllOrNone2_first_none_second_present_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "first");
+    }
+
+    #endregion
+
+    #region AllOrNone — 3 values
+
+    [Fact]
+    public void AllOrNone3_all_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe.From("a");
+        var b = Maybe.From(1);
+        var c = Maybe.From(true);
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone3_all_none_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone3_mixed_returns_validation_error_for_missing_fields()
+    {
+        // Arrange
+        var a = Maybe.From("a");
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, "a", "b", "c");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "b");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "c");
+        validation.FieldErrors.Should().NotContain(fe => fe.FieldName == "a");
+    }
+
+    #endregion
+
+    #region AllOrNone — 4 values
+
+    [Fact]
+    public void AllOrNone4_all_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe.From("a");
+        var b = Maybe.From(1);
+        var c = Maybe.From(true);
+        var d = Maybe.From(3.14);
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, d, "a", "b", "c", "d");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone4_all_none_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+        var d = Maybe<double>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, d, "a", "b", "c", "d");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AllOrNone4_one_missing_returns_validation_error()
+    {
+        // Arrange
+        var a = Maybe.From("a");
+        var b = Maybe.From(1);
+        var c = Maybe<bool>.None;
+        var d = Maybe.From(3.14);
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(a, b, c, d, "a", "b", "c", "d");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().ContainSingle(fe => fe.FieldName == "c");
+    }
+
+    #endregion
+
+    #region Requires
+
+    [Fact]
+    public void Requires_source_none_returns_success()
+    {
+        // Arrange
+        var source = Maybe<string>.None;
+        var required = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.Requires(source, required, "source", "required");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void Requires_both_present_returns_success()
+    {
+        // Arrange
+        var source = Maybe.From("hello");
+        var required = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.Requires(source, required, "source", "required");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void Requires_source_present_required_none_returns_validation_error()
+    {
+        // Arrange
+        var source = Maybe.From("hello");
+        var required = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.Requires(source, required, "source", "required");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().ContainSingle(fe => fe.FieldName == "required");
+    }
+
+    [Fact]
+    public void Requires_source_none_required_present_returns_success()
+    {
+        // Arrange — required being present when source is absent is fine
+        var source = Maybe<string>.None;
+        var required = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.Requires(source, required, "source", "required");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    #endregion
+
+    #region MutuallyExclusive — 2 values
+
+    [Fact]
+    public void MutuallyExclusive2_both_none_returns_success()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void MutuallyExclusive2_first_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void MutuallyExclusive2_second_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void MutuallyExclusive2_both_present_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "first");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "second");
+    }
+
+    #endregion
+
+    #region MutuallyExclusive — 3 values
+
+    [Fact]
+    public void MutuallyExclusive3_none_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void MutuallyExclusive3_one_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe.From(42);
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void MutuallyExclusive3_two_present_returns_validation_error()
+    {
+        // Arrange
+        var a = Maybe.From("hello");
+        var b = Maybe<int>.None;
+        var c = Maybe.From(true);
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(a, b, c, "a", "b", "c");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "a");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "c");
+        validation.FieldErrors.Should().NotContain(fe => fe.FieldName == "b");
+    }
+
+    #endregion
+
+    #region ExactlyOne — 2 values
+
+    [Fact]
+    public void ExactlyOne2_first_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ExactlyOne2_second_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ExactlyOne2_both_none_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "first");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "second");
+    }
+
+    [Fact]
+    public void ExactlyOne2_both_present_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "first");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "second");
+    }
+
+    #endregion
+
+    #region ExactlyOne — 3 values
+
+    [Fact]
+    public void ExactlyOne3_one_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe.From(42);
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ExactlyOne3_none_present_returns_validation_error()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeFailureOfType<ValidationError>();
+    }
+
+    [Fact]
+    public void ExactlyOne3_two_present_returns_validation_error_only_for_present_fields()
+    {
+        // Arrange
+        var a = Maybe.From("hello");
+        var b = Maybe.From(42);
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeFailureOfType<ValidationError>();
+        var error = (ValidationError)result.Error;
+        // Only a and b should be listed, not c (which is absent)
+        error.FieldErrors.Should().HaveCount(2);
+        error.FieldErrors.Select(e => e.FieldName).Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    #endregion
+
+    #region AtLeastOne — 2 values
+
+    [Fact]
+    public void AtLeastOne2_first_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AtLeastOne2_both_present_returns_success()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AtLeastOne2_both_none_returns_validation_error()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(first, second, "first", "second");
+
+        // Assert
+        var validation = result.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "first");
+        validation.FieldErrors.Should().Contain(fe => fe.FieldName == "second");
+    }
+
+    #endregion
+
+    #region AtLeastOne — 3 values
+
+    [Fact]
+    public void AtLeastOne3_one_present_returns_success()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe.From(42);
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AtLeastOne3_none_present_returns_validation_error()
+    {
+        // Arrange
+        var a = Maybe<string>.None;
+        var b = Maybe<int>.None;
+        var c = Maybe<bool>.None;
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(a, b, c, "a", "b", "c");
+
+        // Assert
+        result.Should().BeFailureOfType<ValidationError>();
+    }
+
+    #endregion
+
+    #region Parameter Validation
+
+    [Fact]
+    public void AllOrNone2_null_first_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.AllOrNone(
+            Maybe.From("a"), Maybe.From(1), null!, "second");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("firstFieldName");
+    }
+
+    [Fact]
+    public void AllOrNone2_null_second_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.AllOrNone(
+            Maybe.From("a"), Maybe.From(1), "first", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("secondFieldName");
+    }
+
+    [Fact]
+    public void Requires_null_source_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.Requires(
+            Maybe.From("a"), Maybe.From(1), null!, "required");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("sourceFieldName");
+    }
+
+    [Fact]
+    public void Requires_null_required_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.Requires(
+            Maybe.From("a"), Maybe.From(1), "source", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("requiredFieldName");
+    }
+
+    [Fact]
+    public void MutuallyExclusive2_null_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.MutuallyExclusive(
+            Maybe.From("a"), Maybe.From(1), null!, "second");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("firstFieldName");
+    }
+
+    [Fact]
+    public void ExactlyOne2_null_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.ExactlyOne(
+            Maybe.From("a"), Maybe.From(1), null!, "second");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("firstFieldName");
+    }
+
+    [Fact]
+    public void AtLeastOne2_null_field_name_throws()
+    {
+        // Act
+        var act = () => MaybeInvariant.AtLeastOne(
+            Maybe.From("a"), Maybe.From(1), null!, "second");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("firstFieldName");
+    }
+
+    #endregion
+
+    #region Error Code Validation
+
+    [Fact]
+    public void AllOrNone_failure_uses_standard_validation_error_code()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AllOrNone(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeFailure().Which.Code.Should().Be("validation.error");
+    }
+
+    [Fact]
+    public void Requires_failure_uses_standard_validation_error_code()
+    {
+        // Arrange
+        var source = Maybe.From("hello");
+        var required = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.Requires(source, required, "source", "required");
+
+        // Assert
+        result.Should().BeFailure().Which.Code.Should().Be("validation.error");
+    }
+
+    [Fact]
+    public void MutuallyExclusive_failure_uses_standard_validation_error_code()
+    {
+        // Arrange
+        var first = Maybe.From("hello");
+        var second = Maybe.From(42);
+
+        // Act
+        var result = MaybeInvariant.MutuallyExclusive(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeFailure().Which.Code.Should().Be("validation.error");
+    }
+
+    [Fact]
+    public void ExactlyOne_failure_uses_standard_validation_error_code()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.ExactlyOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeFailure().Which.Code.Should().Be("validation.error");
+    }
+
+    [Fact]
+    public void AtLeastOne_failure_uses_standard_validation_error_code()
+    {
+        // Arrange
+        var first = Maybe<string>.None;
+        var second = Maybe<int>.None;
+
+        // Act
+        var result = MaybeInvariant.AtLeastOne(first, second, "first", "second");
+
+        // Assert
+        result.Should().BeFailure().Which.Code.Should().Be("validation.error");
+    }
+
+    #endregion
+}

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -30,6 +30,7 @@
 | `TRLS020` | Warning | Use SaveChangesResultAsync instead of SaveChangesAsync | Direct SaveChanges/SaveChangesAsync calls bypass the Result pipeline and turn database errors into unhandled exceptions. Use SaveChangesResultAsync (returns Result<int>) or SaveChangesResultUnitAsync (returns Result<Unit>) instead. |
 | `TRLS021` | Warning | HasIndex references a Maybe<T> property | HasIndex with a Maybe<T> property silently fails to create the index because MaybeConvention maps Maybe<T> via generated storage members, so the CLR property is invisible to EF Core's index builder. Prefer HasTrellisIndex so regular properties stay strongly typed and Maybe<T> properties resolve to their mapped storage automatically. If needed, you can also use string-based HasIndex with the storage member name directly. Examples: builder.HasTrellisIndex(e => new { e.Status, e.SubmittedAt }); or builder.HasIndex("Status", "_submittedAt"). |
 | `TRLS022` | Warning | Wrong [StringLength] or [Range] attribute namespace | Trellis [StringLength] and [Range] attributes share names with System.ComponentModel.DataAnnotations versions. Using the wrong namespace compiles silently but the Trellis source generator ignores them, resulting in value objects without the expected validation constraints. Use the Trellis versions (namespace Trellis) instead. |
+| `TRLS023` | Warning | Command or query has resource ID without resource authorization | Commands and queries that carry a typed aggregate ID (a property whose type implements `IScalarValue` and whose name ends with "Id") should typically implement `IAuthorizeResource<T>` to enforce resource-level authorization. When adding `IAuthorizeResource<T>`, also ensure a matching `IResourceLoader` or `IIdentifyResource` implementation is registered. |
 
 ## Analyzer classes
 
@@ -208,6 +209,13 @@
   - `RequiredBool`
   - `RequiredDateTime`
   - `RequiredEnum`
+- No code fix.
+
+#### `MissingResourceAuthorizationAnalyzer` — `TRLS023`
+- Flags commands (`Mediator.ICommand<T>`) and queries (`Mediator.IQuery<T>`) that have a property whose type implements `IScalarValue<,>` and whose name ends with "Id", but do not implement `IAuthorizeResource<T>`.
+- Uses `CompilationStartAction` to cache type symbols; only activates when both `Mediator.ICommand`/`IQuery` and `Trellis.Authorization.IAuthorizeResource` are referenced.
+- Walks the base type hierarchy to catch inherited ID properties.
+- Reports one diagnostic per message type, listing all candidate ID properties.
 - No code fix.
 
 ## Code fix providers

--- a/docs/api_reference/trellis-api-efcore.md
+++ b/docs/api_reference/trellis-api-efcore.md
@@ -74,6 +74,48 @@ public static class QueryableExtensions
 | `public static Task<Result<T>> FirstOrDefaultResultAsync<T>(this IQueryable<T> query, Expression<Func<T, bool>> predicate, Error notFoundError, CancellationToken cancellationToken = default) where T : class` | `Task<Result<T>>` | Returns the first predicate match or **the exact `notFoundError` supplied by the caller**. |
 | `public static IQueryable<T> Where<T>(this IQueryable<T> query, Specification<T> specification) where T : class` | `IQueryable<T>` | Applies a Trellis specification expression to the query. |
 
+### `RepositoryBase<TAggregate, TId>`
+
+```csharp
+public abstract class RepositoryBase<TAggregate, TId>
+    where TAggregate : Aggregate<TId>
+    where TId : notnull
+```
+
+Abstract generic repository base class for EF Core aggregate persistence. Extracts the recurring FindById/Save/Query pattern used by concrete repositories.
+
+#### Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `protected DbSet<TAggregate> DbSet` | `DbSet<TAggregate>` | The EF Core `DbSet` for this aggregate type. |
+| `protected DbContext Context` | `DbContext` | The underlying `DbContext`. Use sparingly — prefer repository methods. |
+
+#### Methods
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public virtual Task<Maybe<TAggregate>> FindByIdAsync(TId id, CancellationToken cancellationToken = default)` | `Task<Maybe<TAggregate>>` | Finds an aggregate by ID using an expression-tree predicate (`Expression.Equal`). Returns `Maybe<T>.None` if not found. |
+| `public virtual Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)` | `Task<Result<Unit>>` | Persists a new or modified aggregate. Detached aggregates are added; tracked aggregates are updated in place. To update, first retrieve via `FindByIdAsync`, mutate, then save. |
+| `public virtual Task<IReadOnlyList<TAggregate>> QueryAsync(Specification<TAggregate> specification, CancellationToken cancellationToken = default)` | `Task<IReadOnlyList<TAggregate>>` | Queries aggregates matching the specification. |
+
+#### Virtual Hooks
+
+| Signature | Description |
+| --- | --- |
+| `protected virtual IQueryable<TAggregate> BuildFindByIdQuery()` | Override to add `.Include()` or filters to the find-by-ID query. Defaults to `DbSet.AsQueryable()`. |
+| `protected virtual IQueryable<TAggregate> BuildQueryBase()` | Override to add `.Include()` or filters to specification queries. Defaults to `DbSet.AsNoTracking()`. |
+
+#### Usage
+
+```csharp
+public class OrderRepository(DbContext context) : RepositoryBase<Order, OrderId>(context)
+{
+    protected override IQueryable<Order> BuildFindByIdQuery() =>
+        DbSet.Include(o => o.LineItems);
+}
+```
+
 ### `EntityTimestampInterceptor`
 
 ```csharp

--- a/docs/api_reference/trellis-api-results.md
+++ b/docs/api_reference/trellis-api-results.md
@@ -194,6 +194,35 @@ None.
 
 ---
 
+### `public static class MaybeInvariant`
+
+Multi-field validation helpers for `Maybe<T>` values. Each method returns `Result<Unit>` — success when the invariant holds, or a `ValidationError` with field-level details when it does not. All error codes use `"validation.error"`.
+
+#### Methods
+
+| Signature | Notes |
+| --- | --- |
+| `public static Result<Unit> AllOrNone<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | All fields present or all absent. Arities 2, 3, 4. |
+| `public static Result<Unit> Requires<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | If `first` is present, `second` must be too. Arity 2. |
+| `public static Result<Unit> MutuallyExclusive<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | At most one field may be present. Arities 2, 3. |
+| `public static Result<Unit> ExactlyOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | Exactly one field must be present. Arities 2, 3. |
+| `public static Result<Unit> AtLeastOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | At least one field must be present. Arities 2, 3. |
+
+#### Usage
+
+```csharp
+// All-or-none: street + city must both be provided or both omitted
+MaybeInvariant.AllOrNone(command.Street, command.City, "street", "city")
+
+// Requires: if discount is given, reason is required
+MaybeInvariant.Requires(command.Discount, command.DiscountReason, "discount", "discountReason")
+
+// ExactlyOne: must provide either email or phone
+MaybeInvariant.ExactlyOne(command.Email, command.Phone, "email", "phone")
+```
+
+---
+
 ### `public readonly struct Maybe<T> where T : notnull`
 
 Optional value container for domain optionality.

--- a/docs/api_reference/trellis-api-results.md
+++ b/docs/api_reference/trellis-api-results.md
@@ -202,23 +202,23 @@ Multi-field validation helpers for `Maybe<T>` values. Each method returns `Resul
 
 | Signature | Notes |
 | --- | --- |
-| `public static Result<Unit> AllOrNone<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | All fields present or all absent. Arities 2, 3, 4. |
-| `public static Result<Unit> Requires<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | If `first` is present, `second` must be too. Arity 2. |
-| `public static Result<Unit> MutuallyExclusive<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | At most one field may be present. Arities 2, 3. |
-| `public static Result<Unit> ExactlyOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | Exactly one field must be present. Arities 2, 3. |
-| `public static Result<Unit> AtLeastOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstName, string secondName)` | At least one field must be present. Arities 2, 3. |
+| `public static Result<Unit> AllOrNone<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstFieldName, string secondFieldName)` | All fields present or all absent. Arities 2, 3, 4. |
+| `public static Result<Unit> Requires<T1, T2>(Maybe<T1> source, Maybe<T2> required, string sourceFieldName, string requiredFieldName)` | If `source` is present, `required` must be too. Arity 2. |
+| `public static Result<Unit> MutuallyExclusive<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstFieldName, string secondFieldName)` | At most one field may be present. Arities 2, 3. |
+| `public static Result<Unit> ExactlyOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstFieldName, string secondFieldName)` | Exactly one field must be present. Arities 2, 3. |
+| `public static Result<Unit> AtLeastOne<T1, T2>(Maybe<T1> first, Maybe<T2> second, string firstFieldName, string secondFieldName)` | At least one field must be present. Arities 2, 3. |
 
 #### Usage
 
 ```csharp
 // All-or-none: street + city must both be provided or both omitted
-MaybeInvariant.AllOrNone(command.Street, command.City, "street", "city")
+MaybeInvariant.AllOrNone(command.Street, command.City, "street", "city");
 
 // Requires: if discount is given, reason is required
-MaybeInvariant.Requires(command.Discount, command.DiscountReason, "discount", "discountReason")
+MaybeInvariant.Requires(command.Discount, command.DiscountReason, "discount", "discountReason");
 
 // ExactlyOne: must provide either email or phone
-MaybeInvariant.ExactlyOne(command.Email, command.Phone, "email", "phone")
+MaybeInvariant.ExactlyOne(command.Email, command.Phone, "email", "phone");
 ```
 
 ---


### PR DESCRIPTION
## Summary
 
 Implements three feature requests from the community feedback evaluation : multi-field Maybe 
invariant validation, an abstract EF Core repository base class, and a Roslyn analyzer for missing resource 
authorization.
 
 ## New Features
 
 ### 1. `MaybeInvariant` static class (Trellis.Results)
 
 Five invariant methods for validating relationships between optional (`Maybe<T>`) fields:
 
 | Method | Semantics |
 |--------|-----------|
 | `AllOrNone` | All fields present or all absent |
 | `Requires` | If the first field is present, the second must be too |
 | `MutuallyExclusive` | At most one field may be present |
 | `ExactlyOne` | Exactly one field must be present |
 | `AtLeastOne` | At least one field must be present |
 
 - Arities 2–4 for `AllOrNone`, 2–3 for others
 - Returns `Result<Unit>` with field-level `ValidationError` on failure
 - Zero-allocation dispatch via `ReadOnlySpan<(bool, string)>` in private core methods
 - 38 tests covering all methods, arities, success/failure, parameter validation, and error codes
 
 ### 2. `RepositoryBase<TAggregate, TId>` (Trellis.EntityFrameworkCore)
 
 Abstract generic repository base class that extracts the recurring FindById/Save/Query pattern:
 
 - `FindByIdAsync` — expression-tree-based `BuildIdPredicate` using `Expression.Equal` (not `.Equals()`) for correct
 EF Core value converter translation
 - `SaveAsync` — detached → Add, tracked → update-in-place (matches template convention)
 - `QueryAsync` — applies `Specification<T>` to a queryable base
 - Virtual hooks: `BuildFindByIdQuery()`, `BuildQueryBase()` for Include/filter customization
 - 9 tests with SQLite in-memory database and scalar value object IDs
 
 ### 3. TRLS023: Missing resource authorization analyzer (Trellis.Analyzers)
 
 Warns when a command (`ICommand<T>`) or query (`IQuery<T>`) carries a typed aggregate ID property but doesn't 
implement `IAuthorizeResource<T>`:
 
 - **Semantic detection** — checks if property type implements `IScalarValue<,>` (not just name-based)
 - **Walks inheritance** — catches ID properties declared on base types
 - **One diagnostic per message** — lists all candidate ID properties
 - `CompilationStartAction` caches type symbols for performance
 - Help text mentions the `IResourceLoader`/`IIdentifyResource` requirement
 - 12 tests (6 warn cases, 6 no-warn cases)
 
 ## Documentation Updated
 
 | File | Change |
 |------|--------|
 | `docs/api_reference/trellis-api-results.md` | Added `MaybeInvariant` class with method table and usage examples |
 | `docs/api_reference/trellis-api-efcore.md` | Added `RepositoryBase<TAggregate, TId>` with properties, methods, 
virtual hooks, and usage |
 | `docs/api_reference/trellis-api-analyzers.md` | Added TRLS023 to diagnostics table and analyzer classes section |
 | `.github/copilot-instructions.md` | Updated analyzer rule range to TRLS001-TRLS023 