### PR TITLE
v2 Phase 1a PR3: remove public Value/Error from Result<T>

### DIFF
--- a/Examples/AuthorizationExample/DirectServiceExample.cs
+++ b/Examples/AuthorizationExample/DirectServiceExample.cs
@@ -26,7 +26,9 @@ public static class DirectServiceExample
         // 1. Alice creates a document
         var createResult = service.CreateDocument(Actors.Alice, "Design Doc", "Initial draft");
         Print("Alice creates 'Design Doc'", createResult);
-        var docId = createResult.Value.Id;
+        if (!createResult.TryGetValue(out var createdDoc))
+            throw new InvalidOperationException("Expected create to succeed.");
+        var docId = createdDoc.Id;
 
         // 2. Alice edits her own document (owner)
         Print("Alice edits her document",

--- a/Examples/AuthorizationExample/MediatorExample.cs
+++ b/Examples/AuthorizationExample/MediatorExample.cs
@@ -160,7 +160,9 @@ public static class MediatorExample
         actorProvider.CurrentActor = Actors.Alice;
         var createResult = await mediator.Send(new CreateDocumentCommand("Design Doc", "Initial draft"));
         Print("Alice creates 'Design Doc'", createResult);
-        var docId = createResult.Value.Id;
+        if (!createResult.TryGetValue(out var createdDoc))
+            throw new InvalidOperationException("Expected create to succeed.");
+        var docId = createdDoc.Id;
 
         // 2. Alice edits her own document (owner)
         actorProvider.CurrentActor = Actors.Alice;

--- a/Examples/BankingExample/BankingExamples.cs
+++ b/Examples/BankingExample/BankingExamples.cs
@@ -1,4 +1,4 @@
-﻿using BankingExample.Aggregates;
+using BankingExample.Aggregates;
 using BankingExample.Services;
 using BankingExample.ValueObjects;
 using BankingExample.Workflows;
@@ -20,6 +20,14 @@ namespace BankingExample;
 /// </summary>
 public static class BankingExamples
 {
+    /// <summary>
+    /// Demo helper: returns the success value or throws if the result is a failure.
+    /// Use <c>Match</c> or <c>TryGetValue</c> in production code instead.
+    /// </summary>
+    private static T OrThrow<T>(this Result<T> result) =>
+        result.Match(
+            onSuccess: v => v,
+            onFailure: e => throw new InvalidOperationException(e.Detail));
     public static async Task RunExamplesAsync()
     {
         Console.WriteLine("=== Banking Transaction Examples ===");
@@ -96,7 +104,7 @@ public static class BankingExamples
             Money.Create(1000m, "USD"),
             Money.Create(500m, "USD"),
             Money.Create(0m, "USD")
-        ).Value;
+        ).OrThrow();
 
         var account2 = BankAccount.TryCreate(
             customer2,
@@ -104,7 +112,7 @@ public static class BankingExamples
             Money.Create(500m, "USD"),
             Money.Create(500m, "USD"),
             Money.Create(0m, "USD")
-        ).Value;
+        ).OrThrow();
 
         // Clear initial creation events for cleaner demo output
         account1.AcceptChanges();
@@ -145,7 +153,7 @@ public static class BankingExamples
             Money.Create(10000m, "USD"),
             Money.Create(10000m, "USD"),
             Money.Create(0m, "USD")
-        ).Value;
+        ).OrThrow();
 
         account.AcceptChanges(); // Clear creation event
 
@@ -186,25 +194,25 @@ public static class BankingExamples
             Money.Create(2000m, "USD"),
             dailyLimit,
             Money.Create(0m, "USD")
-        ).Value;
+        ).OrThrow();
 
         account.AcceptChanges(); // Clear creation event
 
         // Make multiple withdrawals
         var result1 = account.Withdraw(Money.Create(200m, "USD"), "ATM withdrawal");
-        Console.WriteLine(result1.IsSuccess ? "✅ First withdrawal: $200" : $"❌ {result1.Error.Detail}");
+        Console.WriteLine(result1.Match(onSuccess: _ => "✅ First withdrawal: $200", onFailure: e => $"❌ {e.Detail}"));
 
         var result2 = account.Withdraw(Money.Create(200m, "USD"), "ATM withdrawal");
-        Console.WriteLine(result2.IsSuccess ? "✅ Second withdrawal: $200" : $"❌ {result2.Error.Detail}");
+        Console.WriteLine(result2.Match(onSuccess: _ => "✅ Second withdrawal: $200", onFailure: e => $"❌ {e.Detail}"));
 
         // This should exceed daily limit - demonstrates Error.Domain
         var result3 = account.Withdraw(Money.Create(200m, "USD"), "ATM withdrawal");
-        if (result3.IsFailure)
+        if (result3.TryGetError(out var thirdError))
         {
             Console.WriteLine($"⚠️ Third withdrawal blocked:");
-            Console.WriteLine($"   Error Type: {result3.Error.GetType().Name}");
-            Console.WriteLine($"   Code: {result3.Error.Code}");
-            Console.WriteLine($"   Detail: {result3.Error.Detail}");
+            Console.WriteLine($"   Error Type: {thirdError.GetType().Name}");
+            Console.WriteLine($"   Code: {thirdError.Code}");
+            Console.WriteLine($"   Detail: {thirdError.Detail}");
         }
 
         Console.WriteLine($"Final balance: {account.Balance}");
@@ -229,7 +237,7 @@ public static class BankingExamples
             Money.Create(10000m, "USD"),
             Money.Create(100m, "USD"),
             Money.Create(0m, "USD")
-        ).Value;
+        ).OrThrow();
 
         account.AcceptChanges(); // Clear creation event
 
@@ -276,13 +284,13 @@ public static class BankingExamples
             Money.Create(100m, "USD")
         );
 
-        if (accountResult.IsFailure)
+        if (accountResult.TryGetError(out var creationError))
         {
-            Console.WriteLine($"❌ Account creation failed: {accountResult.Error.Detail}");
+            Console.WriteLine($"❌ Account creation failed: {creationError.Detail}");
             return;
         }
 
-        var account = accountResult.Value;
+        var account = accountResult.OrThrow();
 
         Console.WriteLine("After account creation:");
         Console.WriteLine($"  IsChanged: {account.IsChanged}");

--- a/Examples/BankingExample/Workflows/BankingWorkflow.cs
+++ b/Examples/BankingExample/Workflows/BankingWorkflow.cs
@@ -34,8 +34,8 @@ public class BankingWorkflow
         {
             // Fraud detection
             var fraudResult = await _fraudDetection.AnalyzeTransactionAsync(acc, amount, "withdrawal", cancellationToken);
-            if (fraudResult.IsFailure)
-                return fraudResult.Error;
+            if (fraudResult.TryGetError(out var fraudError))
+                return fraudError;
 
             // Require MFA for large withdrawals
             if (amount.Amount > 1000)
@@ -46,8 +46,8 @@ public class BankingWorkflow
                     cancellationToken
                 );
 
-                if (mfaResult.IsFailure)
-                    return mfaResult.Error;
+                if (mfaResult.TryGetError(out var mfaError))
+                    return mfaError;
             }
 
             return acc.ToResult();
@@ -86,8 +86,8 @@ public class BankingWorkflow
             () => _fraudDetection.AnalyzeTransactionAsync(toAccount, amount, "transfer-in", cancellationToken)
         ).WhenAllAsync();
 
-        if (validationResult.IsFailure)
-            return validationResult.Error;
+        if (validationResult.TryGetError(out var validationError))
+            return validationError;
 
         // Perform transfer
         return await fromAccount.TransferTo(toAccount, amount, description)
@@ -149,11 +149,11 @@ public class BankingWorkflow
         {
             var result = account.Deposit(amount, description);
 
-            if (result.IsFailure)
+            if (result.TryGetError(out var depositError))
             {
                 // Don't accept changes - events will be discarded
                 Console.WriteLine($"? Transaction failed at item {processedCount + 1}, discarding {account.UncommittedEvents().Count} uncommitted events");
-                return Error.Domain($"Batch transaction failed at item {processedCount + 1}: {result.Error.Detail}");
+                return Error.Domain($"Batch transaction failed at item {processedCount + 1}: {depositError.Detail}");
             }
 
             processedCount++;

--- a/Examples/EcommerceExample/Aggregates/Order.cs
+++ b/Examples/EcommerceExample/Aggregates/Order.cs
@@ -54,14 +54,10 @@ public class Order : Aggregate<OrderId>
         return new Order(customerId);
     }
 
-    public static Order Create(CustomerId customerId)
-    {
-        var result = TryCreate(customerId);
-        if (result.IsFailure)
-            throw new InvalidOperationException($"Failed to create Order: {result.Error.Detail}");
-
-        return result.Value;
-    }
+    public static Order Create(CustomerId customerId) =>
+        TryCreate(customerId).Match(
+            onSuccess: o => o,
+            onFailure: error => throw new InvalidOperationException($"Failed to create Order: {error.Detail}"));
 
     /// <summary>
     /// Adds a product to the order with Railway Oriented Programming pattern.
@@ -78,7 +74,9 @@ public class Order : Aggregate<OrderId>
                 if (existingLine != null)
                 {
                     _lines.Remove(existingLine);
-                    line = existingLine.UpdateQuantity(existingLine.Quantity + quantity).Value;
+                    line = existingLine.UpdateQuantity(existingLine.Quantity + quantity).Match(
+                        onSuccess: l => l,
+                        onFailure: e => throw new InvalidOperationException($"Failed to update line: {e.Detail}"));
                 }
 
                 _lines.Add(line);
@@ -275,10 +273,13 @@ public class Order : Aggregate<OrderId>
         foreach (var line in _lines)
         {
             var addResult = total.Add(line.LineTotal);
-            if (addResult.IsFailure)
-                return addResult.Error;
+            if (addResult.TryGetError(out var addError))
+                return addError;
 
-            total = addResult.Value;
+            // Safe: TryGetError returned false above, so addResult is success.
+            if (!addResult.TryGetValue(out var newTotal))
+                throw new InvalidOperationException("Result is in an unexpected state.");
+            total = newTotal;
         }
 
         Total = total;

--- a/Examples/EcommerceExample/EcommerceExamples.cs
+++ b/Examples/EcommerceExample/EcommerceExamples.cs
@@ -200,13 +200,14 @@ public static class EcommerceExamples
         // Create order - this raises OrderCreatedEvent
         var orderResult = Order.TryCreate(customerId);
 
-        if (orderResult.IsFailure)
+        if (orderResult.TryGetError(out var orderError))
         {
-            Console.WriteLine($"❌ Order creation failed: {orderResult.Error.Detail}");
+            Console.WriteLine($"❌ Order creation failed: {orderError.Detail}");
             return;
         }
 
-        var order = orderResult.Value;
+        if (!orderResult.TryGetValue(out var order))
+            return;
 
         Console.WriteLine("After order creation:");
         Console.WriteLine($"  IsChanged: {order.IsChanged}");
@@ -258,20 +259,20 @@ public static class EcommerceExamples
 
         // Try to add line to confirmed order (Conflict error)
         var addResult = order.AddLine(productId1, "Another Item", price1, 1);
-        if (addResult.IsFailure)
+        if (addResult.TryGetError(out var addError))
         {
-            Console.WriteLine($"Error Type: {addResult.Error.GetType().Name}");
-            Console.WriteLine($"Code: {addResult.Error.Code}");
-            Console.WriteLine($"Detail: {addResult.Error.Detail}");
+            Console.WriteLine($"Error Type: {addError.GetType().Name}");
+            Console.WriteLine($"Code: {addError.Code}");
+            Console.WriteLine($"Detail: {addError.Detail}");
         }
 
         // Try to cancel confirmed order (Domain error)
         var cancelResult = order.Cancel("Changed my mind");
-        if (cancelResult.IsFailure)
+        if (cancelResult.TryGetError(out var cancelError))
         {
-            Console.WriteLine($"\nError Type: {cancelResult.Error.GetType().Name}");
-            Console.WriteLine($"Code: {cancelResult.Error.Code}");
-            Console.WriteLine($"Detail: {cancelResult.Error.Detail}");
+            Console.WriteLine($"\nError Type: {cancelError.GetType().Name}");
+            Console.WriteLine($"Code: {cancelError.Code}");
+            Console.WriteLine($"Detail: {cancelError.Detail}");
         }
 
         Console.WriteLine();

--- a/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
+++ b/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
@@ -57,11 +57,11 @@ public class OrderWorkflow
                         predicate: error => error is ValidationError,
                         funcAsync: () => SuggestAlternativeProductsAsync(order, ct));
 
-                if (reserveResult.IsFailure)
+                if (reserveResult.TryGetError(out var reserveError))
                 {
                     order.Cancel("Inventory unavailable");
                     // Don't publish events for cancelled orders due to inventory issues
-                    return reserveResult.Error;
+                    return reserveError;
                 }
 
                 return Result.Ok(order);
@@ -80,14 +80,14 @@ public class OrderWorkflow
             {
                 var paymentResult = await ProcessPaymentWithrecoveryAsync(order, paymentInfo, ct);
 
-                if (paymentResult.IsFailure)
+                if (paymentResult.TryGetError(out var paymentError))
                 {
                     await ReleaseInventoryAsync(order, ct);
                     order.Cancel("Payment failed");
                     // Publish events including cancellation
                     await PublishEventsAndAcceptChangesAsync(order, ct);
                     await _notificationService.SendPaymentFailedEmailAsync(customerId, order.Id, ct);
-                    return paymentResult.Error;
+                    return paymentError;
                 }
 
                 return Result.Ok(order);
@@ -121,8 +121,8 @@ public class OrderWorkflow
         );
 
         // If any validation failed, return aggregated errors
-        if (validationResult.IsFailure)
-            return validationResult.Error;
+        if (validationResult.TryGetError(out var validationError))
+            return validationError;
 
         // Add all items to order
         var currentOrder = Result.Ok(order);

--- a/Examples/SampleWeb/SampleMinimalApi/API/MoneyRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/MoneyRoutes.cs
@@ -71,22 +71,21 @@ public static class MoneyRoutes
                 return Result.Fail<Money>(Error.Validation("Cart cannot be empty")).ToHttpResult();
 
             var firstItem = Money.TryCreate(request.Items[0].Amount, request.Items[0].Currency);
-            if (firstItem.IsFailure)
+            if (!firstItem.TryGetValue(out var total))
                 return firstItem.ToHttpResult();
 
-            var total = firstItem.Value;
             for (int i = 1; i < request.Items.Length; i++)
             {
                 var itemResult = Money.TryCreate(request.Items[i].Amount, request.Items[i].Currency)
-                    .Bind(item => total.Add(item));
+                    .Bind(item => total!.Add(item));
 
-                if (itemResult.IsFailure)
+                if (!itemResult.TryGetValue(out var nextTotal))
                     return itemResult.ToHttpResult();
 
-                total = itemResult.Value;
+                total = nextTotal;
             }
 
-            return Result.Ok(total).ToHttpResult();
+            return Result.Ok(total!).ToHttpResult();
         });
 
         moneyApi.MapPost("/ApplyDiscount", (ApplyDiscountRequest request) =>

--- a/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
@@ -80,8 +80,8 @@ public static class NewOrderRoutes
             var authResult = actor.ToResult()
                 .Ensure(a => a.HasPermission("orders:write"),
                     Error.Forbidden("Permission 'orders:write' required."));
-            if (authResult.IsFailure)
-                return authResult.Error.ToHttpResult();
+            if (authResult.TryGetError(out var authError))
+                return authError.ToHttpResult();
 
             // Step 2: Fetch order → Confirm → Save → Pay → Notify
             // Note: Save before external calls ensures DB consistency. If payment/notification
@@ -117,8 +117,8 @@ public static class NewOrderRoutes
             var authResult = actor.ToResult()
                 .Ensure(a => a.HasPermission("orders:write"),
                     Error.Forbidden("Permission 'orders:write' required."));
-            if (authResult.IsFailure)
-                return authResult.Error.ToHttpResult();
+            if (authResult.TryGetError(out var authError))
+                return authError.ToHttpResult();
 
             // Step 2: Fetch → Cancel → Save → Notify
             // Note: Same save-first pattern as confirm. A production system would also call

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/MoneyRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/MoneyRoutes.cs
@@ -71,22 +71,21 @@ public static class MoneyRoutes
                 return Result.Fail<Money>(Error.Validation("Cart cannot be empty")).ToHttpResult();
 
             var firstItem = Money.TryCreate(request.Items[0].Amount, request.Items[0].Currency);
-            if (firstItem.IsFailure)
+            if (!firstItem.TryGetValue(out var total))
                 return firstItem.ToHttpResult();
 
-            var total = firstItem.Value;
             for (int i = 1; i < request.Items.Length; i++)
             {
                 var itemResult = Money.TryCreate(request.Items[i].Amount, request.Items[i].Currency)
-                    .Bind(item => total.Add(item));
+                    .Bind(item => total!.Add(item));
 
-                if (itemResult.IsFailure)
+                if (!itemResult.TryGetValue(out var nextTotal))
                     return itemResult.ToHttpResult();
 
-                total = itemResult.Value;
+                total = nextTotal;
             }
 
-            return Result.Ok(total).ToHttpResult();
+            return Result.Ok(total!).ToHttpResult();
         });
 
         moneyApi.MapPost("/ApplyDiscount", (ApplyDiscountRequest request) =>

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
@@ -80,8 +80,8 @@ public static class NewOrderRoutes
             var authResult = actor.ToResult()
                 .Ensure(a => a.HasPermission("orders:write"),
                     Error.Forbidden("Permission 'orders:write' required."));
-            if (authResult.IsFailure)
-                return authResult.Error.ToHttpResult();
+            if (authResult.TryGetError(out var authError))
+                return authError.ToHttpResult();
 
             // Step 2: Fetch order → Confirm → Save → Pay → Notify
             // Note: Save before external calls ensures DB consistency. If payment/notification
@@ -117,8 +117,8 @@ public static class NewOrderRoutes
             var authResult = actor.ToResult()
                 .Ensure(a => a.HasPermission("orders:write"),
                     Error.Forbidden("Permission 'orders:write' required."));
-            if (authResult.IsFailure)
-                return authResult.Error.ToHttpResult();
+            if (authResult.TryGetError(out var authError))
+                return authError.ToHttpResult();
 
             // Step 2: Fetch → Cancel → Save → Notify
             // Note: Same save-first pattern as confirm. A production system would also call

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/MoneyController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/MoneyController.cs
@@ -79,22 +79,21 @@ public class MoneyController : ControllerBase
             return Result.Fail<Money>(Error.Validation("Cart cannot be empty")).ToActionResult(this);
 
         var firstItem = Money.TryCreate(request.Items[0].Amount, request.Items[0].Currency);
-        if (firstItem.IsFailure)
+        if (!firstItem.TryGetValue(out var total))
             return firstItem.ToActionResult(this);
 
-        var total = firstItem.Value;
         for (int i = 1; i < request.Items.Length; i++)
         {
             var itemResult = Money.TryCreate(request.Items[i].Amount, request.Items[i].Currency)
-                .Bind(item => total.Add(item));
+                .Bind(item => total!.Add(item));
 
-            if (itemResult.IsFailure)
+            if (!itemResult.TryGetValue(out var nextTotal))
                 return itemResult.ToActionResult(this);
 
-            total = itemResult.Value;
+            total = nextTotal;
         }
 
-        return Result.Ok(total).ToActionResult(this);
+        return Result.Ok(total!).ToActionResult(this);
     }
 
     [HttpPost("[action]")]

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
@@ -51,12 +51,14 @@ public class NewOrdersController(
             .TapAsync(order => { db.Orders.Add(order); return Task.CompletedTask; })
             .CheckAsync(_ => db.SaveChangesResultUnitAsync());
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<OrderResponse>(this);
-
-        var response = OrderResponse.From(result.Value);
-        Response.Headers.ETag = $"\"{result.Value.ETag}\"";
-        return CreatedAtAction(nameof(GetOrder), new { id = result.Value.Id.Value }, response);
+        return result.Match<Order, ActionResult<OrderResponse>>(
+            onSuccess: created =>
+            {
+                var response = OrderResponse.From(created);
+                Response.Headers.ETag = $"\"{created.ETag}\"";
+                return CreatedAtAction(nameof(GetOrder), new { id = created.Id.Value }, response);
+            },
+            onFailure: error => error.ToActionResult<OrderResponse>(this));
     }
 
     // GET /orders/{id} — conditional GET with ETag
@@ -69,8 +71,8 @@ public class NewOrdersController(
             .FirstOrDefaultResultAsync(o => o.Id == id,
                 Error.NotFound("Order not found.", id));
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<OrderResponse>(this);
+        if (result.TryGetError(out var fetchError))
+            return fetchError.ToActionResult<OrderResponse>(this);
 
         return result.ToActionResult(this,
             order => RepresentationMetadata.WithStrongETag(order.ETag),
@@ -88,8 +90,8 @@ public class NewOrdersController(
         var authResult = actor.ToResult()
             .Ensure(a => a.HasPermission("orders:write"),
                 Error.Forbidden("Permission 'orders:write' required."));
-        if (authResult.IsFailure)
-            return authResult.Error.ToActionResult<OrderResponse>(this);
+        if (authResult.TryGetError(out var authError))
+            return authError.ToActionResult<OrderResponse>(this);
 
         // Step 2: Fetch order → Confirm → Save → Pay → Notify
         // Note: Save before external calls ensures DB consistency. If payment/notification
@@ -107,8 +109,8 @@ public class NewOrdersController(
             .CheckAsync(order =>
                 notificationService.SendOrderConfirmationAsync(order.Id, order.CustomerId, ct));
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<OrderResponse>(this);
+        if (result.TryGetError(out var confirmError))
+            return confirmError.ToActionResult<OrderResponse>(this);
 
         return result.ToActionResult(this,
             order => RepresentationMetadata.WithStrongETag(order.ETag),
@@ -125,8 +127,8 @@ public class NewOrdersController(
         var authResult = actor.ToResult()
             .Ensure(a => a.HasPermission("orders:write"),
                 Error.Forbidden("Permission 'orders:write' required."));
-        if (authResult.IsFailure)
-            return authResult.Error.ToActionResult<OrderResponse>(this);
+        if (authResult.TryGetError(out var authError))
+            return authError.ToActionResult<OrderResponse>(this);
 
         // Step 2: Fetch → Cancel → Save → Notify
         // Note: Same save-first pattern as confirm. A production system would also call
@@ -143,8 +145,8 @@ public class NewOrdersController(
                 _ => Result.Fail<Order>(
                     Error.Unexpected("Cancellation failed. Please try again.")));
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<OrderResponse>(this);
+        if (result.TryGetError(out var cancelError))
+            return cancelError.ToActionResult<OrderResponse>(this);
 
         return result.ToActionResult(this,
             order => RepresentationMetadata.WithStrongETag(order.ETag),

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
@@ -87,8 +87,8 @@ public class ProductsController(AppDbContext db) : ControllerBase
             .FirstOrDefaultResultAsync(p => p.Id == id,
                 Error.NotFound("Product not found.", id));
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<ProductResponse>(this);
+        if (result.TryGetError(out var fetchError))
+            return fetchError.ToActionResult<ProductResponse>(this);
 
         return result.ToActionResult(this, product => RepresentationMetadata.WithStrongETag(product.ETag), ProductResponse.From);
     }
@@ -104,13 +104,14 @@ public class ProductsController(AppDbContext db) : ControllerBase
             .Tap(product => db.Products.Add(product))
             .CheckAsync(_ => db.SaveChangesResultUnitAsync());
 
-        if (result.IsFailure)
-            return result.Error.ToActionResult<ProductResponse>(this);
-
-        var product = result.Value;
-        var response = ProductResponse.From(product);
-        Response.Headers.ETag = $"\"{product.ETag}\"";
-        return CreatedAtAction(nameof(GetProduct), new { id = product.Id.Value }, response);
+        return result.Match<Product, ActionResult<ProductResponse>>(
+            onSuccess: product =>
+            {
+                var response = ProductResponse.From(product);
+                Response.Headers.ETag = $"\"{product.ETag}\"";
+                return CreatedAtAction(nameof(GetProduct), new { id = product.Id.Value }, response);
+            },
+            onFailure: error => error.ToActionResult<ProductResponse>(this));
     }
 
     // PUT /products/{id} — update with If-Match + Prefer header

--- a/Examples/Xunit/DomainDrivenDesignSamplesTests.cs
+++ b/Examples/Xunit/DomainDrivenDesignSamplesTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Example.Tests;
 
 using Trellis;
@@ -100,9 +101,9 @@ public class DomainDrivenDesignSamplesTests
         {
             var result = TryCreate(name, email);
             if (result.IsFailure)
-                throw new InvalidOperationException($"Failed to create Customer: {result.Error.Detail}");
+                throw new InvalidOperationException($"Failed to create Customer: {result.UnwrapError().Detail}");
 
-            return result.Value;
+            return result.Unwrap();
         }
 
         public Result<Customer> UpdateName(string newName) =>
@@ -129,8 +130,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Name.Should().Be("John Doe");
-        result.Value.Email.Should().Be(email);
+        result.Unwrap().Name.Should().Be("John Doe");
+        result.Unwrap().Email.Should().Be(email);
     }
 
     [Fact]
@@ -144,7 +145,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Name cannot be empty");
+        result.UnwrapError().Detail.Should().Contain("Name cannot be empty");
     }
 
     [Fact]
@@ -158,8 +159,8 @@ public class DomainDrivenDesignSamplesTests
         var customer2 = Customer.TryCreate("John Doe", email);
 
         // Assert - Different instances, different IDs, not equal
-        customer1.Value.Should().NotBe(customer2.Value);
-        customer1.Value.Id.Should().NotBe(customer2.Value.Id);
+        customer1.Unwrap().Should().NotBe(customer2.Unwrap());
+        customer1.Unwrap().Id.Should().NotBe(customer2.Unwrap().Id);
     }
 
     [Fact]
@@ -174,7 +175,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Name.Should().Be("John Smith");
+        result.Unwrap().Name.Should().Be("John Smith");
     }
 
     [Fact]
@@ -190,7 +191,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Email.Should().Be(newEmail);
+        result.Unwrap().Email.Should().Be(newEmail);
     }
 
     [Fact]
@@ -208,8 +209,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Name.Should().Be("John Smith");
-        result.Value.Email.Should().Be(newEmail);
+        result.Unwrap().Name.Should().Be("John Smith");
+        result.Unwrap().Email.Should().Be(newEmail);
     }
 
     #endregion
@@ -277,7 +278,7 @@ public class DomainDrivenDesignSamplesTests
         var address2 = Address.TryCreate("123 Main St", "Springfield", "IL", "62701", "USA");
 
         // Assert - Same values, equal
-        address1.Value.Should().Be(address2.Value);
+        address1.Unwrap().Should().Be(address2.Unwrap());
     }
 
     [Fact]
@@ -288,7 +289,7 @@ public class DomainDrivenDesignSamplesTests
         var address3 = Address.TryCreate("456 Oak Ave", "Springfield", "IL", "62702", "USA");
 
         // Assert - Different values, not equal
-        address1.Value.Should().NotBe(address3.Value);
+        address1.Unwrap().Should().NotBe(address3.Unwrap());
     }
 
     [Fact]
@@ -299,7 +300,7 @@ public class DomainDrivenDesignSamplesTests
         var address3 = Address.TryCreate("456 Oak Ave", "Springfield", "IL", "62702", "USA");
 
         // Act & Assert
-        address1.Value.IsSameCity(address3.Value).Should().BeTrue();
+        address1.Unwrap().IsSameCity(address3.Unwrap()).Should().BeTrue();
     }
 
     [Fact]
@@ -309,7 +310,7 @@ public class DomainDrivenDesignSamplesTests
         var address = Address.TryCreate("123 Main St", "Springfield", "IL", "62701", "USA");
 
         // Act & Assert
-        address.Value.GetFullAddress().Should().Be("123 Main St, Springfield, IL 62701, USA");
+        address.Unwrap().GetFullAddress().Should().Be("123 Main St, Springfield, IL 62701, USA");
     }
 
     // Temperature (Scalar)
@@ -361,7 +362,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(98.6m);
+        result.Unwrap().Value.Should().Be(98.6m);
     }
 
     [Fact]
@@ -372,7 +373,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("below absolute zero");
+        result.UnwrapError().Detail.Should().Contain("below absolute zero");
     }
 
     [Fact]
@@ -383,7 +384,7 @@ public class DomainDrivenDesignSamplesTests
         var temp2 = Temperature.TryCreate(98.60m);
 
         // Assert - Rounded to same value, equal
-        temp1.Value.Should().Be(temp2.Value);
+        temp1.Unwrap().Should().Be(temp2.Unwrap());
     }
 
     [Fact]
@@ -404,7 +405,7 @@ public class DomainDrivenDesignSamplesTests
         var temp2 = Temperature.TryCreate(50m);
 
         // Act
-        var difference = temp1.Value.Subtract(temp2.Value);
+        var difference = temp1.Unwrap().Subtract(temp2.Unwrap());
 
         // Assert
         difference.Value.Should().Be(50m);
@@ -418,9 +419,9 @@ public class DomainDrivenDesignSamplesTests
         var coldTemp = Temperature.TryCreate(-10m);
 
         // Assert
-        hotTemp.Value.IsBoiling.Should().BeTrue();
-        coldTemp.Value.IsFreezing.Should().BeTrue();
-        coldTemp.Value.IsBelowZero.Should().BeTrue();
+        hotTemp.Unwrap().IsBoiling.Should().BeTrue();
+        coldTemp.Unwrap().IsFreezing.Should().BeTrue();
+        coldTemp.Unwrap().IsBelowZero.Should().BeTrue();
     }
 
     // Money (Domain Logic)
@@ -449,9 +450,9 @@ public class DomainDrivenDesignSamplesTests
         {
             var result = TryCreate(amount, currency);
             if (result.IsFailure)
-                throw new InvalidOperationException($"Failed to create Money: {result.Error.Detail}");
+                throw new InvalidOperationException($"Failed to create Money: {result.UnwrapError().Detail}");
 
-            return result.Value;
+            return result.Unwrap();
         }
 
         public static Money Zero(string currency = "USD") => new(0, currency);
@@ -501,8 +502,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(100.00m);
-        result.Value.Currency.Should().Be("USD");
+        result.Unwrap().Amount.Should().Be(100.00m);
+        result.Unwrap().Currency.Should().Be("USD");
     }
 
     [Fact]
@@ -513,7 +514,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Amount cannot be negative");
+        result.UnwrapError().Detail.Should().Contain("Amount cannot be negative");
     }
 
     [Fact]
@@ -524,11 +525,11 @@ public class DomainDrivenDesignSamplesTests
         var money2 = Money.TryCreate(50.00m, "USD");
 
         // Act
-        var result = money1.Value.Add(money2.Value);
+        var result = money1.Unwrap().Add(money2.Unwrap());
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(150.00m);
+        result.Unwrap().Amount.Should().Be(150.00m);
     }
 
     [Fact]
@@ -539,11 +540,11 @@ public class DomainDrivenDesignSamplesTests
         var eur = Money.TryCreate(50.00m, "EUR");
 
         // Act
-        var result = usd.Value.Add(eur.Value);
+        var result = usd.Unwrap().Add(eur.Unwrap());
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Cannot add EUR to USD");
+        result.UnwrapError().Detail.Should().Contain("Cannot add EUR to USD");
     }
 
     [Fact]
@@ -553,7 +554,7 @@ public class DomainDrivenDesignSamplesTests
         var price = Money.TryCreate(100.00m, "USD");
 
         // Act
-        var discount = price.Value.ApplyDiscount(10);
+        var discount = price.Unwrap().ApplyDiscount(10);
 
         // Assert
         discount.Amount.Should().Be(90.00m);
@@ -566,13 +567,13 @@ public class DomainDrivenDesignSamplesTests
         var price = Money.TryCreate(100.00m, "USD");
 
         // Act
-        var discount = price.Value.ApplyDiscount(10); // $90.00
+        var discount = price.Unwrap().ApplyDiscount(10); // $90.00
         var tax = discount.Multiply(0.08m); // $7.20
         var total = discount.Add(tax); // $97.20
 
         // Assert
         total.IsSuccess.Should().BeTrue();
-        total.Value.Amount.Should().Be(97.20m);
+        total.Unwrap().Amount.Should().Be(97.20m);
     }
 
     #endregion
@@ -651,9 +652,9 @@ public class DomainDrivenDesignSamplesTests
         {
             var result = TryCreate(customerId);
             if (result.IsFailure)
-                throw new InvalidOperationException($"Failed to create Order: {result.Error.Detail}");
+                throw new InvalidOperationException($"Failed to create Order: {result.UnwrapError().Detail}");
 
-            return result.Value;
+            return result.Unwrap();
         }
 
         public Result<Order> AddLine(ProductId productId, string productName, Money price, int quantity) =>
@@ -757,10 +758,10 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.CustomerId.Should().Be(customerId);
-        result.Value.Status.Should().Be(OrderStatus.Draft);
-        result.Value.Lines.Should().BeEmpty();
-        result.Value.Total.Amount.Should().Be(0);
+        result.Unwrap().CustomerId.Should().Be(customerId);
+        result.Unwrap().Status.Should().Be(OrderStatus.Draft);
+        result.Unwrap().Lines.Should().BeEmpty();
+        result.Unwrap().Total.Amount.Should().Be(0);
     }
 
     [Fact]
@@ -791,10 +792,10 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Lines.Should().HaveCount(1);
-        result.Value.Lines[0].ProductName.Should().Be("Widget");
-        result.Value.Lines[0].Quantity.Should().Be(5);
-        result.Value.Total.Amount.Should().Be(149.95m);
+        result.Unwrap().Lines.Should().HaveCount(1);
+        result.Unwrap().Lines[0].ProductName.Should().Be("Widget");
+        result.Unwrap().Lines[0].Quantity.Should().Be(5);
+        result.Unwrap().Total.Amount.Should().Be(149.95m);
     }
 
     [Fact]
@@ -813,8 +814,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Lines.Should().HaveCount(1);
-        result.Value.Lines[0].Quantity.Should().Be(8);
+        result.Unwrap().Lines.Should().HaveCount(1);
+        result.Unwrap().Lines[0].Quantity.Should().Be(8);
     }
 
     [Fact]
@@ -832,8 +833,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Lines.Should().BeEmpty();
-        result.Value.Total.Amount.Should().Be(0);
+        result.Unwrap().Lines.Should().BeEmpty();
+        result.Unwrap().Total.Amount.Should().Be(0);
     }
 
     [Fact]
@@ -851,8 +852,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Status.Should().Be(OrderStatus.Submitted);
-        result.Value.SubmittedAt.Should().NotBeNull();
+        result.Unwrap().Status.Should().Be(OrderStatus.Submitted);
+        result.Unwrap().SubmittedAt.Should().NotBeNull();
     }
 
     [Fact]
@@ -867,7 +868,7 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Cannot submit empty order");
+        result.UnwrapError().Detail.Should().Contain("Cannot submit empty order");
     }
 
     [Fact]
@@ -886,8 +887,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Status.Should().Be(OrderStatus.Shipped);
-        result.Value.ShippedAt.Should().NotBeNull();
+        result.Unwrap().Status.Should().Be(OrderStatus.Shipped);
+        result.Unwrap().ShippedAt.Should().NotBeNull();
     }
 
     [Fact]
@@ -905,8 +906,8 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Status.Should().Be(OrderStatus.Cancelled);
-        result.Value.CancelledAt.Should().NotBeNull();
+        result.Unwrap().Status.Should().Be(OrderStatus.Cancelled);
+        result.Unwrap().CancelledAt.Should().NotBeNull();
     }
 
     [Fact]
@@ -963,9 +964,9 @@ public class DomainDrivenDesignSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Status.Should().Be(OrderStatus.Shipped);
-        result.Value.Lines.Should().HaveCount(2);
-        result.Value.Total.Amount.Should().Be(299.92m); // (29.99*5) + (49.99*3)
+        result.Unwrap().Status.Should().Be(OrderStatus.Shipped);
+        result.Unwrap().Lines.Should().HaveCount(2);
+        result.Unwrap().Total.Amount.Should().Be(299.92m); // (29.99*5) + (49.99*3)
     }
 
     #endregion

--- a/Examples/Xunit/Example.Tests.csproj
+++ b/Examples/Xunit/Example.Tests.csproj
@@ -10,4 +10,7 @@
       <ProjectReference Include="..\..\Trellis.FluentValidation\src\Trellis.FluentValidation.csproj" />
       <ProjectReference Include="..\..\Trellis.DomainDrivenDesign\src\Trellis.DomainDrivenDesign.csproj" />
    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
+  </ItemGroup>
 </Project>

--- a/Examples/Xunit/FluentValidationSamplesTests.cs
+++ b/Examples/Xunit/FluentValidationSamplesTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 using Trellis.FluentValidation;
 
 namespace Example.Tests;
@@ -173,7 +174,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(request);
+        result.Unwrap().Should().Be(request);
     }
 
     [Fact]
@@ -193,7 +194,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Email" && e.Details.Contains("Email is already registered"));
     }
@@ -215,7 +216,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Email" && e.Details.Contains("Email domain is not allowed"));
     }
@@ -237,7 +238,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Username" && e.Details.Contains("Username is already taken"));
     }
@@ -259,7 +260,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e => e.FieldName == "Username");
     }
 
@@ -379,9 +380,9 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.ProductId.Value.Should().Be("PROD-001");
-        result.Value.Quantity.Value.Should().Be(5);
-        result.Value.Price.Amount.Should().Be(29.99m);
+        result.Unwrap().ProductId.Value.Should().Be("PROD-001");
+        result.Unwrap().Quantity.Value.Should().Be(5);
+        result.Unwrap().Price.Amount.Should().Be(29.99m);
     }
 
     [Fact]
@@ -403,7 +404,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "value" && e.Details.Contains("Quantity must be positive"));
     }
@@ -427,7 +428,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         // Combine groups all errors into a single FieldError with Details array
         validationError.FieldErrors.Should().HaveCount(1);
         validationError.FieldErrors[0].Details.Should().HaveCount(3);
@@ -457,7 +458,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(3);
+        result.Unwrap().Should().HaveCount(3);
     }
 
     [Fact]
@@ -571,7 +572,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "ShippingAddress" &&
             e.Details.Contains("Shipping address is required for physical orders"));
@@ -617,7 +618,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         // FluentValidation's default message is "'Email' must not be empty."
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Email" &&
@@ -643,7 +644,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "TotalAmount" &&
             e.Details.Contains("Express shipping not available for orders over $10,000"));
@@ -689,7 +690,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "TaxId" &&
             e.Details.Contains("Tax ID required for business orders"));
@@ -743,7 +744,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Price" &&
             e.Details.Any(d => d.Contains("$-5") && d.Contains("must be greater than $0")));
@@ -761,7 +762,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Stock" &&
             e.Details.Any(d => d.Contains("15000") && d.Contains("exceeds maximum of 10,000")));
@@ -779,7 +780,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Name" &&
             e.Details.Any(d => d.Contains("current: 2")));
@@ -797,7 +798,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Discount" &&
             e.Details.Any(d => d.Contains("$60") && d.Contains("$100")));
@@ -854,7 +855,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "OrderIds" &&
             e.Details.Contains("Batch must contain at least one order"));
@@ -873,7 +874,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "OrderIds" &&
             e.Details.Any(d => d.Contains("101") && d.Contains("maximum is 100")));
@@ -891,7 +892,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "OrderIds" &&
             e.Details.Contains("Batch contains duplicate order IDs"));
@@ -1007,7 +1008,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         // Both Email and Phone should have validation errors
         validationError.FieldErrors.Should().Contain(e => e.FieldName.Contains("Email"));
         validationError.FieldErrors.Should().Contain(e => e.FieldName.Contains("Phone"));
@@ -1028,7 +1029,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e => e.FieldName.Contains("Street"));
         validationError.FieldErrors.Should().Contain(e => e.FieldName.Contains("PostalCode"));
         validationError.FieldErrors.Should().Contain(e => e.FieldName.Contains("Country"));
@@ -1049,7 +1050,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "ContactInfo" &&
             e.Details.Contains("Contact information is required"));
@@ -1075,7 +1076,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "value" &&
             e.Details.Contains("'value' must not be empty."));
@@ -1097,7 +1098,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         // ValidateToResult uses custom paramName and message for null values
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "Alias" &&
@@ -1120,7 +1121,7 @@ public class FluentValidationSamplesTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validationError = (ValidationError)result.Error;
+        var validationError = (ValidationError)result.UnwrapError();
         validationError.FieldErrors.Should().Contain(e =>
             e.FieldName == "value" &&
             e.Details.Contains("'value' must not be empty."));

--- a/Examples/Xunit/ParallelExamples.cs
+++ b/Examples/Xunit/ParallelExamples.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Example.Tests;
 
 using Trellis;
@@ -28,9 +29,9 @@ public class ParallelExamples : IClassFixture<TraceFixture>
             new Dashboard(profile, orders, prefs));
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Profile.Should().Be("Profile for user-123");
-        result.Value.Orders.Should().Be("Orders for user-123");
-        result.Value.Preferences.Should().Be("Preferences for user-123");
+        result.Unwrap().Profile.Should().Be("Profile for user-123");
+        result.Unwrap().Orders.Should().Be("Orders for user-123");
+        result.Unwrap().Preferences.Should().Be("Preferences for user-123");
     }
 
     #endregion
@@ -55,7 +56,7 @@ public class ParallelExamples : IClassFixture<TraceFixture>
 
         result.IsSuccess.Should().BeTrue();
         logged.Should().BeTrue("Tap should execute on the success path");
-        result.Value.Should().Contain("order-42");
+        result.Unwrap().Should().Contain("order-42");
     }
 
     #endregion
@@ -84,7 +85,7 @@ public class ParallelExamples : IClassFixture<TraceFixture>
         });
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Invalid payment");
+        result.UnwrapError().Detail.Should().Contain("Invalid payment");
         tapInvoked.Should().BeFalse("Tap should not execute on the failure path");
         bindInvoked.Should().BeFalse("Bind should not execute on the failure path");
     }
@@ -109,7 +110,7 @@ public class ParallelExamples : IClassFixture<TraceFixture>
         .BindAsync(CreateOrderSummaryAsync);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Contain("order-99");
+        result.Unwrap().Should().Contain("order-99");
     }
 
     #endregion
@@ -134,7 +135,7 @@ public class ParallelExamples : IClassFixture<TraceFixture>
         .BindAsync(SaveDashboardAsync);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Contain("Saved dashboard for user-456");
+        result.Unwrap().Should().Contain("Saved dashboard for user-456");
     }
 
     #endregion

--- a/Examples/Xunit/ValidationExample.cs
+++ b/Examples/Xunit/ValidationExample.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 using Trellis.Primitives;
 
 namespace Example;
@@ -21,7 +22,7 @@ public class ValidationExample
             .Combine(Ensure(createdAt <= updatedAt, Error.Validation("updateAt cannot be less than createdAt")))
             .Bind((email, firstName, lastName) => Result.Ok(string.Join(" ", firstName, lastName, email)));
 
-        actual.Value.Should().Be("Xavier John xavier@somewhere.com");
+        actual.Unwrap().Should().Be("Xavier John xavier@somewhere.com");
     }
 
     [Fact]
@@ -49,7 +50,7 @@ public class ValidationExample
             });
         // Assert
         actual.IsFailure.Should().BeTrue();
-        var validationErrors = (ValidationError)actual.Error;
+        var validationErrors = (ValidationError)actual.UnwrapError();
         validationErrors.FieldErrors.Should().HaveCount(3);
         validationErrors.FieldErrors.Should().BeEquivalentTo(expected);
     }
@@ -66,7 +67,7 @@ public class ValidationExample
             .Combine(Maybe.Optional(lastName, s => LastName.TryCreate(s)))
             .Bind(Add);
 
-        actual.Value.Should().Be("xavier@somewhere.com  John");
+        actual.Unwrap().Should().Be("xavier@somewhere.com  John");
 
         static Result<string> Add(EmailAddress emailAddress, Maybe<FirstName> firstname, Maybe<LastName> lastname)
             => emailAddress + " " + firstname + " " + lastname;
@@ -85,8 +86,8 @@ public class ValidationExample
             .Bind(Add);
 
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().BeOfType<ValidationError>();
-        var validationError = (ValidationError)actual.Error;
+        actual.UnwrapError().Should().BeOfType<ValidationError>();
+        var validationError = (ValidationError)actual.UnwrapError();
         validationError.FieldErrors[0].Details[0].Should().Be("First Name cannot be empty.");
 
         static Result<string> Add(EmailAddress emailAddress, Maybe<FirstName> firstname, Maybe<LastName> lastname)

--- a/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
+++ b/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
@@ -415,13 +415,9 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
         sb.AppendLine();
         sb.AppendLine($"        var result = {fullTypeName}.TryCreate(primitiveValue, null);");
         sb.AppendLine();
-        sb.AppendLine("        if (result.IsFailure)");
-        sb.AppendLine("        {");
-        sb.AppendLine("            // Return null on validation failure - the value object's TryCreate handles validation");
-        sb.AppendLine("            return null;");
-        sb.AppendLine("        }");
-        sb.AppendLine();
-        sb.AppendLine("        return result.Value;");
+        sb.AppendLine($"        return result.Match<{fullTypeName}, {fullTypeName}?>(");
+        sb.AppendLine("            onSuccess: v => v,");
+        sb.AppendLine("            onFailure: _ => null);");
         sb.AppendLine("    }");
         sb.AppendLine();
 

--- a/Trellis.Asp/src/ActionResultExtensions.cs
+++ b/Trellis.Asp/src/ActionResultExtensions.cs
@@ -111,19 +111,12 @@ public static class ActionResultExtensions
     /// // Not found: 404 Not Found
     /// </code>
     /// </example>
-    public static ActionResult<TValue> ToActionResult<TValue>(this Result<TValue> result, ControllerBase controllerBase)
-    {
-        if (result.IsSuccess)
-        {
-            // If TValue is Unit, return 204 No Content
-            if (typeof(TValue) == typeof(Unit))
-                return (ActionResult<TValue>)controllerBase.NoContent();
-
-            return (ActionResult<TValue>)controllerBase.Ok(result.Value);
-        }
-
-        return result.Error.ToActionResult<TValue>(controllerBase);
-    }
+    public static ActionResult<TValue> ToActionResult<TValue>(this Result<TValue> result, ControllerBase controllerBase) =>
+        result.Match<TValue, ActionResult<TValue>>(
+            onSuccess: value => typeof(TValue) == typeof(Unit)
+                ? (ActionResult<TValue>)controllerBase.NoContent()
+                : (ActionResult<TValue>)controllerBase.Ok(value),
+            onFailure: error => error.ToActionResult<TValue>(controllerBase));
 
     /// <summary>
     /// Converts a domain <see cref="Error"/> to an <see cref="ActionResult{TValue}"/> with appropriate HTTP status code and Problem Details format.
@@ -311,26 +304,23 @@ public static class ActionResultExtensions
         this Result<TIn> result,
         ControllerBase controllerBase,
         Func<TIn, ContentRangeHeaderValue> funcRange,
-        Func<TIn, TOut> funcValue)
-    {
-        if (result.IsSuccess)
-        {
-            var contentRange = funcRange(result.Value);
-            var value = funcValue(result.Value);
+        Func<TIn, TOut> funcValue) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue =>
+            {
+                var contentRange = funcRange(inValue);
+                var value = funcValue(inValue);
 
-            if (contentRange.From is null || contentRange.To is null || contentRange.Length is null)
+                if (contentRange.From is null || contentRange.To is null || contentRange.Length is null)
+                    return controllerBase.Ok(value);
+
+                var partialResult = contentRange.To - contentRange.From + 1 != contentRange.Length;
+                if (partialResult)
+                    return new PartialContentResult(contentRange, value);
+
                 return controllerBase.Ok(value);
-
-            var partialResult = contentRange.To - contentRange.From + 1 != contentRange.Length;
-            if (partialResult)
-                return new PartialContentResult(contentRange, value);
-
-            return controllerBase.Ok(value);
-        }
-
-        var error = result.Error;
-        return error.ToActionResult<TOut>(controllerBase);
-    }
+            },
+            onFailure: error => error.ToActionResult<TOut>(controllerBase));
 
     /// <summary>
     /// Converts a <see cref="Result{TValue}"/> to an <see cref="ActionResult{TValue}"/> that returns
@@ -349,30 +339,28 @@ public static class ActionResultExtensions
         ControllerBase controllerBase,
         long from,
         long to,
-        long totalLength)
-    {
-        if (result.IsSuccess)
-        {
-            // If TValue is Unit, return 204 No Content
-            if (typeof(TValue) == typeof(Unit))
-                return (ActionResult<TValue>)controllerBase.NoContent();
+        long totalLength) =>
+        result.Match<TValue, ActionResult<TValue>>(
+            onSuccess: value =>
+            {
+                // If TValue is Unit, return 204 No Content
+                if (typeof(TValue) == typeof(Unit))
+                    return (ActionResult<TValue>)controllerBase.NoContent();
 
-            // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
-            if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
-                return (ActionResult<TValue>)controllerBase.Ok(result.Value);
+                // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
+                if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
+                    return (ActionResult<TValue>)controllerBase.Ok(value);
 
-            // Clamp to against totalLength to prevent ContentRangeHeaderValue from throwing
-            var clampedTo = Math.Min(to, totalLength - 1);
+                // Clamp to against totalLength to prevent ContentRangeHeaderValue from throwing
+                var clampedTo = Math.Min(to, totalLength - 1);
 
-            var isCompleteRange = from == 0 && clampedTo == totalLength - 1;
-            if (!isCompleteRange)
-                return new PartialContentResult(from, clampedTo, totalLength, result.Value);
+                var isCompleteRange = from == 0 && clampedTo == totalLength - 1;
+                if (!isCompleteRange)
+                    return new PartialContentResult(from, clampedTo, totalLength, value);
 
-            return (ActionResult<TValue>)controllerBase.Ok(result.Value);
-        }
-
-        return result.Error.ToActionResult<TValue>(controllerBase);
-    }
+                return (ActionResult<TValue>)controllerBase.Ok(value);
+            },
+            onFailure: error => error.ToActionResult<TValue>(controllerBase));
 
     /// <summary>
     /// Converts a <see cref="Result{TIn}"/> to an <see cref="ActionResult{TOut}"/> by applying
@@ -407,13 +395,10 @@ public static class ActionResultExtensions
     public static ActionResult<TOut> ToActionResult<TIn, TOut>(
         this Result<TIn> result,
         ControllerBase controllerBase,
-        Func<TIn, TOut> map)
-    {
-        if (result.IsSuccess)
-            return controllerBase.Ok(map(result.Value));
-
-        return result.Error.ToActionResult<TOut>(controllerBase);
-    }
+        Func<TIn, TOut> map) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue => controllerBase.Ok(map(inValue)),
+            onFailure: error => error.ToActionResult<TOut>(controllerBase));
 
     /// <summary>
     /// Converts a <see cref="Result{TValue}"/> to an <see cref="ActionResult{TValue}"/> that returns
@@ -459,13 +444,10 @@ public static class ActionResultExtensions
         ControllerBase controllerBase,
         string actionName,
         Func<TValue, object?> routeValues,
-        string? controllerName = null)
-    {
-        if (result.IsSuccess)
-            return (ActionResult<TValue>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(result.Value), result.Value);
-
-        return result.Error.ToActionResult<TValue>(controllerBase);
-    }
+        string? controllerName = null) =>
+        result.Match<TValue, ActionResult<TValue>>(
+            onSuccess: value => (ActionResult<TValue>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(value), value),
+            onFailure: error => error.ToActionResult<TValue>(controllerBase));
 
     /// <summary>
     /// Converts a <see cref="Result{TValue}"/> to an <see cref="ActionResult{TOut}"/> that returns
@@ -514,16 +496,10 @@ public static class ActionResultExtensions
         string actionName,
         Func<TValue, object?> routeValues,
         Func<TValue, TOut> map,
-        string? controllerName = null)
-    {
-        if (result.IsSuccess)
-        {
-            var value = map(result.Value);
-            return (ActionResult<TOut>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(result.Value), value);
-        }
-
-        return result.Error.ToActionResult<TOut>(controllerBase);
-    }
+        string? controllerName = null) =>
+        result.Match<TValue, ActionResult<TOut>>(
+            onSuccess: inValue => (ActionResult<TOut>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(inValue), map(inValue)),
+            onFailure: error => error.ToActionResult<TOut>(controllerBase));
 
     /// <summary>
     /// Converts a <see cref="Result{TIn}"/> to an <see cref="ActionResult{TOut}"/> that returns
@@ -569,18 +545,15 @@ public static class ActionResultExtensions
         Func<TIn, object?> routeValues,
         Func<TIn, RepresentationMetadata> metadataSelector,
         Func<TIn, TOut> map,
-        string? controllerName = null)
-    {
-        if (result.IsSuccess)
-        {
-            var metadata = metadataSelector(result.Value);
-            ApplyMetadataHeaders(controllerBase.Response, metadata);
-            var value = map(result.Value);
-            return (ActionResult<TOut>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(result.Value), value);
-        }
-
-        return result.Error.ToActionResult<TOut>(controllerBase);
-    }
+        string? controllerName = null) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue =>
+            {
+                var metadata = metadataSelector(inValue);
+                ApplyMetadataHeaders(controllerBase.Response, metadata);
+                return (ActionResult<TOut>)controllerBase.CreatedAtAction(actionName, controllerName, routeValues(inValue), map(inValue));
+            },
+            onFailure: error => error.ToActionResult<TOut>(controllerBase));
 
     internal static void EmitCompanionHeaders(Error error, Microsoft.AspNetCore.Http.HttpResponse response)
     {
@@ -644,32 +617,32 @@ public static class ActionResultExtensions
         this Result<TIn> result,
         ControllerBase controller,
         Func<TIn, RepresentationMetadata> metadataSelector,
-        Func<TIn, TOut> map)
-    {
-        if (result.IsFailure)
-            return result.Error.ToActionResult<TOut>(controller);
-
-        var metadata = metadataSelector(result.Value);
-        ApplyMetadataHeaders(controller.Response, metadata);
-
-        // Only evaluate conditional headers for safe methods (GET/HEAD).
-        // For unsafe methods, the precondition was already checked before the write
-        // (via OptionalETag/RequireETag), and the response ETag is the NEW value.
-        var method = controller.Request.Method;
-        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
-        {
-            return ConditionalRequestEvaluator.Evaluate(controller.Request, metadata) switch
+        Func<TIn, TOut> map) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue =>
             {
-                ConditionalDecision.NotModified => new StatusCodeResult(StatusCodes.Status304NotModified),
-                ConditionalDecision.PreconditionFailed =>
-                    Error.PreconditionFailed("A conditional request header evaluated to false.")
-                        .ToActionResult<TOut>(controller),
-                _ => controller.Ok(map(result.Value)),
-            };
-        }
+                var metadata = metadataSelector(inValue);
+                ApplyMetadataHeaders(controller.Response, metadata);
 
-        return controller.Ok(map(result.Value));
-    }
+                // Only evaluate conditional headers for safe methods (GET/HEAD).
+                // For unsafe methods, the precondition was already checked before the write
+                // (via OptionalETag/RequireETag), and the response ETag is the NEW value.
+                var method = controller.Request.Method;
+                if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
+                {
+                    return ConditionalRequestEvaluator.Evaluate(controller.Request, metadata) switch
+                    {
+                        ConditionalDecision.NotModified => new StatusCodeResult(StatusCodes.Status304NotModified),
+                        ConditionalDecision.PreconditionFailed =>
+                            Error.PreconditionFailed("A conditional request header evaluated to false.")
+                                .ToActionResult<TOut>(controller),
+                        _ => controller.Ok(map(inValue)),
+                    };
+                }
+
+                return controller.Ok(map(inValue));
+            },
+            onFailure: error => error.ToActionResult<TOut>(controller));
 
     /// <summary>Async Task overload of metadata-selector-aware ToActionResult.</summary>
     public static async Task<ActionResult<TOut>> ToActionResultAsync<TIn, TOut>(

--- a/Trellis.Asp/src/HttpResultExtensions.cs
+++ b/Trellis.Asp/src/HttpResultExtensions.cs
@@ -121,19 +121,10 @@ public static class HttpResultExtensions
     ///         .ToHttpResultAsync());
     /// </code>
     /// </example>
-    public static Microsoft.AspNetCore.Http.IResult ToHttpResult<TValue>(this Result<TValue> result, TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            // If TValue is Unit, return 204 No Content
-            if (typeof(TValue) == typeof(Unit))
-                return Results.NoContent();
-
-            return Results.Ok(result.Value);
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+    public static Microsoft.AspNetCore.Http.IResult ToHttpResult<TValue>(this Result<TValue> result, TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: value => typeof(TValue) == typeof(Unit) ? Results.NoContent() : Results.Ok(value),
+            onFailure: error => error.ToHttpResult(options));
 
     /// <summary>
     /// Converts a domain <see cref="Error"/> to an <see cref="Microsoft.AspNetCore.Http.IResult"/> with appropriate HTTP status code and Problem Details format.
@@ -368,13 +359,10 @@ public static class HttpResultExtensions
         this Result<TValue> result,
         string routeName,
         Func<TValue, RouteValueDictionary> routeValues,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-            return Results.CreatedAtRoute(routeName, routeValues(result.Value), result.Value);
-
-        return result.Error.ToHttpResult(options);
-    }
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: value => Results.CreatedAtRoute(routeName, routeValues(value), value),
+            onFailure: error => error.ToHttpResult(options));
 
     /// <summary>
     /// Converts a <see cref="Result{TValue}"/> to an <see cref="Microsoft.AspNetCore.Http.IResult"/> that returns
@@ -411,16 +399,10 @@ public static class HttpResultExtensions
         string routeName,
         Func<TValue, RouteValueDictionary> routeValues,
         Func<TValue, TOut> map,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            var value = map(result.Value);
-            return Results.CreatedAtRoute(routeName, routeValues(result.Value), value);
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: inValue => Results.CreatedAtRoute(routeName, routeValues(inValue), map(inValue)),
+            onFailure: error => error.ToHttpResult(options));
 
     #region RFC 9110 — Metadata-Aware Response (Minimal API)
 
@@ -434,31 +416,29 @@ public static class HttpResultExtensions
         HttpContext httpContext,
         Func<TIn, RepresentationMetadata> metadataSelector,
         Func<TIn, TOut> map,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            var metadata = metadataSelector(result.Value);
-            ActionResultExtensions.ApplyMetadataHeaders(httpContext.Response, metadata);
-
-            var method = httpContext.Request.Method;
-            if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: inValue =>
             {
-                return ConditionalRequestEvaluator.Evaluate(httpContext.Request, metadata) switch
+                var metadata = metadataSelector(inValue);
+                ActionResultExtensions.ApplyMetadataHeaders(httpContext.Response, metadata);
+
+                var method = httpContext.Request.Method;
+                if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
                 {
-                    ConditionalDecision.NotModified => Results.StatusCode(StatusCodes.Status304NotModified),
-                    ConditionalDecision.PreconditionFailed =>
-                        Error.PreconditionFailed("A conditional request header evaluated to false.")
-                            .ToHttpResult(options),
-                    _ => Results.Ok(map(result.Value)),
-                };
-            }
+                    return ConditionalRequestEvaluator.Evaluate(httpContext.Request, metadata) switch
+                    {
+                        ConditionalDecision.NotModified => Results.StatusCode(StatusCodes.Status304NotModified),
+                        ConditionalDecision.PreconditionFailed =>
+                            Error.PreconditionFailed("A conditional request header evaluated to false.")
+                                .ToHttpResult(options),
+                        _ => Results.Ok(map(inValue)),
+                    };
+                }
 
-            return Results.Ok(map(result.Value));
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+                return Results.Ok(map(inValue));
+            },
+            onFailure: error => error.ToHttpResult(options));
 
     #endregion
 
@@ -474,18 +454,15 @@ public static class HttpResultExtensions
         Func<TIn, string> uriSelector,
         Func<TIn, RepresentationMetadata> metadataSelector,
         Func<TIn, TOut> map,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            var metadata = metadataSelector(result.Value);
-            ActionResultExtensions.ApplyMetadataHeaders(httpContext.Response, metadata);
-
-            return Results.Created(uriSelector(result.Value), map(result.Value));
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: inValue =>
+            {
+                var metadata = metadataSelector(inValue);
+                ActionResultExtensions.ApplyMetadataHeaders(httpContext.Response, metadata);
+                return Results.Created(uriSelector(inValue), map(inValue));
+            },
+            onFailure: error => error.ToHttpResult(options));
 
     #endregion
 
@@ -508,30 +485,28 @@ public static class HttpResultExtensions
         long from,
         long to,
         long totalLength,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            // If TValue is Unit, return 204 No Content
-            if (typeof(TValue) == typeof(Unit))
-                return Results.NoContent();
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: value =>
+            {
+                // If TValue is Unit, return 204 No Content
+                if (typeof(TValue) == typeof(Unit))
+                    return Results.NoContent();
 
-            // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
-            if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
-                return Results.Ok(result.Value);
+                // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
+                if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
+                    return Results.Ok(value);
 
-            // Clamp to against totalLength to prevent ContentRangeHeaderValue from throwing
-            var clampedTo = Math.Min(to, totalLength - 1);
+                // Clamp to against totalLength to prevent ContentRangeHeaderValue from throwing
+                var clampedTo = Math.Min(to, totalLength - 1);
 
-            var isCompleteRange = from == 0 && clampedTo == totalLength - 1;
-            if (!isCompleteRange)
-                return new PartialContentHttpResult(from, clampedTo, totalLength, Results.Ok(result.Value));
+                var isCompleteRange = from == 0 && clampedTo == totalLength - 1;
+                if (!isCompleteRange)
+                    return new PartialContentHttpResult(from, clampedTo, totalLength, Results.Ok(value));
 
-            return Results.Ok(result.Value);
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+                return Results.Ok(value);
+            },
+            onFailure: error => error.ToHttpResult(options));
 
     /// <summary>
     /// Converts a <see cref="Result{TIn}"/> to a Minimal API <see cref="Microsoft.AspNetCore.Http.IResult"/>
@@ -549,28 +524,26 @@ public static class HttpResultExtensions
         this Result<TIn> result,
         Func<TIn, System.Net.Http.Headers.ContentRangeHeaderValue> funcRange,
         Func<TIn, TOut> funcValue,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsSuccess)
-        {
-            var contentRange = funcRange(result.Value);
-            var value = funcValue(result.Value);
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: inValue =>
+            {
+                var contentRange = funcRange(inValue);
+                var value = funcValue(inValue);
 
-            if (contentRange.From is null || contentRange.To is null)
+                if (contentRange.From is null || contentRange.To is null)
+                    return Results.Ok(value);
+
+                if (contentRange.Length is null)
+                    return new PartialContentHttpResult(contentRange, Results.Ok(value));
+
+                var isCompleteRange = contentRange.From == 0 && contentRange.To == contentRange.Length - 1;
+                if (!isCompleteRange)
+                    return new PartialContentHttpResult(contentRange, Results.Ok(value));
+
                 return Results.Ok(value);
-
-            if (contentRange.Length is null)
-                return new PartialContentHttpResult(contentRange, Results.Ok(value));
-
-            var isCompleteRange = contentRange.From == 0 && contentRange.To == contentRange.Length - 1;
-            if (!isCompleteRange)
-                return new PartialContentHttpResult(contentRange, Results.Ok(value));
-
-            return Results.Ok(value);
-        }
-
-        return result.Error.ToHttpResult(options);
-    }
+            },
+            onFailure: error => error.ToHttpResult(options));
 
     #endregion
 
@@ -594,14 +567,10 @@ public static class HttpResultExtensions
         HttpContext httpContext,
         RepresentationMetadata? metadata,
         Func<TIn, TOut> map,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsFailure)
-            return result.Error.ToHttpResult(options);
-
-        var outcome = new WriteOutcome<TIn>.Updated(result.Value, metadata);
-        return outcome.ToHttpResult<TIn, TOut>(httpContext, map);
-    }
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: value => new WriteOutcome<TIn>.Updated(value, metadata).ToHttpResult<TIn, TOut>(httpContext, map),
+            onFailure: error => error.ToHttpResult(options));
 
     /// <summary>
     /// Converts a successful <see cref="Result{TIn}"/> to an updated response for Minimal APIs with dynamic metadata,
@@ -620,15 +589,10 @@ public static class HttpResultExtensions
         HttpContext httpContext,
         Func<TIn, RepresentationMetadata> metadataSelector,
         Func<TIn, TOut> map,
-        TrellisAspOptions? options = null)
-    {
-        if (result.IsFailure)
-            return result.Error.ToHttpResult(options);
-
-        var metadata = metadataSelector(result.Value);
-        var outcome = new WriteOutcome<TIn>.Updated(result.Value, metadata);
-        return outcome.ToHttpResult<TIn, TOut>(httpContext, map);
-    }
+        TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: value => new WriteOutcome<TIn>.Updated(value, metadataSelector(value)).ToHttpResult<TIn, TOut>(httpContext, map),
+            onFailure: error => error.ToHttpResult(options));
 
     #endregion
 

--- a/Trellis.Asp/src/ModelBinding/ScalarValueModelBinderBase.cs
+++ b/Trellis.Asp/src/ModelBinding/ScalarValueModelBinderBase.cs
@@ -57,23 +57,25 @@ public abstract class ScalarValueModelBinderBase<TResult, TValue, TPrimitive> : 
 
         var parseResult = PrimitiveConverter.ConvertToPrimitive<TPrimitive>(rawValue);
 
-        if (parseResult.IsFailure)
+        if (parseResult.TryGetError(out var parseError))
         {
-            bindingContext.ModelState.AddModelError(modelName, parseResult.Error.Detail);
+            bindingContext.ModelState.AddModelError(modelName, parseError.Detail);
             bindingContext.Result = ModelBindingResult.Failed();
             return Task.CompletedTask;
         }
 
-        var primitiveValue = parseResult.Value;
+        // Safe: TryGetError returned false above, so parseResult is success.
+        if (!parseResult.TryGetValue(out var primitiveValue))
+            throw new InvalidOperationException("Result is in an unexpected state.");
         var result = TValue.TryCreate(primitiveValue, modelName);
 
-        if (result.IsSuccess)
+        if (result.TryGetValue(out var typedValue))
         {
-            bindingContext.Result = OnSuccess(result.Value);
+            bindingContext.Result = OnSuccess(typedValue);
         }
-        else
+        else if (result.TryGetError(out var createError))
         {
-            bindingContext.ModelState.AddResultErrors(modelName, result.Error);
+            bindingContext.ModelState.AddResultErrors(modelName, createError);
             bindingContext.Result = ModelBindingResult.Failed();
         }
 

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -59,21 +59,21 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
             return OnValidationFailure();
         }
 
-        var result = TValue.TryCreate(primitiveValue, fieldName);
+        return TValue.TryCreate(primitiveValue, fieldName).Match(
+            onSuccess: WrapSuccess,
+            onFailure: createError =>
+            {
+                if (createError is ValidationError validationError)
+                    ValidationErrorsContext.AddError(validationError);
+                else
+                    ValidationErrorsContext.AddError(
+                        fieldName,
+                        string.IsNullOrWhiteSpace(createError.Detail)
+                            ? $"{typeof(TValue).Name} is invalid."
+                            : createError.Detail);
 
-        if (result.IsSuccess)
-            return WrapSuccess(result.Value);
-
-        if (result.Error is ValidationError validationError)
-            ValidationErrorsContext.AddError(validationError);
-        else
-            ValidationErrorsContext.AddError(
-                fieldName,
-                string.IsNullOrWhiteSpace(result.Error.Detail)
-                    ? $"{typeof(TValue).Name} is invalid."
-                    : result.Error.Detail);
-
-        return OnValidationFailure();
+                return OnValidationFailure();
+            });
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TPrimitive type parameter is preserved by JSON serialization infrastructure")]

--- a/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
@@ -154,16 +154,16 @@ internal static class ScalarValueTypeHelper
 
     private static IDictionary<string, string[]>? ExtractErrors(object? result, string? parameterName)
     {
-        if (result is not IResult { IsFailure: true } failure)
+        if (result is not IResult failure || !failure.TryGetError(out var failureError))
             return null;
 
-        if (failure.Error is ValidationError validationError)
+        if (failureError is ValidationError validationError)
             return validationError.ToDictionary();
 
         var fieldName = parameterName ?? string.Empty;
         return new Dictionary<string, string[]>
         {
-            [fieldName] = [failure.Error.Detail]
+            [fieldName] = [failureError.Detail]
         };
     }
 
@@ -187,12 +187,12 @@ internal static class ScalarValueTypeHelper
             return null;
         }
 
-        if (conversionResult is IResult { IsFailure: true } failure)
+        if (conversionResult is IResult failure && failure.TryGetError(out var convError))
         {
             var fieldName = parameterName ?? string.Empty;
             var detail = string.IsNullOrEmpty(rawValue)
                 ? $"'{fieldName}' is required."
-                : failure.Error.Detail;
+                : convError.Detail;
 
             return new Dictionary<string, string[]>
             {
@@ -200,8 +200,28 @@ internal static class ScalarValueTypeHelper
             };
         }
 
-        var valueProperty = conversionResult?.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
-        return valueProperty?.GetValue(conversionResult);
+        // Extract the value via TryGetValue(out _) since the public Value property was removed.
+        return ExtractSuccessValue(conversionResult);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "TryGetValue is preserved by being public on IResult<TValue> implementations used here.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "TryGetValue is preserved by being public on IResult<TValue> implementations used here.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Reflection-based validation fallback is not Native AOT compatible.")]
+    private static object? ExtractSuccessValue(object? conversionResult)
+    {
+        if (conversionResult is null)
+            return null;
+
+        var tryGetValue = conversionResult.GetType().GetMethod(
+            "TryGetValue",
+            BindingFlags.Public | BindingFlags.Instance);
+
+        if (tryGetValue is null)
+            return null;
+
+        var args = new object?[] { null };
+        var ok = tryGetValue.Invoke(conversionResult, args) as bool?;
+        return ok == true ? args[0] : null;
     }
 
     /// <summary>

--- a/Trellis.Asp/src/WriteOutcomeExtensions.cs
+++ b/Trellis.Asp/src/WriteOutcomeExtensions.cs
@@ -129,14 +129,10 @@ public static class WriteOutcomeExtensions
         this Result<TIn> result,
         ControllerBase controller,
         RepresentationMetadata? metadata,
-        Func<TIn, TOut> map)
-    {
-        if (result.IsFailure)
-            return result.Error.ToActionResult<TOut>(controller);
-
-        var outcome = new WriteOutcome<TIn>.Updated(result.Value, metadata);
-        return outcome.ToActionResult(controller, map);
-    }
+        Func<TIn, TOut> map) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue => new WriteOutcome<TIn>.Updated(inValue, metadata).ToActionResult(controller, map),
+            onFailure: error => error.ToActionResult<TOut>(controller));
 
     /// <summary>
     /// Async Task variant of <see cref="ToUpdatedActionResult{TIn,TOut}(Result{TIn}, ControllerBase, RepresentationMetadata, Func{TIn, TOut})"/>.
@@ -179,15 +175,10 @@ public static class WriteOutcomeExtensions
         this Result<TIn> result,
         ControllerBase controller,
         Func<TIn, RepresentationMetadata> metadataSelector,
-        Func<TIn, TOut> map)
-    {
-        if (result.IsFailure)
-            return result.Error.ToActionResult<TOut>(controller);
-
-        var metadata = metadataSelector(result.Value);
-        var outcome = new WriteOutcome<TIn>.Updated(result.Value, metadata);
-        return outcome.ToActionResult(controller, map);
-    }
+        Func<TIn, TOut> map) =>
+        result.Match<TIn, ActionResult<TOut>>(
+            onSuccess: inValue => new WriteOutcome<TIn>.Updated(inValue, metadataSelector(inValue)).ToActionResult(controller, map),
+            onFailure: error => error.ToActionResult<TOut>(controller));
 
     /// <summary>
     /// Async Task variant of <see cref="ToUpdatedActionResult{TIn,TOut}(Result{TIn}, ControllerBase, Func{TIn, RepresentationMetadata}, Func{TIn, TOut})"/>.

--- a/Trellis.Asp/tests/MaybeScalarValueJsonConverterTests.cs
+++ b/Trellis.Asp/tests/MaybeScalarValueJsonConverterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.Text;
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Trellis;
 using Trellis.Asp.Validation;
 using Xunit;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="MaybeScalarValueJsonConverter{TValue, TPrimitive}"/> and
@@ -432,7 +433,7 @@ public class MaybeScalarValueJsonConverterTests
     {
         // Arrange
         var converter = new MaybeScalarValueJsonConverter<Email, string>();
-        var email = Email.TryCreate("test@example.com", null).Value;
+        var email = Email.TryCreate("test@example.com", null).Unwrap();
         var maybe = Maybe.From(email);
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
@@ -469,7 +470,7 @@ public class MaybeScalarValueJsonConverterTests
     {
         // Arrange
         var converter = new MaybeScalarValueJsonConverter<Age, int>();
-        var age = Age.TryCreate(42, null).Value;
+        var age = Age.TryCreate(42, null).Unwrap();
         var maybe = Maybe.From(age);
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
@@ -506,7 +507,7 @@ public class MaybeScalarValueJsonConverterTests
     {
         // Arrange
         var converter = new MaybeScalarValueJsonConverter<Percentage, decimal>();
-        var percentage = Percentage.TryCreate(99.99m, null).Value;
+        var percentage = Percentage.TryCreate(99.99m, null).Unwrap();
         var maybe = Maybe.From(percentage);
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
@@ -526,7 +527,7 @@ public class MaybeScalarValueJsonConverterTests
         // Arrange
         var converter = new MaybeScalarValueJsonConverter<ItemId, Guid>();
         var guid = Guid.NewGuid();
-        var itemId = ItemId.TryCreate(guid, null).Value;
+        var itemId = ItemId.TryCreate(guid, null).Unwrap();
         var maybe = Maybe.From(itemId);
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
@@ -557,7 +558,7 @@ public class MaybeScalarValueJsonConverterTests
     public void RoundTrip_MaybeEmail_PreservesValue()
     {
         // Arrange
-        var email = Email.TryCreate("user@domain.com", null).Value;
+        var email = Email.TryCreate("user@domain.com", null).Unwrap();
         var maybe = Maybe.From(email);
 
         // Act

--- a/Trellis.Asp/tests/PropertyNameAwareConverterTests.cs
+++ b/Trellis.Asp/tests/PropertyNameAwareConverterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.Text;
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Trellis;
 using Trellis.Asp.Validation;
 using Xunit;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for PropertyNameAwareConverter to ensure proper property name tracking.
@@ -93,8 +94,8 @@ public class PropertyNameAwareConverterTests
             // Assert
             result.Should().BeNull();
             var error = ValidationErrorsContext.GetValidationError();
-            error.Should().NotBeNull();
-            error!.FieldErrors.Should().ContainSingle()
+            error!.Should().NotBeNull();
+                        error!.FieldErrors.Should().ContainSingle()
                 .Which.FieldName.Should().Be("PrimaryEmail", "wrapper should set property name");
         }
     }
@@ -210,7 +211,7 @@ public class PropertyNameAwareConverterTests
         var innerConverter = new ValidatingJsonConverter<Email, string>();
         var wrapper = new PropertyNameAwareConverter<Email>(innerConverter, "Email");
 
-        var email = Email.TryCreate("test@example.com", null).Value;
+        var email = Email.TryCreate("test@example.com", null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -261,8 +262,8 @@ public class PropertyNameAwareConverterTests
             // Assert
             result.Should().BeNull();
             var error = ValidationErrorsContext.GetValidationError();
-            error.Should().NotBeNull();
-            // Empty string should still be set as property name
+            error!.Should().NotBeNull();
+                        // Empty string should still be set as property name
             error!.FieldErrors.Should().ContainSingle()
                 .Which.FieldName.Should().Be("");
         }
@@ -337,8 +338,8 @@ public class PropertyNameAwareConverterTests
             // Assert
             result.Should().BeNull();
             var error = ValidationErrorsContext.GetValidationError();
-            error.Should().NotBeNull();
-            error!.FieldErrors.Should().ContainSingle();
+            error!.Should().NotBeNull();
+                        error!.FieldErrors.Should().ContainSingle();
             error.FieldErrors[0].FieldName.Should().Be("Email");
             error.FieldErrors[0].Details.Should().Equal(["DomainOnlyEmail is invalid."]);
         }

--- a/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.Text;
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Trellis;
 using Trellis.Asp.Validation;
 using Xunit;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for ValidatingJsonConverter to ensure all primitive types are serialized correctly.
@@ -206,7 +207,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         // Arrange
         var converter = new ValidatingJsonConverter<StringVO, string>();
-        var vo = StringVO.TryCreate("Hello World", null).Value;
+        var vo = StringVO.TryCreate("Hello World", null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -222,7 +223,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_String_PreservesValue()
     {
-        var vo = StringVO.TryCreate("Test", null).Value;
+        var vo = StringVO.TryCreate("Test", null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<StringVO, string>());
         roundTripped!.Value.Should().Be("Test");
     }
@@ -237,7 +238,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
         // Arrange
         var guid = Guid.Parse("12345678-1234-1234-1234-123456789012");
         var converter = new ValidatingJsonConverter<GuidVO, Guid>();
-        var vo = GuidVO.TryCreate(guid, null).Value;
+        var vo = GuidVO.TryCreate(guid, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -254,7 +255,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_Guid_PreservesValue()
     {
         var guid = Guid.NewGuid();
-        var vo = GuidVO.TryCreate(guid, null).Value;
+        var vo = GuidVO.TryCreate(guid, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<GuidVO, Guid>());
         roundTripped!.Value.Should().Be(guid);
     }
@@ -267,7 +268,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Int_WritesCorrectly()
     {
         var converter = new ValidatingJsonConverter<IntVO, int>();
-        var vo = IntVO.TryCreate(42, null).Value;
+        var vo = IntVO.TryCreate(42, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -281,7 +282,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Int_PreservesValue()
     {
-        var vo = IntVO.TryCreate(999, null).Value;
+        var vo = IntVO.TryCreate(999, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<IntVO, int>());
         roundTripped!.Value.Should().Be(999);
     }
@@ -290,7 +291,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Int_Zero()
     {
         var converter = new ValidatingJsonConverter<IntVO, int>();
-        var vo = IntVO.TryCreate(0, null).Value;
+        var vo = IntVO.TryCreate(0, null).Unwrap();
         var json = Serialize(vo, converter);
         json.Should().Be("0");
     }
@@ -299,7 +300,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Int_MaxValue()
     {
         var converter = new ValidatingJsonConverter<IntVO, int>();
-        var vo = IntVO.TryCreate(int.MaxValue, null).Value;
+        var vo = IntVO.TryCreate(int.MaxValue, null).Unwrap();
         var json = Serialize(vo, converter);
         json.Should().Be(int.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
@@ -312,7 +313,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Long_WritesCorrectly()
     {
         var converter = new ValidatingJsonConverter<LongVO, long>();
-        var vo = LongVO.TryCreate(9223372036854775807L, null).Value;
+        var vo = LongVO.TryCreate(9223372036854775807L, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -326,7 +327,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Long_PreservesValue()
     {
-        var vo = LongVO.TryCreate(123456789012345L, null).Value;
+        var vo = LongVO.TryCreate(123456789012345L, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<LongVO, long>());
         roundTripped!.Value.Should().Be(123456789012345L);
     }
@@ -339,7 +340,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Double_WritesCorrectly()
     {
         var converter = new ValidatingJsonConverter<DoubleVO, double>();
-        var vo = DoubleVO.TryCreate(3.14159, null).Value;
+        var vo = DoubleVO.TryCreate(3.14159, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -353,7 +354,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Double_PreservesValue()
     {
-        var vo = DoubleVO.TryCreate(2.71828, null).Value;
+        var vo = DoubleVO.TryCreate(2.71828, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<DoubleVO, double>());
         roundTripped!.Value.Should().BeApproximately(2.71828, 0.00001);
     }
@@ -369,7 +370,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Float_WritesCorrectly()
     {
         var converter = new ValidatingJsonConverter<FloatVO, float>();
-        var vo = FloatVO.TryCreate(1.23f, null).Value;
+        var vo = FloatVO.TryCreate(1.23f, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -383,7 +384,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Float_PreservesValue()
     {
-        var vo = FloatVO.TryCreate(9.99f, null).Value;
+        var vo = FloatVO.TryCreate(9.99f, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<FloatVO, float>());
         roundTripped!.Value.Should().BeApproximately(9.99f, 0.01f);
     }
@@ -396,7 +397,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Decimal_WritesCorrectly()
     {
         var converter = new ValidatingJsonConverter<DecimalVO, decimal>();
-        var vo = DecimalVO.TryCreate(99.99m, null).Value;
+        var vo = DecimalVO.TryCreate(99.99m, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -410,7 +411,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Decimal_PreservesValue()
     {
-        var vo = DecimalVO.TryCreate(123.456m, null).Value;
+        var vo = DecimalVO.TryCreate(123.456m, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<DecimalVO, decimal>());
         roundTripped!.Value.Should().Be(123.456m);
     }
@@ -419,7 +420,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Decimal_HighPrecision()
     {
         var converter = new ValidatingJsonConverter<DecimalVO, decimal>();
-        var vo = DecimalVO.TryCreate(0.123456789012345678901234567890m, null).Value;
+        var vo = DecimalVO.TryCreate(0.123456789012345678901234567890m, null).Unwrap();
         var json = Serialize(vo, converter);
         // JSON serialization preserves significant digits but may round the last few digits
         json.Should().StartWith("0.123456789012345678901234");
@@ -433,7 +434,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Bool_True()
     {
         var converter = new ValidatingJsonConverter<BoolVO, bool>();
-        var vo = BoolVO.TryCreate(true, null).Value;
+        var vo = BoolVO.TryCreate(true, null).Unwrap();
         var json = Serialize(vo, converter);
         json.Should().Be("true");
     }
@@ -442,7 +443,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Bool_False()
     {
         var converter = new ValidatingJsonConverter<BoolVO, bool>();
-        var vo = BoolVO.TryCreate(false, null).Value;
+        var vo = BoolVO.TryCreate(false, null).Unwrap();
         var json = Serialize(vo, converter);
         json.Should().Be("false");
     }
@@ -450,7 +451,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Bool_PreservesValue()
     {
-        var vo = BoolVO.TryCreate(true, null).Value;
+        var vo = BoolVO.TryCreate(true, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<BoolVO, bool>());
         roundTripped!.Value.Should().BeTrue();
     }
@@ -464,7 +465,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         var converter = new ValidatingJsonConverter<DateTimeVO, DateTime>();
         var dt = new DateTime(2024, 1, 15, 10, 30, 45, DateTimeKind.Utc);
-        var vo = DateTimeVO.TryCreate(dt, null).Value;
+        var vo = DateTimeVO.TryCreate(dt, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -479,7 +480,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_DateTime_PreservesValue()
     {
         var dt = new DateTime(2024, 6, 15, 14, 30, 0, DateTimeKind.Utc);
-        var vo = DateTimeVO.TryCreate(dt, null).Value;
+        var vo = DateTimeVO.TryCreate(dt, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<DateTimeVO, DateTime>());
         // Note: DateTime round-trip may lose some precision, so we check for closeness
         roundTripped!.Value.Should().BeCloseTo(dt, TimeSpan.FromSeconds(1));
@@ -494,7 +495,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         var converter = new ValidatingJsonConverter<DateTimeOffsetVO, DateTimeOffset>();
         var dto = new DateTimeOffset(2024, 1, 15, 10, 30, 45, TimeSpan.FromHours(-5));
-        var vo = DateTimeOffsetVO.TryCreate(dto, null).Value;
+        var vo = DateTimeOffsetVO.TryCreate(dto, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -510,7 +511,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_DateTimeOffset_PreservesValue()
     {
         var dto = new DateTimeOffset(2024, 12, 25, 18, 0, 0, TimeSpan.FromHours(2));
-        var vo = DateTimeOffsetVO.TryCreate(dto, null).Value;
+        var vo = DateTimeOffsetVO.TryCreate(dto, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<DateTimeOffsetVO, DateTimeOffset>());
         roundTripped!.Value.Should().Be(dto);
     }
@@ -524,7 +525,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         var converter = new ValidatingJsonConverter<DateOnlyVO, DateOnly>();
         var date = new DateOnly(2024, 3, 15);
-        var vo = DateOnlyVO.TryCreate(date, null).Value;
+        var vo = DateOnlyVO.TryCreate(date, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -539,7 +540,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_DateOnly_PreservesValue()
     {
         var date = new DateOnly(2024, 7, 4);
-        var vo = DateOnlyVO.TryCreate(date, null).Value;
+        var vo = DateOnlyVO.TryCreate(date, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<DateOnlyVO, DateOnly>());
         roundTripped!.Value.Should().Be(date);
     }
@@ -553,7 +554,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         var converter = new ValidatingJsonConverter<TimeOnlyVO, TimeOnly>();
         var time = new TimeOnly(14, 30, 45);
-        var vo = TimeOnlyVO.TryCreate(time, null).Value;
+        var vo = TimeOnlyVO.TryCreate(time, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -568,7 +569,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_TimeOnly_PreservesValue()
     {
         var time = new TimeOnly(9, 15, 30);
-        var vo = TimeOnlyVO.TryCreate(time, null).Value;
+        var vo = TimeOnlyVO.TryCreate(time, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<TimeOnlyVO, TimeOnly>());
         roundTripped!.Value.Should().Be(time);
     }
@@ -582,7 +583,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     {
         var converter = new ValidatingJsonConverter<TimeSpanVO, TimeSpan>();
         var value = TimeSpan.FromHours(1) + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(3);
-        var vo = TimeSpanVO.TryCreate(value, null).Value;
+        var vo = TimeSpanVO.TryCreate(value, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -593,7 +594,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void RoundTrip_TimeSpan_PreservesValue()
     {
         var value = TimeSpan.FromDays(1) + TimeSpan.FromMilliseconds(456);
-        var vo = TimeSpanVO.TryCreate(value, null).Value;
+        var vo = TimeSpanVO.TryCreate(value, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<TimeSpanVO, TimeSpan>());
 
         roundTripped!.Value.Should().Be(value);
@@ -607,7 +608,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Short_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<ShortVO, short>();
-        var vo = ShortVO.TryCreate(123, null).Value;
+        var vo = ShortVO.TryCreate(123, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -617,7 +618,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Short_PreservesValue()
     {
-        var vo = ShortVO.TryCreate(321, null).Value;
+        var vo = ShortVO.TryCreate(321, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<ShortVO, short>());
 
         roundTripped!.Value.Should().Be((short)321);
@@ -631,7 +632,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_Byte_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<ByteVO, byte>();
-        var vo = ByteVO.TryCreate(200, null).Value;
+        var vo = ByteVO.TryCreate(200, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -641,7 +642,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_Byte_PreservesValue()
     {
-        var vo = ByteVO.TryCreate(201, null).Value;
+        var vo = ByteVO.TryCreate(201, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<ByteVO, byte>());
 
         roundTripped!.Value.Should().Be((byte)201);
@@ -655,7 +656,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_SByte_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<SByteVO, sbyte>();
-        var vo = SByteVO.TryCreate(100, null).Value;
+        var vo = SByteVO.TryCreate(100, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -665,7 +666,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_SByte_PreservesValue()
     {
-        var vo = SByteVO.TryCreate(101, null).Value;
+        var vo = SByteVO.TryCreate(101, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<SByteVO, sbyte>());
 
         roundTripped!.Value.Should().Be((sbyte)101);
@@ -679,7 +680,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_UShort_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<UShortVO, ushort>();
-        var vo = UShortVO.TryCreate(65000, null).Value;
+        var vo = UShortVO.TryCreate(65000, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -689,7 +690,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_UShort_PreservesValue()
     {
-        var vo = UShortVO.TryCreate(65001, null).Value;
+        var vo = UShortVO.TryCreate(65001, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<UShortVO, ushort>());
 
         roundTripped!.Value.Should().Be((ushort)65001);
@@ -703,7 +704,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_UInt_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<UIntVO, uint>();
-        var vo = UIntVO.TryCreate(4000000000u, null).Value;
+        var vo = UIntVO.TryCreate(4000000000u, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -713,7 +714,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_UInt_PreservesValue()
     {
-        var vo = UIntVO.TryCreate(4000000001u, null).Value;
+        var vo = UIntVO.TryCreate(4000000001u, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<UIntVO, uint>());
 
         roundTripped!.Value.Should().Be(4000000001u);
@@ -727,7 +728,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     public void Write_ULong_WritesNumber()
     {
         var converter = new ValidatingJsonConverter<ULongVO, ulong>();
-        var vo = ULongVO.TryCreate(18446744073709551614ul, null).Value;
+        var vo = ULongVO.TryCreate(18446744073709551614ul, null).Unwrap();
 
         var json = Serialize(vo, converter);
 
@@ -737,7 +738,7 @@ public class ValidatingJsonConverterPrimitiveTypesTests
     [Fact]
     public void RoundTrip_ULong_PreservesValue()
     {
-        var vo = ULongVO.TryCreate(18446744073709551615ul, null).Value;
+        var vo = ULongVO.TryCreate(18446744073709551615ul, null).Unwrap();
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<ULongVO, ulong>());
 
         roundTripped!.Value.Should().Be(18446744073709551615ul);

--- a/Trellis.Asp/tests/ValidatingJsonConverterTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.Text;
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Trellis;
 using Trellis.Asp.Validation;
 using Xunit;
+using Trellis.Testing;
 
 /// <summary>
 /// Direct tests for ValidatingJsonConverter to ensure proper JSON serialization/deserialization.
@@ -184,7 +185,7 @@ public class ValidatingJsonConverterTests
     {
         // Arrange
         var converter = new ValidatingJsonConverter<Email, string>();
-        var email = Email.TryCreate("test@example.com", null).Value;
+        var email = Email.TryCreate("test@example.com", null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -292,7 +293,7 @@ public class ValidatingJsonConverterTests
     {
         // Arrange
         var converter = new ValidatingJsonConverter<Age, int>();
-        var age = Age.TryCreate(42, null).Value;
+        var age = Age.TryCreate(42, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -381,7 +382,7 @@ public class ValidatingJsonConverterTests
     {
         // Arrange
         var converter = new ValidatingJsonConverter<Percentage, decimal>();
-        var percentage = Percentage.TryCreate(99.99m, null).Value;
+        var percentage = Percentage.TryCreate(99.99m, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -452,7 +453,7 @@ public class ValidatingJsonConverterTests
         // Arrange
         var converter = new ValidatingJsonConverter<ItemId, Guid>();
         var guid = Guid.NewGuid();
-        var itemId = ItemId.TryCreate(guid, null).Value;
+        var itemId = ItemId.TryCreate(guid, null).Unwrap();
         using var stream = new System.IO.MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
 
@@ -495,7 +496,7 @@ public class ValidatingJsonConverterTests
     public void RoundTrip_Email_PreservesValue()
     {
         // Arrange
-        var email = Email.TryCreate("user@domain.com", null).Value;
+        var email = Email.TryCreate("user@domain.com", null).Unwrap();
         var options = new JsonSerializerOptions();
         options.Converters.Add(new ValidatingJsonConverterFactory());
 
@@ -518,7 +519,7 @@ public class ValidatingJsonConverterTests
     public void RoundTrip_Age_PreservesValue()
     {
         // Arrange
-        var age = Age.TryCreate(30, null).Value;
+        var age = Age.TryCreate(30, null).Unwrap();
         var options = new JsonSerializerOptions();
         options.Converters.Add(new ValidatingJsonConverterFactory());
 

--- a/Trellis.Authorization/tests/ResourceLoaderByIdTests.cs
+++ b/Trellis.Authorization/tests/ResourceLoaderByIdTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Authorization.Tests;
 
 /// <summary>
@@ -17,7 +18,7 @@ public class ResourceLoaderByIdTests
         var result = await loader.LoadAsync(message, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeSameAs(order);
+        result.Unwrap().Should().BeSameAs(order);
     }
 
     [Fact]
@@ -29,7 +30,7 @@ public class ResourceLoaderByIdTests
         var result = await loader.LoadAsync(message, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
     }
 
     #endregion

--- a/Trellis.Authorization/tests/SharedResourceLoaderByIdTests.cs
+++ b/Trellis.Authorization/tests/SharedResourceLoaderByIdTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Authorization.Tests;
 
 /// <summary>
@@ -16,7 +17,7 @@ public class SharedResourceLoaderByIdTests
         var result = await loader.GetByIdAsync("order-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeSameAs(order);
+        result.Unwrap().Should().BeSameAs(order);
     }
 
     [Fact]
@@ -27,7 +28,7 @@ public class SharedResourceLoaderByIdTests
         var result = await loader.GetByIdAsync("nonexistent", CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
     }
 
     #endregion

--- a/Trellis.Benchmark/BenchmarkROP.cs
+++ b/Trellis.Benchmark/BenchmarkROP.cs
@@ -65,14 +65,14 @@ public class BenchmarkROP
     {
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("xavier@somewhere.com");
-        if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value + " " + rEmailAddress.Value;
+        if (rFirstName.TryGetValue(out var firstName) && rEmailAddress.TryGetValue(out var email))
+            return firstName + " " + email;
 
         Error? error = null;
-        if (rFirstName.IsFailure)
-            error = rFirstName.Error;
-        if (rEmailAddress.IsFailure)
-            error = error.Combine(rEmailAddress.Error);
+        if (rFirstName.TryGetError(out var fnErr))
+            error = fnErr;
+        if (rEmailAddress.TryGetError(out var emErr))
+            error = error.Combine(emErr);
 
         return error!.Detail;
     }
@@ -91,14 +91,14 @@ public class BenchmarkROP
     {
         var rFirstName = FirstName.TryCreate("Xavier");
         var rEmailAddress = EmailAddress.TryCreate("bad email");
-        if (rFirstName.IsSuccess && rEmailAddress.IsSuccess)
-            return rFirstName.Value + " " + rEmailAddress.Value;
+        if (rFirstName.TryGetValue(out var firstName) && rEmailAddress.TryGetValue(out var email))
+            return firstName + " " + email;
 
         Error? error = null;
-        if (rFirstName.IsFailure)
-            error = rFirstName.Error;
-        if (rEmailAddress.IsFailure)
-            error = error.Combine(rEmailAddress.Error);
+        if (rFirstName.TryGetError(out var fnErr))
+            error = fnErr;
+        if (rEmailAddress.TryGetError(out var emErr))
+            error = error.Combine(emErr);
 
         return error!.Detail;
     }
@@ -128,26 +128,26 @@ public class BenchmarkROP
         var hrDateCheck = Ensure(createdAt <= updatedAt, Error.Validation("updateAt cannot be less than createdAt", nameof(updatedAt)));
 
         Error? error = null;
-        if (hrEmail.IsFailure)
-            error = hrEmail.Error;
-        if (hrFname.IsFailure)
-            error = error.Combine(hrFname.Error);
-        if (hrLname.IsFailure)
-            error = error.Combine(hrLname.Error);
-        if (hrEmailSec.IsFailure)
-            error = error.Combine(hrEmailSec.Error);
-        if (hrDateCheck.IsFailure)
-            error = error.Combine(hrDateCheck.Error);
+        if (hrEmail.TryGetError(out var emErr))
+            error = emErr;
+        if (hrFname.TryGetError(out var fnErr))
+            error = error.Combine(fnErr);
+        if (hrLname.TryGetError(out var lnErr))
+            error = error.Combine(lnErr);
+        if (hrEmailSec.TryGetError(out var em2Err))
+            error = error.Combine(em2Err);
+        if (hrDateCheck.TryGetError(out var dateErr))
+            error = error.Combine(dateErr);
 
-        if (error == null)
+        if (error == null
+            && hrEmail.TryGetValue(out var email)
+            && hrFname.TryGetValue(out var firstName)
+            && hrLname.TryGetValue(out var lastName)
+            && hrEmailSec.TryGetValue(out var anotherEmail))
         {
-            var email = hrEmail.Value;
-            var firstName = hrFname.Value;
-            var lastName = hrLname.Value;
-            var anotherEmail = hrEmailSec.Value;
             return Result.Ok(string.Join(" ", firstName, lastName, email, anotherEmail));
         }
 
-        return Result.Fail<string>(error);
+        return Result.Fail<string>(error!);
     }
 }

--- a/Trellis.Benchmark/MoneyBenchmarks.cs
+++ b/Trellis.Benchmark/MoneyBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿namespace Benchmark;
+namespace Benchmark;
 
 using BenchmarkDotNet.Attributes;
 using Trellis;
@@ -46,37 +46,37 @@ public class MoneyBenchmarks
     [Benchmark]
     public Money Add_SameCurrency()
     {
-        return _usd100.Add(_usd50).Value;
+        return _usd100.Add(_usd50).OrThrow();
     }
 
     [Benchmark]
     public Money Subtract_SameCurrency()
     {
-        return _usd100.Subtract(_usd50).Value;
+        return _usd100.Subtract(_usd50).OrThrow();
     }
 
     [Benchmark]
     public Money Multiply_Decimal()
     {
-        return _usd100.Multiply(2.5m).Value;
+        return _usd100.Multiply(2.5m).OrThrow();
     }
 
     [Benchmark]
     public Money Multiply_Integer()
     {
-        return _usd100.Multiply(3).Value;
+        return _usd100.Multiply(3).OrThrow();
     }
 
     [Benchmark]
     public Money Divide_Decimal()
     {
-        return _usd100.Divide(3m).Value;
+        return _usd100.Divide(3m).OrThrow();
     }
 
     [Benchmark]
     public Money Divide_Integer()
     {
-        return _usd100.Divide(4).Value;
+        return _usd100.Divide(4).OrThrow();
     }
 
     #endregion
@@ -118,13 +118,13 @@ public class MoneyBenchmarks
     [Benchmark]
     public Money[] Allocate_ThreeWay()
     {
-        return _usd100.Allocate(1, 2, 1).Value;
+        return _usd100.Allocate(1, 2, 1).OrThrow();
     }
 
     [Benchmark]
     public Money[] Allocate_EvenSplit()
     {
-        return _usd100.Allocate(1, 1, 1).Value;
+        return _usd100.Allocate(1, 1, 1).OrThrow();
     }
 
     #endregion
@@ -138,8 +138,14 @@ public class MoneyBenchmarks
             .Add(_usd50)
             .Bind(m => m.Multiply(2))
             .Bind(m => m.Divide(3))
-            .Value;
+            .OrThrow();
     }
 
     #endregion
+}
+
+internal static class BenchmarkResultExtensions
+{
+    public static T OrThrow<T>(this Result<T> r) =>
+        r.Match(onSuccess: v => v, onFailure: e => throw new InvalidOperationException(e.Detail));
 }

--- a/Trellis.DomainDrivenDesign/src/ScalarValueObject.cs
+++ b/Trellis.DomainDrivenDesign/src/ScalarValueObject.cs
@@ -230,13 +230,10 @@ where T : IComparable
     /// ]]></code>
     /// </example>
 #pragma warning disable CA1000 // Do not declare static members on generic types - Required by CRTP pattern
-    public static TSelf Create(T value)
-    {
-        var result = TSelf.TryCreate(value);
-        if (result.IsFailure)
-            throw new InvalidOperationException($"Failed to create {typeof(TSelf).Name}: {result.Error.Detail}");
-        return result.Value;
-    }
+    public static TSelf Create(T value) =>
+        TSelf.TryCreate(value).Match(
+            onSuccess: created => created,
+            onFailure: error => throw new InvalidOperationException($"Failed to create {typeof(TSelf).Name}: {error.Detail}"));
 #pragma warning restore CA1000
 
     // IConvertible implementation - delegates to Convert class for the wrapped value

--- a/Trellis.DomainDrivenDesign/tests/Aggregates/AggregateTests.cs
+++ b/Trellis.DomainDrivenDesign/tests/Aggregates/AggregateTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.DomainDrivenDesign.Tests.Aggregates;
 
 using Trellis;
@@ -207,7 +208,7 @@ public class AggregateTests
         // Weak tags should not match via strong comparison
         var ensured = result.OptionalETag([EntityTagValue.Weak("abc123")]);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<PreconditionFailedError>();
+        ensured.UnwrapError().Should().BeOfType<PreconditionFailedError>();
     }
 
     [Fact]
@@ -229,7 +230,7 @@ public class AggregateTests
 
         var ensured = result.OptionalETag(Array.Empty<EntityTagValue>());
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<PreconditionFailedError>();
+        ensured.UnwrapError().Should().BeOfType<PreconditionFailedError>();
     }
 
     [Fact]
@@ -254,7 +255,7 @@ public class AggregateTests
 
         var ensured = result.RequireETag((EntityTagValue[]?)null);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<PreconditionRequiredError>();
+        ensured.UnwrapError().Should().BeOfType<PreconditionRequiredError>();
     }
 
     [Fact]
@@ -274,7 +275,7 @@ public class AggregateTests
 
         var ensured = result.RequireETag((EntityTagValue[]?)null);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionRequired");
+        ensured.UnwrapError().Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionRequired");
     }
 
     [Fact]
@@ -284,7 +285,7 @@ public class AggregateTests
 
         var ensured = result.OptionalETag([EntityTagValue.Strong("abc123")]);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionFailed");
+        ensured.UnwrapError().Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionFailed");
     }
 
     [Fact]
@@ -294,7 +295,7 @@ public class AggregateTests
 
         var ensured = result.RequireETag([EntityTagValue.Strong("abc123")]);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionFailed");
+        ensured.UnwrapError().Should().BeOfType<NotFoundError>("existing failure should be preserved, not replaced by PreconditionFailed");
     }
 
     [Fact]
@@ -306,7 +307,7 @@ public class AggregateTests
 
         var ensured = result.OptionalETag([EntityTagValue.Strong("stale")]);
         ensured.IsSuccess.Should().BeFalse();
-        ensured.Error.Should().BeOfType<PreconditionFailedError>();
+        ensured.UnwrapError().Should().BeOfType<PreconditionFailedError>();
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/src/TransactionalCommandBehavior.cs
+++ b/Trellis.EntityFrameworkCore/src/TransactionalCommandBehavior.cs
@@ -39,8 +39,8 @@ public sealed class TransactionalCommandBehavior<TMessage, TResponse>(IUnitOfWor
         if (result.IsSuccess)
         {
             var commitResult = await unitOfWork.CommitAsync(cancellationToken).ConfigureAwait(false);
-            if (commitResult.IsFailure)
-                return TResponse.CreateFailure(commitResult.Error);
+            if (commitResult.TryGetError(out var error))
+                return TResponse.CreateFailure(error);
         }
 
         return result;

--- a/Trellis.EntityFrameworkCore/src/TrellisScalarConverter.cs
+++ b/Trellis.EntityFrameworkCore/src/TrellisScalarConverter.cs
@@ -174,11 +174,8 @@ public class TrellisScalarConverter<TModel, TProvider> : ValueConverter<TModel, 
         }
     }
 
-    private static TModel MaterializeResult(Result<TModel> result, object? persistedValue, string factoryMethod)
-    {
-        if (result.IsFailure)
-            throw new TrellisPersistenceMappingException(typeof(TModel), persistedValue, factoryMethod, result.Error.Detail);
-
-        return result.Value;
-    }
+    private static TModel MaterializeResult(Result<TModel> result, object? persistedValue, string factoryMethod) =>
+        result.Match(
+            onSuccess: v => v,
+            onFailure: error => throw new TrellisPersistenceMappingException(typeof(TModel), persistedValue, factoryMethod, error.Detail));
 }

--- a/Trellis.EntityFrameworkCore/tests/AggregateETagTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/AggregateETagTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -174,7 +175,7 @@ public class AggregateETagTests : IDisposable
         var result = await _context.SaveChangesResultAsync(ct);
 
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     [Fact]
@@ -197,7 +198,7 @@ public class AggregateETagTests : IDisposable
         var result = await _context.SaveChangesResultUnitAsync(ct);
 
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/tests/DbContextExtensionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/DbContextExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -45,7 +46,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(1);
+        result.Unwrap().Should().Be(1);
     }
 
     [Fact]
@@ -73,7 +74,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(2);
+        result.Unwrap().Should().Be(2);
     }
 
     #endregion
@@ -109,7 +110,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     #endregion
@@ -168,7 +169,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<DomainError>();
+        result.UnwrapError().Should().BeOfType<DomainError>();
     }
 
     #endregion
@@ -217,7 +218,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(1);
+        result.Unwrap().Should().Be(1);
     }
 
     [Fact]
@@ -238,7 +239,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(1);
+        result.Unwrap().Should().Be(1);
         _context.ChangeTracker.HasChanges().Should().BeTrue("acceptAllChangesOnSuccess: false should preserve tracker state");
     }
 
@@ -270,7 +271,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     [Fact]
@@ -292,7 +293,7 @@ public class DbContextExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<DomainError>();
+        result.UnwrapError().Should().BeOfType<DomainError>();
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/tests/EfUnitOfWorkTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/EfUnitOfWorkTests.cs
@@ -1,8 +1,8 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Trellis.Testing;
 using static RepositoryBaseTests;
 
 public class EfUnitOfWorkTests : IDisposable
@@ -127,6 +127,6 @@ public class EfUnitOfWorkTests : IDisposable
 
         // Assert
         result.Should().BeFailure();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 }

--- a/Trellis.EntityFrameworkCore/tests/MaybePropertyTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/MaybePropertyTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Trellis.EntityFrameworkCore.Tests.Helpers;
 using Trellis.Primitives;
-using Trellis.Testing;
 
 /// <summary>
 /// Tests for the <see cref="MaybeConvention"/> and source-generated <c>partial Maybe&lt;T&gt;</c> properties.

--- a/Trellis.EntityFrameworkCore/tests/MaybeQueryableExtensionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/MaybeQueryableExtensionsTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Trellis.EntityFrameworkCore.Tests.Helpers;
 using Trellis.Primitives;
-using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="MaybeQueryableExtensions"/> — WhereNone, WhereHasValue, WhereEquals.

--- a/Trellis.EntityFrameworkCore/tests/QueryableExtensionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/QueryableExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -225,8 +226,8 @@ public class QueryableExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().BeOfType<NotFoundError>();
-        result.Error.Detail.Should().Be("Customer not found");
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Detail.Should().Be("Customer not found");
     }
 
     #endregion
@@ -246,7 +247,7 @@ public class QueryableExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Name.Value.Should().Be("Alice");
+        result.Unwrap().Name.Value.Should().Be("Alice");
     }
 
     #endregion
@@ -269,7 +270,7 @@ public class QueryableExtensionsTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Error.Should().Be(notFoundError);
+        result.UnwrapError().Should().Be(notFoundError);
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/RepositoryBaseTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 using Trellis.EntityFrameworkCore.Tests.Helpers;
-using Trellis.Testing;
 
 public partial class RepositoryBaseTests : IDisposable
 {
@@ -385,7 +385,7 @@ public partial class RepositoryBaseTests : IDisposable
 
         // Assert
         result.Should().BeFailure();
-        result.Error.Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
     }
 
     #endregion

--- a/Trellis.EntityFrameworkCore/tests/SqlServerMaybeIntegrationTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/SqlServerMaybeIntegrationTests.cs
@@ -1,9 +1,9 @@
-﻿namespace Trellis.EntityFrameworkCore.Tests;
+using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 using Microsoft.EntityFrameworkCore;
 using Trellis.EntityFrameworkCore.Tests.Helpers;
 using Trellis.Primitives;
-using Trellis.Testing;
 
 /// <summary>
 /// SQL Server integration tests for <c>MaybeConvention</c> and source-generated

--- a/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
@@ -1,6 +1,5 @@
-namespace Trellis.EntityFrameworkCore.Tests;
-
 using Trellis.Testing;
+namespace Trellis.EntityFrameworkCore.Tests;
 
 public class TransactionalCommandBehaviorTests
 {
@@ -21,7 +20,7 @@ public class TransactionalCommandBehaviorTests
 
         // Assert
         result.Should().BeSuccess();
-        result.Value.Should().Be("done");
+        result.Unwrap().Should().Be("done");
         uow.CommitCount.Should().Be(1);
     }
 
@@ -62,7 +61,7 @@ public class TransactionalCommandBehaviorTests
 
         // Assert
         result.Should().BeFailure();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
         uow.CommitCount.Should().Be(1);
     }
 

--- a/Trellis.FluentValidation/tests/FluentTests.cs
+++ b/Trellis.FluentValidation/tests/FluentTests.cs
@@ -1,8 +1,8 @@
-﻿namespace Trellis.FluentValidation.Tests;
+using Trellis.Testing;
+namespace Trellis.FluentValidation.Tests;
 
 using global::FluentValidation;
 using Trellis;
-using Trellis.Testing;
 using Xunit;
 
 public class FluentTests
@@ -14,9 +14,9 @@ public class FluentTests
     {
         // Act
         var rUser = User.TryCreate(
-            FirstName.TryCreate("John").Value,
-            LastName.TryCreate("Doe").Value,
-            EmailAddress.TryCreate("xavier@somewhere.com").Value,
+            FirstName.TryCreate("John").Unwrap(),
+            LastName.TryCreate("Doe").Unwrap(),
+            EmailAddress.TryCreate("xavier@somewhere.com").Unwrap(),
             StrongPassword);
 
         // Assert
@@ -54,7 +54,7 @@ public class FluentTests
         // Arrange
         FirstName firstName = default!;
         LastName lastName = default!;
-        EmailAddress email = EmailAddress.TryCreate("xavier@somewhere.com").Value;
+        EmailAddress email = EmailAddress.TryCreate("xavier@somewhere.com").Unwrap();
 
         // Act
         var rUser = User.TryCreate(firstName, lastName, email, "WeakPassword");

--- a/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/HandleNotFoundTests.cs
+++ b/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/HandleNotFoundTests.cs
@@ -1,9 +1,9 @@
-﻿namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
+using Trellis.Testing;
+namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
 
 using System.Net;
 using System.Threading.Tasks;
 using Trellis;
-using Trellis.Testing;
 
 /// <summary>
 /// Tests for HandleNotFound and HandleNotFoundAsync extension methods.

--- a/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ReadResultFromJsonTests.cs
+++ b/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ReadResultFromJsonTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
 
 using System.Net;
@@ -27,8 +28,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Xavier");
-        result.Value.age.Should().Be(50);
+        result.Unwrap().firstName.Should().Be("Xavier");
+        result.Unwrap().age.Should().Be(50);
     }
 
     [Fact]
@@ -45,8 +46,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
     }
 
     [Fact]
@@ -63,7 +64,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Be("HTTP response is in a failed state for value camelcasePerson. Status code: BadGateway.");
+        result.UnwrapError().Detail.Should().Be("HTTP response is in a failed state for value camelcasePerson. Status code: BadGateway.");
     }
 
     [Fact]
@@ -80,8 +81,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
     }
 
     [Fact]
@@ -98,8 +99,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().Be("HTTP response was null for value camelcasePerson.");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().Be("HTTP response was null for value camelcasePerson.");
     }
 
     [Theory]
@@ -122,13 +123,13 @@ public class ReadResultFromJsonTests
         result.IsSuccess.Should().BeTrue();
         if (propertyNameCaseInsensitive)
         {
-            result.Value.FirstName.Should().Be("Xavier");
-            result.Value.Age.Should().Be(50);
+            result.Unwrap().FirstName.Should().Be("Xavier");
+            result.Unwrap().Age.Should().Be(50);
         }
         else
         {
-            result.Value.FirstName.Should().Be(string.Empty);
-            result.Value.Age.Should().Be(0);
+            result.Unwrap().FirstName.Should().Be(string.Empty);
+            result.Unwrap().Age.Should().Be(0);
         }
     }
 
@@ -147,8 +148,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Xavier");
-        result.Value.age.Should().Be(50);
+        result.Unwrap().firstName.Should().Be("Xavier");
+        result.Unwrap().age.Should().Be(50);
     }
 
     [Fact]
@@ -175,7 +176,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(Error.NotFound("Bad request"));
+        result.UnwrapError().Should().Be(Error.NotFound("Bad request"));
         callbackCalled.Should().BeTrue();
     }
 
@@ -204,7 +205,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(Error.NotFound("Bad request"));
+        result.UnwrapError().Should().Be(Error.NotFound("Bad request"));
         callbackCalled.Should().BeTrue();
     }
 
@@ -225,8 +226,8 @@ public class ReadResultFromJsonTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _callbackCalled.Should().BeFalse();
-        result.Value.firstName.Should().Be("Chris");
-        result.Value.age.Should().Be(18);
+        result.Unwrap().firstName.Should().Be("Chris");
+        result.Unwrap().age.Should().Be(18);
     }
 
     [Fact]
@@ -247,8 +248,8 @@ public class ReadResultFromJsonTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _callbackCalled.Should().BeFalse();
-        result.Value.firstName.Should().Be("Chris");
-        result.Value.age.Should().Be(18);
+        result.Unwrap().firstName.Should().Be("Chris");
+        result.Unwrap().age.Should().Be(18);
     }
 
     private Task<Error> CallbackFailedStatusCode(HttpResponseMessage response, string context, CancellationToken cancellationToken)
@@ -332,7 +333,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain(statusCode.ToString());
+        result.UnwrapError().Detail.Should().Contain(statusCode.ToString());
     }
 
     [Theory]
@@ -354,8 +355,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Xavier");
-        result.Value.age.Should().Be(50);
+        result.Unwrap().firstName.Should().Be("Xavier");
+        result.Unwrap().age.Should().Be(50);
     }
 
     [Theory]
@@ -376,7 +377,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Be("HTTP response was null for value camelcasePerson.");
+        result.UnwrapError().Detail.Should().Be("HTTP response was null for value camelcasePerson.");
     }
 
     #endregion
@@ -399,8 +400,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
     }
 
     [Fact]
@@ -419,8 +420,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().StartWith("Failed to deserialize HTTP response to camelcasePerson:");
     }
 
     [Fact]
@@ -445,8 +446,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().HaveLength(10000);
-        result.Value.age.Should().Be(50);
+        result.Unwrap().firstName.Should().HaveLength(10000);
+        result.Unwrap().age.Should().Be(50);
     }
 
     [Fact]
@@ -466,8 +467,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Xavier");
-        result.Value.age.Should().Be(50);
+        result.Unwrap().firstName.Should().Be("Xavier");
+        result.Unwrap().age.Should().Be(50);
     }
 
     [Fact]
@@ -489,7 +490,7 @@ public class ReadResultFromJsonTests
 
         // Assert - Should still work despite wrong content type
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Xavier");
+        result.Unwrap().firstName.Should().Be("Xavier");
     }
 
     #endregion
@@ -513,8 +514,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Alice");
-        result.Value.age.Should().Be(30);
+        result.Unwrap().firstName.Should().Be("Alice");
+        result.Unwrap().age.Should().Be(30);
     }
 
     [Fact]
@@ -531,7 +532,7 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(error);
+        result.UnwrapError().Should().Be(error);
     }
 
     [Fact]
@@ -551,8 +552,8 @@ public class ReadResultFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.firstName.Should().Be("Bob");
-        result.Value.age.Should().Be(25);
+        result.Unwrap().firstName.Should().Be("Bob");
+        result.Unwrap().age.Should().Be(25);
     }
 
     #endregion

--- a/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ReadResultMaybeFromJsonTests.cs
+++ b/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ReadResultMaybeFromJsonTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Trellis;
+using Trellis.Testing;
 
 public class ReadResultMaybeFromJsonTests
 {
@@ -29,7 +30,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         maybePerson.Value.firstName.Should().Be("Xavier");
         maybePerson.Value.age.Should().Be(50);
@@ -65,7 +66,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Be("HTTP response is in a failed state for value camelcasePerson. Status code: BadGateway.");
+        result.UnwrapError().Detail.Should().Be("HTTP response is in a failed state for value camelcasePerson. Status code: BadGateway.");
     }
 
     [Fact]
@@ -82,7 +83,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.HasNoValue.Should().BeTrue();
+        result.Unwrap().HasNoValue.Should().BeTrue();
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         if (propertyNameCaseInsensitive)
         {
@@ -145,7 +146,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.Value.firstName.Should().Be("Xavier");
         maybePerson.Value.age.Should().Be(50);
     }
@@ -164,7 +165,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        Maybe<camelcasePerson> maybePerson = result.Value;
+        Maybe<camelcasePerson> maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeFalse();
     }
 
@@ -184,7 +185,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.HasNoValue.Should().BeTrue();
+        result.Unwrap().HasNoValue.Should().BeTrue();
     }
 
     [Fact]
@@ -203,7 +204,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.HasNoValue.Should().BeTrue();
+        result.Unwrap().HasNoValue.Should().BeTrue();
     }
 
     [Theory]
@@ -224,7 +225,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.HasNoValue.Should().BeTrue();
+        result.Unwrap().HasNoValue.Should().BeTrue();
     }
 
     [Fact]
@@ -243,7 +244,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.HasNoValue.Should().BeTrue();
+        result.Unwrap().HasNoValue.Should().BeTrue();
     }
 
     [Fact]
@@ -263,7 +264,7 @@ public class ReadResultMaybeFromJsonTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _callbackCalled.Should().BeFalse();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         maybePerson.Value.firstName.Should().Be("Chris");
         maybePerson.Value.age.Should().Be(18);
@@ -298,7 +299,7 @@ public class ReadResultMaybeFromJsonTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _callbackCalled.Should().BeFalse();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         maybePerson.Value.firstName.Should().Be("Chris");
         maybePerson.Value.age.Should().Be(18);
@@ -322,8 +323,8 @@ public class ReadResultMaybeFromJsonTests
         // Assert
         result.IsFailure.Should().BeTrue();
         _callbackCalled.Should().BeTrue();
-        result.Error.Should().BeOfType<NotFoundError>();
-        result.Error.Detail.Should().Be("Bad request");
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Detail.Should().Be("Bad request");
     }
 
     [Fact]
@@ -345,8 +346,8 @@ public class ReadResultMaybeFromJsonTests
         // Assert
         result.IsFailure.Should().BeTrue();
         _callbackCalled.Should().BeTrue();
-        result.Error.Should().BeOfType<NotFoundError>();
-        result.Error.Detail.Should().Be("Bad request");
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Detail.Should().Be("Bad request");
     }
 
     [Fact]
@@ -364,7 +365,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         maybePerson.Value.firstName.Should().Be("Anna");
         maybePerson.Value.age.Should().Be(25);
@@ -382,7 +383,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(error);
+        result.UnwrapError().Should().Be(error);
     }
 
     [Fact]
@@ -400,7 +401,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        var maybePerson = result.Value;
+        var maybePerson = result.Unwrap();
         maybePerson.HasValue.Should().BeTrue();
         maybePerson.Value.firstName.Should().Be("Bob");
         maybePerson.Value.age.Should().Be(30);
@@ -418,7 +419,7 @@ public class ReadResultMaybeFromJsonTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(error);
+        result.UnwrapError().Should().Be(error);
     }
 
     private Task<Error> CallbackFailedStatusCode(HttpResponseMessage response, string context, CancellationToken cancellationToken)

--- a/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ResultOverloadTests.cs
+++ b/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/ResultOverloadTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
 
 using System.Net;
@@ -26,7 +27,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(notFoundError);
+        actual.UnwrapError().Should().Be(notFoundError);
     }
 
     [Fact]
@@ -42,7 +43,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsSuccess.Should().BeTrue();
-        actual.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        actual.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -74,7 +75,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(notFoundError);
+        actual.UnwrapError().Should().Be(notFoundError);
     }
 
     [Fact]
@@ -105,7 +106,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -125,7 +126,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(unauthorizedError);
+        actual.UnwrapError().Should().Be(unauthorizedError);
     }
 
     [Fact]
@@ -156,7 +157,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -172,7 +173,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(unauthorizedError);
+        actual.UnwrapError().Should().Be(unauthorizedError);
     }
 
     [Fact]
@@ -188,7 +189,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -208,7 +209,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(forbiddenError);
+        actual.UnwrapError().Should().Be(forbiddenError);
     }
 
     [Fact]
@@ -239,7 +240,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -255,7 +256,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(forbiddenError);
+        actual.UnwrapError().Should().Be(forbiddenError);
     }
 
     [Fact]
@@ -271,7 +272,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -291,7 +292,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(conflictError);
+        actual.UnwrapError().Should().Be(conflictError);
     }
 
     [Fact]
@@ -322,7 +323,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -338,7 +339,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(conflictError);
+        actual.UnwrapError().Should().Be(conflictError);
     }
 
     [Fact]
@@ -354,7 +355,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -373,7 +374,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("BadRequest");
+        actual.UnwrapError().Detail.Should().Contain("BadRequest");
     }
 
     [Fact]
@@ -402,7 +403,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -417,7 +418,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("BadRequest");
+        actual.UnwrapError().Detail.Should().Contain("BadRequest");
     }
 
     [Fact]
@@ -432,7 +433,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -451,7 +452,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("InternalServerError");
+        actual.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -480,7 +481,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -495,7 +496,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("InternalServerError");
+        actual.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -510,7 +511,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -543,7 +544,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("InternalServerError");
+        actual.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -558,8 +559,8 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().BeOfType<ValidationError>();
-        actual.Error.Detail.Should().Contain("Custom");
+        actual.UnwrapError().Should().BeOfType<ValidationError>();
+        actual.UnwrapError().Detail.Should().Contain("Custom");
     }
 
     [Fact]
@@ -574,7 +575,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     [Fact]
@@ -603,7 +604,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Detail.Should().Contain("InternalServerError");
+        actual.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -618,7 +619,7 @@ public class ResultOverloadTests
 
         // Assert
         actual.IsFailure.Should().BeTrue();
-        actual.Error.Should().Be(originalError);
+        actual.UnwrapError().Should().Be(originalError);
     }
 
     #endregion
@@ -639,7 +640,7 @@ public class ResultOverloadTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ForbiddenError>();
+        result.UnwrapError().Should().BeOfType<ForbiddenError>();
     }
 
     [Fact]
@@ -658,7 +659,7 @@ public class ResultOverloadTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -675,8 +676,8 @@ public class ResultOverloadTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnauthorizedError>();
-        result.Error.Detail.Should().Be("Auth required");
+        result.UnwrapError().Should().BeOfType<UnauthorizedError>();
+        result.UnwrapError().Detail.Should().Be("Auth required");
     }
 
     [Fact]
@@ -694,7 +695,7 @@ public class ResultOverloadTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ConflictError>();
+        result.UnwrapError().Should().BeOfType<ConflictError>();
     }
 
     #endregion

--- a/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/StatusCodeHandlersTests.cs
+++ b/Trellis.Http/tests/HttpResponseMessageJsonExtensionsTests/StatusCodeHandlersTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
+using Trellis.Testing;
+namespace Trellis.Http.Tests.HttpResponseMessageJsonExtensionsTests;
 
 using System.Net;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(unauthorizedError);
+        result.UnwrapError().Should().Be(unauthorizedError);
     }
 
     [Fact]
@@ -39,7 +40,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(unauthorizedError);
+        result.UnwrapError().Should().Be(unauthorizedError);
     }
 
     [Theory]
@@ -75,7 +76,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     #endregion
@@ -94,7 +95,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(forbiddenError);
+        result.UnwrapError().Should().Be(forbiddenError);
     }
 
     [Fact]
@@ -109,7 +110,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -125,7 +126,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(forbiddenError);
+        result.UnwrapError().Should().Be(forbiddenError);
     }
 
     [Theory]
@@ -144,7 +145,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     #endregion
@@ -163,7 +164,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(conflictError);
+        result.UnwrapError().Should().Be(conflictError);
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -194,7 +195,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(conflictError);
+        result.UnwrapError().Should().Be(conflictError);
     }
 
     [Theory]
@@ -213,7 +214,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     #endregion
@@ -238,7 +239,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain(statusCode.ToString());
+        result.UnwrapError().Detail.Should().Contain(statusCode.ToString());
     }
 
     [Theory]
@@ -257,7 +258,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     [Fact]
@@ -273,7 +274,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("BadRequest");
+        result.UnwrapError().Detail.Should().Contain("BadRequest");
     }
 
     [Fact]
@@ -315,7 +316,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain(statusCode.ToString());
+        result.UnwrapError().Detail.Should().Contain(statusCode.ToString());
     }
 
     [Theory]
@@ -334,7 +335,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     [Fact]
@@ -350,7 +351,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("InternalServerError");
+        result.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -391,7 +392,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(statusCode);
+        result.Unwrap().StatusCode.Should().Be(statusCode);
     }
 
     [Theory]
@@ -410,7 +411,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain(statusCode.ToString());
+        result.UnwrapError().Detail.Should().Contain(statusCode.ToString());
     }
 
     [Fact]
@@ -424,9 +425,9 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        result.Error.Detail.Should().Contain("Custom error");
-        result.Error.Detail.Should().Contain("BadRequest");
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        result.UnwrapError().Detail.Should().Contain("Custom error");
+        result.UnwrapError().Detail.Should().Contain("BadRequest");
     }
 
     [Fact]
@@ -441,7 +442,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Unwrap().StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -456,7 +457,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("InternalServerError");
+        result.UnwrapError().Detail.Should().Contain("InternalServerError");
     }
 
     [Fact]
@@ -472,8 +473,8 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Service down");
-        result.Error.Detail.Should().Contain("ServiceUnavailable");
+        result.UnwrapError().Detail.Should().Contain("Service down");
+        result.UnwrapError().Detail.Should().Contain("ServiceUnavailable");
     }
 
     #endregion
@@ -495,7 +496,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(forbiddenError);
+        result.UnwrapError().Should().Be(forbiddenError);
     }
 
     [Fact]
@@ -513,7 +514,7 @@ public class StatusCodeHandlersTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(unauthorizedError);
+        result.UnwrapError().Should().Be(unauthorizedError);
     }
 
     #endregion

--- a/Trellis.Mediator/src/LoggingBehavior.cs
+++ b/Trellis.Mediator/src/LoggingBehavior.cs
@@ -39,10 +39,10 @@ public sealed partial class LoggingBehavior<TMessage, TResponse>
 
         var elapsed = Stopwatch.GetElapsedTime(stopwatch);
 
-        if (response.IsSuccess)
-            LogHandled(_logger, messageName, elapsed.TotalMilliseconds);
+        if (response.TryGetError(out var error))
+            LogHandledWithFailure(_logger, messageName, elapsed.TotalMilliseconds, error.Detail);
         else
-            LogHandledWithFailure(_logger, messageName, elapsed.TotalMilliseconds, response.Error.Detail);
+            LogHandled(_logger, messageName, elapsed.TotalMilliseconds);
 
         return response;
     }

--- a/Trellis.Mediator/src/ResourceAuthorizationBehavior.cs
+++ b/Trellis.Mediator/src/ResourceAuthorizationBehavior.cs
@@ -61,8 +61,8 @@ public sealed class ResourceAuthorizationBehavior<TMessage, TResource, TResponse
 
         // 1. Load the resource
         var loadResult = await loader.LoadAsync(message, cancellationToken).ConfigureAwait(false);
-        if (loadResult.IsFailure)
-            return TResponse.CreateFailure(loadResult.Error);
+        if (loadResult.TryGetError(out var loadError))
+            return TResponse.CreateFailure(loadError);
 
         // 2. Authorize against the loaded resource
         var actor = await actorProvider.GetCurrentActorAsync(cancellationToken).ConfigureAwait(false);
@@ -70,9 +70,12 @@ public sealed class ResourceAuthorizationBehavior<TMessage, TResource, TResponse
         if (actor is null)
             throw new InvalidOperationException("No authenticated actor available. Ensure an IActorProvider is configured and the user is authenticated.");
 
-        var authResult = message.Authorize(actor, loadResult.Value);
-        if (authResult.IsFailure)
-            return TResponse.CreateFailure(authResult.Error);
+        // Safe: TryGetError returned false above, so loadResult is success.
+        if (!loadResult.TryGetValue(out var resource))
+            throw new InvalidOperationException("Result is in an unexpected state.");
+        var authResult = message.Authorize(actor, resource);
+        if (authResult.TryGetError(out var authError))
+            return TResponse.CreateFailure(authError);
 
         // 3. Proceed to handler
         return await next(message, cancellationToken).ConfigureAwait(false);

--- a/Trellis.Mediator/src/TracingBehavior.cs
+++ b/Trellis.Mediator/src/TracingBehavior.cs
@@ -44,11 +44,11 @@ public sealed class TracingBehavior<TMessage, TResponse>
 
         if (activity is not null)
         {
-            if (response.IsFailure)
+            if (response.TryGetError(out var error))
             {
-                activity.SetStatus(ActivityStatusCode.Error, response.Error.Detail);
-                activity.SetTag("error.type", response.Error.GetType().Name);
-                activity.SetTag("error.code", response.Error.Code);
+                activity.SetStatus(ActivityStatusCode.Error, error.Detail);
+                activity.SetTag("error.type", error.GetType().Name);
+                activity.SetTag("error.code", error.Code);
             }
             else
             {

--- a/Trellis.Mediator/src/ValidationBehavior.cs
+++ b/Trellis.Mediator/src/ValidationBehavior.cs
@@ -21,8 +21,8 @@ public sealed class ValidationBehavior<TMessage, TResponse>
         CancellationToken cancellationToken)
     {
         var validationResult = message.Validate();
-        if (validationResult.IsFailure)
-            return new ValueTask<TResponse>(TResponse.CreateFailure(validationResult.Error));
+        if (validationResult.TryGetError(out var error))
+            return new ValueTask<TResponse>(TResponse.CreateFailure(error));
 
         return next(message, cancellationToken);
     }

--- a/Trellis.Mediator/tests/AddResourceLoadersTests.cs
+++ b/Trellis.Mediator/tests/AddResourceLoadersTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using global::Mediator;
@@ -60,7 +61,7 @@ public class AddResourceLoadersTests
         var result = await loader.LoadAsync(new TestMessage("id-1"), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Id.Should().Be("id-1");
+        result.Unwrap().Id.Should().Be("id-1");
     }
 
     #endregion

--- a/Trellis.Mediator/tests/AuthorizationBehaviorTests.cs
+++ b/Trellis.Mediator/tests/AuthorizationBehaviorTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using Trellis.Mediator.Tests.Helpers;
@@ -21,7 +22,7 @@ public class AuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Done");
+        result.Unwrap().Should().Be("Done");
         tracker.WasInvoked.Should().BeTrue();
     }
 
@@ -41,9 +42,9 @@ public class AuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ForbiddenError>();
-        result.Error.Detail.Should().Be("Insufficient permissions.");
-        result.Error.Detail.Should().NotContain("Admin.Write");
+        result.UnwrapError().Should().BeOfType<ForbiddenError>();
+        result.UnwrapError().Detail.Should().Be("Insufficient permissions.");
+        result.UnwrapError().Detail.Should().NotContain("Admin.Write");
         tracker.WasInvoked.Should().BeFalse("handler should not be invoked when permissions are missing");
     }
 
@@ -59,8 +60,8 @@ public class AuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Be("Insufficient permissions.");
-        result.Error.Detail.Should().NotContain("Orders.Write");
+        result.UnwrapError().Detail.Should().Be("Insufficient permissions.");
+        result.UnwrapError().Detail.Should().NotContain("Orders.Write");
         tracker.WasInvoked.Should().BeFalse();
     }
 

--- a/Trellis.Mediator/tests/ExceptionBehaviorTests.cs
+++ b/Trellis.Mediator/tests/ExceptionBehaviorTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using Microsoft.Extensions.Logging;
@@ -23,9 +24,9 @@ public class ExceptionBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<UnexpectedError>();
-        result.Error.Detail.Should().NotContain("Something went wrong");
-        result.Error.Detail.Should().Be("An unexpected error occurred while processing the request.");
+        result.UnwrapError().Should().BeOfType<UnexpectedError>();
+        result.UnwrapError().Detail.Should().NotContain("Something went wrong");
+        result.UnwrapError().Detail.Should().Be("An unexpected error occurred while processing the request.");
     }
 
     [Fact]
@@ -41,9 +42,9 @@ public class ExceptionBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().NotContain("s3cret",
+        result.UnwrapError().Detail.Should().NotContain("s3cret",
             "exception messages may contain credentials and must not be exposed in error details");
-        result.Error.Detail.Should().NotContain("Connection string",
+        result.UnwrapError().Detail.Should().NotContain("Connection string",
             "internal infrastructure details must not be exposed in error details");
     }
 
@@ -121,7 +122,7 @@ public class ExceptionBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Hello, Alice!");
+        result.Unwrap().Should().Be("Hello, Alice!");
         logEntries.Should().BeEmpty("no exception means no logging");
     }
 
@@ -139,7 +140,7 @@ public class ExceptionBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Be("Business rule failed.");
+        result.UnwrapError().Detail.Should().Be("Business rule failed.");
         logEntries.Should().BeEmpty("failure results are not exceptions");
     }
 

--- a/Trellis.Mediator/tests/ResourceAuthorizationBehaviorTests.cs
+++ b/Trellis.Mediator/tests/ResourceAuthorizationBehaviorTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +26,7 @@ public class ResourceAuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Done");
+        result.Unwrap().Should().Be("Done");
         tracker.WasInvoked.Should().BeTrue();
     }
 
@@ -45,8 +46,8 @@ public class ResourceAuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ForbiddenError>();
-        result.Error.Detail.Should().Contain("Only the resource owner");
+        result.UnwrapError().Should().BeOfType<ForbiddenError>();
+        result.UnwrapError().Detail.Should().Contain("Only the resource owner");
         tracker.WasInvoked.Should().BeFalse("handler should not be invoked when authorization fails");
     }
 
@@ -65,7 +66,7 @@ public class ResourceAuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<NotFoundError>();
+        result.UnwrapError().Should().BeOfType<NotFoundError>();
         tracker.WasInvoked.Should().BeFalse("handler should not be invoked when resource is not found");
     }
 
@@ -122,7 +123,7 @@ public class ResourceAuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Cannot modify another user's resource");
+        result.UnwrapError().Detail.Should().Contain("Cannot modify another user's resource");
         tracker.WasInvoked.Should().BeFalse();
     }
 
@@ -142,7 +143,7 @@ public class ResourceAuthorizationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Order 'xyz' was not found.");
+        result.UnwrapError().Detail.Should().Contain("Order 'xyz' was not found.");
     }
 
     #endregion

--- a/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
+++ b/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using global::Mediator;
@@ -185,7 +186,7 @@ public class SharedResourceLoaderTests
             new SharedCancelCommand("order-1"), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Id.Should().Be("order-1");
+        result.Unwrap().Id.Should().Be("order-1");
     }
 
     #endregion
@@ -223,7 +224,7 @@ public class SharedResourceLoaderTests
             new SharedCancelCommand("order-42"), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Id.Should().Be("order-42");
+        result.Unwrap().Id.Should().Be("order-42");
     }
 
     #endregion

--- a/Trellis.Mediator/tests/TracingBehaviorTests.cs
+++ b/Trellis.Mediator/tests/TracingBehaviorTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using System.Diagnostics;
@@ -96,7 +97,7 @@ public class TracingBehaviorTests : IDisposable
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Hello!");
+        result.Unwrap().Should().Be("Hello!");
     }
 
     #endregion

--- a/Trellis.Mediator/tests/ValidationBehaviorTests.cs
+++ b/Trellis.Mediator/tests/ValidationBehaviorTests.cs
@@ -1,3 +1,4 @@
+using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using Trellis.Mediator.Tests.Helpers;
@@ -20,7 +21,7 @@ public class ValidationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Hello, Alice!");
+        result.Unwrap().Should().Be("Hello, Alice!");
         tracker.WasInvoked.Should().BeTrue();
     }
 
@@ -39,8 +40,8 @@ public class ValidationBehaviorTests
         var result = await behavior.Handle(command, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        result.Error.Detail.Should().Contain("Name");
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        result.UnwrapError().Detail.Should().Contain("Name");
         tracker.WasInvoked.Should().BeFalse("handler should not be invoked for invalid messages");
     }
 
@@ -73,7 +74,7 @@ public class ValidationBehaviorTests
         var result = await behavior.Handle(query, next, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Result-42");
+        result.Unwrap().Should().Be("Result-42");
         tracker.WasInvoked.Should().BeTrue();
     }
 
@@ -88,7 +89,7 @@ public class ValidationBehaviorTests
         var result = await behavior.Handle(query, next, CancellationToken.None);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Detail.Should().Contain("Id");
+        result.UnwrapError().Detail.Should().Contain("Id");
         tracker.WasInvoked.Should().BeFalse();
     }
 

--- a/Trellis.Primitives/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Primitives/generator/RequiredPartialClassGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace SourceGenerator;
+namespace SourceGenerator;
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -268,25 +268,26 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Parse(string s, IFormatProvider? provider)
         {{
             var r = TryCreate(s, {(isFormattable ? "provider" : "null")});
-            if (r.IsFailure)
-            {{
-                var val = (ValidationError)r.Error;
-                throw new FormatException(val.FieldErrors[0].Details[0]);
-            }}
-            return r.Value;
+            return r.Match(
+                onSuccess: value => value,
+                onFailure: error =>
+                {{
+                    var val = (ValidationError)error;
+                    throw new FormatException(val.FieldErrors[0].Details[0]);
+                }});
         }}
 
         public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out {g.ClassName} result)
         {{
             var r = TryCreate(s, {(isFormattable ? "provider" : "null")});
-            if (r.IsFailure)
+            if (r.TryGetValue(out var value))
             {{
-                result = default;
-                return false;
+                result = value;
+                return true;
             }}
 
-            result = r.Value;
-            return true;
+            result = default;
+            return false;
         }}";
 
             // Generate type-specific factory methods (TryCreate, Create, validation hooks)
@@ -354,25 +355,26 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Parse(string s, IFormatProvider? provider)
         {{
             var r = TryCreate(s, null);
-            if (r.IsFailure)
-            {{
-                var val = (ValidationError)r.Error;
-                throw new FormatException(val.FieldErrors[0].Details[0]);
-            }}
-            return r.Value;
+            return r.Match(
+                onSuccess: value => value,
+                onFailure: error =>
+                {{
+                    var val = (ValidationError)error;
+                    throw new FormatException(val.FieldErrors[0].Details[0]);
+                }});
         }}
 
         public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out {g.ClassName} result)
         {{
             var r = TryCreate(s, null);
-            if (r.IsFailure)
+            if (r.TryGetValue(out var value))
             {{
-                result = default;
-                return false;
+                result = value;
+                return true;
             }}
 
-            result = r.Value;
-            return true;
+            result = default;
+            return false;
         }}
 
         /// <summary>
@@ -385,9 +387,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
     }}
     {nestedTypeClose}";
@@ -449,10 +451,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var validated = requiredGuidOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field))
                 .Ensure(x => x != Guid.Empty, Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -488,9 +490,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(Guid value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -503,9 +505,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
     private static string? GenerateStringMethods(RequiredPartialClassInfo g, SourceProductionContext context)
@@ -569,9 +571,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var notEmpty = value
                 .EnsureNotNullOrWhiteSpace(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (!notEmpty.IsSuccess)
+            if (!notEmpty.TryGetValue(out var notEmptyValue))
                 return notEmpty.Map(str => new {g.ClassName}(str));
-            var normalized = notEmpty.Value.Trim();{lengthChecks}
+            var normalized = notEmptyValue.Trim();{lengthChecks}
             string? additionalError = null;
             ValidateAdditional(normalized, field, ref additionalError);
             if (additionalError is not null)
@@ -589,9 +591,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string? value, string? fieldName = null)
         {{
             var result = TryCreate(value, fieldName);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
     }
 
@@ -664,10 +666,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field))
                 .Ensure(x => x >= {rangeMin}, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."", field))
                 .Ensure(x => x <= {rangeMax}, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -732,10 +734,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -796,9 +798,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(int value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -811,9 +813,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
         return result;
@@ -909,10 +911,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field))
                 .Ensure(x => x >= {minStr}m, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at least {minStr}."", field))
                 .Ensure(x => x <= {maxStr}m, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -977,10 +979,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -1041,9 +1043,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(decimal value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -1056,9 +1058,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
         return result;
@@ -1133,10 +1135,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field))
                 .Ensure(x => x >= {rangeLongMin}L, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."", field))
                 .Ensure(x => x <= {rangeLongMax}L, Error.Validation(""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -1201,10 +1203,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -1265,9 +1267,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(long value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -1280,9 +1282,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
         return result;
@@ -1324,10 +1326,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -1362,9 +1364,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(bool value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -1377,9 +1379,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
     private static string GenerateDateTimeMethods(RequiredPartialClassInfo g) =>
@@ -1421,10 +1423,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var validated = valueOrNothing
                 .ToResult(Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field))
                 .Ensure(x => x != DateTime.MinValue, Error.Validation(""{g.ClassName.SplitPascalCase()} cannot be empty."", field));
-            if (validated.IsSuccess)
+            if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
-                ValidateAdditional(validated.Value, field, ref additionalError);
+                ValidateAdditional(value, field, ref additionalError);
                 if (additionalError is not null)
                     return Error.Validation(additionalError, field);
             }}
@@ -1479,9 +1481,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static new {g.ClassName} Create(DateTime value)
         {{
             var result = TryCreate(value, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}
 
         /// <summary>
@@ -1494,9 +1496,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
-            if (result.IsFailure)
-                throw new InvalidOperationException($""Failed to create {g.ClassName}: {{result.Error.Detail}}"");
-            return result.Value;
+            return result.Match(
+                onSuccess: created => created,
+                onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.Detail}}""));
         }}";
 
     /// <summary>

--- a/Trellis.Primitives/src/Primitives/Age.cs
+++ b/Trellis.Primitives/src/Primitives/Age.cs
@@ -81,13 +81,10 @@ public class Age : ScalarValueObject<Age, int>, IScalarValue<Age, int>, IFormatt
     /// <summary>
     /// Parses an age.
     /// </summary>
-    public static Age Parse(string? s, IFormatProvider? provider)
-    {
-        var result = TryCreate(s, provider);
-        if (result.IsFailure)
-            throw new FormatException(result.Error.Detail);
-        return result.Value;
-    }
+    public static Age Parse(string? s, IFormatProvider? provider) =>
+        TryCreate(s, provider).Match(
+            onSuccess: value => value,
+            onFailure: error => throw new FormatException(error.Detail));
 
     /// <summary>
     /// Tries to parse an age.
@@ -95,9 +92,9 @@ public class Age : ScalarValueObject<Age, int>, IScalarValue<Age, int>, IFormatt
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out Age result)
     {
         var r = TryCreate(s, provider);
-        if (r.IsSuccess)
+        if (r.TryGetValue(out var value))
         {
-            result = r.Value;
+            result = value;
             return true;
         }
 

--- a/Trellis.Primitives/src/Primitives/MonetaryAmount.cs
+++ b/Trellis.Primitives/src/Primitives/MonetaryAmount.cs
@@ -140,21 +140,18 @@ public class MonetaryAmount : ScalarValueObject<MonetaryAmount, decimal>, IScala
     }
 
     /// <inheritdoc/>
-    public static MonetaryAmount Parse(string? s, IFormatProvider? provider)
-    {
-        var result = TryCreate(s, provider);
-        if (result.IsFailure)
-            throw new FormatException(result.Error.Detail);
-        return result.Value;
-    }
+    public static MonetaryAmount Parse(string? s, IFormatProvider? provider) =>
+        TryCreate(s, provider).Match(
+            onSuccess: value => value,
+            onFailure: error => throw new FormatException(error.Detail));
 
     /// <inheritdoc/>
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out MonetaryAmount result)
     {
         var r = TryCreate(s, provider);
-        if (r.IsSuccess)
+        if (r.TryGetValue(out var value))
         {
-            result = r.Value;
+            result = value;
             return true;
         }
 
@@ -187,7 +184,7 @@ public class MonetaryAmount : ScalarValueObject<MonetaryAmount, decimal>, IScala
             if (addResult.IsFailure)
                 return addResult;
 
-            total = addResult.Value;
+            addResult.TryGetValue(out total);
         }
 
         return Result.Ok(total);

--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -69,14 +69,10 @@ public class Money : ValueObject
     /// Use this method when you know the values are valid (e.g., in tests or with constants).
     /// For user input, use <see cref="TryCreate"/> instead.
     /// </remarks>
-    public static Money Create(decimal amount, string currencyCode)
-    {
-        var result = TryCreate(amount, currencyCode);
-        if (result.IsFailure)
-            throw new InvalidOperationException($"Failed to create Money: {result.Error.Detail}");
-
-        return result.Value;
-    }
+    public static Money Create(decimal amount, string currencyCode) =>
+        TryCreate(amount, currencyCode).Match(
+            onSuccess: money => money,
+            onFailure: error => throw new InvalidOperationException($"Failed to create Money: {error.Detail}"));
 
     /// <summary>
     /// Adds two Money amounts if they have the same currency.

--- a/Trellis.Primitives/src/Primitives/MoneyJsonConverter.cs
+++ b/Trellis.Primitives/src/Primitives/MoneyJsonConverter.cs
@@ -51,14 +51,9 @@ public class MoneyJsonConverter : JsonConverter<Money>
         if (currency == null)
             throw new JsonException("Currency is required.");
 
-        var result = Money.TryCreate(amount, currency);
-        if (result.IsFailure)
-        {
-            var error = result.Error;
-            throw new JsonException(error.Detail);
-        }
-
-        return result.Value;
+        return Money.TryCreate(amount, currency).Match(
+            onSuccess: money => money,
+            onFailure: error => throw new JsonException(error.Detail));
     }
 
     /// <summary>

--- a/Trellis.Primitives/src/Primitives/Percentage.cs
+++ b/Trellis.Primitives/src/Primitives/Percentage.cs
@@ -209,13 +209,10 @@ public class Percentage : ScalarValueObject<Percentage, decimal>, IScalarValue<P
     /// <summary>
     /// Parses the string representation of a decimal to its <see cref="Percentage"/> equivalent.
     /// </summary>
-    public static Percentage Parse(string? s, IFormatProvider? provider)
-    {
-        var result = TryCreate(s, provider);
-        if (result.IsFailure)
-            throw new FormatException(result.Error.Detail);
-        return result.Value;
-    }
+    public static Percentage Parse(string? s, IFormatProvider? provider) =>
+        TryCreate(s, provider).Match(
+            onSuccess: value => value,
+            onFailure: error => throw new FormatException(error.Detail));
 
     /// <summary>
     /// Tries to parse a string into a <see cref="Percentage"/>.
@@ -223,9 +220,9 @@ public class Percentage : ScalarValueObject<Percentage, decimal>, IScalarValue<P
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out Percentage result)
     {
         var r = TryCreate(s, provider);
-        if (r.IsSuccess)
+        if (r.TryGetValue(out var value))
         {
-            result = r.Value;
+            result = value;
             return true;
         }
 

--- a/Trellis.Primitives/src/RequiredEnumJsonConverter.cs
+++ b/Trellis.Primitives/src/RequiredEnumJsonConverter.cs
@@ -49,11 +49,8 @@ public sealed class RequiredEnumJsonConverter<[DynamicallyAccessedMembers(Dynami
     private static TRequiredEnum ReadFromString(ref Utf8JsonReader reader)
     {
         var name = reader.GetString();
-        var result = RequiredEnum<TRequiredEnum>.TryFromName(name);
-
-        if (result.IsFailure)
-            throw new JsonException($"Invalid {typeof(TRequiredEnum).Name} value: '{name}'. {result.Error.Detail}");
-
-        return result.Value;
+        return RequiredEnum<TRequiredEnum>.TryFromName(name).Match(
+            onSuccess: value => value,
+            onFailure: error => throw new JsonException($"Invalid {typeof(TRequiredEnum).Name} value: '{name}'. {error.Detail}"));
     }
 }

--- a/Trellis.Primitives/src/StringExtensions.cs
+++ b/Trellis.Primitives/src/StringExtensions.cs
@@ -20,19 +20,13 @@ public static class StringExtensions
     /// Parses a string value using the specified <see cref="IScalarValue{TSelf, TPrimitive}"/> factory.
     /// Throws <see cref="FormatException"/> if the value is invalid.
     /// </summary>
-    public static T ParseScalarValue<T>(string? s) where T : class, IScalarValue<T, string>
-    {
-        var r = T.TryCreate(s!);
-        if (r.IsFailure)
-        {
-            if (r.Error is ValidationError val && val.FieldErrors.Length > 0 && val.FieldErrors[0].Details.Length > 0)
-                throw new FormatException(val.FieldErrors[0].Details[0]);
-
-            throw new FormatException(r.Error.Detail);
-        }
-
-        return r.Value;
-    }
+    public static T ParseScalarValue<T>(string? s) where T : class, IScalarValue<T, string> =>
+        T.TryCreate(s!).Match(
+            onSuccess: value => value,
+            onFailure: error => throw new FormatException(
+                error is ValidationError val && val.FieldErrors.Length > 0 && val.FieldErrors[0].Details.Length > 0
+                    ? val.FieldErrors[0].Details[0]
+                    : error.Detail));
 
     /// <summary>
     /// Tries to parse a string value using the specified <see cref="IScalarValue{TSelf, TPrimitive}"/> factory.
@@ -40,14 +34,14 @@ public static class StringExtensions
     public static bool TryParseScalarValue<T>([NotNullWhen(true)] string? s, [MaybeNullWhen(false)] out T result) where T : class, IScalarValue<T, string>
     {
         var r = T.TryCreate(s!);
-        if (r.IsFailure)
+        if (r.TryGetValue(out var value))
         {
-            result = default;
-            return false;
+            result = value;
+            return true;
         }
 
-        result = r.Value;
-        return true;
+        result = default;
+        return false;
     }
 
     /// <summary>

--- a/Trellis.Primitives/tests/AgeTests.cs
+++ b/Trellis.Primitives/tests/AgeTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class AgeTests
 {
@@ -21,7 +22,7 @@ public class AgeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(ageValue);
+        result.Unwrap().Value.Should().Be(ageValue);
     }
 
     [Theory]
@@ -35,8 +36,8 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Age must be non-negative.");
     }
 
@@ -51,8 +52,8 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Age is unrealistically high.");
     }
 
@@ -64,7 +65,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("personAge");
     }
 
@@ -92,8 +93,8 @@ public class AgeTests
     public void Two_Age_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = Age.TryCreate(25).Value;
-        var b = Age.TryCreate(25).Value;
+        var a = Age.TryCreate(25).Unwrap();
+        var b = Age.TryCreate(25).Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -105,8 +106,8 @@ public class AgeTests
     public void Two_Age_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = Age.TryCreate(25).Value;
-        var b = Age.TryCreate(30).Value;
+        var a = Age.TryCreate(25).Unwrap();
+        var b = Age.TryCreate(30).Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -117,7 +118,7 @@ public class AgeTests
     public void Can_implicitly_cast_to_int()
     {
         // Arrange
-        Age value = Age.TryCreate(25).Value;
+        Age value = Age.TryCreate(25).Unwrap();
 
         // Act
         int intValue = value;
@@ -197,7 +198,7 @@ public class AgeTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = Age.TryCreate(25).Value;
+        var value = Age.TryCreate(25).Unwrap();
 
         // Act
         var actual = JsonSerializer.Serialize(value);
@@ -247,7 +248,7 @@ public class AgeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Fact]
@@ -258,7 +259,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -269,7 +270,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -280,7 +281,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Theory]
@@ -294,7 +295,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -305,7 +306,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("personAge");
     }
 
@@ -317,7 +318,7 @@ public class AgeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Age is unrealistically high.");
     }
 

--- a/Trellis.Primitives/tests/CountryCodeTests.cs
+++ b/Trellis.Primitives/tests/CountryCodeTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class CountryCodeTests
 {
@@ -22,7 +23,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(code.ToUpperInvariant());
+        result.Unwrap().Value.Should().Be(code.ToUpperInvariant());
     }
 
     [Theory]
@@ -38,7 +39,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -51,7 +52,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -65,7 +66,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Country code is required.");
     }
 
@@ -82,7 +83,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Country code must be an ISO 3166-1 alpha-2 code.");
     }
 
@@ -99,7 +100,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Country code must be an ISO 3166-1 alpha-2 code.");
     }
 
@@ -111,7 +112,7 @@ public class CountryCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("country");
     }
 
@@ -139,8 +140,8 @@ public class CountryCodeTests
     public void Two_CountryCode_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = CountryCode.TryCreate("US").Value;
-        var b = CountryCode.TryCreate("us").Value;
+        var a = CountryCode.TryCreate("US").Unwrap();
+        var b = CountryCode.TryCreate("us").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -152,8 +153,8 @@ public class CountryCodeTests
     public void Two_CountryCode_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = CountryCode.TryCreate("US").Value;
-        var b = CountryCode.TryCreate("GB").Value;
+        var a = CountryCode.TryCreate("US").Unwrap();
+        var b = CountryCode.TryCreate("GB").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -164,7 +165,7 @@ public class CountryCodeTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        CountryCode value = CountryCode.TryCreate("US").Value;
+        CountryCode value = CountryCode.TryCreate("US").Unwrap();
 
         // Act
         string stringValue = value;
@@ -231,7 +232,7 @@ public class CountryCodeTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = CountryCode.TryCreate("US").Value;
+        var value = CountryCode.TryCreate("US").Unwrap();
         var expected = JsonSerializer.Serialize("US");
 
         // Act

--- a/Trellis.Primitives/tests/CurrencyCodeTests.cs
+++ b/Trellis.Primitives/tests/CurrencyCodeTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class CurrencyCodeTests
 {
@@ -20,7 +21,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(code.ToUpperInvariant());
+        result.Unwrap().Value.Should().Be(code.ToUpperInvariant());
     }
 
     [Theory]
@@ -34,7 +35,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -48,7 +49,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Currency code is required.");
     }
 
@@ -63,7 +64,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Currency code must be a 3-letter ISO 4217 code.");
     }
 
@@ -78,7 +79,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Currency code must be a 3-letter ISO 4217 code.");
     }
 
@@ -86,8 +87,8 @@ public class CurrencyCodeTests
     public void Two_CurrencyCode_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = CurrencyCode.TryCreate("USD").Value;
-        var b = CurrencyCode.TryCreate("usd").Value;
+        var a = CurrencyCode.TryCreate("USD").Unwrap();
+        var b = CurrencyCode.TryCreate("usd").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -174,7 +175,7 @@ public class CurrencyCodeTests
     public void ConvertToJson()
     {
         // Arrange
-        var code = CurrencyCode.TryCreate("USD").Value;
+        var code = CurrencyCode.TryCreate("USD").Unwrap();
         var expected = "\"USD\"";
 
         // Act
@@ -205,7 +206,7 @@ public class CurrencyCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("paymentCurrency");
     }
 }

--- a/Trellis.Primitives/tests/EmailAddressTests.cs
+++ b/Trellis.Primitives/tests/EmailAddressTests.cs
@@ -1,10 +1,11 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
 using Xunit;
+using Trellis.Testing;
 
 public class EmailAddressTests
 {
@@ -17,7 +18,7 @@ public class EmailAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(Error.Validation("Email address is not valid.", "school email"));
+        result.UnwrapError().Should().Be(Error.Validation("Email address is not valid.", "school email"));
     }
 
     [Theory]
@@ -29,7 +30,7 @@ public class EmailAddressTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeOfType<EmailAddress>();
+        result.Unwrap().Should().BeOfType<EmailAddress>();
     }
 
     [Theory]
@@ -98,7 +99,7 @@ public class EmailAddressTests
     public void ConvertToJson()
     {
         // Arrange
-        EmailAddress email = EmailAddress.TryCreate("chris@somewhere.com").Value;
+        EmailAddress email = EmailAddress.TryCreate("chris@somewhere.com").Unwrap();
         string primEmail = "chris@somewhere.com";
 
         var expected = JsonSerializer.Serialize(primEmail);
@@ -186,7 +187,7 @@ public class EmailAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -197,7 +198,7 @@ public class EmailAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("school email");
     }
 
@@ -205,8 +206,8 @@ public class EmailAddressTests
     public void Two_EmailAddress_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = EmailAddress.TryCreate("xavier@somewhere.com").Value;
-        var b = EmailAddress.TryCreate("xavier@somewhere.com").Value;
+        var a = EmailAddress.TryCreate("xavier@somewhere.com").Unwrap();
+        var b = EmailAddress.TryCreate("xavier@somewhere.com").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -218,8 +219,8 @@ public class EmailAddressTests
     public void Two_EmailAddress_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = EmailAddress.TryCreate("xavier@somewhere.com").Value;
-        var b = EmailAddress.TryCreate("other@somewhere.com").Value;
+        var a = EmailAddress.TryCreate("xavier@somewhere.com").Unwrap();
+        var b = EmailAddress.TryCreate("other@somewhere.com").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -230,7 +231,7 @@ public class EmailAddressTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        EmailAddress email = EmailAddress.TryCreate("xavier@somewhere.com").Value;
+        EmailAddress email = EmailAddress.TryCreate("xavier@somewhere.com").Unwrap();
 
         // Act
         string stringValue = email;

--- a/Trellis.Primitives/tests/HostnameTests.cs
+++ b/Trellis.Primitives/tests/HostnameTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class HostnameTests
 {
@@ -24,7 +25,7 @@ public class HostnameTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(hostname);
+        result.Unwrap().Value.Should().Be(hostname);
     }
 
     [Theory]
@@ -37,7 +38,7 @@ public class HostnameTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -51,7 +52,7 @@ public class HostnameTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Hostname is required.");
     }
 
@@ -75,7 +76,7 @@ public class HostnameTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Hostname must be RFC 1123 compliant.");
     }
 
@@ -90,7 +91,7 @@ public class HostnameTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Hostname must be RFC 1123 compliant.");
     }
 
@@ -106,7 +107,7 @@ public class HostnameTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Hostname must be RFC 1123 compliant.");
     }
 
@@ -132,7 +133,7 @@ public class HostnameTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("serverName");
     }
 
@@ -160,8 +161,8 @@ public class HostnameTests
     public void Two_Hostname_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = Hostname.TryCreate("example.com").Value;
-        var b = Hostname.TryCreate("example.com").Value;
+        var a = Hostname.TryCreate("example.com").Unwrap();
+        var b = Hostname.TryCreate("example.com").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -173,8 +174,8 @@ public class HostnameTests
     public void Two_Hostname_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = Hostname.TryCreate("example.com").Value;
-        var b = Hostname.TryCreate("other.com").Value;
+        var a = Hostname.TryCreate("example.com").Unwrap();
+        var b = Hostname.TryCreate("other.com").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -185,7 +186,7 @@ public class HostnameTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        Hostname value = Hostname.TryCreate("example.com").Value;
+        Hostname value = Hostname.TryCreate("example.com").Unwrap();
 
         // Act
         string stringValue = value;
@@ -252,7 +253,7 @@ public class HostnameTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = Hostname.TryCreate("example.com").Value;
+        var value = Hostname.TryCreate("example.com").Unwrap();
         var expected = JsonSerializer.Serialize("example.com");
 
         // Act

--- a/Trellis.Primitives/tests/IFormattableScalarValueTests.cs
+++ b/Trellis.Primitives/tests/IFormattableScalarValueTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="IFormattableScalarValue{TSelf, TPrimitive}"/> interface
@@ -37,7 +38,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1234.56m);
+        result.Unwrap().Value.Should().Be(1234.56m);
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1234.56m);
+        result.Unwrap().Value.Should().Be(1234.56m);
     }
 
     [Fact]
@@ -89,7 +90,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("price");
     }
 
@@ -104,7 +105,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1234.56m);
+        result.Unwrap().Value.Should().Be(1234.56m);
     }
 
     #endregion
@@ -119,7 +120,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(25);
+        result.Unwrap().Value.Should().Be(25);
     }
 
     [Fact]
@@ -130,7 +131,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(25);
+        result.Unwrap().Value.Should().Be(25);
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50.5m);
+        result.Unwrap().Value.Should().Be(50.5m);
     }
 
     [Fact]
@@ -189,7 +190,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50.5m);
+        result.Unwrap().Value.Should().Be(50.5m);
     }
 
     [Fact]
@@ -200,7 +201,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50.5m);
+        result.Unwrap().Value.Should().Be(50.5m);
     }
 
     [Fact]
@@ -239,7 +240,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(29.99m);
+        result.Unwrap().Value.Should().Be(29.99m);
     }
 
     [Fact]
@@ -252,7 +253,7 @@ public class IFormattableScalarValueTests
 
         // Assert — InvariantCulture misinterprets "29,99" as 2999
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(2999m);
+        result.Unwrap().Value.Should().Be(2999m);
     }
 
     [Fact]
@@ -266,7 +267,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(29.99m);
+        result.Unwrap().Value.Should().Be(29.99m);
     }
 
     [Fact]
@@ -280,7 +281,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1234.56m);
+        result.Unwrap().Value.Should().Be(1234.56m);
     }
 
     #endregion
@@ -299,7 +300,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(42);
+        result.Unwrap().Value.Should().Be(42);
     }
 
     [Fact]
@@ -332,7 +333,7 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(12345L);
+        result.Unwrap().Value.Should().Be(12345L);
     }
 
     [Fact]
@@ -365,9 +366,9 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Year.Should().Be(2026);
-        result.Value.Value.Month.Should().Be(3);
-        result.Value.Value.Day.Should().Be(28);
+        result.Unwrap().Value.Year.Should().Be(2026);
+        result.Unwrap().Value.Month.Should().Be(3);
+        result.Unwrap().Value.Day.Should().Be(28);
     }
 
     [Fact]
@@ -381,9 +382,9 @@ public class IFormattableScalarValueTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Year.Should().Be(2026);
-        result.Value.Value.Month.Should().Be(3);
-        result.Value.Value.Day.Should().Be(28);
+        result.Unwrap().Value.Year.Should().Be(2026);
+        result.Unwrap().Value.Month.Should().Be(3);
+        result.Unwrap().Value.Day.Should().Be(28);
     }
 
     #endregion

--- a/Trellis.Primitives/tests/IpAddressTests.cs
+++ b/Trellis.Primitives/tests/IpAddressTests.cs
@@ -1,10 +1,11 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Net;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class IpAddressTests
 {
@@ -23,7 +24,7 @@ public class IpAddressTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(ipAddress);
+        result.Unwrap().Value.Should().Be(ipAddress);
     }
 
     [Theory]
@@ -41,7 +42,7 @@ public class IpAddressTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.ToIPAddress().Should().NotBeNull();
+        result.Unwrap().ToIPAddress().Should().NotBeNull();
     }
 
     [Theory]
@@ -54,7 +55,7 @@ public class IpAddressTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -68,7 +69,7 @@ public class IpAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("IP address is required.");
     }
 
@@ -89,7 +90,7 @@ public class IpAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("IP address must be a valid IPv4 or IPv6.");
     }
 
@@ -97,7 +98,7 @@ public class IpAddressTests
     public void ToIPAddress_returns_underlying_IPAddress()
     {
         // Arrange
-        var ipAddress = IpAddress.TryCreate("192.168.1.1").Value;
+        var ipAddress = IpAddress.TryCreate("192.168.1.1").Unwrap();
 
         // Act
         var result = ipAddress.ToIPAddress();
@@ -116,7 +117,7 @@ public class IpAddressTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("clientIP");
     }
 
@@ -144,8 +145,8 @@ public class IpAddressTests
     public void Two_IpAddress_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = IpAddress.TryCreate("192.168.1.1").Value;
-        var b = IpAddress.TryCreate("192.168.1.1").Value;
+        var a = IpAddress.TryCreate("192.168.1.1").Unwrap();
+        var b = IpAddress.TryCreate("192.168.1.1").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -157,8 +158,8 @@ public class IpAddressTests
     public void Two_IpAddress_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = IpAddress.TryCreate("192.168.1.1").Value;
-        var b = IpAddress.TryCreate("192.168.1.2").Value;
+        var a = IpAddress.TryCreate("192.168.1.1").Unwrap();
+        var b = IpAddress.TryCreate("192.168.1.2").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -169,7 +170,7 @@ public class IpAddressTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        IpAddress value = IpAddress.TryCreate("192.168.1.1").Value;
+        IpAddress value = IpAddress.TryCreate("192.168.1.1").Unwrap();
 
         // Act
         string stringValue = value;
@@ -237,7 +238,7 @@ public class IpAddressTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = IpAddress.TryCreate("192.168.1.1").Value;
+        var value = IpAddress.TryCreate("192.168.1.1").Unwrap();
         var expected = JsonSerializer.Serialize("192.168.1.1");
 
         // Act

--- a/Trellis.Primitives/tests/LanguageCodeTests.cs
+++ b/Trellis.Primitives/tests/LanguageCodeTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class LanguageCodeTests
 {
@@ -22,7 +23,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(code.ToLowerInvariant());
+        result.Unwrap().Value.Should().Be(code.ToLowerInvariant());
     }
 
     [Theory]
@@ -38,7 +39,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -51,7 +52,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -65,7 +66,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Language code is required.");
     }
 
@@ -82,7 +83,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Language code must be an ISO 639-1 alpha-2 code.");
     }
 
@@ -99,7 +100,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Language code must be an ISO 639-1 alpha-2 code.");
     }
 
@@ -111,7 +112,7 @@ public class LanguageCodeTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("language");
     }
 
@@ -139,8 +140,8 @@ public class LanguageCodeTests
     public void Two_LanguageCode_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = LanguageCode.TryCreate("en").Value;
-        var b = LanguageCode.TryCreate("EN").Value;
+        var a = LanguageCode.TryCreate("en").Unwrap();
+        var b = LanguageCode.TryCreate("EN").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -152,8 +153,8 @@ public class LanguageCodeTests
     public void Two_LanguageCode_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = LanguageCode.TryCreate("en").Value;
-        var b = LanguageCode.TryCreate("fr").Value;
+        var a = LanguageCode.TryCreate("en").Unwrap();
+        var b = LanguageCode.TryCreate("fr").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -164,7 +165,7 @@ public class LanguageCodeTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        LanguageCode value = LanguageCode.TryCreate("en").Value;
+        LanguageCode value = LanguageCode.TryCreate("en").Unwrap();
 
         // Act
         string stringValue = value;
@@ -231,7 +232,7 @@ public class LanguageCodeTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = LanguageCode.TryCreate("en").Value;
+        var value = LanguageCode.TryCreate("en").Unwrap();
         var expected = JsonSerializer.Serialize("en");
 
         // Act

--- a/Trellis.Primitives/tests/MonetaryAmountTests.cs
+++ b/Trellis.Primitives/tests/MonetaryAmountTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using Trellis.Primitives;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="MonetaryAmount"/> — a single-currency monetary value.
@@ -15,7 +16,7 @@ public class MonetaryAmountTests
     {
         var result = MonetaryAmount.TryCreate(29.99m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(29.99m);
+        result.Unwrap().Value.Should().Be(29.99m);
     }
 
     [Fact]
@@ -23,7 +24,7 @@ public class MonetaryAmountTests
     {
         var result = MonetaryAmount.TryCreate(0m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(0m);
+        result.Unwrap().Value.Should().Be(0m);
     }
 
     [Fact]
@@ -38,7 +39,7 @@ public class MonetaryAmountTests
     {
         var result = MonetaryAmount.TryCreate(29.999m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(30.00m);
+        result.Unwrap().Value.Should().Be(30.00m);
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public class MonetaryAmountTests
         decimal? value = 15.50m;
         var result = MonetaryAmount.TryCreate(value);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(15.50m);
+        result.Unwrap().Value.Should().Be(15.50m);
     }
 
     [Fact]
@@ -91,7 +92,7 @@ public class MonetaryAmountTests
 
         var result = a.Add(b);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(30.50m);
+        result.Unwrap().Value.Should().Be(30.50m);
     }
 
     [Fact]
@@ -102,7 +103,7 @@ public class MonetaryAmountTests
 
         var result = a.Subtract(b);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(30.00m);
+        result.Unwrap().Value.Should().Be(30.00m);
     }
 
     [Fact]
@@ -122,7 +123,7 @@ public class MonetaryAmountTests
 
         var result = amount.Multiply(3);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(30.00m);
+        result.Unwrap().Value.Should().Be(30.00m);
     }
 
     [Fact]
@@ -141,7 +142,7 @@ public class MonetaryAmountTests
 
         var result = amount.Multiply(1.5m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(15.00m);
+        result.Unwrap().Value.Should().Be(15.00m);
     }
 
     [Fact]
@@ -290,7 +291,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Fact]
@@ -301,7 +302,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -312,7 +313,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -323,7 +324,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Theory]
@@ -336,7 +337,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -347,7 +348,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("price");
     }
 
@@ -359,7 +360,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Amount cannot be negative.");
     }
 
@@ -371,7 +372,7 @@ public class MonetaryAmountTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1234.56m);
+        result.Unwrap().Value.Should().Be(1234.56m);
     }
 
     #endregion
@@ -386,7 +387,7 @@ public class MonetaryAmountTests
         var result = MonetaryAmount.Sum(items);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(10.00m);
+        result.Unwrap().Value.Should().Be(10.00m);
     }
 
     [Fact]
@@ -402,7 +403,7 @@ public class MonetaryAmountTests
         var result = MonetaryAmount.Sum(items);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(35.75m);
+        result.Unwrap().Value.Should().Be(35.75m);
     }
 
     [Fact]
@@ -411,7 +412,7 @@ public class MonetaryAmountTests
         var result = MonetaryAmount.Sum(Array.Empty<MonetaryAmount>());
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(0m);
+        result.Unwrap().Value.Should().Be(0m);
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/MoneyTests.cs
+++ b/Trellis.Primitives/tests/MoneyTests.cs
@@ -1,10 +1,11 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Reflection;
 using System.Text.Json;
 using Trellis;
+using Trellis.Testing;
 
 public class MoneyTests
 {
@@ -22,7 +23,7 @@ public class MoneyTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Currency.Value.Should().Be(currency);
+        result.Unwrap().Currency.Value.Should().Be(currency);
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class MoneyTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Amount cannot be negative.");
     }
 
@@ -55,7 +56,7 @@ public class MoneyTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("unitPrice");
     }
 
@@ -103,7 +104,7 @@ public class MoneyTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(expected);
+        result.Unwrap().Amount.Should().Be(expected);
     }
 
     #endregion
@@ -114,31 +115,31 @@ public class MoneyTests
     public void Can_add_Money_with_same_currency()
     {
         // Arrange
-        var left = Money.TryCreate(50.25m, "USD").Value;
-        var right = Money.TryCreate(25.75m, "USD").Value;
+        var left = Money.TryCreate(50.25m, "USD").Unwrap();
+        var right = Money.TryCreate(25.75m, "USD").Unwrap();
 
         // Act
         var result = left.Add(right);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(76.00m);
-        result.Value.Currency.Value.Should().Be("USD");
+        result.Unwrap().Amount.Should().Be(76.00m);
+        result.Unwrap().Currency.Value.Should().Be("USD");
     }
 
     [Fact]
     public void Cannot_add_Money_with_different_currency()
     {
         // Arrange
-        var left = Money.TryCreate(50.00m, "USD").Value;
-        var right = Money.TryCreate(40.00m, "EUR").Value;
+        var left = Money.TryCreate(50.00m, "USD").Unwrap();
+        var right = Money.TryCreate(40.00m, "EUR").Unwrap();
 
         // Act
         var result = left.Add(right);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Cannot add EUR to USD.");
     }
 
@@ -146,30 +147,30 @@ public class MoneyTests
     public void Can_subtract_Money_with_same_currency()
     {
         // Arrange
-        var left = Money.TryCreate(100.00m, "USD").Value;
-        var right = Money.TryCreate(35.50m, "USD").Value;
+        var left = Money.TryCreate(100.00m, "USD").Unwrap();
+        var right = Money.TryCreate(35.50m, "USD").Unwrap();
 
         // Act
         var result = left.Subtract(right);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(64.50m);
+        result.Unwrap().Amount.Should().Be(64.50m);
     }
 
     [Fact]
     public void Subtract_resulting_in_negative_amount_fails()
     {
         // Arrange
-        var left = Money.TryCreate(40.00m, "USD").Value;
-        var right = Money.TryCreate(100.00m, "USD").Value;
+        var left = Money.TryCreate(40.00m, "USD").Unwrap();
+        var right = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = left.Subtract(right);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Subtraction would result in a negative amount.");
     }
 
@@ -177,15 +178,15 @@ public class MoneyTests
     public void Cannot_subtract_Money_with_different_currency()
     {
         // Arrange
-        var left = Money.TryCreate(100.00m, "USD").Value;
-        var right = Money.TryCreate(35.50m, "GBP").Value;
+        var left = Money.TryCreate(100.00m, "USD").Unwrap();
+        var right = Money.TryCreate(35.50m, "GBP").Unwrap();
 
         // Act
         var result = left.Subtract(right);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Cannot subtract GBP from USD.");
     }
 
@@ -193,36 +194,36 @@ public class MoneyTests
     public void Can_multiply_Money_by_decimal()
     {
         // Arrange
-        var money = Money.TryCreate(19.99m, "USD").Value;
+        var money = Money.TryCreate(19.99m, "USD").Unwrap();
 
         // Act
         var result = money.Multiply(3.5m);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(69.97m);
-        result.Value.Currency.Value.Should().Be("USD");
+        result.Unwrap().Amount.Should().Be(69.97m);
+        result.Unwrap().Currency.Value.Should().Be("USD");
     }
 
     [Fact]
     public void Can_multiply_Money_by_integer()
     {
         // Arrange
-        var money = Money.TryCreate(12.50m, "USD").Value;
+        var money = Money.TryCreate(12.50m, "USD").Unwrap();
 
         // Act
         var result = money.Multiply(5);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(62.50m);
+        result.Unwrap().Amount.Should().Be(62.50m);
     }
 
     [Fact]
     public void Cannot_multiply_Money_by_negative()
     {
         // Arrange
-        var money = Money.TryCreate(50.00m, "USD").Value;
+        var money = Money.TryCreate(50.00m, "USD").Unwrap();
 
         // Act
         var resultDecimal = money.Multiply(-2m);
@@ -230,11 +231,11 @@ public class MoneyTests
 
         // Assert
         resultDecimal.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)resultDecimal.Error;
+        var validation = (ValidationError)resultDecimal.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Multiplier cannot be negative.");
 
         resultInt.IsFailure.Should().BeTrue();
-        var validationInt = (ValidationError)resultInt.Error;
+        var validationInt = (ValidationError)resultInt.UnwrapError();
         validationInt.FieldErrors[0].Details[0].Should().Be("Quantity cannot be negative.");
     }
 
@@ -242,42 +243,42 @@ public class MoneyTests
     public void Can_divide_Money_by_decimal()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Divide(3m);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(33.33m);
+        result.Unwrap().Amount.Should().Be(33.33m);
     }
 
     [Fact]
     public void Can_divide_Money_by_integer()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Divide(4);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(25.00m);
+        result.Unwrap().Amount.Should().Be(25.00m);
     }
 
     [Fact]
     public void Cannot_divide_Money_by_zero()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Divide(0m);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Divisor must be positive.");
     }
 
@@ -285,14 +286,14 @@ public class MoneyTests
     public void Cannot_divide_Money_by_negative_integer()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Divide(-2);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Divisor must be positive.");
     }
 
@@ -315,49 +316,49 @@ public class MoneyTests
     public void Can_allocate_Money_equally()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Allocate(1, 1, 1);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(3);
-        result.Value[0].Amount.Should().Be(33.34m); // Gets the remainder
-        result.Value[1].Amount.Should().Be(33.33m);
-        result.Value[2].Amount.Should().Be(33.33m);
-        result.Value.Sum(m => m.Amount).Should().Be(100.00m); // No money lost
+        result.Unwrap().Should().HaveCount(3);
+        result.Unwrap()[0].Amount.Should().Be(33.34m); // Gets the remainder
+        result.Unwrap()[1].Amount.Should().Be(33.33m);
+        result.Unwrap()[2].Amount.Should().Be(33.33m);
+        result.Unwrap().Sum(m => m.Amount).Should().Be(100.00m); // No money lost
     }
 
     [Fact]
     public void Can_allocate_Money_by_ratio()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Allocate(1, 2, 1); // 25%, 50%, 25%
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(3);
-        result.Value[0].Amount.Should().Be(25.00m);
-        result.Value[1].Amount.Should().Be(50.00m);
-        result.Value[2].Amount.Should().Be(25.00m);
+        result.Unwrap().Should().HaveCount(3);
+        result.Unwrap()[0].Amount.Should().Be(25.00m);
+        result.Unwrap()[1].Amount.Should().Be(50.00m);
+        result.Unwrap()[2].Amount.Should().Be(25.00m);
     }
 
     [Fact]
     public void Cannot_allocate_Money_with_empty_ratios()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Allocate();
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("At least one ratio required.");
     }
 
@@ -365,14 +366,14 @@ public class MoneyTests
     public void Cannot_allocate_Money_with_negative_ratio()
     {
         // Arrange
-        var money = Money.TryCreate(100.00m, "USD").Value;
+        var money = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act
         var result = money.Allocate(1, -2, 1);
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("All ratios must be positive.");
     }
 
@@ -384,8 +385,8 @@ public class MoneyTests
     public void Can_compare_Money_IsGreaterThan()
     {
         // Arrange
-        var left = Money.TryCreate(100.00m, "USD").Value;
-        var right = Money.TryCreate(50.00m, "USD").Value;
+        var left = Money.TryCreate(100.00m, "USD").Unwrap();
+        var right = Money.TryCreate(50.00m, "USD").Unwrap();
 
         // Act & Assert
         left.IsGreaterThan(right).Should().BeTrue();
@@ -396,8 +397,8 @@ public class MoneyTests
     public void Can_compare_Money_IsLessThan()
     {
         // Arrange
-        var left = Money.TryCreate(25.00m, "USD").Value;
-        var right = Money.TryCreate(50.00m, "USD").Value;
+        var left = Money.TryCreate(25.00m, "USD").Unwrap();
+        var right = Money.TryCreate(50.00m, "USD").Unwrap();
 
         // Act & Assert
         left.IsLessThan(right).Should().BeTrue();
@@ -408,9 +409,9 @@ public class MoneyTests
     public void Can_compare_Money_IsGreaterThanOrEqual()
     {
         // Arrange
-        var left = Money.TryCreate(100.00m, "USD").Value;
-        var right = Money.TryCreate(50.00m, "USD").Value;
-        var equal = Money.TryCreate(100.00m, "USD").Value;
+        var left = Money.TryCreate(100.00m, "USD").Unwrap();
+        var right = Money.TryCreate(50.00m, "USD").Unwrap();
+        var equal = Money.TryCreate(100.00m, "USD").Unwrap();
 
         // Act & Assert
         left.IsGreaterThanOrEqual(right).Should().BeTrue();
@@ -422,9 +423,9 @@ public class MoneyTests
     public void Can_compare_Money_IsLessThanOrEqual()
     {
         // Arrange
-        var left = Money.TryCreate(25.00m, "USD").Value;
-        var right = Money.TryCreate(50.00m, "USD").Value;
-        var equal = Money.TryCreate(25.00m, "USD").Value;
+        var left = Money.TryCreate(25.00m, "USD").Unwrap();
+        var right = Money.TryCreate(50.00m, "USD").Unwrap();
+        var equal = Money.TryCreate(25.00m, "USD").Unwrap();
 
         // Act & Assert
         left.IsLessThanOrEqual(right).Should().BeTrue();
@@ -436,8 +437,8 @@ public class MoneyTests
     public void Cannot_compare_Money_with_different_currency()
     {
         // Arrange
-        var left = Money.TryCreate(100.00m, "USD").Value;
-        var right = Money.TryCreate(80.00m, "EUR").Value;
+        var left = Money.TryCreate(100.00m, "USD").Unwrap();
+        var right = Money.TryCreate(80.00m, "EUR").Unwrap();
 
         // Act & Assert
         left.IsGreaterThan(right).Should().BeFalse();
@@ -454,8 +455,8 @@ public class MoneyTests
     public void Two_Money_with_same_amount_and_currency_should_be_equal()
     {
         // Arrange
-        var a = Money.TryCreate(50.00m, "USD").Value;
-        var b = Money.TryCreate(50.00m, "USD").Value;
+        var a = Money.TryCreate(50.00m, "USD").Unwrap();
+        var b = Money.TryCreate(50.00m, "USD").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -467,8 +468,8 @@ public class MoneyTests
     public void Two_Money_with_different_amount_should_not_be_equal()
     {
         // Arrange
-        var a = Money.TryCreate(50.00m, "USD").Value;
-        var b = Money.TryCreate(75.00m, "USD").Value;
+        var a = Money.TryCreate(50.00m, "USD").Unwrap();
+        var b = Money.TryCreate(75.00m, "USD").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -479,8 +480,8 @@ public class MoneyTests
     public void Two_Money_with_different_currency_should_not_be_equal()
     {
         // Arrange
-        var a = Money.TryCreate(50.00m, "USD").Value;
-        var b = Money.TryCreate(50.00m, "EUR").Value;
+        var a = Money.TryCreate(50.00m, "USD").Unwrap();
+        var b = Money.TryCreate(50.00m, "EUR").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -495,7 +496,7 @@ public class MoneyTests
     public void ConvertToJson()
     {
         // Arrange
-        var money = Money.TryCreate(99.99m, "USD").Value;
+        var money = Money.TryCreate(99.99m, "USD").Unwrap();
 
         // Act
         var json = JsonSerializer.Serialize(money);
@@ -616,8 +617,8 @@ public class MoneyTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(0m);
-        result.Value.Currency.Value.Should().Be("EUR");
+        result.Unwrap().Amount.Should().Be(0m);
+        result.Unwrap().Currency.Value.Should().Be("EUR");
     }
 
     [Fact]
@@ -628,14 +629,14 @@ public class MoneyTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Currency.Value.Should().Be("USD");
+        result.Unwrap().Currency.Value.Should().Be("USD");
     }
 
     [Fact]
     public void ToString_returns_formatted_amount_with_currency()
     {
         // Arrange
-        var money = Money.TryCreate(99.99m, "USD").Value;
+        var money = Money.TryCreate(99.99m, "USD").Unwrap();
 
         // Act
         var str = money.ToString();
@@ -668,7 +669,7 @@ public class MoneyTests
         var result = Money.Sum(items);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(10.00m);
+        result.Unwrap().Amount.Should().Be(10.00m);
     }
 
     [Fact]
@@ -684,8 +685,8 @@ public class MoneyTests
         var result = Money.Sum(items);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Amount.Should().Be(35.75m);
-        result.Value.Currency.Should().Be(CurrencyCode.Create("USD"));
+        result.Unwrap().Amount.Should().Be(35.75m);
+        result.Unwrap().Currency.Should().Be(CurrencyCode.Create("USD"));
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/PercentageTests.cs
+++ b/Trellis.Primitives/tests/PercentageTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class PercentageTests
 {
@@ -20,7 +21,7 @@ public class PercentageTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(value);
+        result.Unwrap().Value.Should().Be(value);
     }
 
     [Theory]
@@ -35,8 +36,8 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Percentage must be between 0 and 100.");
     }
 
@@ -48,7 +49,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Percentage is required.");
     }
 
@@ -102,7 +103,7 @@ public class PercentageTests
     public void AsFraction_returns_correct_value(decimal percentage, decimal expectedFraction)
     {
         // Arrange
-        var pct = Percentage.TryCreate(percentage).Value;
+        var pct = Percentage.TryCreate(percentage).Unwrap();
 
         // Act
         var fraction = pct.AsFraction();
@@ -120,7 +121,7 @@ public class PercentageTests
     public void Of_calculates_correct_percentage(decimal percentage, decimal amount, decimal expected)
     {
         // Arrange
-        var pct = Percentage.TryCreate(percentage).Value;
+        var pct = Percentage.TryCreate(percentage).Unwrap();
 
         // Act
         var result = pct.Of(amount);
@@ -141,7 +142,7 @@ public class PercentageTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expectedPercentage);
+        result.Unwrap().Value.Should().Be(expectedPercentage);
     }
 
     [Theory]
@@ -164,7 +165,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = result.Error.Should().BeOfType<ValidationError>().Subject;
+        var validation = result.UnwrapError().Should().BeOfType<ValidationError>().Subject;
         validation.FieldErrors[0].FieldName.Should().Be("discountRate");
         validation.FieldErrors[0].Details[0].Should().Be("Fraction must be between 0 and 1.");
     }
@@ -173,8 +174,8 @@ public class PercentageTests
     public void Two_Percentage_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = Percentage.TryCreate(50m).Value;
-        var b = Percentage.TryCreate(50m).Value;
+        var a = Percentage.TryCreate(50m).Unwrap();
+        var b = Percentage.TryCreate(50m).Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -186,8 +187,8 @@ public class PercentageTests
     public void Two_Percentage_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = Percentage.TryCreate(25m).Value;
-        var b = Percentage.TryCreate(75m).Value;
+        var a = Percentage.TryCreate(25m).Unwrap();
+        var b = Percentage.TryCreate(75m).Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -198,7 +199,7 @@ public class PercentageTests
     public void Can_implicitly_cast_to_decimal()
     {
         // Arrange
-        Percentage value = Percentage.TryCreate(50m).Value;
+        Percentage value = Percentage.TryCreate(50m).Unwrap();
 
         // Act
         decimal decimalValue = value;
@@ -300,7 +301,7 @@ public class PercentageTests
     public void ToString_returns_percentage_format()
     {
         // Arrange
-        var pct = Percentage.TryCreate(50.5m).Value;
+        var pct = Percentage.TryCreate(50.5m).Unwrap();
 
         // Act
         var result = pct.ToString();
@@ -313,7 +314,7 @@ public class PercentageTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = Percentage.TryCreate(50m).Value;
+        var value = Percentage.TryCreate(50m).Unwrap();
         var expected = "\"50%\"";  // Percentage.ToString() adds % suffix
 
         // Act
@@ -385,7 +386,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("discountRate");
     }
 
@@ -403,7 +404,7 @@ public class PercentageTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Fact]
@@ -414,7 +415,7 @@ public class PercentageTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50m);
+        result.Unwrap().Value.Should().Be(50m);
     }
 
     [Fact]
@@ -425,7 +426,7 @@ public class PercentageTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(75m);
+        result.Unwrap().Value.Should().Be(75m);
     }
 
     [Fact]
@@ -436,7 +437,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -447,7 +448,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -458,7 +459,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Theory]
@@ -471,7 +472,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -482,7 +483,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("discountRate");
     }
 
@@ -494,7 +495,7 @@ public class PercentageTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Percentage must be between 0 and 100.");
     }
 

--- a/Trellis.Primitives/tests/PhoneNumberTests.cs
+++ b/Trellis.Primitives/tests/PhoneNumberTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class PhoneNumberTests
 {
@@ -20,7 +21,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(phone);
+        result.Unwrap().Value.Should().Be(phone);
     }
 
     [Theory]
@@ -34,7 +35,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -54,7 +55,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -65,7 +66,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Phone number is required.");
     }
 
@@ -77,7 +78,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Phone number must be in E.164 format (e.g., +14155551234).");
     }
 
@@ -110,7 +111,7 @@ public class PhoneNumberTests
     public void GetCountryCode_returns_correct_code(string phone, string expectedCountryCode)
     {
         // Arrange
-        var phoneNumber = PhoneNumber.TryCreate(phone).Value;
+        var phoneNumber = PhoneNumber.TryCreate(phone).Unwrap();
 
         // Act
         var countryCode = phoneNumber.GetCountryCode();
@@ -123,8 +124,8 @@ public class PhoneNumberTests
     public void Two_PhoneNumber_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = PhoneNumber.TryCreate("+14155551234").Value;
-        var b = PhoneNumber.TryCreate("+14155551234").Value;
+        var a = PhoneNumber.TryCreate("+14155551234").Unwrap();
+        var b = PhoneNumber.TryCreate("+14155551234").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -136,8 +137,8 @@ public class PhoneNumberTests
     public void Two_PhoneNumber_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = PhoneNumber.TryCreate("+14155551234").Value;
-        var b = PhoneNumber.TryCreate("+14155559999").Value;
+        var a = PhoneNumber.TryCreate("+14155551234").Unwrap();
+        var b = PhoneNumber.TryCreate("+14155559999").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -148,7 +149,7 @@ public class PhoneNumberTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        PhoneNumber value = PhoneNumber.TryCreate("+14155551234").Value;
+        PhoneNumber value = PhoneNumber.TryCreate("+14155551234").Unwrap();
 
         // Act
         string stringValue = value;
@@ -213,7 +214,7 @@ public class PhoneNumberTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = PhoneNumber.TryCreate("+14155551234").Value;
+        var value = PhoneNumber.TryCreate("+14155551234").Unwrap();
         var expected = JsonSerializer.Serialize("+14155551234");
 
         // Act
@@ -258,7 +259,7 @@ public class PhoneNumberTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("contactPhone");
     }
 }

--- a/Trellis.Primitives/tests/RangedDecimalTests.cs
+++ b/Trellis.Primitives/tests/RangedDecimalTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.Primitives.Tests;
+using Trellis.Testing;
+namespace Trellis.Primitives.Tests;
 
 /// <summary>
 /// Test value object with range constraint (1–999).
@@ -36,7 +37,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(99.99m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(99.99m);
+        result.Unwrap().Value.Should().Be(99.99m);
     }
 
     [Fact]
@@ -44,7 +45,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(0m);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Test Price must be at least 1.");
     }
 
@@ -53,7 +54,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(1000m);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Test Price must be at most 999.");
     }
 
@@ -76,7 +77,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(1m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1m);
+        result.Unwrap().Value.Should().Be(1m);
     }
 
     [Fact]
@@ -84,7 +85,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(999m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(999m);
+        result.Unwrap().Value.Should().Be(999m);
     }
 
     [Fact]
@@ -158,7 +159,7 @@ public class RangedDecimalTests
     {
         var result = TestPrice.TryCreate(0m, "myField");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -182,7 +183,7 @@ public class RangedDecimalTests
     {
         var result = LargeRangeDecimal.TryCreate(-1_000_000_000_000_000m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(-1_000_000_000_000_000m);
+        result.Unwrap().Value.Should().Be(-1_000_000_000_000_000m);
     }
 
     [Fact]
@@ -190,7 +191,7 @@ public class RangedDecimalTests
     {
         var result = LargeRangeDecimal.TryCreate(1_000_000_000_000_000m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1_000_000_000_000_000m);
+        result.Unwrap().Value.Should().Be(1_000_000_000_000_000m);
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RangedIntTests.cs
+++ b/Trellis.Primitives/tests/RangedIntTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.Primitives.Tests;
+using Trellis.Testing;
+namespace Trellis.Primitives.Tests;
 
 /// <summary>
 /// Test value object with range constraint (1–999).
@@ -31,7 +32,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(500);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(500);
+        result.Unwrap().Value.Should().Be(500);
     }
 
     [Fact]
@@ -39,8 +40,8 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(-10);
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("testQuantity");
         validation.FieldErrors[0].Details[0].Should().Be("Test Quantity must be at least 1.");
     }
@@ -50,8 +51,8 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(5000);
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("testQuantity");
         validation.FieldErrors[0].Details[0].Should().Be("Test Quantity must be at most 999.");
     }
@@ -61,7 +62,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(1);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1);
+        result.Unwrap().Value.Should().Be(1);
     }
 
     [Fact]
@@ -69,7 +70,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(999);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(999);
+        result.Unwrap().Value.Should().Be(999);
     }
 
     [Fact]
@@ -77,7 +78,7 @@ public class RangedIntTests
     {
         var result = TestPercentageInt.TryCreate(0);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(0);
+        result.Unwrap().Value.Should().Be(0);
     }
 
     [Fact]
@@ -103,7 +104,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate("500");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(500);
+        result.Unwrap().Value.Should().Be(500);
     }
 
     [Fact]
@@ -111,8 +112,8 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate("1000");
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Test Quantity must be at most 999.");
     }
 
@@ -132,7 +133,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate((int?)500);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(500);
+        result.Unwrap().Value.Should().Be(500);
     }
 
     #endregion
@@ -144,7 +145,7 @@ public class RangedIntTests
     {
         var result = TestQuantity.TryCreate(0, "myField");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -168,7 +169,7 @@ public class RangedIntTests
     {
         var result = FullRangeInt.TryCreate(int.MinValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(int.MinValue);
+        result.Unwrap().Value.Should().Be(int.MinValue);
     }
 
     [Fact]
@@ -176,7 +177,7 @@ public class RangedIntTests
     {
         var result = FullRangeInt.TryCreate(int.MaxValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(int.MaxValue);
+        result.Unwrap().Value.Should().Be(int.MaxValue);
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredBoolTests.cs
+++ b/Trellis.Primitives/tests/RequiredBoolTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Text.Json;
+using Trellis.Testing;
 
 public partial class GiftWrap : RequiredBool<GiftWrap>
 {
@@ -18,7 +19,7 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate(true);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().BeTrue();
+        result.Unwrap().Value.Should().BeTrue();
     }
 
     [Fact]
@@ -28,7 +29,7 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate(false);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().BeFalse();
+        result.Unwrap().Value.Should().BeFalse();
     }
 
     [Fact]
@@ -37,8 +38,8 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate((bool?)null);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("giftWrap");
         validation.FieldErrors[0].Details[0].Should().Be("Gift Wrap cannot be empty.");
     }
@@ -49,7 +50,7 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate("true");
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().BeTrue();
+        result.Unwrap().Value.Should().BeTrue();
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate("false");
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().BeFalse();
+        result.Unwrap().Value.Should().BeFalse();
     }
 
     [Theory]
@@ -99,7 +100,7 @@ public class RequiredBoolTests
     [Fact]
     public void Can_use_ToString()
     {
-        GiftWrap giftWrap = GiftWrap.TryCreate(true).Value;
+        GiftWrap giftWrap = GiftWrap.TryCreate(true).Unwrap();
         giftWrap.ToString(System.Globalization.CultureInfo.InvariantCulture).Should().Be("True");
     }
 
@@ -107,14 +108,14 @@ public class RequiredBoolTests
     public void Can_explicitly_cast_to_RequiredBool()
     {
         GiftWrap giftWrap = (GiftWrap)true;
-        giftWrap.Should().Be(GiftWrap.TryCreate(true).Value);
+        giftWrap.Should().Be(GiftWrap.TryCreate(true).Unwrap());
     }
 
     [Fact]
     public void Can_use_Contains()
     {
-        var b1 = GiftWrap.TryCreate(true).Value;
-        var b2 = GiftWrap.TryCreate(false).Value;
+        var b1 = GiftWrap.TryCreate(true).Unwrap();
+        var b2 = GiftWrap.TryCreate(false).Unwrap();
         IReadOnlyList<GiftWrap> items = new List<GiftWrap> { b1, b2 };
 
         items.Contains(b1).Should().BeTrue();
@@ -123,7 +124,7 @@ public class RequiredBoolTests
     [Fact]
     public void ConvertToJson()
     {
-        GiftWrap giftWrap = GiftWrap.TryCreate(true).Value;
+        GiftWrap giftWrap = GiftWrap.TryCreate(true).Unwrap();
         var actual = JsonSerializer.Serialize(giftWrap);
         actual.Should().Be("\"True\"");
     }
@@ -150,7 +151,7 @@ public class RequiredBoolTests
         var result = GiftWrap.TryCreate((bool?)null, "myField");
 
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -160,7 +161,7 @@ public class RequiredBoolTests
         var result = InternalFlag.TryCreate(true);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeOfType<InternalFlag>();
+        result.Unwrap().Should().BeOfType<InternalFlag>();
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredDateTimeTests.cs
+++ b/Trellis.Primitives/tests/RequiredDateTimeTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Text.Json;
+using Trellis.Testing;
 
 public partial class OrderDate : RequiredDateTime<OrderDate>
 {
@@ -19,7 +20,7 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate(date);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(date);
+        result.Unwrap().Value.Should().Be(date);
     }
 
     [Fact]
@@ -29,7 +30,7 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate(now);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(now);
+        result.Unwrap().Value.Should().Be(now);
     }
 
     [Fact]
@@ -38,8 +39,8 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate(DateTime.MinValue);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("orderDate");
         validation.FieldErrors[0].Details[0].Should().Be("Order Date cannot be empty.");
     }
@@ -49,7 +50,7 @@ public class RequiredDateTimeTests
     {
         var result = OrderDate.TryCreate(DateTime.MaxValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(DateTime.MaxValue);
+        result.Unwrap().Value.Should().Be(DateTime.MaxValue);
     }
 
     [Fact]
@@ -58,8 +59,8 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate((DateTime?)null);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("orderDate");
         validation.FieldErrors[0].Details[0].Should().Be("Order Date cannot be empty.");
     }
@@ -70,9 +71,9 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate("2026-01-15T12:00:00Z");
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Year.Should().Be(2026);
-        result.Value.Value.Month.Should().Be(1);
-        result.Value.Value.Day.Should().Be(15);
+        result.Unwrap().Value.Year.Should().Be(2026);
+        result.Unwrap().Value.Month.Should().Be(1);
+        result.Unwrap().Value.Day.Should().Be(15);
     }
 
     [Theory]
@@ -121,7 +122,7 @@ public class RequiredDateTimeTests
     public void Can_use_ToString()
     {
         var date = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
-        OrderDate orderDate = OrderDate.TryCreate(date).Value;
+        OrderDate orderDate = OrderDate.TryCreate(date).Unwrap();
         orderDate.ToString(System.Globalization.CultureInfo.InvariantCulture).Should().NotBeNullOrWhiteSpace();
     }
 
@@ -130,14 +131,14 @@ public class RequiredDateTimeTests
     {
         var date = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
         OrderDate orderDate = (OrderDate)date;
-        orderDate.Should().Be(OrderDate.TryCreate(date).Value);
+        orderDate.Should().Be(OrderDate.TryCreate(date).Unwrap());
     }
 
     [Fact]
     public void ConvertToJson()
     {
         var date = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
-        OrderDate orderDate = OrderDate.TryCreate(date).Value;
+        OrderDate orderDate = OrderDate.TryCreate(date).Unwrap();
 
         var actual = JsonSerializer.Serialize(orderDate);
         actual.Should().NotBeNullOrWhiteSpace();
@@ -147,7 +148,7 @@ public class RequiredDateTimeTests
     public void JsonRoundTrip()
     {
         var date = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
-        OrderDate original = OrderDate.TryCreate(date).Value;
+        OrderDate original = OrderDate.TryCreate(date).Unwrap();
 
         var json = JsonSerializer.Serialize(original);
         var deserialized = JsonSerializer.Deserialize<OrderDate>(json);
@@ -159,7 +160,7 @@ public class RequiredDateTimeTests
     public void JsonRoundTrip_PreservesUtcKind()
     {
         var utcDate = new DateTime(2026, 6, 15, 9, 30, 0, DateTimeKind.Utc);
-        OrderDate original = OrderDate.TryCreate(utcDate).Value;
+        OrderDate original = OrderDate.TryCreate(utcDate).Unwrap();
 
         var json = JsonSerializer.Serialize(original);
         var deserialized = JsonSerializer.Deserialize<OrderDate>(json)!;
@@ -172,7 +173,7 @@ public class RequiredDateTimeTests
     public void ToString_ProducesIso8601RoundTrippableFormat()
     {
         var date = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
-        OrderDate orderDate = OrderDate.TryCreate(date).Value;
+        OrderDate orderDate = OrderDate.TryCreate(date).Unwrap();
 
         // ParsableJsonConverter uses ToString() — must produce round-trippable output
 #pragma warning disable CA1305 // Testing the parameterless ToString used by JSON serialization
@@ -192,7 +193,7 @@ public class RequiredDateTimeTests
         var result = OrderDate.TryCreate((DateTime?)null, "myField");
 
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -202,7 +203,7 @@ public class RequiredDateTimeTests
         var result = InternalDate.TryCreate(DateTime.UtcNow);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeOfType<InternalDate>();
+        result.Unwrap().Should().BeOfType<InternalDate>();
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredDecimalTests.cs
+++ b/Trellis.Primitives/tests/RequiredDecimalTests.cs
@@ -1,7 +1,8 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public partial class UnitPrice : RequiredDecimal<UnitPrice>
 {
@@ -21,8 +22,8 @@ public class RequiredDecimalTests
 
         // Assert
         unitPrice.IsFailure.Should().BeTrue();
-        unitPrice.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)unitPrice.Error;
+        unitPrice.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)unitPrice.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("unitPrice");
         validation.FieldErrors[0].Details[0].Should().Be("Unit Price cannot be empty.");
     }
@@ -40,8 +41,8 @@ public class RequiredDecimalTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeOfType<InternalUnitPrice>();
-        result.Value.Value.Should().Be(value);
+        result.Unwrap().Should().BeOfType<InternalUnitPrice>();
+        result.Unwrap().Value.Should().Be(value);
     }
 
     [Fact]
@@ -49,7 +50,7 @@ public class RequiredDecimalTests
     {
         var result = InternalUnitPrice.TryCreate(decimal.MaxValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(decimal.MaxValue);
+        result.Unwrap().Value.Should().Be(decimal.MaxValue);
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public class RequiredDecimalTests
     {
         var result = InternalUnitPrice.TryCreate(decimal.MinValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(decimal.MinValue);
+        result.Unwrap().Value.Should().Be(decimal.MinValue);
     }
 
     [Fact]
@@ -87,7 +88,7 @@ public class RequiredDecimalTests
     public void Can_implicitly_cast_to_decimal()
     {
         // Arrange
-        UnitPrice unitPrice = UnitPrice.TryCreate(19.99m).Value;
+        UnitPrice unitPrice = UnitPrice.TryCreate(19.99m).Unwrap();
 
         // Act
         decimal decimalValue = unitPrice;
@@ -103,14 +104,14 @@ public class RequiredDecimalTests
         UnitPrice unitPrice = (UnitPrice)19.99m;
 
         // Assert
-        unitPrice.Should().Be(UnitPrice.TryCreate(19.99m).Value);
+        unitPrice.Should().Be(UnitPrice.TryCreate(19.99m).Unwrap());
     }
 
     [Fact]
     public void Can_use_ToString()
     {
         // Arrange
-        UnitPrice unitPrice = UnitPrice.TryCreate(19.99m).Value;
+        UnitPrice unitPrice = UnitPrice.TryCreate(19.99m).Unwrap();
 
         // Act
         var strValue = unitPrice.ToString(CultureInfo.InvariantCulture);
@@ -180,8 +181,8 @@ public class RequiredDecimalTests
     public void Can_use_Contains()
     {
         // Arrange
-        var p1 = UnitPrice.TryCreate(10.00m).Value;
-        var p2 = UnitPrice.TryCreate(20.00m).Value;
+        var p1 = UnitPrice.TryCreate(10.00m).Unwrap();
+        var p2 = UnitPrice.TryCreate(20.00m).Unwrap();
         IReadOnlyList<UnitPrice> prices = new List<UnitPrice> { p1, p2 };
 
         // Act
@@ -196,7 +197,7 @@ public class RequiredDecimalTests
     {
         // Arrange
         var decimalValue = 19.99m;
-        UnitPrice unitPrice = UnitPrice.TryCreate(decimalValue).Value;
+        UnitPrice unitPrice = UnitPrice.TryCreate(decimalValue).Unwrap();
 
         // Act
         var actual = JsonSerializer.Serialize(unitPrice);
@@ -241,7 +242,7 @@ public class RequiredDecimalTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 }

--- a/Trellis.Primitives/tests/RequiredEnumTests.cs
+++ b/Trellis.Primitives/tests/RequiredEnumTests.cs
@@ -1,8 +1,9 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Text.Json;
 using Trellis;
 using Xunit;
+using Trellis.Testing;
 
 /// <summary>
 /// Test enum value object for order states.
@@ -79,7 +80,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(TestOrderState.Draft);
+        result.Unwrap().Should().Be(TestOrderState.Draft);
     }
 
     [Fact]
@@ -90,7 +91,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(TestOrderState.Confirmed);
+        result.Unwrap().Should().Be(TestOrderState.Confirmed);
     }
 
     [Fact]
@@ -101,8 +102,8 @@ public class RequiredEnumTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Contain("'InvalidState' is not a valid TestOrderState");
     }
 
@@ -114,7 +115,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -125,7 +126,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -136,7 +137,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("orderStatus");
     }
 
@@ -355,7 +356,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Fee.Should().Be(0.005m);
+        result.Unwrap().Fee.Should().Be(0.005m);
     }
 
     [Fact]
@@ -366,7 +367,7 @@ public class RequiredEnumTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(TestOverriddenOrderState.AwaitingPayment);
+        result.Unwrap().Should().Be(TestOverriddenOrderState.AwaitingPayment);
     }
 
     #endregion

--- a/Trellis.Primitives/tests/RequiredGuidTests.cs
+++ b/Trellis.Primitives/tests/RequiredGuidTests.cs
@@ -1,9 +1,10 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System;
 using System.Globalization;
 using System.Text.Json;
 using Xunit;
+using Trellis.Testing;
 
 public partial class EmployeeId : RequiredGuid<EmployeeId>
 {
@@ -16,8 +17,8 @@ public class RequiredGuidTests
     {
         var guidId1 = EmployeeId.TryCreate(default(Guid));
         guidId1.IsFailure.Should().BeTrue();
-        guidId1.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)guidId1.Error;
+        guidId1.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)guidId1.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("employeeId");
         validation.FieldErrors[0].Details[0].Should().Be("Employee Id cannot be empty.");
         validation.Code.Should().Be("validation.error");
@@ -31,7 +32,7 @@ public class RequiredGuidTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -95,7 +96,7 @@ public class RequiredGuidTests
     {
         // Arrange
         var guid = Guid.NewGuid();
-        var myGuid = EmployeeId.TryCreate(guid).Value;
+        var myGuid = EmployeeId.TryCreate(guid).Unwrap();
 
         // Act
         var actual = myGuid.ToString(CultureInfo.InvariantCulture);
@@ -109,7 +110,7 @@ public class RequiredGuidTests
     {
         // Arrange
         Guid myGuid = Guid.NewGuid();
-        EmployeeId myGuidId1 = EmployeeId.TryCreate(myGuid).Value;
+        EmployeeId myGuidId1 = EmployeeId.TryCreate(myGuid).Unwrap();
 
         // Act
         Guid primGuid = myGuidId1;
@@ -156,8 +157,8 @@ public class RequiredGuidTests
 
         // Assert
         myGuidResult.IsFailure.Should().BeTrue();
-        myGuidResult.Error.Should().BeOfType<ValidationError>();
-        ValidationError ve = (ValidationError)myGuidResult.Error;
+        myGuidResult.UnwrapError().Should().BeOfType<ValidationError>();
+        ValidationError ve = (ValidationError)myGuidResult.UnwrapError();
         ve.FieldErrors[0].FieldName.Should().Be("employeeId");
         ve.FieldErrors[0].Details[0].Should().Be("Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)");
 
@@ -173,8 +174,8 @@ public class RequiredGuidTests
 
         // Assert
         myGuidResult.IsFailure.Should().BeTrue();
-        myGuidResult.Error.Should().BeOfType<ValidationError>();
-        ValidationError ve = (ValidationError)myGuidResult.Error;
+        myGuidResult.UnwrapError().Should().BeOfType<ValidationError>();
+        ValidationError ve = (ValidationError)myGuidResult.UnwrapError();
         ve.FieldErrors[0].FieldName.Should().Be("employeeId");
         ve.FieldErrors[0].Details[0].Should().Be("Employee Id cannot be empty.");
     }

--- a/Trellis.Primitives/tests/RequiredGuidValidateAdditionalTests.cs
+++ b/Trellis.Primitives/tests/RequiredGuidValidateAdditionalTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.Primitives.Tests;
+using Trellis.Testing;
+namespace Trellis.Primitives.Tests;
 
 /// <summary>
 /// RequiredGuid with custom validation — rejects Version 4 GUIDs (only allows V7).
@@ -37,7 +38,7 @@ public class RequiredGuidValidateAdditionalTests
         var v4 = Guid.NewGuid();
         var result = V7OnlyId.TryCreate(v4);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Only Version 7 GUIDs are allowed.");
     }
 

--- a/Trellis.Primitives/tests/RequiredIntTests.cs
+++ b/Trellis.Primitives/tests/RequiredIntTests.cs
@@ -1,7 +1,8 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public partial class TicketNumber : RequiredInt<TicketNumber>
 {
@@ -21,8 +22,8 @@ public class RequiredIntTests
 
         // Assert
         ticketNumber.IsFailure.Should().BeTrue();
-        ticketNumber.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)ticketNumber.Error;
+        ticketNumber.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)ticketNumber.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("ticketNumber");
         validation.FieldErrors[0].Details[0].Should().Be("Ticket Number cannot be empty.");
     }
@@ -41,8 +42,8 @@ public class RequiredIntTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeOfType<InternalTicketNumber>();
-        result.Value.Value.Should().Be(value);
+        result.Unwrap().Should().BeOfType<InternalTicketNumber>();
+        result.Unwrap().Value.Should().Be(value);
     }
 
     [Fact]
@@ -72,7 +73,7 @@ public class RequiredIntTests
     public void Can_implicitly_cast_to_int()
     {
         // Arrange
-        TicketNumber ticketNumber = TicketNumber.TryCreate(12345).Value;
+        TicketNumber ticketNumber = TicketNumber.TryCreate(12345).Unwrap();
 
         // Act
         int intValue = ticketNumber;
@@ -88,14 +89,14 @@ public class RequiredIntTests
         TicketNumber ticketNumber = (TicketNumber)12345;
 
         // Assert
-        ticketNumber.Should().Be(TicketNumber.TryCreate(12345).Value);
+        ticketNumber.Should().Be(TicketNumber.TryCreate(12345).Unwrap());
     }
 
     [Fact]
     public void Can_use_ToString()
     {
         // Arrange
-        TicketNumber ticketNumber = TicketNumber.TryCreate(12345).Value;
+        TicketNumber ticketNumber = TicketNumber.TryCreate(12345).Unwrap();
 
         // Act
         var strValue = ticketNumber.ToString(CultureInfo.InvariantCulture);
@@ -165,8 +166,8 @@ public class RequiredIntTests
     public void Can_use_Contains()
     {
         // Arrange
-        var id1 = TicketNumber.TryCreate(1).Value;
-        var id2 = TicketNumber.TryCreate(2).Value;
+        var id1 = TicketNumber.TryCreate(1).Unwrap();
+        var id2 = TicketNumber.TryCreate(2).Unwrap();
         IReadOnlyList<TicketNumber> ids = new List<TicketNumber> { id1, id2 };
 
         // Act
@@ -181,7 +182,7 @@ public class RequiredIntTests
     {
         // Arrange
         var intValue = 12345;
-        TicketNumber ticketNumber = TicketNumber.TryCreate(intValue).Value;
+        TicketNumber ticketNumber = TicketNumber.TryCreate(intValue).Unwrap();
 
         // Act
         var actual = JsonSerializer.Serialize(ticketNumber);
@@ -226,7 +227,7 @@ public class RequiredIntTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 }

--- a/Trellis.Primitives/tests/RequiredLongTests.cs
+++ b/Trellis.Primitives/tests/RequiredLongTests.cs
@@ -1,4 +1,5 @@
-﻿namespace Trellis.Primitives.Tests;
+using Trellis.Testing;
+namespace Trellis.Primitives.Tests;
 
 /// <summary>
 /// RequiredLong without [Range] — accepts any non-null long.
@@ -33,7 +34,7 @@ public class RequiredLongTests
     {
         var result = TraceId.TryCreate(123456789L);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(123456789L);
+        result.Unwrap().Value.Should().Be(123456789L);
     }
 
     [Theory]
@@ -45,7 +46,7 @@ public class RequiredLongTests
     {
         var result = TraceId.TryCreate(value);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(value);
+        result.Unwrap().Value.Should().Be(value);
     }
 
     [Fact]
@@ -60,7 +61,7 @@ public class RequiredLongTests
     {
         var result = TraceId.TryCreate("999999999999");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(999999999999L);
+        result.Unwrap().Value.Should().Be(999999999999L);
     }
 
     [Fact]
@@ -89,7 +90,7 @@ public class RequiredLongTests
     {
         var result = SequenceNumber.TryCreate(1L);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1L);
+        result.Unwrap().Value.Should().Be(1L);
     }
 
     [Fact]
@@ -97,7 +98,7 @@ public class RequiredLongTests
     {
         var result = SequenceNumber.TryCreate(1000000L);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(1000000L);
+        result.Unwrap().Value.Should().Be(1000000L);
     }
 
     [Fact]
@@ -112,7 +113,7 @@ public class RequiredLongTests
     {
         var result = SequenceNumber.TryCreate("500");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(500L);
+        result.Unwrap().Value.Should().Be(500L);
     }
 
     [Fact]
@@ -127,7 +128,7 @@ public class RequiredLongTests
     {
         var result = SequenceNumber.TryCreate(0L, "myField");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("myField");
     }
 
@@ -141,7 +142,7 @@ public class RequiredLongTests
     [Fact]
     public void JsonRoundTrip()
     {
-        var original = TraceId.TryCreate(42L).Value;
+        var original = TraceId.TryCreate(42L).Unwrap();
         var json = System.Text.Json.JsonSerializer.Serialize(original);
         var deserialized = System.Text.Json.JsonSerializer.Deserialize<TraceId>(json);
         deserialized.Should().Be(original);
@@ -154,7 +155,7 @@ public class RequiredLongTests
     {
         var result = LargeSequence.TryCreate(5000000000L);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(5000000000L);
+        result.Unwrap().Value.Should().Be(5000000000L);
     }
 
     [Fact]
@@ -187,7 +188,7 @@ public class RequiredLongTests
     {
         var result = FullRangeLong.TryCreate(long.MinValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(long.MinValue);
+        result.Unwrap().Value.Should().Be(long.MinValue);
     }
 
     [Fact]
@@ -195,7 +196,7 @@ public class RequiredLongTests
     {
         var result = FullRangeLong.TryCreate(long.MaxValue);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(long.MaxValue);
+        result.Unwrap().Value.Should().Be(long.MaxValue);
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredStringLengthTests.cs
+++ b/Trellis.Primitives/tests/RequiredStringLengthTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Text.Json;
+using Trellis.Testing;
 
 /// <summary>
 /// Test value object with max length only.
@@ -31,7 +32,7 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate("ABC");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("ABC");
+        result.Unwrap().Value.Should().Be("ABC");
     }
 
     [Fact]
@@ -39,7 +40,7 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate("1234567890"); // exactly 10
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("1234567890");
+        result.Unwrap().Value.Should().Be("1234567890");
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public class RequiredStringLengthTests
         var result = ShortCode.TryCreate("  ABC123  "); // trims to 6 characters
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("ABC123");
+        result.Unwrap().Value.Should().Be("ABC123");
     }
 
     [Fact]
@@ -56,8 +57,8 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate("12345678901"); // 11 characters
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("shortCode");
         validation.FieldErrors[0].Details[0].Should().Be("Short Code must be 10 characters or fewer.");
     }
@@ -67,7 +68,7 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate(null);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Short Code cannot be empty.");
     }
 
@@ -76,7 +77,7 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate("");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Short Code cannot be empty.");
     }
 
@@ -85,7 +86,7 @@ public class RequiredStringLengthTests
     {
         var result = ShortCode.TryCreate("12345678901", "code");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("code");
     }
 
@@ -98,7 +99,7 @@ public class RequiredStringLengthTests
     {
         var result = UserName.TryCreate("John");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("John");
+        result.Unwrap().Value.Should().Be("John");
     }
 
     [Fact]
@@ -106,7 +107,7 @@ public class RequiredStringLengthTests
     {
         var result = UserName.TryCreate("abc"); // exactly 3
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("abc");
+        result.Unwrap().Value.Should().Be("abc");
     }
 
     [Fact]
@@ -121,8 +122,8 @@ public class RequiredStringLengthTests
     {
         var result = UserName.TryCreate("ab"); // 2 characters, min is 3
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("userName");
         validation.FieldErrors[0].Details[0].Should().Be("User Name must be at least 3 characters.");
     }
@@ -132,8 +133,8 @@ public class RequiredStringLengthTests
     {
         var result = UserName.TryCreate(new string('x', 51)); // 51 characters, max is 50
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("User Name must be 50 characters or fewer.");
     }
 
@@ -142,7 +143,7 @@ public class RequiredStringLengthTests
     {
         var result = UserName.TryCreate(null);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("User Name cannot be empty.");
     }
 

--- a/Trellis.Primitives/tests/RequiredStringTests.cs
+++ b/Trellis.Primitives/tests/RequiredStringTests.cs
@@ -1,7 +1,8 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public partial class TrackingId : RequiredString<TrackingId>
 {
@@ -18,8 +19,8 @@ public class RequiredStringTests
     {
         var trackingId1 = TrackingId.TryCreate(input, null);
         trackingId1.IsFailure.Should().BeTrue();
-        trackingId1.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)trackingId1.Error;
+        trackingId1.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)trackingId1.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("trackingId");
         validation.FieldErrors[0].Details[0].Should().Be("Tracking Id cannot be empty.");
         validation.Code.Should().Be("validation.error");
@@ -62,7 +63,7 @@ public class RequiredStringTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
+        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Unwrap();
 
         // Act
         string strTracking = trackingId1;
@@ -80,14 +81,14 @@ public class RequiredStringTests
         TrackingId trackingId1 = (TrackingId)"32141sd";
 
         // Assert
-        trackingId1.Should().Be(TrackingId.TryCreate("32141sd").Value);
+        trackingId1.Should().Be(TrackingId.TryCreate("32141sd").Unwrap());
     }
 
     [Fact]
     public void Can_use_ToString()
     {
         // Arrange
-        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Value;
+        TrackingId trackingId1 = TrackingId.TryCreate("32141sd").Unwrap();
 
         // Act
         var strTracking = trackingId1.ToString(CultureInfo.InvariantCulture);
@@ -170,8 +171,8 @@ public class RequiredStringTests
     public void Can_use_Contains()
     {
         // Arrange
-        var id1 = TrackingId.TryCreate("id1").Value;
-        var id2 = TrackingId.TryCreate("id2").Value;
+        var id1 = TrackingId.TryCreate("id1").Unwrap();
+        var id2 = TrackingId.TryCreate("id2").Unwrap();
         IReadOnlyList<TrackingId> ids = new List<TrackingId> { id1, id2 };
 
         // Act
@@ -186,7 +187,7 @@ public class RequiredStringTests
     {
         // Arrange
         var strTrackingId = "MyTrackingId";
-        TrackingId trackingId = TrackingId.TryCreate(strTrackingId).Value;
+        TrackingId trackingId = TrackingId.TryCreate(strTrackingId).Unwrap();
         var expected = JsonSerializer.Serialize(strTrackingId);
 
         // Act
@@ -230,7 +231,7 @@ public class RequiredStringTests
         var result = TrackingId.TryCreate("  ABC123  ");
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("ABC123",
+        result.Unwrap().Value.Should().Be("ABC123",
             "RequiredString should trim leading and trailing whitespace per its XML documentation");
     }
 

--- a/Trellis.Primitives/tests/SlugTests.cs
+++ b/Trellis.Primitives/tests/SlugTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class SlugTests
 {
@@ -23,7 +24,7 @@ public class SlugTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(slug);
+        result.Unwrap().Value.Should().Be(slug);
     }
 
     [Theory]
@@ -36,7 +37,7 @@ public class SlugTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -50,7 +51,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Slug is required.");
     }
 
@@ -67,7 +68,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Slug must contain lower-case letters, numbers, and hyphens, without leading/trailing hyphens.");
     }
 
@@ -82,7 +83,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Slug must contain lower-case letters, numbers, and hyphens, without leading/trailing hyphens.");
     }
 
@@ -98,7 +99,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Slug must contain lower-case letters, numbers, and hyphens, without leading/trailing hyphens.");
     }
 
@@ -116,7 +117,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Slug must contain lower-case letters, numbers, and hyphens, without leading/trailing hyphens.");
     }
 
@@ -128,7 +129,7 @@ public class SlugTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("articleSlug");
     }
 
@@ -156,8 +157,8 @@ public class SlugTests
     public void Two_Slug_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = Slug.TryCreate("hello-world").Value;
-        var b = Slug.TryCreate("hello-world").Value;
+        var a = Slug.TryCreate("hello-world").Unwrap();
+        var b = Slug.TryCreate("hello-world").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -169,8 +170,8 @@ public class SlugTests
     public void Two_Slug_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = Slug.TryCreate("hello-world").Value;
-        var b = Slug.TryCreate("goodbye-world").Value;
+        var a = Slug.TryCreate("hello-world").Unwrap();
+        var b = Slug.TryCreate("goodbye-world").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -181,7 +182,7 @@ public class SlugTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        Slug value = Slug.TryCreate("hello-world").Value;
+        Slug value = Slug.TryCreate("hello-world").Unwrap();
 
         // Act
         string stringValue = value;
@@ -249,7 +250,7 @@ public class SlugTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = Slug.TryCreate("hello-world").Value;
+        var value = Slug.TryCreate("hello-world").Unwrap();
         var expected = JsonSerializer.Serialize("hello-world");
 
         // Act

--- a/Trellis.Primitives/tests/Trellis.Primitives.Tests.csproj
+++ b/Trellis.Primitives/tests/Trellis.Primitives.Tests.csproj
@@ -11,4 +11,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
       <PackageReference Include="OpenTelemetry" />
    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
+  </ItemGroup>
 </Project>

--- a/Trellis.Primitives/tests/UrlTests.cs
+++ b/Trellis.Primitives/tests/UrlTests.cs
@@ -1,9 +1,10 @@
-﻿using Trellis.Primitives;
+using Trellis.Primitives;
 
 namespace Trellis.Primitives.Tests;
 
 using System.Globalization;
 using System.Text.Json;
+using Trellis.Testing;
 
 public class UrlTests
 {
@@ -21,7 +22,7 @@ public class UrlTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(expected);
+        result.Unwrap().Value.Should().Be(expected);
     }
 
     [Theory]
@@ -42,7 +43,7 @@ public class UrlTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
+        result.UnwrapError().Should().BeOfType<ValidationError>();
     }
 
     [Fact]
@@ -53,7 +54,7 @@ public class UrlTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("URL is required.");
     }
 
@@ -65,7 +66,7 @@ public class UrlTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         // Note: On some platforms, Uri.TryCreate treats "/path" as absolute with "file" scheme
         // So we check for either error message depending on platform behavior
         validation.FieldErrors[0].Details[0].Should().Match(e =>
@@ -81,7 +82,7 @@ public class UrlTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("URL must use HTTP or HTTPS scheme.");
     }
 
@@ -91,7 +92,7 @@ public class UrlTests
     public void Scheme_returns_correct_value(string url, string expectedScheme)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.Scheme.Should().Be(expectedScheme);
@@ -104,7 +105,7 @@ public class UrlTests
     public void Host_returns_correct_value(string url, string expectedHost)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.Host.Should().Be(expectedHost);
@@ -118,7 +119,7 @@ public class UrlTests
     public void Port_returns_correct_value(string url, int expectedPort)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.Port.Should().Be(expectedPort);
@@ -131,7 +132,7 @@ public class UrlTests
     public void Path_returns_correct_value(string url, string expectedPath)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.Path.Should().Be(expectedPath);
@@ -144,7 +145,7 @@ public class UrlTests
     public void Query_returns_correct_value(string url, string expectedQuery)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.Query.Should().Be(expectedQuery);
@@ -156,7 +157,7 @@ public class UrlTests
     public void IsSecure_returns_correct_value(string url, bool expectedIsSecure)
     {
         // Arrange
-        var urlObj = Url.TryCreate(url).Value;
+        var urlObj = Url.TryCreate(url).Unwrap();
 
         // Act & Assert
         urlObj.IsSecure.Should().Be(expectedIsSecure);
@@ -166,7 +167,7 @@ public class UrlTests
     public void ToUri_returns_valid_Uri()
     {
         // Arrange
-        var url = Url.TryCreate("https://example.com/path").Value;
+        var url = Url.TryCreate("https://example.com/path").Unwrap();
 
         // Act
         var uri = url.ToUri();
@@ -180,8 +181,8 @@ public class UrlTests
     public void Two_Url_with_same_value_should_be_equal()
     {
         // Arrange
-        var a = Url.TryCreate("https://example.com").Value;
-        var b = Url.TryCreate("https://example.com").Value;
+        var a = Url.TryCreate("https://example.com").Unwrap();
+        var b = Url.TryCreate("https://example.com").Unwrap();
 
         // Assert
         (a == b).Should().BeTrue();
@@ -193,8 +194,8 @@ public class UrlTests
     public void Two_Url_with_different_value_should_not_be_equal()
     {
         // Arrange
-        var a = Url.TryCreate("https://example.com").Value;
-        var b = Url.TryCreate("https://other.com").Value;
+        var a = Url.TryCreate("https://example.com").Unwrap();
+        var b = Url.TryCreate("https://other.com").Unwrap();
 
         // Assert
         (a != b).Should().BeTrue();
@@ -205,7 +206,7 @@ public class UrlTests
     public void Can_implicitly_cast_to_string()
     {
         // Arrange
-        Url value = Url.TryCreate("https://example.com").Value;
+        Url value = Url.TryCreate("https://example.com").Unwrap();
 
         // Act
         string stringValue = value;
@@ -270,7 +271,7 @@ public class UrlTests
     public void ConvertToJson()
     {
         // Arrange
-        var value = Url.TryCreate("https://example.com").Value;
+        var value = Url.TryCreate("https://example.com").Unwrap();
         var expected = JsonSerializer.Serialize("https://example.com/");
 
         // Act
@@ -315,7 +316,7 @@ public class UrlTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("webhookUrl");
     }
 

--- a/Trellis.Primitives/tests/ValidateAdditionalTests.cs
+++ b/Trellis.Primitives/tests/ValidateAdditionalTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Trellis.Primitives.Tests;
+namespace Trellis.Primitives.Tests;
 
 using System.Text.RegularExpressions;
+using Trellis.Testing;
 
 // --- Test value objects with ValidateAdditional ---
 
@@ -80,7 +81,7 @@ public class ValidateAdditionalTests
     {
         var result = Sku.TryCreate("SKU-123456");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("SKU-123456");
+        result.Unwrap().Value.Should().Be("SKU-123456");
     }
 
     [Fact]
@@ -88,8 +89,8 @@ public class ValidateAdditionalTests
     {
         var result = Sku.TryCreate("INVALID");
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<ValidationError>();
-        var validation = (ValidationError)result.Error;
+        result.UnwrapError().Should().BeOfType<ValidationError>();
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Sku must match pattern SKU-XXXXXX.");
     }
 
@@ -99,7 +100,7 @@ public class ValidateAdditionalTests
         // 11 chars — should fail StringLength before reaching ValidateAdditional
         var result = Sku.TryCreate("SKU-1234567");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Sku must be 10 characters or fewer.");
     }
 
@@ -108,7 +109,7 @@ public class ValidateAdditionalTests
     {
         var result = Sku.TryCreate(null);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Sku cannot be empty.");
     }
 
@@ -117,7 +118,7 @@ public class ValidateAdditionalTests
     {
         var result = Sku.TryCreate("BAD", "itemSku");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("itemSku");
     }
 
@@ -127,7 +128,7 @@ public class ValidateAdditionalTests
         // "SKU-123456" is 10 chars (at StringLength limit), spaces should be trimmed before validation
         var result = Sku.TryCreate(" SKU-123456 ");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("SKU-123456");
+        result.Unwrap().Value.Should().Be("SKU-123456");
     }
 
     #endregion
@@ -139,7 +140,7 @@ public class ValidateAdditionalTests
     {
         var result = PlainName.TryCreate("Hello");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be("Hello");
+        result.Unwrap().Value.Should().Be("Hello");
     }
 
     #endregion
@@ -151,7 +152,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate(50);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50);
+        result.Unwrap().Value.Should().Be(50);
     }
 
     [Fact]
@@ -159,7 +160,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate(51);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Even Percentage must be an even number.");
     }
 
@@ -168,7 +169,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate(102);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Even Percentage must be at most 100.");
     }
 
@@ -177,7 +178,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate((int?)51);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Even Percentage must be an even number.");
     }
 
@@ -186,7 +187,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate("50");
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(50);
+        result.Unwrap().Value.Should().Be(50);
     }
 
     [Fact]
@@ -194,7 +195,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate("51");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Even Percentage must be an even number.");
     }
 
@@ -214,7 +215,7 @@ public class ValidateAdditionalTests
     {
         var result = PositiveScore.TryCreate(-1);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Positive Score must be positive.");
     }
 
@@ -224,7 +225,7 @@ public class ValidateAdditionalTests
         // Zero passes built-in (no zero-check), but ValidateAdditional allows it (< 0 check)
         var result = PositiveScore.TryCreate(0);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(0);
+        result.Unwrap().Value.Should().Be(0);
     }
 
     [Fact]
@@ -232,7 +233,7 @@ public class ValidateAdditionalTests
     {
         var result = PositiveScore.TryCreate((int?)-3);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Positive Score must be positive.");
     }
 
@@ -241,7 +242,7 @@ public class ValidateAdditionalTests
     {
         var result = PositiveScore.TryCreate("-5");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Positive Score must be positive.");
     }
 
@@ -254,7 +255,7 @@ public class ValidateAdditionalTests
     {
         var result = PreciseAmount.TryCreate(10.99m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(10.99m);
+        result.Unwrap().Value.Should().Be(10.99m);
     }
 
     [Fact]
@@ -262,7 +263,7 @@ public class ValidateAdditionalTests
     {
         var result = PreciseAmount.TryCreate(10.999m);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Precise Amount must have at most 2 decimal places.");
     }
 
@@ -272,7 +273,7 @@ public class ValidateAdditionalTests
         // Zero passes built-in (no zero-check) and ValidateAdditional (0.00 has 2 decimal places)
         var result = PreciseAmount.TryCreate(0m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(0m);
+        result.Unwrap().Value.Should().Be(0m);
     }
 
     [Fact]
@@ -287,7 +288,7 @@ public class ValidateAdditionalTests
     {
         var result = PreciseAmount.TryCreate((decimal?)5.555m);
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Precise Amount must have at most 2 decimal places.");
     }
 
@@ -303,7 +304,7 @@ public class ValidateAdditionalTests
     {
         var result = PreciseAmount.TryCreate("25.123");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].Details[0].Should().Be("Precise Amount must have at most 2 decimal places.");
     }
 
@@ -316,7 +317,7 @@ public class ValidateAdditionalTests
     {
         var result = PlainCount.TryCreate(42);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(42);
+        result.Unwrap().Value.Should().Be(42);
     }
 
     #endregion
@@ -328,7 +329,7 @@ public class ValidateAdditionalTests
     {
         var result = PlainRate.TryCreate(3.14m);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Value.Should().Be(3.14m);
+        result.Unwrap().Value.Should().Be(3.14m);
     }
 
     #endregion
@@ -378,7 +379,7 @@ public class ValidateAdditionalTests
     {
         var result = EvenPercentage.TryCreate(51, "discount");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("discount");
     }
 
@@ -387,7 +388,7 @@ public class ValidateAdditionalTests
     {
         var result = PreciseAmount.TryCreate(1.999m, "price");
         result.IsFailure.Should().BeTrue();
-        var validation = (ValidationError)result.Error;
+        var validation = (ValidationError)result.UnwrapError();
         validation.FieldErrors[0].FieldName.Should().Be("price");
     }
 

--- a/Trellis.Results/src/Result/IResult.cs
+++ b/Trellis.Results/src/Result/IResult.cs
@@ -23,10 +23,10 @@ public interface IResult
 
 #pragma warning disable CA1716 // Identifiers should not match keywords
     /// <summary>
-    /// Gets the error information if this is a failure result.
+    /// Attempts to get the error without throwing.
     /// </summary>
-    /// <value>An <see cref="Trellis.Error"/> instance describing the failure.</value>
-    /// <exception cref="InvalidOperationException">Thrown when accessed on a successful result.</exception>
-    Error Error { get; }
+    /// <param name="error">When this method returns true, contains the error; otherwise, null.</param>
+    /// <returns>True if the result is a failure; otherwise false.</returns>
+    bool TryGetError(out Error error);
 #pragma warning restore CA1716 // Identifiers should not match keywords
 }

--- a/Trellis.Results/src/Result/IResult{TValue}.cs
+++ b/Trellis.Results/src/Result/IResult{TValue}.cs
@@ -10,9 +10,9 @@
 public interface IResult<TValue> : IResult
 {
     /// <summary>
-    /// Gets the success value if this result represents success.
+    /// Attempts to get the success value without throwing.
     /// </summary>
-    /// <value>The value of type <typeparamref name="TValue"/>.</value>
-    /// <exception cref="InvalidOperationException">Thrown when accessed on a failed result.</exception>
-    TValue Value { get; }
+    /// <param name="value">When this method returns true, contains the success value; otherwise, the default value.</param>
+    /// <returns>True if the result is successful; otherwise false.</returns>
+    bool TryGetValue(out TValue value);
 }

--- a/Trellis.Results/src/Result/Result{TValue}.cs
+++ b/Trellis.Results/src/Result/Result{TValue}.cs
@@ -18,12 +18,15 @@ using System.Diagnostics;
 /// Result&lt;User&gt; success = Result.Ok(user);
 /// Result&lt;User&gt; failure = Error.NotFound("User not found");
 /// 
-/// // Pattern matching
-/// var message = result switch
-/// {
-///     { IsSuccess: true } => $"Found user: {result.Value.Name}",
-///     { IsFailure: true } => $"Error: {result.Error.Detail}"
-/// };
+/// // Pattern matching with Deconstruct
+/// var (isSuccess, value, error) = result;
+/// var message = isSuccess
+///     ? $"Found user: {value!.Name}"
+///     : $"Error: {error!.Detail}";
+/// 
+/// // Or use the safe accessors
+/// if (result.TryGetValue(out var user)) Console.WriteLine(user.Name);
+/// else if (result.TryGetError(out var err)) Console.WriteLine(err.Detail);
 /// 
 /// // Chaining operations
 /// var finalResult = GetUser(id)
@@ -35,32 +38,6 @@ using System.Diagnostics;
 [DebuggerTypeProxy(typeof(ResultDebugView<>))]
 public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>, IFailureFactory<Result<TValue>>
 {
-    /// <summary>
-    /// Gets the underlying value if the result is successful; otherwise throws.
-    /// </summary>
-    /// <value>The success value.</value>
-    /// <exception cref="InvalidOperationException">Thrown when accessing Value on a failed result.</exception>
-    /// <remarks>
-    /// Always check <see cref="IsSuccess"/> before accessing this property, or use <see cref="TryGetValue"/> instead.
-    /// </remarks>
-    public TValue Value =>
-        IsSuccess
-            ? _value!
-            : throw new InvalidOperationException("Attempted to access the Value for a failed result. A failed result has no Value.");
-
-    /// <summary>
-    /// Gets the error if the result is a failure; otherwise throws.
-    /// </summary>
-    /// <value>The error describing why the result failed.</value>
-    /// <exception cref="InvalidOperationException">Thrown when accessing Error on a successful result.</exception>
-    /// <remarks>
-    /// Always check <see cref="IsFailure"/> before accessing this property, or use <see cref="TryGetError"/> instead.
-    /// </remarks>
-    public Error Error =>
-        IsFailure
-            ? _error!
-            : throw new InvalidOperationException("Attempted to access the Error property for a successful result. A successful result has no Error.");
-
     /// <summary>
     /// True when the result represents success.
     /// </summary>
@@ -128,6 +105,22 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
 
     private readonly TValue? _value;
     private readonly Error? _error;
+
+    // ------------- Internal accessors for in-assembly use -------------
+    // These intentionally mirror the v1 public Value/Error properties so that
+    // ROP combinator extensions in this assembly stay readable and avoid the
+    // (out param) cost of TryGet*. They are not part of the public API; external
+    // consumers must use TryGetValue/TryGetError/Deconstruct (see plan §3.1).
+
+    internal TValue Value =>
+        IsSuccess
+            ? _value!
+            : throw new InvalidOperationException("Cannot access Value on a failed result.");
+
+    internal Error Error =>
+        IsFailure
+            ? _error!
+            : throw new InvalidOperationException("Cannot access Error on a successful result.");
 
     // ------------- Convenience / ergonomic APIs ------------
 

--- a/Trellis.Stateless/tests/LazyStateMachineTests.cs
+++ b/Trellis.Stateless/tests/LazyStateMachineTests.cs
@@ -97,7 +97,8 @@ public class LazyStateMachineTests
         var result = lazy.FireResult(Trigger.Submit);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Submitted);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Submitted);
         status.Should().Be(State.Submitted);
     }
 
@@ -110,8 +111,9 @@ public class LazyStateMachineTests
         var result = lazy.FireResult(Trigger.Ship);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
-        result.Error.Code.Should().Be("state.machine.invalid.transition");
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
+        err.Code.Should().Be("state.machine.invalid.transition");
     }
 
     [Fact]
@@ -184,7 +186,8 @@ public class LazyStateMachineTests
         // Now it's safe to use
         var result = lazy.FireResult(Trigger.Submit);
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Submitted);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Submitted);
     }
 
     #endregion
@@ -221,7 +224,8 @@ public class LazyStateMachineTests
         var result = lazy.FireResult(Trigger.Submit);
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
     }
 
     #endregion
@@ -240,7 +244,8 @@ public class LazyStateMachineTests
         var result = lazy.FireResult("Publish");
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Published");
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be("Published");
         status.Should().Be("Published");
     }
 
@@ -256,7 +261,8 @@ public class LazyStateMachineTests
         var result = lazy.FireResult("Archive");
 
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
     }
 
     #endregion

--- a/Trellis.Stateless/tests/StateMachineExtensionsTests.cs
+++ b/Trellis.Stateless/tests/StateMachineExtensionsTests.cs
@@ -25,7 +25,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Running);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Running);
     }
 
     [Fact]
@@ -40,15 +41,18 @@ public class StateMachineExtensionsTests
         // Act & Assert
         var result1 = machine.FireResult(Trigger.Start);
         result1.IsSuccess.Should().BeTrue();
-        result1.Value.Should().Be(State.Running);
+        result1.TryGetValue(out var v1).Should().BeTrue();
+        v1.Should().Be(State.Running);
 
         var result2 = machine.FireResult(Trigger.Pause);
         result2.IsSuccess.Should().BeTrue();
-        result2.Value.Should().Be(State.Paused);
+        result2.TryGetValue(out var v2).Should().BeTrue();
+        v2.Should().Be(State.Paused);
 
         var result3 = machine.FireResult(Trigger.Resume);
         result3.IsSuccess.Should().BeTrue();
-        result3.Value.Should().Be(State.Running);
+        result3.TryGetValue(out var v3).Should().BeTrue();
+        v3.Should().Be(State.Running);
     }
 
     [Fact]
@@ -63,7 +67,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Running);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Running);
     }
 
     #endregion
@@ -82,9 +87,10 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
-        result.Error.Detail.Should().Contain("Pause");
-        result.Error.Detail.Should().Contain("Idle");
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
+        err.Detail.Should().Contain("Pause");
+        err.Detail.Should().Contain("Idle");
     }
 
     [Fact]
@@ -112,7 +118,8 @@ public class StateMachineExtensionsTests
         var result = machine.FireResult(Trigger.Complete);
 
         // Assert
-        result.Error.Code.Should().Be("state.machine.invalid.transition");
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Code.Should().Be("state.machine.invalid.transition");
     }
 
     [Fact]
@@ -126,7 +133,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
     }
 
     #endregion
@@ -147,7 +155,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Running);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Running);
     }
 
     [Fact]
@@ -164,9 +173,10 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
-        result.Error.Detail.Should().Contain("Start");
-        result.Error.Detail.Should().Contain("Idle");
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
+        err.Detail.Should().Contain("Start");
+        err.Detail.Should().Contain("Idle");
     }
 
     [Fact]
@@ -204,7 +214,8 @@ public class StateMachineExtensionsTests
         // Act — guard is now true
         var result2 = machine.FireResult(Trigger.Start);
         result2.IsSuccess.Should().BeTrue();
-        result2.Value.Should().Be(State.Running);
+        result2.TryGetValue(out var v2).Should().BeTrue();
+        v2.Should().Be(State.Running);
     }
 
     [Fact]
@@ -225,7 +236,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(State.Running);
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be(State.Running);
         guardCallCount.Should().Be(1, "FireResult should not evaluate transition guards more than once");
     }
 
@@ -278,7 +290,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("Published");
+        result.TryGetValue(out var v).Should().BeTrue();
+        v.Should().Be("Published");
     }
 
     [Fact]
@@ -293,7 +306,8 @@ public class StateMachineExtensionsTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().BeOfType<DomainError>();
+        result.TryGetError(out var err).Should().BeTrue();
+        err.Should().BeOfType<DomainError>();
     }
 
     #endregion

--- a/Trellis.Testing/src/Assertions/ResultAssertions.cs
+++ b/Trellis.Testing/src/Assertions/ResultAssertions.cs
@@ -45,13 +45,15 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
         string because = "",
         params object[] becauseArgs)
     {
+        Subject.TryGetError(out var error);
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
             .FailWith("Expected {context:result} to be success{reason}, but it failed with error: {0}",
-                Subject.IsFailure ? Subject.Error : null);
+                error);
 
-        return new AndWhichConstraint<ResultAssertions<TValue>, TValue>(this, Subject.Value);
+        Subject.TryGetValue(out var value);
+        return new AndWhichConstraint<ResultAssertions<TValue>, TValue>(this, value);
     }
 
     /// <summary>
@@ -67,13 +69,15 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
         string because = "",
         params object[] becauseArgs)
     {
+        Subject.TryGetValue(out var value);
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
             .FailWith("Expected {context:result} to be failure{reason}, but it succeeded with value: {0}",
-                Subject.IsSuccess ? Subject.Value : default);
+                value);
 
-        return new AndWhichConstraint<ResultAssertions<TValue>, Error>(this, Subject.Error);
+        Subject.TryGetError(out var error);
+        return new AndWhichConstraint<ResultAssertions<TValue>, Error>(this, error);
     }
 
     /// <summary>
@@ -93,16 +97,17 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeFailure(because, becauseArgs);
 
+        Subject.TryGetError(out var error);
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .ForCondition(Subject.Error is TError)
+            .ForCondition(error is TError)
             .FailWith("Expected {context:result} error to be of type {0}{reason}, but found {1}",
                 typeof(TError).Name,
-                Subject.Error.GetType().Name);
+                error?.GetType().Name);
 
         return new AndWhichConstraint<ResultAssertions<TValue>, TError>(
             this,
-            (TError)Subject.Error);
+            (TError)error!);
     }
 
     /// <summary>
@@ -122,7 +127,8 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeSuccess(because, becauseArgs);
 
-        Subject.Value.Should().Be(expectedValue, because, becauseArgs);
+        Subject.TryGetValue(out var actualValue);
+        actualValue.Should().Be(expectedValue, because, becauseArgs);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }
@@ -144,11 +150,12 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeSuccess(because, becauseArgs);
 
+        Subject.TryGetValue(out var actualValue);
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .ForCondition(predicate(Subject.Value))
+            .ForCondition(predicate(actualValue))
             .FailWith("Expected {context:result} value to match predicate{reason}, but it did not. Value: {0}",
-                Subject.Value);
+                actualValue);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }
@@ -170,7 +177,8 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeSuccess(because, becauseArgs);
 
-        Subject.Value.Should().BeEquivalentTo(expectedValue, because, becauseArgs);
+        Subject.TryGetValue(out var actualValue);
+        actualValue.Should().BeEquivalentTo(expectedValue, because, becauseArgs);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }
@@ -192,7 +200,8 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeFailure(because, becauseArgs);
 
-        Subject.Error.Code.Should().Be(expectedCode, because, becauseArgs);
+        Subject.TryGetError(out var error);
+        error.Code.Should().Be(expectedCode, because, becauseArgs);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }
@@ -214,7 +223,8 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeFailure(because, becauseArgs);
 
-        Subject.Error.Detail.Should().Be(expectedDetail, because, becauseArgs);
+        Subject.TryGetError(out var error);
+        error.Detail.Should().Be(expectedDetail, because, becauseArgs);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }
@@ -236,7 +246,8 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
     {
         BeFailure(because, becauseArgs);
 
-        Subject.Error.Detail.Should().Contain(substring, because, becauseArgs);
+        Subject.TryGetError(out var error);
+        error.Detail.Should().Contain(substring, because, becauseArgs);
 
         return new AndConstraint<ResultAssertions<TValue>>(this);
     }

--- a/Trellis.Testing/src/UnwrapExtensions.cs
+++ b/Trellis.Testing/src/UnwrapExtensions.cs
@@ -29,13 +29,33 @@ public static class UnwrapExtensions
     /// <returns>The success value.</returns>
     /// <exception cref="UnwrapFailedException">Thrown when the result is a failure.</exception>
     public static T Unwrap<T>(this Result<T> result) =>
-        result.IsSuccess
-#pragma warning disable TRLS003 // Guarded by IsSuccess check above
-            ? result.Value
-#pragma warning restore TRLS003
+        result.TryGetValue(out var value)
+            ? value
             : throw new UnwrapFailedException(
-                $"Called Unwrap() on a failed Result<{typeof(T).Name}>. " +
-                $"Error: [{result.Error.Code}] {result.Error.Detail}");
+                BuildUnwrapErrorMessage<T>(result));
+
+    /// <summary>
+    /// Extracts the error from a failed result, or throws <see cref="UnwrapFailedException"/>
+    /// if the result is a success.
+    /// </summary>
+    /// <typeparam name="T">Type of the result value.</typeparam>
+    /// <param name="result">The result to unwrap the error from.</param>
+    /// <returns>The error.</returns>
+    /// <exception cref="UnwrapFailedException">Thrown when the result is a success.</exception>
+    public static Error UnwrapError<T>(this Result<T> result) =>
+        result.TryGetError(out var error)
+            ? error
+            : throw new UnwrapFailedException(
+                $"Called UnwrapError() on a successful Result<{typeof(T).Name}>.");
+
+    private static string BuildUnwrapErrorMessage<T>(Result<T> result)
+    {
+        // Caller (Unwrap) only invokes this when the result is known to be a failure.
+        if (!result.TryGetError(out var error))
+            return $"Called Unwrap() on a Result<{typeof(T).Name}> in an unexpected state.";
+        return $"Called Unwrap() on a failed Result<{typeof(T).Name}>. " +
+               $"Error: [{error.Code}] {error.Detail}";
+    }
 
     /// <summary>
     /// Extracts the value from a Maybe that has a value, or throws <see cref="UnwrapFailedException"/>

--- a/Trellis.Testing/tests/Fakes/FakeRepositoryTests.cs
+++ b/Trellis.Testing/tests/Fakes/FakeRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Testing.Tests.Fakes;
+namespace Trellis.Testing.Tests.Fakes;
 
 public class FakeRepositoryTests
 {
@@ -106,7 +106,7 @@ public class FakeRepositoryTests
 
         // Assert
         result.Should().BeSuccess();
-        result.Value.Name.Should().Be("Test");
+        result.Unwrap().Name.Should().Be("Test");
     }
 
     [Fact]

--- a/Trellis.Testing/tests/MaybeAssertionsTests.cs
+++ b/Trellis.Testing/tests/MaybeAssertionsTests.cs
@@ -1,7 +1,7 @@
+using Trellis.Testing;
 namespace Trellis.Testing.Tests;
 
 using Trellis;
-using Trellis.Testing;
 
 /// <summary>
 /// Tests for MaybeAssertions - testing the testing utilities themselves.
@@ -415,7 +415,7 @@ public class MaybeAssertionsTests
     {
         // Arrange
         var result = Result.Ok("test");
-        var maybe = result.IsSuccess ? Maybe.From(result.Value) : Maybe<string>.None;
+        var maybe = result.IsSuccess ? Maybe.From(result.Unwrap()) : Maybe<string>.None;
 
         // Act & Assert
         maybe.Should().HaveValueEqualTo("test");
@@ -426,7 +426,7 @@ public class MaybeAssertionsTests
     {
         // Arrange
         var result = Result.Fail<string>(Error.NotFound("Not found"));
-        var maybe = result.IsSuccess ? Maybe.From(result.Value) : Maybe<string>.None;
+        var maybe = result.IsSuccess ? Maybe.From(result.Unwrap()) : Maybe<string>.None;
 
         // Act & Assert
         maybe.Should().BeNone();

--- a/docs/api_reference/trellis-api-results.md
+++ b/docs/api_reference/trellis-api-results.md
@@ -10,7 +10,7 @@ See also: [trellis-api-patterns.md](trellis-api-patterns.md), [trellis-api-asp.m
 
 ## Breaking changes from v1 (Phase 1a, in progress)
 
-This is the running list of breaking changes the v2 redesign introduces in `Trellis.Results`. Items below are landed; remaining Phase 1a items (removal of `.Value`/`.Error` properties, removal of implicit operators, non-generic `Result`, abstract `Error` base record, etc.) will be added as they ship. See `v2-redesign-plan.md` §3.1 for the full Phase 1a target.
+This is the running list of breaking changes the v2 redesign introduces in `Trellis.Results`. Items below are landed; remaining Phase 1a items (removal of implicit operators, non-generic `Result`, abstract `Error` base record, etc.) will be added as they ship. See `v2-redesign-plan.md` §3.1 for the full Phase 1a target.
 
 | Change | v1 | v2 | Migration |
 |---|---|---|---|
@@ -22,6 +22,7 @@ This is the running list of breaking changes the v2 redesign introduces in `Trel
 | Inverse-conditional factory | `Result.FailureIf(cond, value, error)` / `Result.FailureIf(predicate, value, error)` | *(removed)* | Use a ternary: `cond ? Result.Fail<T>(error) : Result.Ok(value)` |
 | Async-conditional factories | `Result.SuccessIfAsync(predicate, value, error)` / `Result.FailureIfAsync(predicate, value, error)` | *(removed)* | `await predicate() ? Result.Ok(value) : Result.Fail<T>(error)` (invert as needed) |
 | Exception → result helpers | `Result.FromException(ex)` / `Result.FromException<T>(ex)` | *(removed)* | Use `Result.Fail(Error.Unexpected(ex.Message))` or `Result.Fail<T>(...)` directly. `Result.Try`/`Result.TryAsync` continue to handle exception capture inside their lambdas. |
+| Public `Value` / `Error` properties on `Result<T>` | `result.Value` (throws if failure) / `result.Error` (throws if success) | *(now `internal`; not part of the public surface)* | Replace with one of: `result.TryGetValue(out var v)` / `result.TryGetError(out var e)` for imperative early-return, `result.Match(onSuccess, onFailure)` for transforms producing one value on both branches, `var (v, e) = result;` for destructuring, or — in test code only — `result.Unwrap()` / `result.UnwrapError()` from `Trellis.Testing` (throws `UnwrapFailedException` on wrong state). |
 
 The renames bring the factory names in line with Rust (`Ok`/`Err`), F# (`Ok`), and FluentResults (`Ok`/`Fail`). The `IsSuccess`/`IsFailure` predicate properties are **not** renamed — predicates read as questions and stay long-form. The `SuccessIf`/`FailureIf`/`SuccessIfAsync`/`FailureIfAsync`/`Result.Success(Func<T>)`/`Result.Failure<T>(Func<Error>)`/`Result.FromException` methods have all been removed (this PR); call sites should inline a ternary or invoke the factory directly per the table above.
 


### PR DESCRIPTION
Make Result<T>.Value/.Error internal; consumers must use TryGetValue/TryGetError, Match, or Deconstruct. Add Unwrap()/UnwrapError() to Trellis.Testing for tests (throws UnwrapFailedException on wrong state).

- Refactor source generators (RequiredPartialClassGenerator, ScalarValueJsonConverterGenerator) to emit Match-based code.
- Refactor framework code (TrellisScalarConverter, TransactionalCommandBehavior, ResourceAuthorizationBehavior, ScalarValueModelBinderBase, ScalarValueJsonConverterBase) to TryGetError/TryGetValue/Match.
- Refactor Examples (Banking, Ecommerce, SampleWeb controllers and Minimal API routes) to TryGetError/Match patterns; introduce private OrThrow helper for demo code.
- Migrate ~50 test files to Unwrap()/UnwrapError(); add Trellis.Testing reference to Trellis.Primitives.Tests and Examples/Xunit.
- Trellis.Benchmark uses internal OrThrow extension (not a test project).
- Update docs/api_reference/trellis-api-results.md with PR3 migration row.
