### PR TITLE
Redesign RepositoryBase with Unit of Work and auto-commit pipeline behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,6 +176,17 @@ For `Result<T>`, `Maybe<T>`, `Error`, and all ROP extension methods (`Bind`, `Ma
 
 For `Maybe<T>` usage in ASP.NET DTOs and EF Core, see `docs/api_reference/trellis-api-asp.md` and `docs/api_reference/trellis-api-efcore.md`.
 
+### Repository and Unit of Work Pattern
+
+**Critical Rule:** Repositories stage changes. The pipeline commits. Handlers never call `SaveChanges`.
+
+- `RepositoryBase` provides staging methods (`Add`, `Remove`, `RemoveByIdAsync`) and read methods (`FindByIdAsync`, `QueryAsync`, `ExistsAsync`, `CountAsync`). None of these call `SaveChanges`.
+- `TransactionalCommandBehavior` is a pipeline behavior that auto-commits after a successful command handler. Queries are skipped (no overhead).
+- `IUnitOfWork.CommitAsync()` is the single commit point. In the standard pipeline it's called automatically. Inject `IUnitOfWork` directly only for non-pipeline scenarios (background jobs, tests).
+- Register with `services.AddTrellisUnitOfWork<AppDbContext>()` in the ACL layer.
+
+For the full API surface, see `docs/api_reference/trellis-api-efcore.md`.
+
 ### Testing Philosophy
 
 1. **Railway track behavior**: Once on failure track, stay there

--- a/Trellis.EntityFrameworkCore/NUGET_README.md
+++ b/Trellis.EntityFrameworkCore/NUGET_README.md
@@ -26,6 +26,9 @@ Result<int> saved = await dbContext.SaveChangesResultAsync(cancellationToken);
 - Apply Trellis value converters and owned-type conventions with one registration point.
 - Query `Maybe<T>` naturally instead of dropping to storage-specific null handling.
 - Return `Result<int>` or `Result<Unit>` from save operations instead of throwing on expected failures.
+- `RepositoryBase<TAggregate, TId>` — staging-only base class (Add/Remove/Query/Exists/Count).
+- `IUnitOfWork` / `EfUnitOfWork<TContext>` — single commit boundary for staged changes.
+- `TransactionalCommandBehavior` — pipeline behavior that auto-commits after successful command handlers.
 
 ## Documentation
 - [Full documentation](https://xavierjohn.github.io/Trellis/articles/integration-ef.html)

--- a/Trellis.EntityFrameworkCore/NUGET_README.md
+++ b/Trellis.EntityFrameworkCore/NUGET_README.md
@@ -28,7 +28,7 @@ Result<int> saved = await dbContext.SaveChangesResultAsync(cancellationToken);
 - Return `Result<int>` or `Result<Unit>` from save operations instead of throwing on expected failures.
 - `RepositoryBase<TAggregate, TId>` — staging-only base class (Add/Remove/Query/Exists/Count).
 - `IUnitOfWork` / `EfUnitOfWork<TContext>` — single commit boundary for staged changes.
-- `TransactionalCommandBehavior` — pipeline behavior that auto-commits after successful command handlers.
+- `TransactionalCommandBehavior` — Mediator pipeline behavior that auto-commits after successful command handlers (requires Mediator pipeline registration).
 
 ## Documentation
 - [Full documentation](https://xavierjohn.github.io/Trellis/articles/integration-ef.html)

--- a/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
@@ -1,0 +1,19 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// EF Core implementation of <see cref="IUnitOfWork"/>.
+/// Delegates to <see cref="DbContextExtensions.SaveChangesResultUnitAsync(DbContext, CancellationToken)"/>
+/// which already maps <see cref="DbUpdateConcurrencyException"/> to <see cref="Error.Conflict(string, string?)"/>,
+/// duplicate-key exceptions to <see cref="Error.Conflict(string, string?)"/>,
+/// and foreign-key violations to <see cref="Error.Domain(string, string?)"/>.
+/// </summary>
+/// <typeparam name="TContext">The concrete <see cref="DbContext"/> type registered in DI.</typeparam>
+public class EfUnitOfWork<TContext>(TContext context) : IUnitOfWork
+    where TContext : DbContext
+{
+    /// <inheritdoc />
+    public Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default)
+        => context.SaveChangesResultUnitAsync(cancellationToken);
+}

--- a/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
@@ -1,0 +1,23 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+/// <summary>
+/// Abstraction over the commit boundary for staged changes.
+/// Repositories stage changes; calling <see cref="CommitAsync"/> persists them.
+/// <para>
+/// In the standard Trellis pipeline, commit is handled automatically by
+/// <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/> after a successful handler.
+/// Inject <see cref="IUnitOfWork"/> directly only in non-pipeline scenarios
+/// (background jobs, integration tests, etc.).
+/// </para>
+/// </summary>
+public interface IUnitOfWork
+{
+    /// <summary>
+    /// Persists all staged changes to the database.
+    /// Returns <see cref="Result{Unit}"/> to surface concurrency, duplicate-key,
+    /// and foreign-key errors as <see cref="Error"/> instead of exceptions.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
+    Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default);
+}

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -5,14 +5,15 @@ using Microsoft.EntityFrameworkCore;
 
 /// <summary>
 /// Base class for EF Core repositories that persist <see cref="Aggregate{TId}"/> instances.
-/// Provides standard <see cref="FindByIdAsync"/>, <see cref="SaveAsync"/>, and
-/// <see cref="QueryAsync"/> implementations that compose the existing Trellis EF Core helpers.
+/// Provides standard read and staging methods. Repositories stage changes to the
+/// <see cref="DbContext"/> change tracker; the <see cref="IUnitOfWork"/> (typically driven
+/// by a pipeline behavior) is responsible for committing staged changes.
 /// </summary>
 /// <typeparam name="TAggregate">The aggregate root type.</typeparam>
 /// <typeparam name="TId">The type of the aggregate's unique identifier.</typeparam>
 /// <remarks>
 /// <para>
-/// This base class eliminates the repetitive save/find/query boilerplate that appears in every
+/// This base class eliminates the repetitive find/query/add/remove boilerplate that appears in every
 /// concrete repository. Repositories with custom queries inherit and add methods.
 /// </para>
 /// <para>
@@ -20,12 +21,11 @@ using Microsoft.EntityFrameworkCore;
 /// <c>.Include()</c> chains for eager loading.
 /// </para>
 /// <para>
-/// <see cref="SaveAsync"/> uses detached-entity detection: if the aggregate's change tracker
-/// state is <see cref="EntityState.Detached"/>, it is added to the <see cref="DbSet"/>.
-/// This means new aggregates are inserted and already-tracked aggregates are updated.
-/// If your scenario requires disconnected-update semantics (attaching a deserialized
-/// aggregate that was never tracked), override <see cref="SaveAsync"/> in the concrete
-/// repository.
+/// <b>Staging vs. Committing:</b> Methods like <see cref="Add"/>, <see cref="Remove"/>,
+/// and <see cref="RemoveByIdAsync"/> stage changes in the EF Core change tracker but never
+/// call <c>SaveChanges</c>. The commit boundary is owned by the pipeline
+/// (see <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/>) or by explicitly
+/// calling <see cref="IUnitOfWork.CommitAsync"/>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -69,6 +69,10 @@ public abstract class RepositoryBase<TAggregate, TId>
     /// </summary>
     protected DbContext Context => _context;
 
+    // ──────────────────────────────────────────────
+    // Virtual hooks
+    // ──────────────────────────────────────────────
+
     /// <summary>
     /// Builds the base query used by <see cref="FindByIdAsync"/>. Override to add
     /// <c>.Include()</c> chains for eager loading when finding by ID.
@@ -77,15 +81,20 @@ public abstract class RepositoryBase<TAggregate, TId>
     protected virtual IQueryable<TAggregate> BuildFindByIdQuery() => DbSet;
 
     /// <summary>
-    /// Builds the base query used by <see cref="QueryAsync"/>. Override to add
-    /// <c>.Include()</c> chains for list/search queries.
+    /// Builds the base query used by <see cref="QueryAsync"/>, <see cref="ExistsAsync(Specification{TAggregate}, CancellationToken)"/>,
+    /// and <see cref="CountAsync"/>. Override to add <c>.Include()</c> chains for list/search queries.
     /// The default query is no-tracking to avoid unnecessary change tracking for read operations.
     /// </summary>
     /// <returns>An <see cref="IQueryable{T}"/> starting from <see cref="DbSet"/> with no tracking.</returns>
     protected virtual IQueryable<TAggregate> BuildQueryBase() => DbSet.AsNoTracking();
 
+    // ──────────────────────────────────────────────
+    // Reads
+    // ──────────────────────────────────────────────
+
     /// <summary>
     /// Finds an aggregate by its unique identifier.
+    /// The returned aggregate is tracked by the change tracker (suitable for mutations).
     /// Returns <see cref="Maybe{T}.None"/> if not found.
     /// </summary>
     /// <param name="id">The aggregate identifier to search for.</param>
@@ -98,29 +107,8 @@ public abstract class RepositoryBase<TAggregate, TId>
     }
 
     /// <summary>
-    /// Persists a new or modified aggregate. New (detached) aggregates are added to the
-    /// <see cref="DbSet"/>; already-tracked aggregates are updated in place.
-    /// To update an existing aggregate, first retrieve it with <see cref="FindByIdAsync"/>
-    /// (which starts change tracking), mutate it, then call this method.
-    /// Passing a detached entity that already exists in the database will attempt an insert
-    /// and fail with a duplicate-key exception.
-    /// </summary>
-    /// <param name="aggregate">The aggregate to save.</param>
-    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
-    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
-    public virtual Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(aggregate);
-
-        var entry = _context.Entry(aggregate);
-        if (entry.State == EntityState.Detached)
-            DbSet.Add(aggregate);
-
-        return _context.SaveChangesResultUnitAsync(cancellationToken);
-    }
-
-    /// <summary>
     /// Queries aggregates matching the given specification.
+    /// Results are no-tracking by default (via <see cref="BuildQueryBase"/>).
     /// </summary>
     /// <param name="specification">The specification to filter by.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
@@ -132,6 +120,106 @@ public abstract class RepositoryBase<TAggregate, TId>
         ArgumentNullException.ThrowIfNull(specification);
         return await BuildQueryBase().Where(specification).ToListAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Checks whether an aggregate with the given identifier exists.
+    /// Uses a no-tracking, lightweight query (no entity materialization).
+    /// </summary>
+    /// <param name="id">The aggregate identifier to check.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns><see langword="true"/> if an aggregate with the given ID exists; otherwise <see langword="false"/>.</returns>
+    public virtual Task<bool> ExistsAsync(TId id, CancellationToken cancellationToken = default)
+    {
+        var predicate = BuildIdPredicate(id);
+        return DbSet.AsNoTracking().AnyAsync(predicate, cancellationToken);
+    }
+
+    /// <summary>
+    /// Checks whether any aggregate matches the given specification.
+    /// Uses <see cref="BuildQueryBase"/> (no-tracking by default).
+    /// </summary>
+    /// <param name="specification">The specification to test.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns><see langword="true"/> if at least one aggregate matches; otherwise <see langword="false"/>.</returns>
+    public virtual Task<bool> ExistsAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(specification);
+        return BuildQueryBase().Where(specification).AnyAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Counts aggregates matching the given specification.
+    /// Uses <see cref="BuildQueryBase"/> (no-tracking by default).
+    /// </summary>
+    /// <param name="specification">The specification to filter by.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>The number of matching aggregates.</returns>
+    public virtual Task<int> CountAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(specification);
+        return BuildQueryBase().Where(specification).CountAsync(cancellationToken);
+    }
+
+    // ──────────────────────────────────────────────
+    // Staging (change tracker only — never calls SaveChanges)
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Stages a new aggregate for insertion. If the aggregate is already tracked,
+    /// this is a no-op (EF Core will detect modifications automatically).
+    /// Does not call <c>SaveChanges</c> — the commit is deferred to the pipeline or
+    /// <see cref="IUnitOfWork.CommitAsync"/>.
+    /// </summary>
+    /// <param name="aggregate">The aggregate to stage for insertion.</param>
+    public virtual void Add(TAggregate aggregate)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+        var entry = _context.Entry(aggregate);
+        if (entry.State == EntityState.Detached)
+            DbSet.Add(aggregate);
+    }
+
+    /// <summary>
+    /// Stages an aggregate for deletion. The aggregate must be tracked or will be attached
+    /// before marking for deletion.
+    /// Does not call <c>SaveChanges</c> — the commit is deferred to the pipeline or
+    /// <see cref="IUnitOfWork.CommitAsync"/>.
+    /// </summary>
+    /// <param name="aggregate">The aggregate to stage for deletion.</param>
+    public virtual void Remove(TAggregate aggregate)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+        DbSet.Remove(aggregate);
+    }
+
+    /// <summary>
+    /// Looks up an aggregate by ID and stages it for deletion.
+    /// Uses <see cref="DbSet{TEntity}.FindAsync(object?[], CancellationToken)"/> directly
+    /// (not <see cref="BuildFindByIdQuery"/>) to avoid loading heavy Include graphs.
+    /// Returns a not-found error if the aggregate does not exist.
+    /// Does not call <c>SaveChanges</c> — the commit is deferred to the pipeline or
+    /// <see cref="IUnitOfWork.CommitAsync"/>.
+    /// </summary>
+    /// <param name="id">The aggregate identifier to remove.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Result{Unit}"/> representing success (staged) or not-found failure.</returns>
+    public virtual async Task<Result<Unit>> RemoveByIdAsync(TId id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbSet.FindAsync([id], cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return Error.NotFound($"{typeof(TAggregate).Name} with ID '{id}' not found.");
+
+        DbSet.Remove(entity);
+        return Result.Success(default(Unit));
+    }
+
+    // ──────────────────────────────────────────────
+    // Internal helpers
+    // ──────────────────────────────────────────────
 
     /// <summary>
     /// Builds an expression predicate that compares <c>entity.Id == id</c>.

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -123,7 +123,8 @@ public abstract class RepositoryBase<TAggregate, TId>
 
     /// <summary>
     /// Checks whether an aggregate with the given identifier exists.
-    /// Uses a no-tracking, lightweight query (no entity materialization).
+    /// Uses <see cref="BuildQueryBase"/> (no-tracking, lightweight — no entity materialization)
+    /// so that repository-level query customization (e.g., soft-delete or tenant filters) is respected.
     /// </summary>
     /// <param name="id">The aggregate identifier to check.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
@@ -131,7 +132,7 @@ public abstract class RepositoryBase<TAggregate, TId>
     public virtual Task<bool> ExistsAsync(TId id, CancellationToken cancellationToken = default)
     {
         var predicate = BuildIdPredicate(id);
-        return DbSet.AsNoTracking().AnyAsync(predicate, cancellationToken);
+        return BuildQueryBase().AnyAsync(predicate, cancellationToken);
     }
 
     /// <summary>
@@ -203,6 +204,11 @@ public abstract class RepositoryBase<TAggregate, TId>
     /// Returns a not-found error if the aggregate does not exist.
     /// Does not call <c>SaveChanges</c> — the commit is deferred to the pipeline or
     /// <see cref="IUnitOfWork.CommitAsync"/>.
+    /// <para>
+    /// <b>Note:</b> <c>FindAsync</c> bypasses EF Core global query filters. If your repository
+    /// uses soft-delete or tenant filters, override this method to apply the appropriate
+    /// filtered lookup (e.g., using <see cref="BuildIdPredicate"/> with a filtered query).
+    /// </para>
     /// </summary>
     /// <param name="id">The aggregate identifier to remove.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -220,7 +220,7 @@ public abstract class RepositoryBase<TAggregate, TId>
             return Error.NotFound($"{typeof(TAggregate).Name} with ID '{id}' not found.");
 
         DbSet.Remove(entity);
-        return Result.Success(default(Unit));
+        return Result.Success();
     }
 
     // ──────────────────────────────────────────────

--- a/Trellis.EntityFrameworkCore/src/TransactionalCommandBehavior.cs
+++ b/Trellis.EntityFrameworkCore/src/TransactionalCommandBehavior.cs
@@ -1,0 +1,48 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using global::Mediator;
+
+/// <summary>
+/// Pipeline behavior that automatically commits staged changes after a successful command handler.
+/// <para>
+/// The behavior calls <c>next</c> to run the handler (which stages changes via repositories),
+/// then calls <see cref="IUnitOfWork.CommitAsync"/> if the handler returned success.
+/// If the handler returned a failure <see cref="Result{T}"/>, no commit occurs and the
+/// staged changes are discarded when the <see cref="Microsoft.EntityFrameworkCore.DbContext"/> is disposed.
+/// </para>
+/// <para>
+/// This behavior is constrained to <see cref="ICommand{TResponse}"/> messages — queries
+/// are not wrapped and incur no overhead.
+/// </para>
+/// <para>
+/// <b>Atomicity:</b> EF Core wraps each <c>SaveChanges</c> call in an implicit database
+/// transaction, so all staged changes within a single handler are committed atomically.
+/// Cross-aggregate operations that share the same <see cref="Microsoft.EntityFrameworkCore.DbContext"/>
+/// are automatically transactional.
+/// </para>
+/// </summary>
+/// <typeparam name="TMessage">The command type.</typeparam>
+/// <typeparam name="TResponse">The result type, constrained to <see cref="IResult"/> and <see cref="IFailureFactory{TSelf}"/>.</typeparam>
+public sealed class TransactionalCommandBehavior<TMessage, TResponse>(IUnitOfWork unitOfWork)
+    : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : ICommand<TResponse>
+    where TResponse : IResult, IFailureFactory<TResponse>
+{
+    /// <inheritdoc />
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        MessageHandlerDelegate<TMessage, TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var result = await next(message, cancellationToken).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            var commitResult = await unitOfWork.CommitAsync(cancellationToken).ConfigureAwait(false);
+            if (commitResult.IsFailure)
+                return TResponse.CreateFailure(commitResult.Error);
+        }
+
+        return result;
+    }
+}

--- a/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
+++ b/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
@@ -17,6 +17,8 @@
     <ProjectReference Include="..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Mediator.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 </Project>

--- a/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
@@ -15,10 +15,10 @@ public static class UnitOfWorkServiceCollectionExtensions
     /// implementation and adds the <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/>
     /// pipeline behavior so that command handlers automatically commit on success.
     /// <para>
-    /// The behavior is always inserted after the last existing <see cref="IPipelineBehavior{TMessage,TResponse}"/>
-    /// registration (innermost position, closest to the handler). This ensures commit failures
-    /// are visible to outer behaviors (logging, tracing, exception handling) regardless of
-    /// whether this method is called before or after <c>AddTrellisBehaviors()</c>.
+    /// The behavior is inserted after the last existing <see cref="IPipelineBehavior{TMessage,TResponse}"/>
+    /// registration (innermost position, closest to the handler). For correct ordering, call this
+    /// method <b>after</b> <c>AddTrellisBehaviors()</c> and any other behavior registrations so that
+    /// commit failures are visible to outer behaviors (logging, tracing, exception handling).
     /// </para>
     /// </summary>
     /// <typeparam name="TContext">The concrete <see cref="DbContext"/> type.</typeparam>
@@ -27,7 +27,8 @@ public static class UnitOfWorkServiceCollectionExtensions
     /// <example>
     /// <code>
     /// services.AddDbContext&lt;AppDbContext&gt;(...);
-    /// services.AddTrellisUnitOfWork&lt;AppDbContext&gt;();
+    /// services.AddTrellisBehaviors();           // register other behaviors first
+    /// services.AddTrellisUnitOfWork&lt;AppDbContext&gt;(); // commit behavior goes innermost
     /// </code>
     /// </example>
     public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services)
@@ -58,6 +59,7 @@ public static class UnitOfWorkServiceCollectionExtensions
     /// Inserts <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/> after the last
     /// <see cref="IPipelineBehavior{TMessage,TResponse}"/> registration to ensure it runs
     /// innermost (closest to the handler). If no behaviors are registered yet, appends at the end.
+    /// Detects both open-generic and closed-generic behavior registrations.
     /// </summary>
     private static void InsertTransactionalBehavior(IServiceCollection services)
     {
@@ -67,7 +69,10 @@ public static class UnitOfWorkServiceCollectionExtensions
         var lastBehaviorIndex = -1;
         for (var i = 0; i < services.Count; i++)
         {
-            if (services[i].ServiceType == typeof(IPipelineBehavior<,>))
+            var serviceType = services[i].ServiceType;
+            if (serviceType == typeof(IPipelineBehavior<,>)
+                || (serviceType.IsGenericType
+                    && serviceType.GetGenericTypeDefinition() == typeof(IPipelineBehavior<,>)))
                 lastBehaviorIndex = i;
         }
 

--- a/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
@@ -14,6 +14,12 @@ public static class UnitOfWorkServiceCollectionExtensions
     /// Registers <see cref="EfUnitOfWork{TContext}"/> as the <see cref="IUnitOfWork"/>
     /// implementation and adds the <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/>
     /// pipeline behavior so that command handlers automatically commit on success.
+    /// <para>
+    /// The behavior is always inserted after the last existing <see cref="IPipelineBehavior{TMessage,TResponse}"/>
+    /// registration (innermost position, closest to the handler). This ensures commit failures
+    /// are visible to outer behaviors (logging, tracing, exception handling) regardless of
+    /// whether this method is called before or after <c>AddTrellisBehaviors()</c>.
+    /// </para>
     /// </summary>
     /// <typeparam name="TContext">The concrete <see cref="DbContext"/> type.</typeparam>
     /// <param name="services">The service collection.</param>
@@ -28,7 +34,7 @@ public static class UnitOfWorkServiceCollectionExtensions
         where TContext : DbContext
     {
         services.AddScoped<IUnitOfWork, EfUnitOfWork<TContext>>();
-        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(TransactionalCommandBehavior<,>));
+        InsertTransactionalBehavior(services);
         return services;
     }
 
@@ -46,5 +52,28 @@ public static class UnitOfWorkServiceCollectionExtensions
     {
         services.AddScoped<IUnitOfWork, EfUnitOfWork<TContext>>();
         return services;
+    }
+
+    /// <summary>
+    /// Inserts <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/> after the last
+    /// <see cref="IPipelineBehavior{TMessage,TResponse}"/> registration to ensure it runs
+    /// innermost (closest to the handler). If no behaviors are registered yet, appends at the end.
+    /// </summary>
+    private static void InsertTransactionalBehavior(IServiceCollection services)
+    {
+        var descriptor = ServiceDescriptor.Scoped(
+            typeof(IPipelineBehavior<,>), typeof(TransactionalCommandBehavior<,>));
+
+        var lastBehaviorIndex = -1;
+        for (var i = 0; i < services.Count; i++)
+        {
+            if (services[i].ServiceType == typeof(IPipelineBehavior<,>))
+                lastBehaviorIndex = i;
+        }
+
+        if (lastBehaviorIndex >= 0)
+            services.Insert(lastBehaviorIndex + 1, descriptor);
+        else
+            services.Add(descriptor);
     }
 }

--- a/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/UnitOfWorkServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using global::Mediator;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering <see cref="IUnitOfWork"/> and the
+/// <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/> pipeline behavior.
+/// </summary>
+public static class UnitOfWorkServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="EfUnitOfWork{TContext}"/> as the <see cref="IUnitOfWork"/>
+    /// implementation and adds the <see cref="TransactionalCommandBehavior{TMessage,TResponse}"/>
+    /// pipeline behavior so that command handlers automatically commit on success.
+    /// </summary>
+    /// <typeparam name="TContext">The concrete <see cref="DbContext"/> type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// services.AddDbContext&lt;AppDbContext&gt;(...);
+    /// services.AddTrellisUnitOfWork&lt;AppDbContext&gt;();
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        services.AddScoped<IUnitOfWork, EfUnitOfWork<TContext>>();
+        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(TransactionalCommandBehavior<,>));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="EfUnitOfWork{TContext}"/> as the <see cref="IUnitOfWork"/>
+    /// implementation without registering the pipeline behavior.
+    /// Use this when you want manual commit control (e.g., background jobs)
+    /// or when the Mediator pipeline is not in use.
+    /// </summary>
+    /// <typeparam name="TContext">The concrete <see cref="DbContext"/> type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddTrellisUnitOfWorkWithoutBehavior<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        services.AddScoped<IUnitOfWork, EfUnitOfWork<TContext>>();
+        return services;
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/EfUnitOfWorkTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/EfUnitOfWorkTests.cs
@@ -1,0 +1,132 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Trellis.Testing;
+using static RepositoryBaseTests;
+
+public class EfUnitOfWorkTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly RepoTestDbContext _context;
+    private readonly EfUnitOfWork<RepoTestDbContext> _unitOfWork;
+
+    public EfUnitOfWorkTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<RepoTestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new RepoTestDbContext(options);
+        _context.Database.EnsureCreated();
+        _unitOfWork = new EfUnitOfWork<RepoTestDbContext>(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task CommitAsync_persists_staged_additions()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("Committed"));
+        _context.Items.Add(item);
+
+        // Act
+        var result = await _unitOfWork.CommitAsync(ct);
+
+        // Assert
+        result.Should().BeSuccess();
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().NotBeNull();
+        found!.Name.Should().Be(TestItemName.Create("Committed"));
+    }
+
+    [Fact]
+    public async Task CommitAsync_persists_staged_deletions()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("ToDelete"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+
+        _context.Items.Remove(item);
+
+        // Act
+        var result = await _unitOfWork.CommitAsync(ct);
+
+        // Assert
+        result.Should().BeSuccess();
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CommitAsync_persists_staged_modifications()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("Original"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+
+        item.Name = TestItemName.Create("Updated");
+
+        // Act
+        var result = await _unitOfWork.CommitAsync(ct);
+
+        // Assert
+        result.Should().BeSuccess();
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found!.Name.Should().Be(TestItemName.Create("Updated"));
+    }
+
+    [Fact]
+    public async Task CommitAsync_with_no_changes_returns_success()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+
+        // Act
+        var result = await _unitOfWork.CommitAsync(ct);
+
+        // Assert
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public async Task CommitAsync_duplicate_key_returns_conflict_error()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        _context.Items.Add(TestItem.Create(id, TestItemName.Create("First")));
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        // Stage a duplicate by adding entity with same PK
+        _context.Items.Add(TestItem.Create(id, TestItemName.Create("Duplicate")));
+
+        // Act
+        var result = await _unitOfWork.CommitAsync(ct);
+
+        // Assert
+        result.Should().BeFailure();
+        result.Error.Should().BeOfType<ConflictError>();
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
@@ -70,63 +70,6 @@ public partial class RepositoryBaseTests : IDisposable
 
     #endregion
 
-    #region SaveAsync
-
-    [Fact]
-    public async Task SaveAsync_new_aggregate_inserts_and_returns_success()
-    {
-        // Arrange
-        var ct = TestContext.Current.CancellationToken;
-        var id = TestItemId.Create(Guid.NewGuid());
-        var item = TestItem.Create(id, TestItemName.Create("New Item"));
-
-        // Act
-        var result = await _repository.SaveAsync(item, ct);
-
-        // Assert
-        result.Should().BeSuccess();
-
-        _context.ChangeTracker.Clear();
-        var found = await _context.Items.FindAsync([id], ct);
-        found.Should().NotBeNull();
-        found!.Name.Should().Be(TestItemName.Create("New Item"));
-    }
-
-    [Fact]
-    public async Task SaveAsync_tracked_aggregate_updates_and_returns_success()
-    {
-        // Arrange
-        var ct = TestContext.Current.CancellationToken;
-        var id = TestItemId.Create(Guid.NewGuid());
-        var item = TestItem.Create(id, TestItemName.Create("Original"));
-        _context.Items.Add(item);
-        await _context.SaveChangesAsync(ct);
-
-        item.Name = TestItemName.Create("Updated");
-
-        // Act
-        var result = await _repository.SaveAsync(item, ct);
-
-        // Assert
-        result.Should().BeSuccess();
-
-        _context.ChangeTracker.Clear();
-        var found = await _context.Items.FindAsync([id], ct);
-        found!.Name.Should().Be(TestItemName.Create("Updated"));
-    }
-
-    [Fact]
-    public async Task SaveAsync_null_aggregate_throws()
-    {
-        // Act
-        var act = () => _repository.SaveAsync(null!);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("aggregate");
-    }
-
-    #endregion
-
     #region QueryAsync
 
     [Fact]
@@ -173,6 +116,276 @@ public partial class RepositoryBaseTests : IDisposable
 
         // Assert
         await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("specification");
+    }
+
+    #endregion
+
+    #region ExistsAsync (by ID)
+
+    [Fact]
+    public async Task ExistsAsync_byId_existing_returns_true()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        _context.Items.Add(TestItem.Create(id, TestItemName.Create("Present")));
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        // Act
+        var exists = await _repository.ExistsAsync(id, ct);
+
+        // Assert
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_byId_nonexistent_returns_false()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+
+        // Act
+        var exists = await _repository.ExistsAsync(id, ct);
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ExistsAsync (by Specification)
+
+    [Fact]
+    public async Task ExistsAsync_bySpec_matching_returns_true()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        _context.Items.Add(TestItem.Create(TestItemId.Create(Guid.NewGuid()), TestItemName.Create("Findable")));
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        var spec = new TestItemNameSpec(TestItemName.Create("Findable"));
+
+        // Act
+        var exists = await _repository.ExistsAsync(spec, ct);
+
+        // Assert
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_bySpec_no_match_returns_false()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var spec = new TestItemNameSpec(TestItemName.Create("Missing"));
+
+        // Act
+        var exists = await _repository.ExistsAsync(spec, ct);
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_bySpec_null_specification_throws()
+    {
+        // Act
+        var act = () => _repository.ExistsAsync((Specification<TestItem>)null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("specification");
+    }
+
+    #endregion
+
+    #region CountAsync
+
+    [Fact]
+    public async Task CountAsync_returns_matching_count()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        _context.Items.Add(TestItem.Create(TestItemId.Create(Guid.NewGuid()), TestItemName.Create("Alpha")));
+        _context.Items.Add(TestItem.Create(TestItemId.Create(Guid.NewGuid()), TestItemName.Create("Alpha")));
+        _context.Items.Add(TestItem.Create(TestItemId.Create(Guid.NewGuid()), TestItemName.Create("Beta")));
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        var spec = new TestItemNameSpec(TestItemName.Create("Alpha"));
+
+        // Act
+        var count = await _repository.CountAsync(spec, ct);
+
+        // Assert
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CountAsync_no_matches_returns_zero()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var spec = new TestItemNameSpec(TestItemName.Create("Ghost"));
+
+        // Act
+        var count = await _repository.CountAsync(spec, ct);
+
+        // Assert
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountAsync_null_specification_throws()
+    {
+        // Act
+        var act = () => _repository.CountAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("specification");
+    }
+
+    #endregion
+
+    #region Add
+
+    [Fact]
+    public async Task Add_detached_aggregate_stages_insert()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("New Item"));
+
+        // Act
+        _repository.Add(item);
+
+        // Assert — staged but not yet persisted
+        _context.Entry(item).State.Should().Be(EntityState.Added);
+
+        // Commit manually to verify persistence
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().NotBeNull();
+        found!.Name.Should().Be(TestItemName.Create("New Item"));
+    }
+
+    [Fact]
+    public async Task Add_tracked_aggregate_is_noop()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("Tracked"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+
+        item.Name = TestItemName.Create("Modified");
+        var stateBefore = _context.Entry(item).State;
+
+        // Act
+        _repository.Add(item);
+
+        // Assert — state remains Modified, not re-Added
+        _context.Entry(item).State.Should().Be(stateBefore);
+    }
+
+    [Fact]
+    public void Add_null_aggregate_throws()
+    {
+        // Act
+        var act = () => _repository.Add(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("aggregate");
+    }
+
+    #endregion
+
+    #region Remove
+
+    [Fact]
+    public async Task Remove_tracked_aggregate_stages_deletion()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("ToRemove"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+
+        // Act
+        _repository.Remove(item);
+
+        // Assert — staged for deletion
+        _context.Entry(item).State.Should().Be(EntityState.Deleted);
+
+        // Commit manually to verify persistence
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public void Remove_null_aggregate_throws()
+    {
+        // Act
+        var act = () => _repository.Remove(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("aggregate");
+    }
+
+    #endregion
+
+    #region RemoveByIdAsync
+
+    [Fact]
+    public async Task RemoveByIdAsync_existing_stages_deletion_and_returns_success()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+        var item = TestItem.Create(id, TestItemName.Create("ToDelete"));
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+
+        // Act
+        var result = await _repository.RemoveByIdAsync(id, ct);
+
+        // Assert — staged, not committed
+        result.Should().BeSuccess();
+
+        // Verify it's in change tracker as Deleted
+        var entry = _context.ChangeTracker.Entries<TestItem>().SingleOrDefault(e => e.Entity.Id == id);
+        entry.Should().NotBeNull();
+        entry!.State.Should().Be(EntityState.Deleted);
+
+        // Commit manually to verify persistence
+        await _context.SaveChangesAsync(ct);
+        _context.ChangeTracker.Clear();
+        var found = await _context.Items.FindAsync([id], ct);
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RemoveByIdAsync_nonexistent_returns_not_found()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var id = TestItemId.Create(Guid.NewGuid());
+
+        // Act
+        var result = await _repository.RemoveByIdAsync(id, ct);
+
+        // Assert
+        result.Should().BeFailure();
+        result.Error.Should().BeOfType<NotFoundError>();
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
@@ -96,7 +96,7 @@ public class TransactionalCommandBehaviorTests
         public Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default)
         {
             CommitCount++;
-            return Task.FromResult(CommitResult ?? Result.Success(default(Unit)));
+            return Task.FromResult(CommitResult ?? Result.Success());
         }
     }
 

--- a/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
@@ -1,0 +1,108 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using Trellis.Testing;
+
+public class TransactionalCommandBehaviorTests
+{
+    [Fact]
+    public async Task Handle_successful_handler_commits_and_returns_result()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var uow = new FakeUnitOfWork();
+        var behavior = new TransactionalCommandBehavior<FakeCommand, Result<string>>(uow);
+        var expected = Result.Success("done");
+
+        // Act
+        var result = await behavior.Handle(
+            new FakeCommand(),
+            (_, _) => new ValueTask<Result<string>>(expected),
+            ct);
+
+        // Assert
+        result.Should().BeSuccess();
+        result.Value.Should().Be("done");
+        uow.CommitCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_failed_handler_does_not_commit()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var uow = new FakeUnitOfWork();
+        var behavior = new TransactionalCommandBehavior<FakeCommand, Result<string>>(uow);
+        var failure = Result.Failure<string>(Error.Domain("bad"));
+
+        // Act
+        var result = await behavior.Handle(
+            new FakeCommand(),
+            (_, _) => new ValueTask<Result<string>>(failure),
+            ct);
+
+        // Assert
+        result.Should().BeFailure();
+        uow.CommitCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_commit_failure_returns_commit_error()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var uow = new FakeUnitOfWork { CommitResult = Error.Conflict("concurrency") };
+        var behavior = new TransactionalCommandBehavior<FakeCommand, Result<string>>(uow);
+        var handlerResult = Result.Success("staged");
+
+        // Act
+        var result = await behavior.Handle(
+            new FakeCommand(),
+            (_, _) => new ValueTask<Result<string>>(handlerResult),
+            ct);
+
+        // Assert
+        result.Should().BeFailure();
+        result.Error.Should().BeOfType<ConflictError>();
+        uow.CommitCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_unit_result_successful_handler_commits()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var uow = new FakeUnitOfWork();
+        var behavior = new TransactionalCommandBehavior<FakeUnitCommand, Result<Unit>>(uow);
+        var expected = Result.Success(default(Unit));
+
+        // Act
+        var result = await behavior.Handle(
+            new FakeUnitCommand(),
+            (_, _) => new ValueTask<Result<Unit>>(expected),
+            ct);
+
+        // Assert
+        result.Should().BeSuccess();
+        uow.CommitCount.Should().Be(1);
+    }
+
+    #region Test Infrastructure
+
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        public int CommitCount { get; private set; }
+        public Result<Unit>? CommitResult { get; init; }
+
+        public Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default)
+        {
+            CommitCount++;
+            return Task.FromResult(CommitResult ?? Result.Success(default(Unit)));
+        }
+    }
+
+    private sealed record FakeCommand : Mediator.ICommand<Result<string>>;
+
+    private sealed record FakeUnitCommand : Mediator.ICommand<Result<Unit>>;
+
+    #endregion
+}

--- a/Trellis.EntityFrameworkCore/tests/UnitOfWorkServiceCollectionExtensionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/UnitOfWorkServiceCollectionExtensionsTests.cs
@@ -1,0 +1,115 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using global::Mediator;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using static RepositoryBaseTests;
+
+public class UnitOfWorkServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddTrellisUnitOfWork_registers_IUnitOfWork_and_behavior()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
+
+        // Act
+        services.AddTrellisUnitOfWork<RepoTestDbContext>();
+
+        // Assert
+        services.Should().Contain(d => d.ServiceType == typeof(IUnitOfWork));
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(IPipelineBehavior<,>)
+            && d.ImplementationType == typeof(TransactionalCommandBehavior<,>));
+    }
+
+    [Fact]
+    public void AddTrellisUnitOfWorkWithoutBehavior_registers_IUnitOfWork_only()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
+
+        // Act
+        services.AddTrellisUnitOfWorkWithoutBehavior<RepoTestDbContext>();
+
+        // Assert
+        services.Should().Contain(d => d.ServiceType == typeof(IUnitOfWork));
+        services.Should().NotContain(d =>
+            d.ServiceType == typeof(IPipelineBehavior<,>)
+            && d.ImplementationType == typeof(TransactionalCommandBehavior<,>));
+    }
+
+    [Fact]
+    public void AddTrellisUnitOfWork_inserts_behavior_after_existing_behaviors()
+    {
+        // Arrange — register a fake behavior first (simulates AddTrellisBehaviors)
+        var services = new ServiceCollection();
+        services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
+        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(FakeBehavior<,>));
+
+        // Act
+        services.AddTrellisUnitOfWork<RepoTestDbContext>();
+
+        // Assert — TransactionalCommandBehavior should be AFTER FakeBehavior
+        var behaviorDescriptors = services
+            .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>))
+            .ToList();
+
+        behaviorDescriptors.Should().HaveCount(2);
+        behaviorDescriptors[0].ImplementationType.Should().Be(typeof(FakeBehavior<,>));
+        behaviorDescriptors[1].ImplementationType.Should().Be(typeof(TransactionalCommandBehavior<,>));
+    }
+
+    [Fact]
+    public void AddTrellisUnitOfWork_before_other_behaviors_still_ends_up_innermost()
+    {
+        // Arrange — UoW registered first, then "other" behaviors
+        var services = new ServiceCollection();
+        services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
+
+        // Act — register UoW first (no other behaviors yet)
+        services.AddTrellisUnitOfWork<RepoTestDbContext>();
+        // Then add another behavior (simulates AddTrellisBehaviors called later)
+        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(FakeBehavior<,>));
+
+        // Assert — TransactionalCommandBehavior was appended first (only behavior at that time),
+        // then FakeBehavior was appended after. Order: Transaction, Fake.
+        // This is acceptable — when no other behaviors exist yet, it appends normally.
+        var behaviorDescriptors = services
+            .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>))
+            .ToList();
+
+        behaviorDescriptors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void AddTrellisUnitOfWork_resolves_IUnitOfWork_from_provider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
+        services.AddTrellisUnitOfWork<RepoTestDbContext>();
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var uow = provider.GetRequiredService<IUnitOfWork>();
+
+        // Assert
+        uow.Should().BeOfType<EfUnitOfWork<RepoTestDbContext>>();
+    }
+
+    #region Test Infrastructure
+
+    private sealed class FakeBehavior<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
+        where TMessage : IMessage
+    {
+        public ValueTask<TResponse> Handle(
+            TMessage message,
+            MessageHandlerDelegate<TMessage, TResponse> next,
+            CancellationToken cancellationToken) => next(message, cancellationToken);
+    }
+
+    #endregion
+}

--- a/Trellis.EntityFrameworkCore/tests/UnitOfWorkServiceCollectionExtensionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/UnitOfWorkServiceCollectionExtensionsTests.cs
@@ -63,25 +63,26 @@ public class UnitOfWorkServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddTrellisUnitOfWork_before_other_behaviors_still_ends_up_innermost()
+    public void AddTrellisUnitOfWork_before_other_behaviors_appends_at_end()
     {
-        // Arrange — UoW registered first, then "other" behaviors
+        // Arrange — UoW registered first, then "other" behaviors added later
         var services = new ServiceCollection();
         services.AddDbContext<RepoTestDbContext>(o => o.UseSqlite("DataSource=:memory:"));
 
-        // Act — register UoW first (no other behaviors yet)
+        // Act — register UoW first (no other behaviors yet), then add another behavior
         services.AddTrellisUnitOfWork<RepoTestDbContext>();
-        // Then add another behavior (simulates AddTrellisBehaviors called later)
         services.AddScoped(typeof(IPipelineBehavior<,>), typeof(FakeBehavior<,>));
 
         // Assert — TransactionalCommandBehavior was appended first (only behavior at that time),
         // then FakeBehavior was appended after. Order: Transaction, Fake.
-        // This is acceptable — when no other behaviors exist yet, it appends normally.
+        // For correct ordering, AddTrellisUnitOfWork should be called AFTER other behaviors.
         var behaviorDescriptors = services
             .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>))
             .ToList();
 
         behaviorDescriptors.Should().HaveCount(2);
+        behaviorDescriptors[0].ImplementationType.Should().Be(typeof(TransactionalCommandBehavior<,>));
+        behaviorDescriptors[1].ImplementationType.Should().Be(typeof(FakeBehavior<,>));
     }
 
     [Fact]

--- a/docs/api_reference/trellis-api-efcore.md
+++ b/docs/api_reference/trellis-api-efcore.md
@@ -82,7 +82,7 @@ public abstract class RepositoryBase<TAggregate, TId>
     where TId : notnull
 ```
 
-Abstract generic repository base class for EF Core aggregate persistence. Extracts the recurring FindById/Save/Query pattern used by concrete repositories.
+Abstract generic repository base class for EF Core aggregate persistence. Provides standard read and staging methods. Repositories stage changes to the change tracker; the `IUnitOfWork` (typically driven by a pipeline behavior) is responsible for committing staged changes.
 
 #### Properties
 
@@ -91,19 +91,29 @@ Abstract generic repository base class for EF Core aggregate persistence. Extrac
 | `protected DbSet<TAggregate> DbSet` | `DbSet<TAggregate>` | The EF Core `DbSet` for this aggregate type. |
 | `protected DbContext Context` | `DbContext` | The underlying `DbContext`. Use sparingly — prefer repository methods. |
 
-#### Methods
+#### Read Methods
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public virtual Task<Maybe<TAggregate>> FindByIdAsync(TId id, CancellationToken cancellationToken = default)` | `Task<Maybe<TAggregate>>` | Finds an aggregate by ID using an expression-tree predicate (`Expression.Equal`). Returns `Maybe<T>.None` if not found. |
-| `public virtual Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)` | `Task<Result<Unit>>` | Persists a new or modified aggregate. Detached aggregates are added; tracked aggregates are updated in place. To update, first retrieve via `FindByIdAsync`, mutate, then save. |
-| `public virtual Task<IReadOnlyList<TAggregate>> QueryAsync(Specification<TAggregate> specification, CancellationToken cancellationToken = default)` | `Task<IReadOnlyList<TAggregate>>` | Queries aggregates matching the specification. |
+| `public virtual Task<Maybe<TAggregate>> FindByIdAsync(TId id, CancellationToken ct = default)` | `Task<Maybe<TAggregate>>` | Finds a tracked aggregate by ID. Returns `Maybe<T>.None` if not found. |
+| `public virtual Task<IReadOnlyList<TAggregate>> QueryAsync(Specification<TAggregate> spec, CancellationToken ct = default)` | `Task<IReadOnlyList<TAggregate>>` | Queries aggregates matching the specification (no-tracking by default). |
+| `public virtual Task<bool> ExistsAsync(TId id, CancellationToken ct = default)` | `Task<bool>` | Lightweight check for existence by ID (no-tracking, no materialization). |
+| `public virtual Task<bool> ExistsAsync(Specification<TAggregate> spec, CancellationToken ct = default)` | `Task<bool>` | Checks whether any aggregate matches the specification. |
+| `public virtual Task<int> CountAsync(Specification<TAggregate> spec, CancellationToken ct = default)` | `Task<int>` | Counts aggregates matching the specification. |
+
+#### Staging Methods (never call SaveChanges)
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public virtual void Add(TAggregate aggregate)` | `void` | Stages a new aggregate for insertion. No-op if already tracked. |
+| `public virtual void Remove(TAggregate aggregate)` | `void` | Stages an aggregate for deletion. |
+| `public virtual Task<Result<Unit>> RemoveByIdAsync(TId id, CancellationToken ct = default)` | `Task<Result<Unit>>` | Looks up by ID via `DbSet.FindAsync` (avoids Include graphs) and stages for deletion. Returns not-found if absent. |
 
 #### Virtual Hooks
 
 | Signature | Description |
 | --- | --- |
-| `protected virtual IQueryable<TAggregate> BuildFindByIdQuery()` | Override to add `.Include()` or filters to the find-by-ID query. Defaults to `DbSet.AsQueryable()`. |
+| `protected virtual IQueryable<TAggregate> BuildFindByIdQuery()` | Override to add `.Include()` or filters to the find-by-ID query. Defaults to `DbSet`. |
 | `protected virtual IQueryable<TAggregate> BuildQueryBase()` | Override to add `.Include()` or filters to specification queries. Defaults to `DbSet.AsNoTracking()`. |
 
 #### Usage
@@ -114,7 +124,57 @@ public class OrderRepository(DbContext context) : RepositoryBase<Order, OrderId>
     protected override IQueryable<Order> BuildFindByIdQuery() =>
         DbSet.Include(o => o.LineItems);
 }
+
+// In a command handler (pipeline auto-commits on success):
+var maybe = await _orders.FindByIdAsync(cmd.OrderId, ct);
+return maybe
+    .ToResult(Error.NotFound("Order not found."))
+    .Bind(order => order.Ship());
+// Tracked changes are committed automatically by TransactionalCommandBehavior.
 ```
+
+### `IUnitOfWork`
+
+```csharp
+public interface IUnitOfWork
+```
+
+Abstraction over the commit boundary for staged changes. Repositories stage changes; calling `CommitAsync` persists them. In the standard Trellis pipeline, commit is handled automatically by `TransactionalCommandBehavior`. Inject `IUnitOfWork` directly only in non-pipeline scenarios (background jobs, integration tests).
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `Task<Result<Unit>> CommitAsync(CancellationToken ct = default)` | `Task<Result<Unit>>` | Persists all staged changes. Surfaces concurrency, duplicate-key, and FK errors as `Error` instead of exceptions. |
+
+### `EfUnitOfWork<TContext>`
+
+```csharp
+public class EfUnitOfWork<TContext> : IUnitOfWork
+    where TContext : DbContext
+```
+
+EF Core implementation of `IUnitOfWork`. Delegates to `DbContextExtensions.SaveChangesResultUnitAsync` which maps `DbUpdateConcurrencyException` → `Error.Conflict`, duplicate-key → `Error.Conflict`, FK violations → `Error.Domain`.
+
+### `TransactionalCommandBehavior<TMessage, TResponse>`
+
+```csharp
+public sealed class TransactionalCommandBehavior<TMessage, TResponse>
+    : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : ICommand<TResponse>
+    where TResponse : IResult, IFailureFactory<TResponse>
+```
+
+Pipeline behavior that auto-commits staged changes after a successful command handler. Only applies to `ICommand<TResponse>` messages — queries are skipped. If the handler returns a failure, no commit occurs and staged changes are discarded with the `DbContext`.
+
+### `UnitOfWorkServiceCollectionExtensions`
+
+```csharp
+public static class UnitOfWorkServiceCollectionExtensions
+```
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` as `IUnitOfWork` and adds the `TransactionalCommandBehavior` pipeline behavior. |
+| `public static IServiceCollection AddTrellisUnitOfWorkWithoutBehavior<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` without the pipeline behavior. Use for manual commit control or non-Mediator scenarios. |
 
 ### `EntityTimestampInterceptor`
 

--- a/docs/api_reference/trellis-api-efcore.md
+++ b/docs/api_reference/trellis-api-efcore.md
@@ -173,7 +173,7 @@ public static class UnitOfWorkServiceCollectionExtensions
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` as `IUnitOfWork` and adds the `TransactionalCommandBehavior` pipeline behavior. |
+| `public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` as `IUnitOfWork` and adds the `TransactionalCommandBehavior` pipeline behavior. The behavior is always inserted after the last existing `IPipelineBehavior<,>` registration (innermost position) so that commit failures are visible to outer behaviors (logging, tracing) regardless of call order. |
 | `public static IServiceCollection AddTrellisUnitOfWorkWithoutBehavior<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` without the pipeline behavior. Use for manual commit control or non-Mediator scenarios. |
 
 ### `EntityTimestampInterceptor`

--- a/docs/api_reference/trellis-api-efcore.md
+++ b/docs/api_reference/trellis-api-efcore.md
@@ -173,7 +173,7 @@ public static class UnitOfWorkServiceCollectionExtensions
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` as `IUnitOfWork` and adds the `TransactionalCommandBehavior` pipeline behavior. The behavior is always inserted after the last existing `IPipelineBehavior<,>` registration (innermost position) so that commit failures are visible to outer behaviors (logging, tracing) regardless of call order. |
+| `public static IServiceCollection AddTrellisUnitOfWork<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` as `IUnitOfWork` and adds the `TransactionalCommandBehavior` pipeline behavior. The behavior is inserted after the last existing `IPipelineBehavior<,>` registration (innermost position). Call this **after** `AddTrellisBehaviors()` so that commit failures are visible to outer behaviors (logging, tracing). |
 | `public static IServiceCollection AddTrellisUnitOfWorkWithoutBehavior<TContext>(this IServiceCollection services) where TContext : DbContext` | `IServiceCollection` | Registers `EfUnitOfWork<TContext>` without the pipeline behavior. Use for manual commit control or non-Mediator scenarios. |
 
 ### `EntityTimestampInterceptor`

--- a/docs/docfx_project/articles/integration-ef.md
+++ b/docs/docfx_project/articles/integration-ef.md
@@ -168,6 +168,32 @@ public sealed class CustomerRepository(AppDbContext db)
 > [!NOTE]
 > The Trellis save helpers call EF Core’s `SaveChangesAsync(...)` internally. The public API you should use is `SaveChangesResultAsync(...)` or `SaveChangesResultUnitAsync(...)`.
 
+### Preferred approach: RepositoryBase + IUnitOfWork
+
+For CQRS applications using the Trellis Mediator pipeline, use `RepositoryBase<TAggregate, TId>` with `IUnitOfWork` instead of calling `SaveChangesResultAsync` directly. Repositories stage changes; the `TransactionalCommandBehavior` pipeline behavior auto-commits after successful command handlers.
+
+```csharp
+// Repository — staging only, never calls SaveChanges
+public class OrderRepository(AppDbContext db) : RepositoryBase<Order, OrderId>(db)
+{
+    protected override IQueryable<Order> BuildFindByIdQuery() =>
+        DbSet.Include(o => o.LineItems);
+}
+
+// Command handler — pure domain logic, no persistence concerns
+public async ValueTask<Result<Order>> Handle(ShipOrderCommand cmd, CancellationToken ct)
+{
+    var maybe = await _orders.FindByIdAsync(cmd.OrderId, ct);
+    return maybe
+        .ToResult(Error.NotFound("Order not found."))
+        .Bind(order => order.Ship());
+    // TransactionalCommandBehavior auto-commits the tracked changes on success.
+}
+
+// DI registration
+services.AddTrellisUnitOfWork<AppDbContext>();
+```
+
 ## What `ApplyTrellisConventions` actually does
 
 Most teams adopt the package for one reason: they do not want to hand-write `HasConversion(...)` for every value object. That is the first benefit, but not the only one.

--- a/docs/docfx_project/articles/integration-ef.md
+++ b/docs/docfx_project/articles/integration-ef.md
@@ -190,7 +190,9 @@ public async ValueTask<Result<Order>> Handle(ShipOrderCommand cmd, CancellationT
     // TransactionalCommandBehavior auto-commits the tracked changes on success.
 }
 
-// DI registration
+// DI registration — call AddTrellisUnitOfWork after AddTrellisBehaviors
+// so the commit behavior runs innermost (closest to the handler).
+services.AddTrellisBehaviors();
 services.AddTrellisUnitOfWork<AppDbContext>();
 ```
 


### PR DESCRIPTION
 ## Summary
 
 Separates the repository commit boundary from staging, introducing `IUnitOfWork` and a 
`TransactionalCommandBehavior` pipeline behavior that auto-commits after successful command handlers. Repositories 
now only stage changes — they never call `SaveChanges`.
 
 ## Motivation
 
 The previous `RepositoryBase` coupled each repository method (`SaveAsync`, `DeleteAsync`) to `SaveChanges`, making 
transactional multi-aggregate operations impossible and violating the Unit of Work pattern. 
 
 ## Architecture
 
 **Core rule:** Repos stage changes → Pipeline commits → Handlers are pure domain logic.
 
 | Old Pattern | New Pattern |
 |---|---|
 | `repo.SaveAsync(entity)` calls SaveChanges | `repo.Add(entity)` stages only |
 | `repo.DeleteAsync(id)` finds + removes + SaveChanges | `repo.RemoveByIdAsync(id)` finds + stages removal |
 | No unit of work abstraction | `IUnitOfWork.CommitAsync()` |
 | No pipeline transaction support | `TransactionalCommandBehavior` auto-commits on success |
 
 ## New Types
 
 ### `IUnitOfWork` / `EfUnitOfWork<TContext>`
 - Single `CommitAsync()` method delegating to `SaveChangesResultUnitAsync`
 - Concurrency, duplicate-key, and FK errors surfaced as `Error` (not exceptions)
 - Inject directly only for non-pipeline scenarios (background jobs, tests)
 
 ### `TransactionalCommandBehavior<TMessage, TResponse>`
 - Pipeline behavior constrained to `ICommand<TResponse>` — queries skip it
 - Calls `IUnitOfWork.CommitAsync()` after a successful handler
 - On handler failure: no commit, staged changes discarded with `DbContext`
 - On commit failure: maps to `TResponse.CreateFailure(commitResult.Error)`
 
 ### `UnitOfWorkServiceCollectionExtensions`
 - `AddTrellisUnitOfWork<TContext>()` — registers UoW + behavior
 - `AddTrellisUnitOfWorkWithoutBehavior<TContext>()` — UoW only (manual commit)
 
 ## RepositoryBase Changes
 
 ### Removed
 - `SaveAsync(TAggregate)` — called SaveChanges internally
 - `DeleteAsync(TId)` — called SaveChanges internally
 
 ### Added (staging — never calls SaveChanges)
 - `void Add(TAggregate)` — stages insert (no-op if already tracked)
 - `void Remove(TAggregate)` — stages deletion
 - `Task<Result<Unit>> RemoveByIdAsync(TId)` — loads via `DbSet.FindAsync` (avoids heavy Include graphs), stages 
removal
 
 ### Added (reads)
 - `Task<bool> ExistsAsync(TId)` — lightweight no-tracking existence check
 - `Task<bool> ExistsAsync(Specification<TAggregate>)` — spec-based existence check
 - `Task<int> CountAsync(Specification<TAggregate>)` — spec-based count
 
 ## Package Dependency
 
 Added `Mediator.Abstractions` to `Trellis.EntityFrameworkCore` to support the pipeline behavior. This is a 
lightweight abstractions-only package (~50KB). Non-Mediator users are unaffected — the behavior class is unused 
unless registered.