### PR TITLE
Replace Result<Unit> with non-generic Result (Phase 1a PR5)

### DIFF
--- a/Examples/BankingExample/Services/FraudDetectionService.cs
+++ b/Examples/BankingExample/Services/FraudDetectionService.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace BankingExample.Services;
 

--- a/Examples/BankingExample/Services/FraudDetectionService.cs
+++ b/Examples/BankingExample/Services/FraudDetectionService.cs
@@ -21,7 +21,7 @@ public class FraudDetectionService
     /// Returns Success if transaction appears legitimate, Failure if suspicious.
     /// Demonstrates: Error.Domain, Error.Validation, custom error codes
     /// </summary>
-    public async Task<Result<Unit>> AnalyzeTransactionAsync(
+    public async Task<Result> AnalyzeTransactionAsync(
         BankAccount account,
         Money amount,
         string transactionType,
@@ -30,23 +30,23 @@ public class FraudDetectionService
         await Task.Delay(50, cancellationToken); // Simulate API call
 
         return CheckSuspiciousAmount(amount)
-            .Ensure(_ => !IsHighFrequencyTrading(account),
+            .Ensure(() => !IsHighFrequencyTrading(account),
                 Error.Domain("Suspicious activity: Too many transactions in short period", "fraud.detected", account.Id.ToString(CultureInfo.InvariantCulture)))
-            .Ensure(_ => !IsUnusualPattern(account, amount),
+            .Ensure(() => !IsUnusualPattern(account, amount),
                 Error.Domain("Suspicious activity: Unusual transaction pattern", "fraud.detected", account.Id.ToString(CultureInfo.InvariantCulture)))
-            .Tap(_ => Console.WriteLine($"? Fraud check passed for {transactionType} of {amount}"));
+            .Tap(() => Console.WriteLine($"? Fraud check passed for {transactionType} of {amount}"));
     }
 
     /// <summary>
     /// Checks if amount exceeds suspicious threshold.
     /// Demonstrates: Error.Domain with custom code for fraud detection
     /// </summary>
-    private static Result<Unit> CheckSuspiciousAmount(Money amount)
+    private static Result CheckSuspiciousAmount(Money amount)
     {
         if (amount.Amount > SuspiciousAmountThreshold)
         {
             Console.WriteLine($"⚠️ Large transaction detected: {amount}");
-            return Result.Fail<Unit>(Error.Domain(
+            return Result.Fail(Error.Domain(
                 $"Transaction amount {amount} exceeds threshold of ${SuspiciousAmountThreshold}. Manual review required.",
                 "fraud.detected",
                 null
@@ -87,7 +87,7 @@ public class FraudDetectionService
     /// Verifies customer identity for high-value transactions.
     /// Demonstrates: Error.Unauthorized for authentication failures
     /// </summary>
-    public async Task<Result<Unit>> VerifyCustomerIdentityAsync(
+    public async Task<Result> VerifyCustomerIdentityAsync(
         CustomerId customerId,
         string verificationCode,
         CancellationToken cancellationToken = default)
@@ -95,14 +95,14 @@ public class FraudDetectionService
         await Task.Delay(200, cancellationToken); // Simulate MFA verification
 
         if (string.IsNullOrWhiteSpace(verificationCode))
-            return Result.Fail<Unit>(Error.Unauthorized("Verification code required for this transaction", customerId));
+            return Result.Fail(Error.Unauthorized("Verification code required for this transaction", customerId));
 
         if (verificationCode.Length != 6 || !verificationCode.All(char.IsDigit))
-            return Result.Fail<Unit>(Error.Validation("Invalid verification code format", nameof(verificationCode)));
+            return Result.Fail(Error.Validation("Invalid verification code format", nameof(verificationCode)));
 
         // Simulate verification check
         if (verificationCode == "000000")
-            return Result.Fail<Unit>(Error.Unauthorized("Invalid verification code", customerId));
+            return Result.Fail(Error.Unauthorized("Invalid verification code", customerId));
 
         Console.WriteLine($"? Customer {customerId} identity verified");
         return Result.Ok();
@@ -112,7 +112,7 @@ public class FraudDetectionService
     /// Checks if the external fraud detection service is available.
     /// Demonstrates: Error.ServiceUnavailable for external service failures
     /// </summary>
-    public async Task<Result<Unit>> CheckServiceHealthAsync(CancellationToken cancellationToken = default)
+    public async Task<Result> CheckServiceHealthAsync(CancellationToken cancellationToken = default)
     {
         await Task.Delay(100, cancellationToken);
 
@@ -120,7 +120,7 @@ public class FraudDetectionService
         var random = new Random();
         if (random.Next(100) < 5) // 5% chance of service being down
         {
-            return Result.Fail<Unit>(Error.ServiceUnavailable(
+            return Result.Fail(Error.ServiceUnavailable(
                 "Fraud detection service is temporarily unavailable. Please try again later.",
                 "fraud-service"));
         }
@@ -132,7 +132,7 @@ public class FraudDetectionService
     /// Checks if the customer has exceeded their daily transaction rate limit.
     /// Demonstrates: Error.RateLimit for quota exceeded scenarios
     /// </summary>
-    public async Task<Result<Unit>> CheckRateLimitAsync(
+    public async Task<Result> CheckRateLimitAsync(
         CustomerId customerId,
         CancellationToken cancellationToken = default)
     {

--- a/Examples/BankingExample/Workflows/BankingWorkflow.cs
+++ b/Examples/BankingExample/Workflows/BankingWorkflow.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace BankingExample.Workflows;
 

--- a/Examples/BankingExample/Workflows/BankingWorkflow.cs
+++ b/Examples/BankingExample/Workflows/BankingWorkflow.cs
@@ -80,11 +80,11 @@ public class BankingWorkflow
         string description,
         CancellationToken cancellationToken = default)
     {
-        // Validate both accounts in parallel using Result.ParallelAsync
-        var validationResult = await Result.ParallelAsync(
-            () => _fraudDetection.AnalyzeTransactionAsync(fromAccount, amount, "transfer-out", cancellationToken),
-            () => _fraudDetection.AnalyzeTransactionAsync(toAccount, amount, "transfer-in", cancellationToken)
-        ).WhenAllAsync();
+        // Validate both accounts in parallel
+        var fromTask = _fraudDetection.AnalyzeTransactionAsync(fromAccount, amount, "transfer-out", cancellationToken);
+        var toTask = _fraudDetection.AnalyzeTransactionAsync(toAccount, amount, "transfer-in", cancellationToken);
+        await Task.WhenAll(fromTask, toTask);
+        var validationResult = fromTask.Result.Combine(toTask.Result);
 
         if (validationResult.TryGetError(out var validationError))
             return Result.Fail<(BankingExample.Aggregates.BankAccount From, BankingExample.Aggregates.BankAccount To)>(validationError);

--- a/Examples/EcommerceExample/Aggregates/Order.cs
+++ b/Examples/EcommerceExample/Aggregates/Order.cs
@@ -92,7 +92,7 @@ public class Order : Aggregate<OrderId>
                     DateTime.UtcNow));
             })
             .Bind(_ => RecalculateTotal())
-            .Map(_ => this);
+            .Map(() => this);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public class Order : Aggregate<OrderId>
                 DomainEvents.Add(new OrderLineRemoved(Id, productId, DateTime.UtcNow));
             })
             .Bind(_ => RecalculateTotal())
-            .Map(_ => this);
+            .Map(() => this);
     }
 
     /// <summary>
@@ -266,7 +266,7 @@ public class Order : Aggregate<OrderId>
             .Map(_ => this);
     }
 
-    private Result<Unit> RecalculateTotal()
+    private Result RecalculateTotal()
     {
         var total = Money.Create(0, "USD");
 
@@ -274,7 +274,7 @@ public class Order : Aggregate<OrderId>
         {
             var addResult = total.Add(line.LineTotal);
             if (addResult.TryGetError(out var addError))
-                return Result.Fail<Unit>(addError);
+                return Result.Fail(addError);
 
             // Safe: TryGetError returned false above, so addResult is success.
             if (!addResult.TryGetValue(out var newTotal))

--- a/Examples/EcommerceExample/Aggregates/Order.cs
+++ b/Examples/EcommerceExample/Aggregates/Order.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace EcommerceExample.Aggregates;
 

--- a/Examples/EcommerceExample/Services/InventoryService.cs
+++ b/Examples/EcommerceExample/Services/InventoryService.cs
@@ -1,4 +1,4 @@
-namespace EcommerceExample.Services;
+﻿namespace EcommerceExample.Services;
 
 using EcommerceExample.ValueObjects;
 using Trellis;

--- a/Examples/EcommerceExample/Services/InventoryService.cs
+++ b/Examples/EcommerceExample/Services/InventoryService.cs
@@ -25,16 +25,16 @@ public class InventoryService
     /// <summary>
     /// Checks if sufficient stock is available for a product.
     /// </summary>
-    public Result<Unit> CheckAvailability(ProductId productId, int quantity)
+    public Result CheckAvailability(ProductId productId, int quantity)
     {
         if (quantity <= 0)
-            return Result.Fail<Unit>(Error.Validation("Quantity must be greater than zero", nameof(quantity)));
+            return Result.Fail(Error.Validation("Quantity must be greater than zero", nameof(quantity)));
 
         if (!_stock.TryGetValue(productId, out var available))
-            return Result.Fail<Unit>(Error.NotFound($"Product {productId} not found in inventory"));
+            return Result.Fail(Error.NotFound($"Product {productId} not found in inventory"));
 
         if (available < quantity)
-            return Result.Fail<Unit>(Error.Validation($"Insufficient stock. Available: {available}, Requested: {quantity}"));
+            return Result.Fail(Error.Validation($"Insufficient stock. Available: {available}, Requested: {quantity}"));
 
         return Result.Ok();
     }
@@ -42,12 +42,12 @@ public class InventoryService
     /// <summary>
     /// Reserves stock for an order with Railway Oriented Programming.
     /// </summary>
-    public async Task<Result<Unit>> ReserveStockAsync(ProductId productId, int quantity, CancellationToken cancellationToken = default)
+    public async Task<Result> ReserveStockAsync(ProductId productId, int quantity, CancellationToken cancellationToken = default)
     {
         await Task.Delay(100, cancellationToken); // Simulate async operation
 
         return CheckAvailability(productId, quantity)
-            .Tap(_ =>
+            .Tap(() =>
             {
                 _stock[productId] -= quantity;
                 Console.WriteLine($"Reserved {quantity} units of product {productId}. Remaining: {_stock[productId]}");
@@ -57,12 +57,12 @@ public class InventoryService
     /// <summary>
     /// Releases reserved stock if order is cancelled.
     /// </summary>
-    public async Task<Result<Unit>> ReleaseStockAsync(ProductId productId, int quantity, CancellationToken cancellationToken = default)
+    public async Task<Result> ReleaseStockAsync(ProductId productId, int quantity, CancellationToken cancellationToken = default)
     {
         await Task.Delay(50, cancellationToken); // Simulate async operation
 
         if (!_stock.TryGetValue(productId, out _))
-            return Result.Fail<Unit>(Error.NotFound($"Product {productId} not found in inventory"));
+            return Result.Fail(Error.NotFound($"Product {productId} not found in inventory"));
 
         _stock[productId] += quantity;
         Console.WriteLine($"Released {quantity} units of product {productId}. New total: {_stock[productId]}");

--- a/Examples/EcommerceExample/Services/NotificationService.cs
+++ b/Examples/EcommerceExample/Services/NotificationService.cs
@@ -1,4 +1,4 @@
-namespace EcommerceExample.Services;
+﻿namespace EcommerceExample.Services;
 
 using EcommerceExample.ValueObjects;
 using Trellis;

--- a/Examples/EcommerceExample/Services/NotificationService.cs
+++ b/Examples/EcommerceExample/Services/NotificationService.cs
@@ -8,28 +8,28 @@ using Trellis;
 /// </summary>
 public class NotificationService
 {
-    public async Task<Result<Unit>> SendOrderCreatedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
+    public async Task<Result> SendOrderCreatedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
     {
         await Task.Delay(50, cancellationToken);
         Console.WriteLine($"📧 Email sent to customer {customerId}: Order {orderId} created");
         return Result.Ok();
     }
 
-    public async Task<Result<Unit>> SendOrderConfirmedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
+    public async Task<Result> SendOrderConfirmedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
     {
         await Task.Delay(50, cancellationToken);
         Console.WriteLine($"📧 Email sent to customer {customerId}: Order {orderId} confirmed and will be shipped soon");
         return Result.Ok();
     }
 
-    public async Task<Result<Unit>> SendPaymentFailedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
+    public async Task<Result> SendPaymentFailedEmailAsync(CustomerId customerId, OrderId orderId, CancellationToken cancellationToken = default)
     {
         await Task.Delay(50, cancellationToken);
         Console.WriteLine($"📧 Email sent to customer {customerId}: Payment failed for order {orderId}");
         return Result.Ok();
     }
 
-    public async Task<Result<Unit>> SendOrderShippedEmailAsync(CustomerId customerId, OrderId orderId, string trackingNumber, CancellationToken cancellationToken = default)
+    public async Task<Result> SendOrderShippedEmailAsync(CustomerId customerId, OrderId orderId, string trackingNumber, CancellationToken cancellationToken = default)
     {
         await Task.Delay(50, cancellationToken);
         Console.WriteLine($"📧 Email sent to customer {customerId}: Order {orderId} shipped with tracking number {trackingNumber}");

--- a/Examples/EcommerceExample/Services/PaymentService.cs
+++ b/Examples/EcommerceExample/Services/PaymentService.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace EcommerceExample.Services;
 

--- a/Examples/EcommerceExample/Services/PaymentService.cs
+++ b/Examples/EcommerceExample/Services/PaymentService.cs
@@ -15,42 +15,42 @@ public class PaymentService
     {
         return await Task.FromResult(ValidateCardNumber(cardNumber)
             .Combine(ValidateCVV(cvv))
-            .Ensure(_ => order.Total.Amount >= 0.01m, Error.Validation("Payment amount must be at least 0.01")))
-            .BindAsync(async _ => await ChargeCardAsync(order.Total, cardNumber, cancellationToken))
+            .Ensure(() => order.Total.Amount >= 0.01m, Error.Validation("Payment amount must be at least 0.01")))
+            .BindAsync(async () => await ChargeCardAsync(order.Total, cardNumber, cancellationToken))
             .TapAsync(async transactionId => await LogPaymentSuccessAsync(order.Id, transactionId, cancellationToken))
             .TapOnFailureAsync(async error => await LogPaymentFailureAsync(order.Id, error, cancellationToken));
     }
 
-    public async Task<Result<Unit>> RefundPaymentAsync(string transactionId, CancellationToken cancellationToken = default)
+    public async Task<Result> RefundPaymentAsync(string transactionId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(transactionId))
-            return Result.Fail<Unit>(Error.Validation("Transaction ID is required"));
+            return Result.Fail(Error.Validation("Transaction ID is required"));
 
         await Task.Delay(100, cancellationToken); // Simulate API call
 
         return Result.Ok();
     }
 
-    private static Result<Unit> ValidateCardNumber(string cardNumber)
+    private static Result ValidateCardNumber(string cardNumber)
     {
         if (string.IsNullOrWhiteSpace(cardNumber))
-            return Result.Fail<Unit>(Error.Validation("Card number is required", nameof(cardNumber)));
+            return Result.Fail(Error.Validation("Card number is required", nameof(cardNumber)));
 
         var digitsOnly = new string(cardNumber.Where(char.IsDigit).ToArray());
 
         if (digitsOnly.Length is < 13 or > 19)
-            return Result.Fail<Unit>(Error.Validation("Card number must be between 13 and 19 digits", nameof(cardNumber)));
+            return Result.Fail(Error.Validation("Card number must be between 13 and 19 digits", nameof(cardNumber)));
 
         return Result.Ok();
     }
 
-    private static Result<Unit> ValidateCVV(string cvv)
+    private static Result ValidateCVV(string cvv)
     {
         if (string.IsNullOrWhiteSpace(cvv))
-            return Result.Fail<Unit>(Error.Validation("CVV is required", nameof(cvv)));
+            return Result.Fail(Error.Validation("CVV is required", nameof(cvv)));
 
         if (cvv.Length < 3 || cvv.Length > 4 || !cvv.All(char.IsDigit))
-            return Result.Fail<Unit>(Error.Validation("CVV must be 3 or 4 digits", nameof(cvv)));
+            return Result.Fail(Error.Validation("CVV must be 3 or 4 digits", nameof(cvv)));
 
         return Result.Ok();
     }

--- a/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
+++ b/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
@@ -142,7 +142,7 @@ public class OrderWorkflow
     /// <summary>
     /// Reserves inventory for all order lines.
     /// </summary>
-    private async Task<Result<Unit>> ReserveInventoryAsync(Order order, CancellationToken cancellationToken)
+    private async Task<Result> ReserveInventoryAsync(Order order, CancellationToken cancellationToken)
     {
         foreach (var line in order.Lines)
         {
@@ -204,14 +204,14 @@ public class OrderWorkflow
     /// Suggests alternative products when requested items are out of stock.
     /// Demonstrates: RecoverOnFailure for providing alternative paths.
     /// </summary>
-    private async Task<Result<Unit>> SuggestAlternativeProductsAsync(Order order, CancellationToken cancellationToken)
+    private async Task<Result> SuggestAlternativeProductsAsync(Order order, CancellationToken cancellationToken)
     {
         await Task.Delay(100, cancellationToken);
         Console.WriteLine($"Inventory unavailable for order {order.Id}. Suggesting alternatives...");
 
         // In a real system, this would query for similar products
         // For now, just return the original error
-        return Result.Fail<Unit>(Error.Domain("Products out of stock. Please check alternative products."));
+        return Result.Fail(Error.Domain("Products out of stock. Please check alternative products."));
     }
 
     /// <summary>

--- a/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
+++ b/Examples/EcommerceExample/Workflows/OrderWorkflow.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace EcommerceExample.Workflows;
 

--- a/Examples/SampleWeb/SampleDataAccess/DatabaseSeeder.cs
+++ b/Examples/SampleWeb/SampleDataAccess/DatabaseSeeder.cs
@@ -34,7 +34,8 @@ public static class DatabaseSeeder
                   .TapOnFailure(error => throw new InvalidOperationException($"Seed data failed: {error.Detail}"));
         }
 
-        (await context.SaveChangesResultUnitAsync())
-            .TapOnFailure(error => throw new InvalidOperationException($"Seed save failed: {error.Detail}"));
+        var saveResult = await context.SaveChangesResultUnitAsync();
+        if (saveResult.TryGetError(out var saveError))
+            throw new InvalidOperationException($"Seed save failed: {saveError.Detail}");
     }
 }

--- a/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
@@ -1,4 +1,4 @@
-namespace SampleMinimalApi.API;
+﻿namespace SampleMinimalApi.API;
 
 using Microsoft.EntityFrameworkCore;
 using SampleDataAccess;

--- a/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/NewOrderRoutes.cs
@@ -36,7 +36,7 @@ public static class NewOrderRoutes
             var result = await Result.Ensure(
                     request.Lines is { Length: > 0 },
                     Error.Validation("Order must have at least one line item.", "lines"))
-                .Bind(_ => Order.TryCreate(request.CustomerId))
+                .Bind(() => Order.TryCreate(request.CustomerId))
                 .BindAsync(order =>
                     request.Lines.TraverseAsync(line =>
                         db.Products

--- a/Examples/SampleWeb/SampleMinimalApi/API/ProductRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/ProductRoutes.cs
@@ -1,4 +1,4 @@
-namespace SampleMinimalApi.API;
+﻿namespace SampleMinimalApi.API;
 
 using Microsoft.EntityFrameworkCore;
 using SampleDataAccess;

--- a/Examples/SampleWeb/SampleMinimalApi/API/ProductRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApi/API/ProductRoutes.cs
@@ -123,7 +123,7 @@ public static class ProductRoutes
             db.Products.Remove(product);
             var saveResult = await db.SaveChangesResultUnitAsync();
             return saveResult.Match(
-                _ => Results.NoContent(),
+                () => Results.NoContent(),
                 error => error.ToHttpResult());
         }).WithScalarValueValidation();
 

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
@@ -1,4 +1,4 @@
-namespace SampleMinimalApiNoAot.API;
+﻿namespace SampleMinimalApiNoAot.API;
 
 using Microsoft.EntityFrameworkCore;
 using SampleDataAccess;

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/NewOrderRoutes.cs
@@ -36,7 +36,7 @@ public static class NewOrderRoutes
             var result = await Result.Ensure(
                     request.Lines is { Length: > 0 },
                     Error.Validation("Order must have at least one line item.", "lines"))
-                .Bind(_ => Order.TryCreate(request.CustomerId))
+                .Bind(() => Order.TryCreate(request.CustomerId))
                 .BindAsync(order =>
                     request.Lines.TraverseAsync(line =>
                         db.Products

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/ProductRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/ProductRoutes.cs
@@ -123,7 +123,7 @@ public static class ProductRoutes
             db.Products.Remove(product);
             var saveResult = await db.SaveChangesResultUnitAsync();
             return saveResult.Match(
-                _ => Results.NoContent(),
+                () => Results.NoContent(),
                 error => error.ToHttpResult());
         }).WithScalarValueValidation();
 

--- a/Examples/SampleWeb/SampleMinimalApiNoAot/API/ProductRoutes.cs
+++ b/Examples/SampleWeb/SampleMinimalApiNoAot/API/ProductRoutes.cs
@@ -1,4 +1,4 @@
-namespace SampleMinimalApiNoAot.API;
+﻿namespace SampleMinimalApiNoAot.API;
 
 using Microsoft.EntityFrameworkCore;
 using SampleDataAccess;

--- a/Examples/SampleWeb/SampleUserLibrary/Services/Services.cs
+++ b/Examples/SampleWeb/SampleUserLibrary/Services/Services.cs
@@ -1,4 +1,4 @@
-namespace SampleUserLibrary;
+﻿namespace SampleUserLibrary;
 
 using Trellis;
 

--- a/Examples/SampleWeb/SampleUserLibrary/Services/Services.cs
+++ b/Examples/SampleWeb/SampleUserLibrary/Services/Services.cs
@@ -9,7 +9,7 @@ using Trellis;
 public interface IPaymentService
 {
     Task<Result<string>> ProcessPaymentAsync(OrderId orderId, decimal amount, CancellationToken ct = default);
-    Task<Result<Unit>> RefundPaymentAsync(string paymentReference, CancellationToken ct = default);
+    Task<Result> RefundPaymentAsync(string paymentReference, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -17,8 +17,8 @@ public interface IPaymentService
 /// </summary>
 public interface INotificationService
 {
-    Task<Result<Unit>> SendOrderConfirmationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default);
-    Task<Result<Unit>> SendOrderCancellationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default);
+    Task<Result> SendOrderConfirmationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default);
+    Task<Result> SendOrderCancellationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -34,10 +34,10 @@ public class FakePaymentService : IPaymentService
         return Result.Ok(paymentRef);
     }
 
-    public async Task<Result<Unit>> RefundPaymentAsync(string paymentReference, CancellationToken ct = default)
+    public async Task<Result> RefundPaymentAsync(string paymentReference, CancellationToken ct = default)
     {
         await Task.Delay(30, ct);
-        return Result.Ok(new Unit());
+        return Result.Ok();
     }
 }
 
@@ -47,15 +47,15 @@ public class FakePaymentService : IPaymentService
 /// </summary>
 public class FakeNotificationService : INotificationService
 {
-    public async Task<Result<Unit>> SendOrderConfirmationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default)
+    public async Task<Result> SendOrderConfirmationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default)
     {
         await Task.Delay(20, ct);
-        return Result.Ok(new Unit());
+        return Result.Ok();
     }
 
-    public async Task<Result<Unit>> SendOrderCancellationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default)
+    public async Task<Result> SendOrderCancellationAsync(OrderId orderId, CustomerId customerId, CancellationToken ct = default)
     {
         await Task.Delay(20, ct);
-        return Result.Ok(new Unit());
+        return Result.Ok();
     }
 }

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
@@ -1,4 +1,4 @@
-namespace SampleWebApplication.Controllers;
+﻿namespace SampleWebApplication.Controllers;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/NewOrdersController.cs
@@ -40,13 +40,13 @@ public class NewOrdersController(
         var result = await Result.Ensure(
                 request.Lines is { Length: > 0 },
                 Error.Validation("Order must have at least one line item.", "lines"))
-            .Bind(_ => Order.TryCreate(request.CustomerId))
+            .Bind(() => Order.TryCreate(request.CustomerId))
             .BindAsync(order =>
                 request.Lines.TraverseAsync(line =>
                     db.Products
                         .FirstOrDefaultResultAsync(p => p.Id == line.ProductId,
                             Error.NotFound("Product not found.", line.ProductId))
-                        .BindAsync(product => order.AddLine(product, line.Quantity)))
+                        .BindAsync<Product, Order>(product => order.AddLine(product, line.Quantity)))
                 .MapAsync(_ => order))
             .TapAsync(order => { db.Orders.Add(order); return Task.CompletedTask; })
             .CheckAsync(_ => db.SaveChangesResultUnitAsync());

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
@@ -1,4 +1,4 @@
-namespace SampleWebApplication.Controllers;
+﻿namespace SampleWebApplication.Controllers;
 
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc;

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/ProductsController.cs
@@ -136,17 +136,17 @@ public class ProductsController(AppDbContext db) : ControllerBase
 
     // DELETE /products/{id}
     [HttpDelete("{id}")]
-    public async Task<ActionResult<Unit>> Delete(ProductId id)
+    public async Task<ActionResult> Delete(ProductId id)
     {
         var product = await db.Products.FindAsync(id);
         if (product is null)
-            return Error.NotFound("Product not found.", id).ToActionResult<Unit>(this);
+            return Error.NotFound("Product not found.", id).ToActionResult(this);
 
         db.Products.Remove(product);
         var saveResult = await db.SaveChangesResultUnitAsync();
         return saveResult.Match(
-            _ => (ActionResult<Unit>)new NoContentResult(),
-            error => error.ToActionResult<Unit>(this));
+            () => (ActionResult)new NoContentResult(),
+            error => error.ToActionResult(this));
     }
 
     // GET /products/legacy/{id} — redirect demo

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/UsersController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/UsersController.cs
@@ -55,35 +55,35 @@ public class UsersController : ControllerBase
     public ActionResult<string> Get(string name) => Ok($"Hello {name}!");
 
     [HttpGet("notfound/{id}")]
-    public ActionResult<Unit> NotFound(int id) =>
-        Result.Fail<Unit>(Error.NotFound("User not found", id))
+    public ActionResult NotFound(int id) =>
+        Result.Fail(Error.NotFound("User not found", id))
             .ToActionResult(this);
 
     [HttpGet("conflict/{id}")]
-    public ActionResult<Unit> Conflict(int id) =>
-        Result.Fail<Unit>(Error.Conflict("Record has changed.", id))
+    public ActionResult Conflict(int id) =>
+        Result.Fail(Error.Conflict("Record has changed.", id))
             .ToActionResult(this);
 
     [HttpGet("forbidden/{id}")]
-    public ActionResult<Unit> Forbidden(int id) =>
-        Result.Fail<Unit>(Error.Forbidden("You do not have access.", id))
+    public ActionResult Forbidden(int id) =>
+        Result.Fail(Error.Forbidden("You do not have access.", id))
             .ToActionResult(this);
 
     [HttpGet("unauthorized/{id}")]
-    public ActionResult<Unit> Unauthorized(int id) =>
-        Result.Fail<Unit>(Error.Unauthorized("Please log in."))
+    public ActionResult Unauthorized(int id) =>
+        Result.Fail(Error.Unauthorized("Please log in."))
             .ToActionResult(this);
 
     [HttpGet("unexpected/{id}")]
-    public ActionResult<Unit> Unexpected(int id) =>
-        Result.Fail<Unit>(Error.Unexpected("Something went wrong."))
+    public ActionResult Unexpected(int id) =>
+        Result.Fail(Error.Unexpected("Something went wrong."))
             .ToActionResult(this);
 
     [HttpDelete("{id}")]
-    public ActionResult<Unit> Delete(string id) =>
+    public ActionResult Delete(string id) =>
         UserId.TryCreate(id).Match(
             onSuccess: ok => NoContent(),
-            onFailure: err => err.ToActionResult<Unit>(this));
+            onFailure: err => err.ToActionResult(this));
 
     /// <summary>
     /// Registers a new user with automatic value object validation.

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/UsersController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/UsersController.cs
@@ -1,4 +1,4 @@
-using Trellis.Asp;
+﻿using Trellis.Asp;
 using Trellis.Primitives;
 
 namespace SampleWebApplication.Controllers;

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/WeatherForecastController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/WeatherForecastController.cs
@@ -55,28 +55,28 @@ public class WeatherForecastController : ControllerBase
     }
 
     [HttpGet("Forbidden")]
-    public ActionResult<Unit> Forbidden(string instance)
-        => Error.Forbidden("You are forbidden.", instance).ToActionResult<Unit>(this);
+    public ActionResult Forbidden(string instance)
+        => Error.Forbidden("You are forbidden.", instance).ToActionResult(this);
 
     [HttpGet("Unauthorized")]
-    public ActionResult<Unit> Unauthorized(string instance)
-        => Error.Unauthorized("You are not authorized.", instance).ToActionResult<Unit>(this);
+    public ActionResult Unauthorized(string instance)
+        => Error.Unauthorized("You are not authorized.", instance).ToActionResult(this);
 
     [HttpGet("Conflict")]
-    public ActionResult<Unit> Conflict(string instance)
-        => Error.Conflict("There is a conflict. " + instance, instance).ToActionResult<Unit>(this);
+    public ActionResult Conflict(string instance)
+        => Error.Conflict("There is a conflict. " + instance, instance).ToActionResult(this);
 
     [HttpGet("NotFound")]
-    public ActionResult<Unit> NotFound(string? instance)
-        => Error.NotFound("Record not found. " + instance, instance).ToActionResult<Unit>(this);
+    public ActionResult NotFound(string? instance)
+        => Error.NotFound("Record not found. " + instance, instance).ToActionResult(this);
 
     [HttpGet("ValidationError")]
-    public ActionResult<Unit> ValidationError(string? instance, string? detail)
+    public ActionResult ValidationError(string? instance, string? detail)
     {
         ImmutableArray<FieldError> errors = [
             new("Field1",["Field is required.", "It cannot be empty."]),
             new("Field2",["Field is required."])
         ];
-        return Error.Validation(errors, detail ?? string.Empty, instance).ToActionResult<Unit>(this);
+        return Error.Validation(errors, detail ?? string.Empty, instance).ToActionResult(this);
     }
 }

--- a/Examples/SampleWeb/SampleWebApplication/src/Controllers/WeatherForecastController.cs
+++ b/Examples/SampleWeb/SampleWebApplication/src/Controllers/WeatherForecastController.cs
@@ -1,4 +1,4 @@
-using Trellis.Asp;
+﻿using Trellis.Asp;
 
 namespace SampleWebApplication.Controllers;
 

--- a/Examples/Xunit/AsyncUsageExamples.cs
+++ b/Examples/Xunit/AsyncUsageExamples.cs
@@ -1,4 +1,4 @@
-namespace Example.Tests;
+﻿namespace Example.Tests;
 
 using System.Diagnostics;
 using Trellis;

--- a/Examples/Xunit/AsyncUsageExamples.cs
+++ b/Examples/Xunit/AsyncUsageExamples.cs
@@ -18,7 +18,7 @@ public class AsyncUsageExamples : IClassFixture<TraceFixture>
             .EnsureAsync(customer => customer.CanBePromoted, Error.Validation("The customer has the highest status possible"))
             .TapAsync(customer => customer.Promote())
             .BindAsync(customer => EmailGateway.SendPromotionNotification(customer.Email))
-            .MatchAsync(ok => "Okay", error => "Failed");
+            .MatchAsync(() => "Okay", error => "Failed");
 
         if (id == 1)
             result.Should().Be("Okay");
@@ -37,7 +37,7 @@ public class AsyncUsageExamples : IClassFixture<TraceFixture>
             .EnsureAsync(static customer => customer.CanBePromoted, Error.Validation("The customer has the highest status possible"))
             .TapAsync(static customer => customer.PromoteAsync())
             .BindAsync(static customer => EmailGateway.SendPromotionNotificationAsync(customer.Email))
-            .MatchAsync(static ok => "Okay", static error => error.Detail);
+            .MatchAsync(static () => "Okay", static error => error.Detail);
 
         result.Should().Be("Okay");
     }
@@ -57,7 +57,7 @@ public class AsyncUsageExamples : IClassFixture<TraceFixture>
             .TapAsync(static customer => Log("Manager approved promotion"))
             .TapAsync(static customer => customer.PromoteAsync())
             .BindAsync(static customer => EmailGateway.SendPromotionNotificationAsync(customer.Email))
-            .MatchAsync(static ok => "Okay", static error => error.Detail);
+            .MatchAsync(static () => "Okay", static error => error.Detail);
 
         result.Should().Be("Okay");
     }
@@ -105,8 +105,8 @@ public class AsyncUsageExamples : IClassFixture<TraceFixture>
 
     public static class EmailGateway
     {
-        public static Result<Unit> SendPromotionNotification(string email) => Result.Ok<Unit>(new Unit());
+        public static Result SendPromotionNotification(string email) => Result.Ok();
 
-        public static Task<Result<Unit>> SendPromotionNotificationAsync(string email) => Task.FromResult(SendPromotionNotification(email));
+        public static Task<Result> SendPromotionNotificationAsync(string email) => Task.FromResult(SendPromotionNotification(email));
     }
 }

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -290,7 +290,7 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Direct SaveChanges/SaveChangesAsync calls bypass the Result pipeline and turn database errors into unhandled exceptions. " +
-                     "Use SaveChangesResultAsync (returns Result<int>) or SaveChangesResultUnitAsync (returns Result<Unit>) instead.",
+                     "Use SaveChangesResultAsync (returns Result<int>) or SaveChangesResultUnitAsync (returns Result) instead.",
         helpLinkUri: HelpLinkBase + "TRLS020");
 
     /// <summary>

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Analyzers;
+﻿namespace Trellis.Analyzers;
 
 using Microsoft.CodeAnalysis;
 

--- a/Trellis.Asp/src/ActionResultExtensions.cs
+++ b/Trellis.Asp/src/ActionResultExtensions.cs
@@ -99,24 +99,37 @@ public static class ActionResultExtensions
     /// </code>
     /// </example>
     /// <example>
-    /// DELETE endpoint returning Unit:
+    /// DELETE endpoint returning a non-generic <see cref="Result"/>:
     /// <code>
     /// [HttpDelete("{id}")]
-    /// public ActionResult&lt;Unit&gt; DeleteUser(Guid id) =>
+    /// public ActionResult DeleteUser(Guid id) =>
     ///     UserId.TryCreate(id)
     ///         .Bind(_repository.DeleteAsync)
     ///         .ToActionResult(this);
     /// 
-    /// // Success: 204 No Content (automatic for Unit)
+    /// // Success: 204 No Content (automatic for non-generic Result)
     /// // Not found: 404 Not Found
     /// </code>
     /// </example>
     public static ActionResult<TValue> ToActionResult<TValue>(this Result<TValue> result, ControllerBase controllerBase) =>
         result.Match<TValue, ActionResult<TValue>>(
-            onSuccess: value => typeof(TValue) == typeof(Unit)
-                ? (ActionResult<TValue>)controllerBase.NoContent()
-                : (ActionResult<TValue>)controllerBase.Ok(value),
+            onSuccess: value => (ActionResult<TValue>)controllerBase.Ok(value),
             onFailure: error => error.ToActionResult<TValue>(controllerBase));
+
+    /// <summary>
+    /// Converts a non-generic <see cref="Result"/> to an <see cref="ActionResult"/>.
+    /// On success returns 204 No Content; on failure returns an error result.
+    /// </summary>
+    public static ActionResult ToActionResult(this Result result, ControllerBase controllerBase) =>
+        result.Match(
+            onSuccess: () => (ActionResult)controllerBase.NoContent(),
+            onFailure: error => error.ToActionResult(controllerBase));
+
+    /// <summary>
+    /// Converts a domain <see cref="Error"/> directly to a non-generic <see cref="ActionResult"/> with appropriate HTTP status code and Problem Details format.
+    /// </summary>
+    public static ActionResult ToActionResult(this Error error, ControllerBase controllerBase) =>
+        error.ToActionResult<object>(controllerBase).Result!;
 
     /// <summary>
     /// Converts a domain <see cref="Error"/> to an <see cref="ActionResult{TValue}"/> with appropriate HTTP status code and Problem Details format.
@@ -343,10 +356,6 @@ public static class ActionResultExtensions
         result.Match<TValue, ActionResult<TValue>>(
             onSuccess: value =>
             {
-                // If TValue is Unit, return 204 No Content
-                if (typeof(TValue) == typeof(Unit))
-                    return (ActionResult<TValue>)controllerBase.NoContent();
-
                 // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
                 if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
                     return (ActionResult<TValue>)controllerBase.Ok(value);

--- a/Trellis.Asp/src/ActionResultExtensionsAsync.cs
+++ b/Trellis.Asp/src/ActionResultExtensionsAsync.cs
@@ -521,4 +521,22 @@ public static class ActionResultExtensionsAsync
         return result.ToCreatedAtActionResult(controllerBase, actionName, routeValues, metadataSelector, map, controllerName);
     }
 
+    /// <summary>
+    /// Converts a Task-wrapped non-generic <see cref="Result"/> to an <see cref="ActionResult"/>.
+    /// </summary>
+    public static async Task<ActionResult> ToActionResultAsync(this Task<Result> resultTask, ControllerBase controllerBase)
+    {
+        Result result = await resultTask.ConfigureAwait(false);
+        return result.ToActionResult(controllerBase);
+    }
+
+    /// <summary>
+    /// Converts a ValueTask-wrapped non-generic <see cref="Result"/> to an <see cref="ActionResult"/>.
+    /// </summary>
+    public static async ValueTask<ActionResult> ToActionResultAsync(this ValueTask<Result> resultTask, ControllerBase controllerBase)
+    {
+        Result result = await resultTask.ConfigureAwait(false);
+        return result.ToActionResult(controllerBase);
+    }
+
 }

--- a/Trellis.Asp/src/HttpResultExtensions.cs
+++ b/Trellis.Asp/src/HttpResultExtensions.cs
@@ -123,7 +123,16 @@ public static class HttpResultExtensions
     /// </example>
     public static Microsoft.AspNetCore.Http.IResult ToHttpResult<TValue>(this Result<TValue> result, TrellisAspOptions? options = null) =>
         result.Match(
-            onSuccess: value => typeof(TValue) == typeof(Unit) ? Results.NoContent() : Results.Ok(value),
+            onSuccess: value => Results.Ok(value),
+            onFailure: error => error.ToHttpResult(options));
+
+    /// <summary>
+    /// Converts a non-generic <see cref="Result"/> to an <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// On success returns 204 No Content; on failure returns an error result.
+    /// </summary>
+    public static Microsoft.AspNetCore.Http.IResult ToHttpResult(this Result result, TrellisAspOptions? options = null) =>
+        result.Match(
+            onSuccess: () => Results.NoContent(),
             onFailure: error => error.ToHttpResult(options));
 
     /// <summary>
@@ -489,10 +498,6 @@ public static class HttpResultExtensions
         result.Match(
             onSuccess: value =>
             {
-                // If TValue is Unit, return 204 No Content
-                if (typeof(TValue) == typeof(Unit))
-                    return Results.NoContent();
-
                 // Guard: invalid, empty, or out-of-range → return 200 OK (no Content-Range)
                 if (from < 0 || to < from || totalLength <= 0 || from >= totalLength)
                     return Results.Ok(value);

--- a/Trellis.Asp/src/HttpResultExtensionsAsync.cs
+++ b/Trellis.Asp/src/HttpResultExtensionsAsync.cs
@@ -528,5 +528,22 @@ public static class HttpResultExtensionsAsync
         return result.ToUpdatedHttpResult(httpContext, metadataSelector, map, options);
     }
 
+    /// <summary>
+    /// Converts a Task-wrapped non-generic <see cref="Result"/> to an <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// </summary>
+    public static async Task<Microsoft.AspNetCore.Http.IResult> ToHttpResultAsync(this Task<Result> resultTask, TrellisAspOptions? options = null)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToHttpResult(options);
+    }
+
+    /// <summary>
+    /// Converts a ValueTask-wrapped non-generic <see cref="Result"/> to an <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// </summary>
+    public static async ValueTask<Microsoft.AspNetCore.Http.IResult> ToHttpResultAsync(this ValueTask<Result> resultTask, TrellisAspOptions? options = null)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToHttpResult(options);
+    }
     #endregion
 }

--- a/Trellis.Asp/tests/ActionResultTaskTests.cs
+++ b/Trellis.Asp/tests/ActionResultTaskTests.cs
@@ -226,8 +226,8 @@ public class ActionResultTaskTests
         var response = await result.ToActionResultAsync(controller);
 
         // Assert
-        response.Result.Should().BeOfType<NoContentResult>();
-        response.Result.As<NoContentResult>().StatusCode.Should().Be(StatusCodes.Status204NoContent);
+        response.Should().BeOfType<NoContentResult>();
+        response.As<NoContentResult>().StatusCode.Should().Be(StatusCodes.Status204NoContent);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public class ActionResultTaskTests
         // Arrange
         var controller = new Mock<ControllerBase> { CallBase = true }.Object;
         var error = Error.NotFound("Resource not found");
-        var result = Task.FromResult(Result.Fail<Unit>(error));
+        var result = Task.FromResult(Result.Fail(error));
         var expected = new ProblemDetails
         {
             Detail = "Resource not found",
@@ -247,8 +247,8 @@ public class ActionResultTaskTests
         var response = await result.ToActionResultAsync(controller);
 
         // Assert
-        response.Result.Should().BeOfType<ObjectResult>();
-        var objectResult = response.Result.As<ObjectResult>();
+        response.Should().BeOfType<ObjectResult>();
+        var objectResult = response.As<ObjectResult>();
         objectResult.Value.Should().BeEquivalentTo(expected);
         objectResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }

--- a/Trellis.Asp/tests/ActionResultTaskTests.cs
+++ b/Trellis.Asp/tests/ActionResultTaskTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System.Collections.Immutable;
 using System.Net.Http.Headers;

--- a/Trellis.Asp/tests/ActionResultTests.cs
+++ b/Trellis.Asp/tests/ActionResultTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using System.Net.Http.Headers;

--- a/Trellis.Asp/tests/ActionResultTests.cs
+++ b/Trellis.Asp/tests/ActionResultTests.cs
@@ -105,8 +105,8 @@ public class ActionResultTests : IDisposable
         var response = result.ToActionResult(controller);
 
         // Assert
-        response.Result.Should().BeOfType<NoContentResult>();
-        response.Result.As<NoContentResult>().StatusCode.Should().Be(StatusCodes.Status204NoContent);
+        response.Should().BeOfType<NoContentResult>();
+        response.As<NoContentResult>().StatusCode.Should().Be(StatusCodes.Status204NoContent);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class ActionResultTests : IDisposable
         // Arrange
         var controller = new Mock<ControllerBase> { CallBase = true }.Object;
         var error = Error.BadRequest("Operation failed");
-        var result = Result.Fail<Unit>(error);
+        var result = Result.Fail(error);
         var expected = new ProblemDetails
         {
             Detail = "Operation failed",
@@ -126,8 +126,8 @@ public class ActionResultTests : IDisposable
         var response = result.ToActionResult(controller);
 
         // Assert
-        response.Result.Should().BeOfType<ObjectResult>();
-        var objectResult = response.Result.As<ObjectResult>();
+        response.Should().BeOfType<ObjectResult>();
+        var objectResult = response.As<ObjectResult>();
         objectResult.Value.Should().BeEquivalentTo(expected);
         objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }

--- a/Trellis.Asp/tests/HttpResultValueTaskTests.cs
+++ b/Trellis.Asp/tests/HttpResultValueTaskTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/Trellis.Asp/tests/HttpResultValueTaskTests.cs
+++ b/Trellis.Asp/tests/HttpResultValueTaskTests.cs
@@ -77,7 +77,7 @@ public class HttpResultValueTaskTests : IDisposable
     {
         // Arrange
         var error = Error.Conflict("Conflict occurred");
-        var result = ValueTask.FromResult(Result.Fail<Unit>(error));
+        var result = ValueTask.FromResult(Result.Fail(error));
         var expected = new ProblemDetails
         {
             Title = "Conflict",

--- a/Trellis.Asp/tests/HttpResultsTests.cs
+++ b/Trellis.Asp/tests/HttpResultsTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/Trellis.Asp/tests/HttpResultsTests.cs
+++ b/Trellis.Asp/tests/HttpResultsTests.cs
@@ -231,7 +231,7 @@ public class HttpResultsTests : IDisposable
     public void Will_return_NotFound_for_Unit_failure()
     {
         // Arrange
-        var result = Result.Fail<Unit>(Error.NotFound("Resource not found", "UnitResource"));
+        var result = Result.Fail(Error.NotFound("Resource not found", "UnitResource"));
         var expected = new ProblemDetails
         {
             Title = "Not Found",

--- a/Trellis.Authorization/src/IIdentifyResource.cs
+++ b/Trellis.Authorization/src/IIdentifyResource.cs
@@ -12,7 +12,7 @@
 /// <example>
 /// <code>
 /// public record CancelOrderCommand(OrderId OrderId)
-///     : ICommand&lt;Result&lt;Unit&gt;&gt;, IAuthorizeResource&lt;Order&gt;, IIdentifyResource&lt;Order, OrderId&gt;
+///     : ICommand&lt;Result&gt;, IAuthorizeResource&lt;Order&gt;, IIdentifyResource&lt;Order, OrderId&gt;
 /// {
 ///     public OrderId GetResourceId() =&gt; OrderId;
 ///     public IResult Authorize(Actor actor, Order order) =&gt; ...;

--- a/Trellis.Benchmark/CombineBenchmarks.cs
+++ b/Trellis.Benchmark/CombineBenchmarks.cs
@@ -210,11 +210,11 @@ public class CombineBenchmarks
     }
 
     [Benchmark]
-    public Result<Unit> Combine_WithUnit_Success()
+    public Result Combine_WithUnit_Success()
     {
         return _successInt1
             .Combine(Result.Ok())
-            .Map((tuple) => new Unit());
+            .AsUnit();
     }
 
     public record Person(string Name, string Email, int Age);

--- a/Trellis.Benchmark/CombineBenchmarks.cs
+++ b/Trellis.Benchmark/CombineBenchmarks.cs
@@ -1,4 +1,4 @@
-using Trellis.Primitives;
+﻿using Trellis.Primitives;
 
 namespace Benchmark;
 

--- a/Trellis.EntityFrameworkCore/src/DbContextExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/DbContextExtensions.cs
@@ -1,4 +1,4 @@
-namespace Trellis.EntityFrameworkCore;
+﻿namespace Trellis.EntityFrameworkCore;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Trellis.EntityFrameworkCore/src/DbContextExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/DbContextExtensions.cs
@@ -83,23 +83,23 @@ public static class DbContextExtensions
     }
 
     /// <summary>
-    /// Convenience overload: calls <see cref="SaveChangesResultAsync(DbContext, CancellationToken)"/> and maps success to <see cref="Result{Unit}"/>.
+    /// Convenience overload: calls <see cref="SaveChangesResultAsync(DbContext, CancellationToken)"/> and maps success to <see cref="Result"/>.
     /// Use when callers don't need the affected row count.
     /// </summary>
     /// <param name="context">The <see cref="DbContext"/> to save changes on.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
-    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
-    public static async Task<Result<Unit>> SaveChangesResultUnitAsync(
+    /// <returns>A <see cref="Result"/> representing success or failure.</returns>
+    public static async Task<Result> SaveChangesResultUnitAsync(
         this DbContext context,
         CancellationToken cancellationToken = default)
     {
         var result = await context.SaveChangesResultAsync(cancellationToken).ConfigureAwait(false);
-        return result.Map(_ => default(Unit));
+        return result.AsUnit();
     }
 
     /// <summary>
     /// Convenience overload: calls <see cref="SaveChangesResultAsync(DbContext, bool, CancellationToken)"/>
-    /// and maps success to <see cref="Result{Unit}"/>.
+    /// and maps success to <see cref="Result"/>.
     /// Use when callers don't need the affected row count.
     /// </summary>
     /// <param name="context">The <see cref="DbContext"/> to save changes on.</param>
@@ -108,13 +108,13 @@ public static class DbContextExtensions
     /// <see langword="false"/> to leave the change tracker state unchanged.
     /// </param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
-    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
-    public static async Task<Result<Unit>> SaveChangesResultUnitAsync(
+    /// <returns>A <see cref="Result"/> representing success or failure.</returns>
+    public static async Task<Result> SaveChangesResultUnitAsync(
         this DbContext context,
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
         var result = await context.SaveChangesResultAsync(acceptAllChangesOnSuccess, cancellationToken).ConfigureAwait(false);
-        return result.Map(_ => default(Unit));
+        return result.AsUnit();
     }
 }

--- a/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.EntityFrameworkCore;
+namespace Trellis.EntityFrameworkCore;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -14,6 +14,6 @@ public class EfUnitOfWork<TContext>(TContext context) : IUnitOfWork
     where TContext : DbContext
 {
     /// <inheritdoc />
-    public Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default)
+    public Task<Result> CommitAsync(CancellationToken cancellationToken = default)
         => context.SaveChangesResultUnitAsync(cancellationToken);
 }

--- a/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/EfUnitOfWork.cs
@@ -1,4 +1,4 @@
-namespace Trellis.EntityFrameworkCore;
+﻿namespace Trellis.EntityFrameworkCore;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.EntityFrameworkCore;
+namespace Trellis.EntityFrameworkCore;
 
 /// <summary>
 /// Abstraction over the commit boundary for staged changes.
@@ -14,10 +14,10 @@ public interface IUnitOfWork
 {
     /// <summary>
     /// Persists all staged changes to the database.
-    /// Returns <see cref="Result{Unit}"/> to surface concurrency, duplicate-key,
+    /// Returns <see cref="Result"/> to surface concurrency, duplicate-key,
     /// and foreign-key errors as <see cref="Error"/> instead of exceptions.
     /// </summary>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
-    /// <returns>A <see cref="Result{Unit}"/> representing success or failure.</returns>
-    Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default);
+    /// <returns>A <see cref="Result"/> representing success or failure.</returns>
+    Task<Result> CommitAsync(CancellationToken cancellationToken = default);
 }

--- a/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
+++ b/Trellis.EntityFrameworkCore/src/IUnitOfWork.cs
@@ -1,4 +1,4 @@
-namespace Trellis.EntityFrameworkCore;
+﻿namespace Trellis.EntityFrameworkCore;
 
 /// <summary>
 /// Abstraction over the commit boundary for staged changes.

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -1,4 +1,4 @@
-namespace Trellis.EntityFrameworkCore;
+﻿namespace Trellis.EntityFrameworkCore;
 
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -212,7 +212,7 @@ public abstract class RepositoryBase<TAggregate, TId>
     /// </summary>
     /// <param name="id">The aggregate identifier to remove.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
-    /// <returns>A <see cref="Result{Unit}"/> representing success (staged) or not-found failure.</returns>
+    /// <returns>A non-generic <see cref="Result"/> representing success (staged) or not-found failure.</returns>
     public virtual async Task<Result> RemoveByIdAsync(TId id, CancellationToken cancellationToken = default)
     {
         var entity = await DbSet.FindAsync([id], cancellationToken).ConfigureAwait(false);

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -213,11 +213,11 @@ public abstract class RepositoryBase<TAggregate, TId>
     /// <param name="id">The aggregate identifier to remove.</param>
     /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
     /// <returns>A <see cref="Result{Unit}"/> representing success (staged) or not-found failure.</returns>
-    public virtual async Task<Result<Unit>> RemoveByIdAsync(TId id, CancellationToken cancellationToken = default)
+    public virtual async Task<Result> RemoveByIdAsync(TId id, CancellationToken cancellationToken = default)
     {
         var entity = await DbSet.FindAsync([id], cancellationToken).ConfigureAwait(false);
         if (entity is null)
-            return Result.Fail<Unit>(Error.NotFound($"{typeof(TAggregate).Name} with ID '{id}' not found."));
+            return Result.Fail(Error.NotFound($"{typeof(TAggregate).Name} with ID '{id}' not found."));
 
         DbSet.Remove(entity);
         return Result.Ok();

--- a/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
@@ -1,4 +1,4 @@
-using Trellis.Testing;
+﻿using Trellis.Testing;
 namespace Trellis.EntityFrameworkCore.Tests;
 
 public class TransactionalCommandBehaviorTests

--- a/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/TransactionalCommandBehaviorTests.cs
@@ -71,13 +71,13 @@ public class TransactionalCommandBehaviorTests
         // Arrange
         var ct = TestContext.Current.CancellationToken;
         var uow = new FakeUnitOfWork();
-        var behavior = new TransactionalCommandBehavior<FakeUnitCommand, Result<Unit>>(uow);
-        var expected = Result.Ok(default(Unit));
+        var behavior = new TransactionalCommandBehavior<FakeUnitCommand, Result>(uow);
+        var expected = Result.Ok();
 
         // Act
         var result = await behavior.Handle(
             new FakeUnitCommand(),
-            (_, _) => new ValueTask<Result<Unit>>(expected),
+            (_, _) => new ValueTask<Result>(expected),
             ct);
 
         // Assert
@@ -90,9 +90,9 @@ public class TransactionalCommandBehaviorTests
     private sealed class FakeUnitOfWork : IUnitOfWork
     {
         public int CommitCount { get; private set; }
-        public Result<Unit>? CommitResult { get; init; }
+        public Result? CommitResult { get; init; }
 
-        public Task<Result<Unit>> CommitAsync(CancellationToken cancellationToken = default)
+        public Task<Result> CommitAsync(CancellationToken cancellationToken = default)
         {
             CommitCount++;
             return Task.FromResult(CommitResult ?? Result.Ok());
@@ -101,7 +101,7 @@ public class TransactionalCommandBehaviorTests
 
     private sealed record FakeCommand : Mediator.ICommand<Result<string>>;
 
-    private sealed record FakeUnitCommand : Mediator.ICommand<Result<Unit>>;
+    private sealed record FakeUnitCommand : Mediator.ICommand<Result>;
 
     #endregion
 }

--- a/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
+++ b/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
@@ -244,14 +244,14 @@ public class SharedResourceLoaderTests
     // -- Commands that use IIdentifyResource (should be auto-bridged)
 
     public sealed record SharedCancelCommand(string OrderId)
-        : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
+        : ICommand<Result>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
     {
         public string GetResourceId() => OrderId;
         public IResult Authorize(Actor actor, SharedOrder order) => Result.Ok();
     }
 
     public sealed record SharedReturnCommand(string OrderId)
-        : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
+        : ICommand<Result>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
     {
         public string GetResourceId() => OrderId;
         public IResult Authorize(Actor actor, SharedOrder order) => Result.Ok();
@@ -260,7 +260,7 @@ public class SharedResourceLoaderTests
     // -- Command WITHOUT IIdentifyResource (should NOT be auto-bridged)
 
     public sealed record NonIdentifyCommand(string OrderId)
-        : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<SharedOrder>
+        : ICommand<Result>, IAuthorizeResource<SharedOrder>
     {
         public IResult Authorize(Actor actor, SharedOrder order) => Result.Ok();
     }
@@ -268,7 +268,7 @@ public class SharedResourceLoaderTests
     // -- Command with explicit loader (explicit should win)
 
     public sealed record ExplicitLoaderCommand(string OrderId)
-        : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
+        : ICommand<Result>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, string>
     {
         public string GetResourceId() => OrderId;
         public IResult Authorize(Actor actor, SharedOrder order) => Result.Ok();
@@ -292,7 +292,7 @@ public class SharedResourceLoaderTests
     // -- Command with mismatched TId (shared loader uses string, command uses int)
 
     public sealed record MismatchedIdCommand(int OrderNumber)
-        : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, int>
+        : ICommand<Result>, IAuthorizeResource<SharedOrder>, IIdentifyResource<SharedOrder, int>
     {
         public int GetResourceId() => OrderNumber;
         public IResult Authorize(Actor actor, SharedOrder order) => Result.Ok();
@@ -300,3 +300,4 @@ public class SharedResourceLoaderTests
 
     #endregion
 }
+

--- a/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
+++ b/Trellis.Mediator/tests/SharedResourceLoaderTests.cs
@@ -1,4 +1,4 @@
-using Trellis.Testing;
+﻿using Trellis.Testing;
 namespace Trellis.Mediator.Tests;
 
 using global::Mediator;

--- a/Trellis.Results/src/Maybe/MaybeInvariant.cs
+++ b/Trellis.Results/src/Maybe/MaybeInvariant.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 /// multiple optional values must satisfy a relationship constraint.
 /// </para>
 /// <para>
-/// All methods return <see cref="Result{Unit}"/>. Chain with <c>.Combine()</c> to compose
+/// All methods return <see cref="Result"/>. Chain with <c>.Combine()</c> to compose
 /// multiple invariant checks, or use as a step in a result pipeline.
 /// </para>
 /// </remarks>
@@ -47,7 +47,7 @@ public static class MaybeInvariant
     /// <param name="firstFieldName">Field name for the first value (used in validation errors).</param>
     /// <param name="secondFieldName">Field name for the second value (used in validation errors).</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// <see cref="Result"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
     public static Result AllOrNone<T1, T2>(
@@ -77,7 +77,7 @@ public static class MaybeInvariant
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <param name="thirdFieldName">Field name for the third value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// <see cref="Result"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
     public static Result AllOrNone<T1, T2, T3>(
@@ -113,7 +113,7 @@ public static class MaybeInvariant
     /// <param name="thirdFieldName">Field name for the third value.</param>
     /// <param name="fourthFieldName">Field name for the fourth value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
+    /// <see cref="Result"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
     public static Result AllOrNone<T1, T2, T3, T4>(
@@ -151,7 +151,7 @@ public static class MaybeInvariant
     /// <param name="sourceFieldName">Field name for the source value.</param>
     /// <param name="requiredFieldName">Field name for the required value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if source is absent or both are present;
+    /// <see cref="Result"/> success if source is absent or both are present;
     /// otherwise a <see cref="ValidationError"/> for the missing required field.
     /// </returns>
     public static Result Requires<T1, T2>(
@@ -189,7 +189,7 @@ public static class MaybeInvariant
     /// <param name="firstFieldName">Field name for the first value.</param>
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if zero or one value is present;
+    /// <see cref="Result"/> success if zero or one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all present fields.
     /// </returns>
     public static Result MutuallyExclusive<T1, T2>(
@@ -219,7 +219,7 @@ public static class MaybeInvariant
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <param name="thirdFieldName">Field name for the third value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if zero or one value is present;
+    /// <see cref="Result"/> success if zero or one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all present fields.
     /// </returns>
     public static Result MutuallyExclusive<T1, T2, T3>(
@@ -253,7 +253,7 @@ public static class MaybeInvariant
     /// <param name="firstFieldName">Field name for the first value.</param>
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if exactly one value is present;
+    /// <see cref="Result"/> success if exactly one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
     public static Result ExactlyOne<T1, T2>(
@@ -283,7 +283,7 @@ public static class MaybeInvariant
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <param name="thirdFieldName">Field name for the third value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if exactly one value is present;
+    /// <see cref="Result"/> success if exactly one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
     public static Result ExactlyOne<T1, T2, T3>(
@@ -317,7 +317,7 @@ public static class MaybeInvariant
     /// <param name="firstFieldName">Field name for the first value.</param>
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if at least one value is present;
+    /// <see cref="Result"/> success if at least one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
     public static Result AtLeastOne<T1, T2>(
@@ -347,7 +347,7 @@ public static class MaybeInvariant
     /// <param name="secondFieldName">Field name for the second value.</param>
     /// <param name="thirdFieldName">Field name for the third value.</param>
     /// <returns>
-    /// <see cref="Result{Unit}"/> success if at least one value is present;
+    /// <see cref="Result"/> success if at least one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
     public static Result AtLeastOne<T1, T2, T3>(

--- a/Trellis.Results/src/Maybe/MaybeInvariant.cs
+++ b/Trellis.Results/src/Maybe/MaybeInvariant.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Maybe/MaybeInvariant.cs
+++ b/Trellis.Results/src/Maybe/MaybeInvariant.cs
@@ -50,7 +50,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
-    public static Result<Unit> AllOrNone<T1, T2>(
+    public static Result AllOrNone<T1, T2>(
         Maybe<T1> first, Maybe<T2> second,
         string firstFieldName, string secondFieldName)
         where T1 : notnull
@@ -80,7 +80,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
-    public static Result<Unit> AllOrNone<T1, T2, T3>(
+    public static Result AllOrNone<T1, T2, T3>(
         Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
         string firstFieldName, string secondFieldName, string thirdFieldName)
         where T1 : notnull
@@ -116,7 +116,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if all values are present or all are absent;
     /// otherwise a <see cref="ValidationError"/> listing the fields that violate the invariant.
     /// </returns>
-    public static Result<Unit> AllOrNone<T1, T2, T3, T4>(
+    public static Result AllOrNone<T1, T2, T3, T4>(
         Maybe<T1> first, Maybe<T2> second, Maybe<T3> third, Maybe<T4> fourth,
         string firstFieldName, string secondFieldName, string thirdFieldName, string fourthFieldName)
         where T1 : notnull
@@ -154,7 +154,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if source is absent or both are present;
     /// otherwise a <see cref="ValidationError"/> for the missing required field.
     /// </returns>
-    public static Result<Unit> Requires<T1, T2>(
+    public static Result Requires<T1, T2>(
         Maybe<T1> source, Maybe<T2> required,
         string sourceFieldName, string requiredFieldName)
         where T1 : notnull
@@ -168,7 +168,7 @@ public static class MaybeInvariant
         if (source.HasNoValue || required.HasValue)
             return Result.Ok();
 
-        return Result.Fail<Unit>(
+        return Result.Fail(
             ValidationError.For(
                 requiredFieldName,
                 $"'{requiredFieldName}' is required when '{sourceFieldName}' is provided.",
@@ -192,7 +192,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if zero or one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all present fields.
     /// </returns>
-    public static Result<Unit> MutuallyExclusive<T1, T2>(
+    public static Result MutuallyExclusive<T1, T2>(
         Maybe<T1> first, Maybe<T2> second,
         string firstFieldName, string secondFieldName)
         where T1 : notnull
@@ -222,7 +222,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if zero or one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all present fields.
     /// </returns>
-    public static Result<Unit> MutuallyExclusive<T1, T2, T3>(
+    public static Result MutuallyExclusive<T1, T2, T3>(
         Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
         string firstFieldName, string secondFieldName, string thirdFieldName)
         where T1 : notnull
@@ -256,7 +256,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if exactly one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
-    public static Result<Unit> ExactlyOne<T1, T2>(
+    public static Result ExactlyOne<T1, T2>(
         Maybe<T1> first, Maybe<T2> second,
         string firstFieldName, string secondFieldName)
         where T1 : notnull
@@ -286,7 +286,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if exactly one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
-    public static Result<Unit> ExactlyOne<T1, T2, T3>(
+    public static Result ExactlyOne<T1, T2, T3>(
         Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
         string firstFieldName, string secondFieldName, string thirdFieldName)
         where T1 : notnull
@@ -320,7 +320,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if at least one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
-    public static Result<Unit> AtLeastOne<T1, T2>(
+    public static Result AtLeastOne<T1, T2>(
         Maybe<T1> first, Maybe<T2> second,
         string firstFieldName, string secondFieldName)
         where T1 : notnull
@@ -350,7 +350,7 @@ public static class MaybeInvariant
     /// <see cref="Result{Unit}"/> success if at least one value is present;
     /// otherwise a <see cref="ValidationError"/> listing all fields.
     /// </returns>
-    public static Result<Unit> AtLeastOne<T1, T2, T3>(
+    public static Result AtLeastOne<T1, T2, T3>(
         Maybe<T1> first, Maybe<T2> second, Maybe<T3> third,
         string firstFieldName, string secondFieldName, string thirdFieldName)
         where T1 : notnull
@@ -371,7 +371,7 @@ public static class MaybeInvariant
 
     #region Core implementations
 
-    private static Result<Unit> AllOrNoneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    private static Result AllOrNoneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(AllOrNone));
 
@@ -398,10 +398,10 @@ public static class MaybeInvariant
             }
         }
 
-        return Result.Fail<Unit>(error!);
+        return Result.Fail(error!);
     }
 
-    private static Result<Unit> MutuallyExclusiveCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    private static Result MutuallyExclusiveCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(MutuallyExclusive));
 
@@ -428,10 +428,10 @@ public static class MaybeInvariant
             }
         }
 
-        return Result.Fail<Unit>(error!);
+        return Result.Fail(error!);
     }
 
-    private static Result<Unit> ExactlyOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    private static Result ExactlyOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ExactlyOne));
 
@@ -471,10 +471,10 @@ public static class MaybeInvariant
             }
         }
 
-        return Result.Fail<Unit>(error!);
+        return Result.Fail(error!);
     }
 
-    private static Result<Unit> AtLeastOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
+    private static Result AtLeastOneCore(params ReadOnlySpan<(bool hasValue, string fieldName)> fields)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(AtLeastOne));
 
@@ -494,7 +494,7 @@ public static class MaybeInvariant
                 : error.And(fields[i].fieldName, message);
         }
 
-        return Result.Fail<Unit>(error!);
+        return Result.Fail(error!);
     }
 
     #endregion

--- a/Trellis.Results/src/Result/Extensions/Check.Task.Left.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.Task.Left.cs
@@ -32,6 +32,12 @@ public static partial class CheckExtensionsAsync
     /// <param name="resultTask">The task containing the result to check.</param>
     /// <param name="func">The sync validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static Task<Result<T>> CheckAsync<T>(this Task<Result<T>> resultTask, Func<T, Result<Unit>> func)
-        => CheckAsync<T, Unit>(resultTask, func);
+    public static async Task<Result<T>> CheckAsync<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.Check(func);
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.Task.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.Task.Right.cs
@@ -47,6 +47,27 @@ public static partial class CheckExtensionsAsync
     /// <param name="result">The result to check.</param>
     /// <param name="func">The async validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static Task<Result<T>> CheckAsync<T>(this Result<T> result, Func<T, Task<Result<Unit>>> func)
-        => CheckAsync<T, Unit>(result, func);
+    public static async Task<Result<T>> CheckAsync<T>(this Result<T> result, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckExtensions.Check));
+
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.Task.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.Task.Right.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async Check extensions where only the RIGHT (check function) is async (Task), input is sync.

--- a/Trellis.Results/src/Result/Extensions/Check.Task.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.Task.cs
@@ -49,6 +49,29 @@ public static partial class CheckExtensionsAsync
     /// <param name="resultTask">The task containing the result to check.</param>
     /// <param name="func">The async validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static Task<Result<T>> CheckAsync<T>(this Task<Result<T>> resultTask, Func<T, Task<Result<Unit>>> func)
-        => CheckAsync<T, Unit>(resultTask, func);
+    public static async Task<Result<T>> CheckAsync<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckExtensions.Check));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.Task.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.Task.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async Check extensions where BOTH input and check function are async (Task).

--- a/Trellis.Results/src/Result/Extensions/Check.ValueTask.Left.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.ValueTask.Left.cs
@@ -31,6 +31,11 @@ public static partial class CheckExtensionsAsync
     /// <param name="resultTask">The async result to check.</param>
     /// <param name="func">The sync validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static ValueTask<Result<T>> CheckAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, Result<Unit>> func)
-        => CheckAsync<T, Unit>(resultTask, func);
+    public static async ValueTask<Result<T>> CheckAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.Check(func);
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.ValueTask.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.ValueTask.Right.cs
@@ -47,6 +47,27 @@ public static partial class CheckExtensionsAsync
     /// <param name="result">The result to check.</param>
     /// <param name="func">The async validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static ValueTask<Result<T>> CheckAsync<T>(this Result<T> result, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckAsync<T, Unit>(result, func);
+    public static async ValueTask<Result<T>> CheckAsync<T>(this Result<T> result, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckExtensions.Check));
+
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.ValueTask.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.ValueTask.Right.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async Check extensions where only the RIGHT (check function) is async (ValueTask), input is sync.

--- a/Trellis.Results/src/Result/Extensions/Check.ValueTask.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.ValueTask.cs
@@ -54,6 +54,28 @@ public static partial class CheckExtensionsAsync
     /// <param name="resultTask">The async result to check.</param>
     /// <param name="func">The async validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static ValueTask<Result<T>> CheckAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckAsync<T, Unit>(resultTask, func);
+    public static async ValueTask<Result<T>> CheckAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckExtensions.Check));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Check.ValueTask.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.ValueTask.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Result/Extensions/Check.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System;
 using System.Diagnostics;

--- a/Trellis.Results/src/Result/Extensions/Check.cs
+++ b/Trellis.Results/src/Result/Extensions/Check.cs
@@ -57,6 +57,27 @@ public static class CheckExtensions
     /// <param name="result">The result to check.</param>
     /// <param name="func">The validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the check passes; otherwise the check's failure.</returns>
-    public static Result<T> Check<T>(this Result<T> result, Func<T, Result<Unit>> func)
-        => Check<T, Unit>(result, func);
+    public static Result<T> Check<T>(this Result<T> result, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity();
+
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = func(result.Value);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.Task.Left.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.Task.Left.cs
@@ -25,8 +25,14 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Task{Result{T}}, bool, Func{T, Result{TK}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<Unit>> func)
-        => CheckIfAsync<T, Unit>(resultTask, condition, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, func);
+    }
 
     /// <summary>
     /// Conditionally runs a sync validation function when the predicate returns true.
@@ -49,6 +55,13 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Task{Result{T}}, Func{T, bool}, Func{T, Result{TK}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<Unit>> func)
-        => CheckIfAsync<T, Unit>(resultTask, predicate, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, func);
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.Task.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.Task.Right.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async CheckIf extensions where only the RIGHT (check function) is async (Task), input is sync.

--- a/Trellis.Results/src/Result/Extensions/CheckIf.Task.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.Task.Right.cs
@@ -40,8 +40,29 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Result{T}, bool, Func{T, Task{Result{TK}}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Result<T> result, bool condition, Func<T, Task<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(result, condition, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+
+        if (result.IsFailure || !condition)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 
     /// <summary>
     /// Conditionally runs an async validation function when the predicate returns true.
@@ -79,6 +100,28 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Result{T}, Func{T, bool}, Func{T, Task{Result{TK}}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(result, predicate, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+
+        if (result.IsFailure || !predicate(result.Value))
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.Task.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.Task.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Result/Extensions/CheckIf.Task.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.Task.cs
@@ -45,8 +45,31 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Task{Result{T}}, bool, Func{T, Task{Result{TK}}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(resultTask, condition, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure || !condition)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 
     /// <summary>
     /// Conditionally runs an async validation function when the predicate returns true.
@@ -86,6 +109,30 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Task{Result{T}}, Func{T, bool}, Func{T, Task{Result{TK}}})"/>
-    public static Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(resultTask, predicate, func);
+    public static async Task<Result<T>> CheckIfAsync<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure || !predicate(result.Value))
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Left.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Left.cs
@@ -24,8 +24,13 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(ValueTask{Result{T}}, bool, Func{T, Result{TK}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result<Unit>> func)
-        => CheckIfAsync<T, Unit>(resultTask, condition, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, func);
+    }
 
     /// <summary>
     /// Conditionally runs a sync validation function when the predicate returns true.
@@ -47,6 +52,12 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(ValueTask{Result{T}}, Func{T, bool}, Func{T, Result{TK}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<Unit>> func)
-        => CheckIfAsync<T, Unit>(resultTask, predicate, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        Result<T> result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, func);
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Right.cs
@@ -40,8 +40,29 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Result{T}, bool, Func{T, ValueTask{Result{TK}}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(result, condition, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+
+        if (result.IsFailure || !condition)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 
     /// <summary>
     /// Conditionally runs an async validation function when the predicate returns true.
@@ -79,6 +100,28 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(Result{T}, Func{T, bool}, Func{T, ValueTask{Result{TK}}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(result, predicate, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+
+        if (result.IsFailure || !predicate(result.Value))
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Right.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.Right.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async CheckIf extensions where only the RIGHT (check function) is async (ValueTask), input is sync.

--- a/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.cs
@@ -41,8 +41,30 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(ValueTask{Result{T}}, bool, Func{T, ValueTask{Result{TK}}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(resultTask, condition, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure || !condition)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 
     /// <summary>
     /// Conditionally runs an async validation function when the predicate returns true.
@@ -81,6 +103,29 @@ public static partial class CheckIfExtensionsAsync
     }
 
     /// <inheritdoc cref="CheckIfAsync{T,TK}(ValueTask{Result{T}}, Func{T, bool}, Func{T, ValueTask{Result{TK}}})"/>
-    public static ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result<Unit>>> func)
-        => CheckIfAsync<T, Unit>(resultTask, predicate, func);
+    public static async ValueTask<Result<T>> CheckIfAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CheckIfExtensions.CheckIf));
+        Result<T> result = await resultTask.ConfigureAwait(false);
+
+        if (result.IsFailure || !predicate(result.Value))
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = await func(result.Value).ConfigureAwait(false);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.ValueTask.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Async CheckIf extensions where BOTH input and check function are async (ValueTask).

--- a/Trellis.Results/src/Result/Extensions/CheckIf.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System;
 using System.Diagnostics;

--- a/Trellis.Results/src/Result/Extensions/CheckIf.cs
+++ b/Trellis.Results/src/Result/Extensions/CheckIf.cs
@@ -59,8 +59,29 @@ public static class CheckIfExtensions
     /// <param name="condition">The condition that must be true for the check to run.</param>
     /// <param name="func">The validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the condition is false or the check passes; otherwise the check's failure.</returns>
-    public static Result<T> CheckIf<T>(this Result<T> result, bool condition, Func<T, Result<Unit>> func)
-        => CheckIf<T, Unit>(result, condition, func);
+    public static Result<T> CheckIf<T>(this Result<T> result, bool condition, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity();
+
+        if (result.IsFailure || !condition)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = func(result.Value);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 
     /// <summary>
     /// Conditionally runs a validation function when the predicate returns true for the success value.
@@ -106,6 +127,28 @@ public static class CheckIfExtensions
     /// <param name="predicate">The predicate to evaluate against the success value.</param>
     /// <param name="func">The validation function that returns a Result of Unit.</param>
     /// <returns>The original result if the predicate is false or the check passes; otherwise the check's failure.</returns>
-    public static Result<T> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<Unit>> func)
-        => CheckIf<T, Unit>(result, predicate, func);
+    public static Result<T> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        using var activity = RopTrace.ActivitySource.StartActivity();
+
+        if (result.IsFailure || !predicate(result.Value))
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var checkResult = func(result.Value);
+        if (checkResult.IsFailure)
+        {
+            var failure = Result.Fail<T>(checkResult.Error);
+            failure.LogActivityStatus();
+            return failure;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
 }

--- a/Trellis.Results/src/Result/Extensions/Combine.cs
+++ b/Trellis.Results/src/Result/Extensions/Combine.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Result/Extensions/Combine.cs
+++ b/Trellis.Results/src/Result/Extensions/Combine.cs
@@ -9,13 +9,9 @@ using System.Diagnostics;
 public static partial class CombineExtensions
 {
     /// <summary>
-    /// Combine a <see cref="Result{TValue}"/> with <see cref="Result{Unit}"/> return <see cref="Result{TValue}"/>.
+    /// Combine a <see cref="Result{TValue}"/> with a non-generic <see cref="Result"/> (unit-shaped), returning <see cref="Result{TValue}"/>.
     /// </summary>
-    /// <typeparam name="T1"></typeparam>
-    /// <param name="t1"></param>
-    /// <param name="t2"></param>
-    /// <returns>Tuple containing both the results.</returns>
-    public static Result<T1> Combine<T1>(this Result<T1> t1, Result<Unit> t2)
+    public static Result<T1> Combine<T1>(this Result<T1> t1, Result t2)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;
@@ -23,6 +19,19 @@ public static partial class CombineExtensions
         if (t2.IsFailure) error = error.Combine(t2.Error);
         if (error is not null) return Result.Fail<T1>(error);
         return Result.Ok(t1.Value);
+    }
+
+    /// <summary>
+    /// Combine two non-generic <see cref="Result"/> values into one.
+    /// </summary>
+    public static Result Combine(this Result r1, Result r2)
+    {
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
+        Error? error = null;
+        if (r1.IsFailure) error = error.Combine(r1.Error);
+        if (r2.IsFailure) error = error.Combine(r2.Error);
+        if (error is not null) return Result.Fail(error);
+        return Result.Ok();
     }
 
     /// <summary>
@@ -96,9 +105,9 @@ public static partial class CombineExtensionsAsync
     }
 
     /// <summary>
-    /// Combine a Task result with a Unit result.
+    /// Combine a Task result with a non-generic unit result.
     /// </summary>
-    public static async Task<Result<T1>> CombineAsync<T1>(this Task<Result<T1>> tt1, Result<Unit> t2)
+    public static async Task<Result<T1>> CombineAsync<T1>(this Task<Result<T1>> tt1, Result t2)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;
@@ -157,9 +166,9 @@ public static partial class CombineExtensionsAsync
     }
 
     /// <summary>
-    /// Combine a ValueTask result with a Unit result.
+    /// Combine a ValueTask result with a non-generic unit result.
     /// </summary>
-    public static async ValueTask<Result<T1>> CombineAsync<T1>(this ValueTask<Result<T1>> vt1, Result<Unit> t2)
+    public static async ValueTask<Result<T1>> CombineAsync<T1>(this ValueTask<Result<T1>> vt1, Result t2)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;

--- a/Trellis.Results/src/Result/Extensions/CombineTs.g.tt
+++ b/Trellis.Results/src/Result/Extensions/CombineTs.g.tt
@@ -79,7 +79,7 @@ public static partial class CombineExtensions
     /// </returns>
     /// <remarks>
     /// This overload is useful when you need to validate a condition without adding to the tuple.
-    /// The Unit result acts as a validation gate that must pass, but contributes no value.
+    /// The non-generic Result acts as a validation gate that must pass, but contributes no value.
     /// </remarks>
     /// <example>
     /// <code>
@@ -160,7 +160,7 @@ public static partial class CombineExtensionsAsync
     #region <#= i - 1 #>-Tuple Task Left-Async
 
     /// <summary>
-    /// Combine a Task-wrapped <#= i - 1 #>-tuple result with a Unit result. Left is async (Task).
+    /// Combine a Task-wrapped <#= i - 1 #>-tuple result with a non-generic <see cref="Result"/>. Left is async (Task).
     /// </summary>
     public static async Task<Result<(<# WriteTs(i - 1); #>)>> CombineAsync<<# WriteTs(i - 1); #>>(
       this Task<Result<(<# WriteTs(i - 1); #>)>> tt1, Result tc)
@@ -194,7 +194,7 @@ public static partial class CombineExtensionsAsync
     #region <#= i - 1 #>-Tuple ValueTask Left-Async
 
     /// <summary>
-    /// Combine a ValueTask-wrapped <#= i - 1 #>-tuple result with a Unit result. Left is async (ValueTask).
+    /// Combine a ValueTask-wrapped <#= i - 1 #>-tuple result with a non-generic <see cref="Result"/>. Left is async (ValueTask).
     /// </summary>
     public static async ValueTask<Result<(<# WriteTs(i - 1); #>)>> CombineAsync<<# WriteTs(i - 1); #>>(
       this ValueTask<Result<(<# WriteTs(i - 1); #>)>> vt1, Result tc)

--- a/Trellis.Results/src/Result/Extensions/CombineTs.g.tt
+++ b/Trellis.Results/src/Result/Extensions/CombineTs.g.tt
@@ -91,7 +91,7 @@ public static partial class CombineExtensions
     /// </code>
     /// </example>
     public static Result<(<# WriteTs(i - 1); #>)> Combine<<# WriteTs(i - 1); #>>(
-      this Result<(<# WriteTs(i - 1); #>)> t1, Result<Unit> tc)
+      this Result<(<# WriteTs(i - 1); #>)> t1, Result tc)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;
@@ -163,7 +163,7 @@ public static partial class CombineExtensionsAsync
     /// Combine a Task-wrapped <#= i - 1 #>-tuple result with a Unit result. Left is async (Task).
     /// </summary>
     public static async Task<Result<(<# WriteTs(i - 1); #>)>> CombineAsync<<# WriteTs(i - 1); #>>(
-      this Task<Result<(<# WriteTs(i - 1); #>)>> tt1, Result<Unit> tc)
+      this Task<Result<(<# WriteTs(i - 1); #>)>> tt1, Result tc)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;
@@ -197,7 +197,7 @@ public static partial class CombineExtensionsAsync
     /// Combine a ValueTask-wrapped <#= i - 1 #>-tuple result with a Unit result. Left is async (ValueTask).
     /// </summary>
     public static async ValueTask<Result<(<# WriteTs(i - 1); #>)>> CombineAsync<<# WriteTs(i - 1); #>>(
-      this ValueTask<Result<(<# WriteTs(i - 1); #>)>> vt1, Result<Unit> tc)
+      this ValueTask<Result<(<# WriteTs(i - 1); #>)>> vt1, Result tc)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(CombineExtensions.Combine));
         Error? error = null;

--- a/Trellis.Results/src/Result/Extensions/RecoverOnFailure.cs
+++ b/Trellis.Results/src/Result/Extensions/RecoverOnFailure.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Result/Extensions/RecoverOnFailure.cs
+++ b/Trellis.Results/src/Result/Extensions/RecoverOnFailure.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis;
+namespace Trellis;
 
 using System.Diagnostics;
 
@@ -586,6 +586,28 @@ public static class RecoverOnFailureExtensionsAsync
         if (predicate(result.Error))
         {
             var output = await funcAsync(result.Error).ConfigureAwait(false);
+            output.LogActivityStatus();
+            return output;
+        }
+
+        result.LogActivityStatus();
+        return result;
+    }
+
+    /// <summary>Recovers from a failed non-generic result with predicate and async recovery function.</summary>
+    [RailwayTrack(TrackBehavior.Failure)]
+    public static async Task<Result> RecoverOnFailureAsync(this Task<Result> resultTask, Func<Error, bool> predicate, Func<Task<Result>> funcAsync)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(funcAsync);
+
+        Result result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess) return result;
+
+        if (predicate(result.Error))
+        {
+            var output = await funcAsync().ConfigureAwait(false);
             output.LogActivityStatus();
             return output;
         }

--- a/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
+++ b/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
@@ -4,13 +4,11 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-#pragma warning disable CS1591 // Missing XML comment — overload-heavy mirror file; one summary per region documents intent.
-
 // =============================================================================
 // Pipeline verb extensions for the non-generic Result.
 //
 // This file mirrors the seven pipeline verbs (Map, Bind, Tap, TapError, Ensure,
-// Match, Recover) plus Try and a small set of cross-shape helpers, but for the
+// Match, Recover) plus a small set of cross-shape helpers, but for the
 // non-generic Result that replaces Result<Unit>. It is deliberately a single
 // file rather than the per-verb / per-async-shape split that Result<T> uses,
 // because:
@@ -21,6 +19,13 @@ using System.Threading.Tasks;
 // Async overload model mirrors §3.3 of the v2 redesign plan: 6 overloads per
 // verb covering Sync/Task/ValueTask × sync/async function. Mixing Task and
 // ValueTask requires explicit conversion (deliberate constraint).
+//
+// Tracing parity: every overload that owns an Activity (i.e., starts one with
+// RopTrace.ActivitySource.StartActivity) calls LogActivityStatus() before
+// returning on every exit path — short-circuit, success and failure — to
+// mirror the behavior of the generic Result<T> verbs. Pure passthrough
+// overloads delegate to an inner overload that owns the activity; they only
+// validate their arguments and forward.
 // =============================================================================
 
 #region Map (unit → value)
@@ -42,40 +47,66 @@ public static class ResultMapExtensions
 [DebuggerStepThrough]
 public static class ResultMapExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and projects success to a value via <paramref name="func"/>.</summary>
     public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<TOut> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         return (await resultTask.ConfigureAwait(false)).Map(func);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and projects success to a value via <paramref name="func"/>.</summary>
     public static async ValueTask<Result<TOut>> MapAsync<TOut>(this ValueTask<Result> resultTask, Func<TOut> func)
-        => (await resultTask.ConfigureAwait(false)).Map(func);
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return (await resultTask.ConfigureAwait(false)).Map(func);
+    }
 
+    /// <summary>Projects success to a value via async <paramref name="func"/>; failure propagates unchanged.</summary>
     public static async Task<Result<TOut>> MapAsync<TOut>(this Result result, Func<Task<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultMapExtensions.Map));
-        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
-        return Result.Ok(await func().ConfigureAwait(false));
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail<TOut>(result.Error);
+        }
+
+        var output = Result.Ok(await func().ConfigureAwait(false));
+        output.LogActivityStatus();
+        return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and projects success to a value via async <paramref name="func"/>.</summary>
     public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MapAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Projects success to a value via async <paramref name="func"/> (ValueTask); failure propagates unchanged.</summary>
     public static async ValueTask<Result<TOut>> MapAsync<TOut>(this Result result, Func<ValueTask<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultMapExtensions.Map));
-        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
-        return Result.Ok(await func().ConfigureAwait(false));
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail<TOut>(result.Error);
+        }
+
+        var output = Result.Ok(await func().ConfigureAwait(false));
+        output.LogActivityStatus();
+        return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and projects success via async <paramref name="func"/> (ValueTask).</summary>
     public static async ValueTask<Result<TOut>> MapAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<TOut>> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MapAsync(func).ConfigureAwait(false);
     }
@@ -94,18 +125,28 @@ public static class ResultBindExtensions
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
-        if (result.IsFailure) return result;
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = func();
         output.LogActivityStatus();
         return output;
     }
 
-    /// <summary>Chains a value-producing step from a unit-shaped success.</summary>
+    /// <summary>Chains a value-producing step from a unit-shaped success. Failure short-circuits.</summary>
     public static Result<TOut> Bind<TOut>(this Result result, Func<Result<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
-        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail<TOut>(result.Error);
+        }
+
         var output = func();
         output.LogActivityStatus();
         return output;
@@ -116,7 +157,12 @@ public static class ResultBindExtensions
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
-        if (result.IsFailure) return Result.Fail(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail(result.Error);
+        }
+
         var output = func(result.Value);
         output.LogActivityStatus();
         return output;
@@ -128,130 +174,199 @@ public static class ResultBindExtensions
 public static class ResultBindExtensionsAsync
 {
     // unit → unit
+
+    /// <summary>Awaits <paramref name="resultTask"/> and chains a unit-shaped step via <paramref name="func"/>.</summary>
     public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Result> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         return (await resultTask.ConfigureAwait(false)).Bind(func);
     }
 
+    /// <summary>Chains an async unit-shaped step via <paramref name="func"/>. Failure short-circuits.</summary>
     public static async Task<Result> BindAsync(this Result result, Func<Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return result;
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async unit-shaped step via <paramref name="func"/>.</summary>
     public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains a unit-shaped step via <paramref name="func"/>.</summary>
     public static async ValueTask<Result> BindAsync(this ValueTask<Result> resultTask, Func<Result> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
+    /// <summary>Chains an async unit-shaped step (ValueTask). Failure short-circuits.</summary>
     public static async ValueTask<Result> BindAsync(this Result result, Func<ValueTask<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return result;
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async unit-shaped step (ValueTask).</summary>
     public static async ValueTask<Result> BindAsync(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
 
     // unit → value
+
+    /// <summary>Awaits <paramref name="resultTask"/> and chains a value-producing step via <paramref name="func"/>.</summary>
     public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Result<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         return (await resultTask.ConfigureAwait(false)).Bind(func);
     }
 
+    /// <summary>Chains an async value-producing step via <paramref name="func"/>. Failure short-circuits.</summary>
     public static async Task<Result<TOut>> BindAsync<TOut>(this Result result, Func<Task<Result<TOut>>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail<TOut>(result.Error);
+        }
+
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async value-producing step via <paramref name="func"/>.</summary>
     public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Task<Result<TOut>>> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains a value-producing step via <paramref name="func"/>.</summary>
     public static async ValueTask<Result<TOut>> BindAsync<TOut>(this ValueTask<Result> resultTask, Func<Result<TOut>> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
+    /// <summary>Chains an async value-producing step (ValueTask). Failure short-circuits.</summary>
     public static async ValueTask<Result<TOut>> BindAsync<TOut>(this Result result, Func<ValueTask<Result<TOut>>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail<TOut>(result.Error);
+        }
+
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async value-producing step (ValueTask).</summary>
     public static async ValueTask<Result<TOut>> BindAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<Result<TOut>>> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
 
     // value → unit (cross-shape)
+
+    /// <summary>Awaits <paramref name="resultTask"/> and discards the value to chain a unit-shaped step.</summary>
     public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Result> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         return (await resultTask.ConfigureAwait(false)).Bind(func);
     }
 
+    /// <summary>Cross-shape async: chains an async unit-shaped step from a value-bearing success.</summary>
     public static async Task<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return Result.Fail(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail(result.Error);
+        }
+
         var output = await func(result.Value).ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async unit-shaped step from a value-bearing success.</summary>
     public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and discards the value to chain a unit-shaped step.</summary>
     public static async ValueTask<Result> BindAsync<TIn>(this ValueTask<Result<TIn>> resultTask, Func<TIn, Result> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
+    /// <summary>Cross-shape async (ValueTask): chains an async unit-shaped step from a value-bearing success.</summary>
     public static async ValueTask<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, ValueTask<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
-        if (result.IsFailure) return Result.Fail(result.Error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return Result.Fail(result.Error);
+        }
+
         var output = await func(result.Value).ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and chains an async unit-shaped step (ValueTask) from a value-bearing success.</summary>
     public static async ValueTask<Result> BindAsync<TIn>(this ValueTask<Result<TIn>> resultTask, Func<TIn, ValueTask<Result>> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
@@ -265,6 +380,7 @@ public static class ResultBindExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultTapExtensions
 {
+    /// <summary>Invokes <paramref name="action"/> if the result is a success; returns the result unchanged.</summary>
     public static Result Tap(this Result result, Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
@@ -279,12 +395,15 @@ public static class ResultTapExtensions
 [DebuggerStepThrough]
 public static class ResultTapExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes <paramref name="action"/> on success.</summary>
     public static async Task<Result> TapAsync(this Task<Result> resultTask, Action action)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(action);
         return (await resultTask.ConfigureAwait(false)).Tap(action);
     }
 
+    /// <summary>Invokes async <paramref name="func"/> on success; returns the result unchanged.</summary>
     public static async Task<Result> TapAsync(this Result result, Func<Task> func)
     {
         ArgumentNullException.ThrowIfNull(func);
@@ -294,16 +413,23 @@ public static class ResultTapExtensionsAsync
         return result;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes async <paramref name="func"/> on success.</summary>
     public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes <paramref name="action"/> on success.</summary>
     public static async ValueTask<Result> TapAsync(this ValueTask<Result> resultTask, Action action)
-        => (await resultTask.ConfigureAwait(false)).Tap(action);
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return (await resultTask.ConfigureAwait(false)).Tap(action);
+    }
 
+    /// <summary>Invokes async <paramref name="func"/> on success (ValueTask); returns the result unchanged.</summary>
     public static async ValueTask<Result> TapAsync(this Result result, Func<ValueTask> func)
     {
         ArgumentNullException.ThrowIfNull(func);
@@ -313,8 +439,10 @@ public static class ResultTapExtensionsAsync
         return result;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes async <paramref name="func"/> on success (ValueTask).</summary>
     public static async ValueTask<Result> TapAsync(this ValueTask<Result> resultTask, Func<ValueTask> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapAsync(func).ConfigureAwait(false);
     }
@@ -328,6 +456,7 @@ public static class ResultTapExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultTapErrorExtensions
 {
+    /// <summary>Invokes <paramref name="action"/> with the error if the result is a failure; returns the result unchanged.</summary>
     public static Result TapError(this Result result, Action<Error> action)
     {
         ArgumentNullException.ThrowIfNull(action);
@@ -342,12 +471,15 @@ public static class ResultTapErrorExtensions
 [DebuggerStepThrough]
 public static class ResultTapErrorExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes <paramref name="action"/> on failure.</summary>
     public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Action<Error> action)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(action);
         return (await resultTask.ConfigureAwait(false)).TapError(action);
     }
 
+    /// <summary>Invokes async <paramref name="func"/> with the error on failure; returns the result unchanged.</summary>
     public static async Task<Result> TapErrorAsync(this Result result, Func<Error, Task> func)
     {
         ArgumentNullException.ThrowIfNull(func);
@@ -357,16 +489,23 @@ public static class ResultTapErrorExtensionsAsync
         return result;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes async <paramref name="func"/> on failure.</summary>
     public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<Error, Task> func)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapErrorAsync(func).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes <paramref name="action"/> on failure.</summary>
     public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Action<Error> action)
-        => (await resultTask.ConfigureAwait(false)).TapError(action);
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return (await resultTask.ConfigureAwait(false)).TapError(action);
+    }
 
+    /// <summary>Invokes async <paramref name="func"/> with the error on failure (ValueTask); returns the result unchanged.</summary>
     public static async ValueTask<Result> TapErrorAsync(this Result result, Func<Error, ValueTask> func)
     {
         ArgumentNullException.ThrowIfNull(func);
@@ -376,8 +515,10 @@ public static class ResultTapErrorExtensionsAsync
         return result;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and invokes async <paramref name="func"/> on failure (ValueTask).</summary>
     public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<Error, ValueTask> func)
     {
+        ArgumentNullException.ThrowIfNull(func);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapErrorAsync(func).ConfigureAwait(false);
     }
@@ -391,13 +532,21 @@ public static class ResultTapErrorExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultEnsureExtensions
 {
+    /// <summary>Returns success if the predicate holds; otherwise a failure with <paramref name="error"/>. Failure short-circuits.</summary>
     public static Result Ensure(this Result result, Func<bool> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(predicate);
         ArgumentNullException.ThrowIfNull(error);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Ensure));
-        if (result.IsFailure) return result;
-        return predicate() ? Result.Ok() : Result.Fail(error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var output = predicate() ? Result.Ok() : Result.Fail(error);
+        output.LogActivityStatus();
+        return output;
     }
 }
 
@@ -405,42 +554,72 @@ public static class ResultEnsureExtensions
 [DebuggerStepThrough]
 public static class ResultEnsureExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and applies <see cref="ResultEnsureExtensions.Ensure"/>.</summary>
     public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<bool> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
         return (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
     }
 
+    /// <summary>Returns success if the async predicate holds; otherwise a failure with <paramref name="error"/>. Failure short-circuits.</summary>
     public static async Task<Result> EnsureAsync(this Result result, Func<Task<bool>> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(predicate);
         ArgumentNullException.ThrowIfNull(error);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultEnsureExtensions.Ensure));
-        if (result.IsFailure) return result;
-        return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var output = await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+        output.LogActivityStatus();
+        return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies the async predicate gate.</summary>
     public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<Task<bool>> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
         var result = await resultTask.ConfigureAwait(false);
         return await result.EnsureAsync(predicate, error).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies <see cref="ResultEnsureExtensions.Ensure"/>.</summary>
     public static async ValueTask<Result> EnsureAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Error error)
-        => (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
+        return (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+    }
 
+    /// <summary>Returns success if the async predicate (ValueTask) holds; otherwise a failure. Failure short-circuits.</summary>
     public static async ValueTask<Result> EnsureAsync(this Result result, Func<ValueTask<bool>> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(predicate);
         ArgumentNullException.ThrowIfNull(error);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultEnsureExtensions.Ensure));
-        if (result.IsFailure) return result;
-        return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+        if (result.IsFailure)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
+        var output = await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+        output.LogActivityStatus();
+        return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies the async predicate gate (ValueTask).</summary>
     public static async ValueTask<Result> EnsureAsync(this ValueTask<Result> resultTask, Func<ValueTask<bool>> predicate, Error error)
     {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
         var result = await resultTask.ConfigureAwait(false);
         return await result.EnsureAsync(predicate, error).ConfigureAwait(false);
     }
@@ -454,6 +633,7 @@ public static class ResultEnsureExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultMatchExtensions
 {
+    /// <summary>Collapses to a value: invokes <paramref name="onSuccess"/> on success, <paramref name="onFailure"/> on failure.</summary>
     public static TOut Match<TOut>(this Result result, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
     {
         ArgumentNullException.ThrowIfNull(onSuccess);
@@ -461,6 +641,7 @@ public static class ResultMatchExtensions
         return result.IsFailure ? onFailure(result.Error) : onSuccess();
     }
 
+    /// <summary>Collapses to side effects: invokes <paramref name="onSuccess"/> on success, <paramref name="onFailure"/> on failure.</summary>
     public static void Match(this Result result, Action onSuccess, Action<Error> onFailure)
     {
         ArgumentNullException.ThrowIfNull(onSuccess);
@@ -473,12 +654,16 @@ public static class ResultMatchExtensions
 [DebuggerStepThrough]
 public static class ResultMatchExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and collapses to a value via the appropriate handler.</summary>
     public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
         return (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
     }
 
+    /// <summary>Collapses to a value via async handlers.</summary>
     public static async Task<TOut> MatchAsync<TOut>(this Result result, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
     {
         ArgumentNullException.ThrowIfNull(onSuccess);
@@ -488,16 +673,25 @@ public static class ResultMatchExtensionsAsync
             : await onSuccess().ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and collapses to a value via async handlers.</summary>
     public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and collapses to a value via the appropriate handler.</summary>
     public static async ValueTask<TOut> MatchAsync<TOut>(this ValueTask<Result> resultTask, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
-        => (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+        return (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+    }
 
+    /// <summary>Collapses to a value via async handlers (ValueTask).</summary>
     public static async ValueTask<TOut> MatchAsync<TOut>(this Result result, Func<ValueTask<TOut>> onSuccess, Func<Error, ValueTask<TOut>> onFailure)
     {
         ArgumentNullException.ThrowIfNull(onSuccess);
@@ -507,8 +701,11 @@ public static class ResultMatchExtensionsAsync
             : await onSuccess().ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and collapses to a value via async handlers (ValueTask).</summary>
     public static async ValueTask<TOut> MatchAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<TOut>> onSuccess, Func<Error, ValueTask<TOut>> onFailure)
     {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
     }
@@ -522,11 +719,17 @@ public static class ResultMatchExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultRecoverExtensions
 {
+    /// <summary>Replaces a failure with the result of <paramref name="recovery"/>; success passes through unchanged.</summary>
     public static Result Recover(this Result result, Func<Error, Result> recovery)
     {
         ArgumentNullException.ThrowIfNull(recovery);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Recover));
-        if (result.IsSuccess) return result;
+        if (result.IsSuccess)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = recovery(result.Error);
         output.LogActivityStatus();
         return output;
@@ -537,44 +740,66 @@ public static class ResultRecoverExtensions
 [DebuggerStepThrough]
 public static class ResultRecoverExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and applies <see cref="ResultRecoverExtensions.Recover"/>.</summary>
     public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Result> recovery)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(recovery);
         return (await resultTask.ConfigureAwait(false)).Recover(recovery);
     }
 
+    /// <summary>Replaces a failure with the result of an async <paramref name="recovery"/>; success passes through unchanged.</summary>
     public static async Task<Result> RecoverAsync(this Result result, Func<Error, Task<Result>> recovery)
     {
         ArgumentNullException.ThrowIfNull(recovery);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultRecoverExtensions.Recover));
-        if (result.IsSuccess) return result;
+        if (result.IsSuccess)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = await recovery(result.Error).ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies an async recovery.</summary>
     public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Task<Result>> recovery)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(recovery);
         var result = await resultTask.ConfigureAwait(false);
         return await result.RecoverAsync(recovery).ConfigureAwait(false);
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies <see cref="ResultRecoverExtensions.Recover"/>.</summary>
     public static async ValueTask<Result> RecoverAsync(this ValueTask<Result> resultTask, Func<Error, Result> recovery)
-        => (await resultTask.ConfigureAwait(false)).Recover(recovery);
+    {
+        ArgumentNullException.ThrowIfNull(recovery);
+        return (await resultTask.ConfigureAwait(false)).Recover(recovery);
+    }
 
+    /// <summary>Replaces a failure with the result of an async <paramref name="recovery"/> (ValueTask); success passes through unchanged.</summary>
     public static async ValueTask<Result> RecoverAsync(this Result result, Func<Error, ValueTask<Result>> recovery)
     {
         ArgumentNullException.ThrowIfNull(recovery);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultRecoverExtensions.Recover));
-        if (result.IsSuccess) return result;
+        if (result.IsSuccess)
+        {
+            result.LogActivityStatus();
+            return result;
+        }
+
         var output = await recovery(result.Error).ConfigureAwait(false);
         output.LogActivityStatus();
         return output;
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and applies an async recovery (ValueTask).</summary>
     public static async ValueTask<Result> RecoverAsync(this ValueTask<Result> resultTask, Func<Error, ValueTask<Result>> recovery)
     {
+        ArgumentNullException.ThrowIfNull(recovery);
         var result = await resultTask.ConfigureAwait(false);
         return await result.RecoverAsync(recovery).ConfigureAwait(false);
     }
@@ -588,12 +813,14 @@ public static class ResultRecoverExtensionsAsync
 [DebuggerStepThrough]
 public static class ResultAsUnitExtensionsAsync
 {
+    /// <summary>Awaits <paramref name="resultTask"/> and discards its value, producing a non-generic <see cref="Result"/>.</summary>
     public static async Task<Result> AsUnitAsync<T>(this Task<Result<T>> resultTask)
     {
         ArgumentNullException.ThrowIfNull(resultTask);
         return (await resultTask.ConfigureAwait(false)).AsUnit();
     }
 
+    /// <summary>Awaits <paramref name="resultTask"/> and discards its value, producing a non-generic <see cref="Result"/>.</summary>
     public static async ValueTask<Result> AsUnitAsync<T>(this ValueTask<Result<T>> resultTask)
         => (await resultTask.ConfigureAwait(false)).AsUnit();
 }

--- a/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
+++ b/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
@@ -1,0 +1,546 @@
+namespace Trellis;
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1591 // Missing XML comment — overload-heavy mirror file; one summary per region documents intent.
+
+// =============================================================================
+// Pipeline verb extensions for the non-generic Result.
+//
+// This file mirrors the seven pipeline verbs (Map, Bind, Tap, TapError, Ensure,
+// Match, Recover) plus Try and a small set of cross-shape helpers, but for the
+// non-generic Result that replaces Result<Unit>. It is deliberately a single
+// file rather than the per-verb / per-async-shape split that Result<T> uses,
+// because:
+//   1. The unit shape has no value to project, so Map/Bind/Tap/Ensure/Recover
+//      collapse to a much smaller set of overloads (no Func<T, …> shape).
+//   2. Co-locating the unit-Result surface keeps the migration auditable.
+//
+// Async overload model mirrors §3.3 of the v2 redesign plan: 6 overloads per
+// verb covering Sync/Task/ValueTask × sync/async function. Mixing Task and
+// ValueTask requires explicit conversion (deliberate constraint).
+// =============================================================================
+
+#region Map (unit → value)
+
+/// <summary>Map for the non-generic <see cref="Result"/>: projects a successful unit-result into a value-bearing result.</summary>
+[DebuggerStepThrough]
+public static class ResultMapExtensions
+{
+    /// <summary>Maps a successful <see cref="Result"/> to a value via <paramref name="func"/>; failure propagates unchanged.</summary>
+    public static Result<TOut> Map<TOut>(this Result result, Func<TOut> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Map));
+        return result.IsFailure ? Result.Fail<TOut>(result.Error) : Result.Ok(func());
+    }
+}
+
+/// <summary>Async Map for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultMapExtensionsAsync
+{
+    public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<TOut> func)
+        => (await resultTask.ConfigureAwait(false)).Map(func);
+
+    public static async ValueTask<Result<TOut>> MapAsync<TOut>(this ValueTask<Result> resultTask, Func<TOut> func)
+        => (await resultTask.ConfigureAwait(false)).Map(func);
+
+    public static async Task<Result<TOut>> MapAsync<TOut>(this Result result, Func<Task<TOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        return Result.Ok(await func().ConfigureAwait(false));
+    }
+
+    public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TOut>> MapAsync<TOut>(this Result result, Func<ValueTask<TOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        return Result.Ok(await func().ConfigureAwait(false));
+    }
+
+    public static async ValueTask<Result<TOut>> MapAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<TOut>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region Bind (unit → unit, unit → value, value → unit)
+
+/// <summary>Bind for the non-generic <see cref="Result"/>, including cross-shape forms.</summary>
+[DebuggerStepThrough]
+public static class ResultBindExtensions
+{
+    /// <summary>Chains another non-generic <see cref="Result"/>-returning step. Failure short-circuits.</summary>
+    public static Result Bind(this Result result, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
+        if (result.IsFailure) return result;
+        var output = func();
+        output.LogActivityStatus();
+        return output;
+    }
+
+    /// <summary>Chains a value-producing step from a unit-shaped success.</summary>
+    public static Result<TOut> Bind<TOut>(this Result result, Func<Result<TOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
+        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        var output = func();
+        output.LogActivityStatus();
+        return output;
+    }
+
+    /// <summary>Cross-shape: discards the value of a value-bearing result and chains a unit-shaped step.</summary>
+    public static Result Bind<TIn>(this Result<TIn> result, Func<TIn, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Bind));
+        if (result.IsFailure) return Result.Fail(result.Error);
+        var output = func(result.Value);
+        output.LogActivityStatus();
+        return output;
+    }
+}
+
+/// <summary>Async Bind for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultBindExtensionsAsync
+{
+    // unit → unit
+    public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Result> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async Task<Result> BindAsync(this Result result, Func<Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return result;
+        var output = await func().ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Task<Result>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> BindAsync(this ValueTask<Result> resultTask, Func<Result> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async ValueTask<Result> BindAsync(this Result result, Func<ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return result;
+        var output = await func().ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async ValueTask<Result> BindAsync(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+
+    // unit → value
+    public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Result<TOut>> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async Task<Result<TOut>> BindAsync<TOut>(this Result result, Func<Task<Result<TOut>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        var output = await func().ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Task<Result<TOut>>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TOut>> BindAsync<TOut>(this ValueTask<Result> resultTask, Func<Result<TOut>> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async ValueTask<Result<TOut>> BindAsync<TOut>(this Result result, Func<ValueTask<Result<TOut>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail<TOut>(result.Error);
+        var output = await func().ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async ValueTask<Result<TOut>> BindAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<Result<TOut>>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+
+    // value → unit (cross-shape)
+    public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Result> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async Task<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail(result.Error);
+        var output = await func(result.Value).ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Task<Result>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> BindAsync<TIn>(this ValueTask<Result<TIn>> resultTask, Func<TIn, Result> func)
+        => (await resultTask.ConfigureAwait(false)).Bind(func);
+
+    public static async ValueTask<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) return Result.Fail(result.Error);
+        var output = await func(result.Value).ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async ValueTask<Result> BindAsync<TIn>(this ValueTask<Result<TIn>> resultTask, Func<TIn, ValueTask<Result>> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindAsync(func).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region Tap (success-side side effect)
+
+/// <summary>Tap for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultTapExtensions
+{
+    public static Result Tap(this Result result, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Tap));
+        if (result.IsSuccess) action();
+        result.LogActivityStatus();
+        return result;
+    }
+}
+
+/// <summary>Async Tap for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultTapExtensionsAsync
+{
+    public static async Task<Result> TapAsync(this Task<Result> resultTask, Action action)
+        => (await resultTask.ConfigureAwait(false)).Tap(action);
+
+    public static async Task<Result> TapAsync(this Result result, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsSuccess) await func().ConfigureAwait(false);
+        result.LogActivityStatus();
+        return result;
+    }
+
+    public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> TapAsync(this ValueTask<Result> resultTask, Action action)
+        => (await resultTask.ConfigureAwait(false)).Tap(action);
+
+    public static async ValueTask<Result> TapAsync(this Result result, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsSuccess) await func().ConfigureAwait(false);
+        result.LogActivityStatus();
+        return result;
+    }
+
+    public static async ValueTask<Result> TapAsync(this ValueTask<Result> resultTask, Func<ValueTask> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapAsync(func).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region TapError (failure-side side effect)
+
+/// <summary>TapError for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultTapErrorExtensions
+{
+    public static Result TapError(this Result result, Action<Error> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(TapError));
+        if (result.IsFailure) action(result.Error);
+        result.LogActivityStatus();
+        return result;
+    }
+}
+
+/// <summary>Async TapError for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultTapErrorExtensionsAsync
+{
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Action<Error> action)
+        => (await resultTask.ConfigureAwait(false)).TapError(action);
+
+    public static async Task<Result> TapErrorAsync(this Result result, Func<Error, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) await func(result.Error).ConfigureAwait(false);
+        result.LogActivityStatus();
+        return result;
+    }
+
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<Error, Task> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Action<Error> action)
+        => (await resultTask.ConfigureAwait(false)).TapError(action);
+
+    public static async ValueTask<Result> TapErrorAsync(this Result result, Func<Error, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (result.IsFailure) await func(result.Error).ConfigureAwait(false);
+        result.LogActivityStatus();
+        return result;
+    }
+
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<Error, ValueTask> func)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region Ensure (predicate gate, instance-shape on Result)
+
+/// <summary>Ensure for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultEnsureExtensions
+{
+    public static Result Ensure(this Result result, Func<bool> predicate, Error error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Ensure));
+        if (result.IsFailure) return result;
+        return predicate() ? Result.Ok() : Result.Fail(error);
+    }
+}
+
+/// <summary>Async Ensure for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultEnsureExtensionsAsync
+{
+    public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<bool> predicate, Error error)
+        => (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+
+    public static async Task<Result> EnsureAsync(this Result result, Func<Task<bool>> predicate, Error error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
+        if (result.IsFailure) return result;
+        return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+    }
+
+    public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<Task<bool>> predicate, Error error)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.EnsureAsync(predicate, error).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> EnsureAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Error error)
+        => (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+
+    public static async ValueTask<Result> EnsureAsync(this Result result, Func<ValueTask<bool>> predicate, Error error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(error);
+        if (result.IsFailure) return result;
+        return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
+    }
+
+    public static async ValueTask<Result> EnsureAsync(this ValueTask<Result> resultTask, Func<ValueTask<bool>> predicate, Error error)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.EnsureAsync(predicate, error).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region Match (collapse to a single value)
+
+/// <summary>Match for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultMatchExtensions
+{
+    public static TOut Match<TOut>(this Result result, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+        return result.IsFailure ? onFailure(result.Error) : onSuccess();
+    }
+
+    public static void Match(this Result result, Action onSuccess, Action<Error> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+        if (result.IsFailure) onFailure(result.Error); else onSuccess();
+    }
+}
+
+/// <summary>Async Match for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultMatchExtensionsAsync
+{
+    public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
+        => (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+
+    public static async Task<TOut> MatchAsync<TOut>(this Result result, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+        return result.IsFailure
+            ? await onFailure(result.Error).ConfigureAwait(false)
+            : await onSuccess().ConfigureAwait(false);
+    }
+
+    public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<TOut> MatchAsync<TOut>(this ValueTask<Result> resultTask, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
+        => (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+
+    public static async ValueTask<TOut> MatchAsync<TOut>(this Result result, Func<ValueTask<TOut>> onSuccess, Func<Error, ValueTask<TOut>> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+        return result.IsFailure
+            ? await onFailure(result.Error).ConfigureAwait(false)
+            : await onSuccess().ConfigureAwait(false);
+    }
+
+    public static async ValueTask<TOut> MatchAsync<TOut>(this ValueTask<Result> resultTask, Func<ValueTask<TOut>> onSuccess, Func<Error, ValueTask<TOut>> onFailure)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region Recover (failure → success)
+
+/// <summary>Recover for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultRecoverExtensions
+{
+    public static Result Recover(this Result result, Func<Error, Result> recovery)
+    {
+        ArgumentNullException.ThrowIfNull(recovery);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(Recover));
+        if (result.IsSuccess) return result;
+        var output = recovery(result.Error);
+        output.LogActivityStatus();
+        return output;
+    }
+}
+
+/// <summary>Async Recover for the non-generic <see cref="Result"/>.</summary>
+[DebuggerStepThrough]
+public static class ResultRecoverExtensionsAsync
+{
+    public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Result> recovery)
+        => (await resultTask.ConfigureAwait(false)).Recover(recovery);
+
+    public static async Task<Result> RecoverAsync(this Result result, Func<Error, Task<Result>> recovery)
+    {
+        ArgumentNullException.ThrowIfNull(recovery);
+        if (result.IsSuccess) return result;
+        var output = await recovery(result.Error).ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Task<Result>> recovery)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.RecoverAsync(recovery).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> RecoverAsync(this ValueTask<Result> resultTask, Func<Error, Result> recovery)
+        => (await resultTask.ConfigureAwait(false)).Recover(recovery);
+
+    public static async ValueTask<Result> RecoverAsync(this Result result, Func<Error, ValueTask<Result>> recovery)
+    {
+        ArgumentNullException.ThrowIfNull(recovery);
+        if (result.IsSuccess) return result;
+        var output = await recovery(result.Error).ConfigureAwait(false);
+        output.LogActivityStatus();
+        return output;
+    }
+
+    public static async ValueTask<Result> RecoverAsync(this ValueTask<Result> resultTask, Func<Error, ValueTask<Result>> recovery)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.RecoverAsync(recovery).ConfigureAwait(false);
+    }
+}
+
+#endregion
+
+#region AsUnit (cross-shape async wrappers)
+
+/// <summary>Async <see cref="Result{TValue}.AsUnit"/> wrappers.</summary>
+[DebuggerStepThrough]
+public static class ResultAsUnitExtensionsAsync
+{
+    public static async Task<Result> AsUnitAsync<T>(this Task<Result<T>> resultTask)
+        => (await resultTask.ConfigureAwait(false)).AsUnit();
+
+    public static async ValueTask<Result> AsUnitAsync<T>(this ValueTask<Result<T>> resultTask)
+        => (await resultTask.ConfigureAwait(false)).AsUnit();
+}
+
+#endregion

--- a/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
+++ b/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System;
 using System.Diagnostics;
@@ -51,6 +51,7 @@ public static class ResultMapExtensionsAsync
     public static async Task<Result<TOut>> MapAsync<TOut>(this Result result, Func<Task<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultMapExtensions.Map));
         if (result.IsFailure) return Result.Fail<TOut>(result.Error);
         return Result.Ok(await func().ConfigureAwait(false));
     }
@@ -64,6 +65,7 @@ public static class ResultMapExtensionsAsync
     public static async ValueTask<Result<TOut>> MapAsync<TOut>(this Result result, Func<ValueTask<TOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultMapExtensions.Map));
         if (result.IsFailure) return Result.Fail<TOut>(result.Error);
         return Result.Ok(await func().ConfigureAwait(false));
     }
@@ -128,6 +130,7 @@ public static class ResultBindExtensionsAsync
     public static async Task<Result> BindAsync(this Result result, Func<Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return result;
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
@@ -146,6 +149,7 @@ public static class ResultBindExtensionsAsync
     public static async ValueTask<Result> BindAsync(this Result result, Func<ValueTask<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return result;
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
@@ -165,6 +169,7 @@ public static class ResultBindExtensionsAsync
     public static async Task<Result<TOut>> BindAsync<TOut>(this Result result, Func<Task<Result<TOut>>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return Result.Fail<TOut>(result.Error);
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
@@ -183,6 +188,7 @@ public static class ResultBindExtensionsAsync
     public static async ValueTask<Result<TOut>> BindAsync<TOut>(this Result result, Func<ValueTask<Result<TOut>>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return Result.Fail<TOut>(result.Error);
         var output = await func().ConfigureAwait(false);
         output.LogActivityStatus();
@@ -202,6 +208,7 @@ public static class ResultBindExtensionsAsync
     public static async Task<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, Task<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return Result.Fail(result.Error);
         var output = await func(result.Value).ConfigureAwait(false);
         output.LogActivityStatus();
@@ -220,6 +227,7 @@ public static class ResultBindExtensionsAsync
     public static async ValueTask<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, ValueTask<Result>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultBindExtensions.Bind));
         if (result.IsFailure) return Result.Fail(result.Error);
         var output = await func(result.Value).ConfigureAwait(false);
         output.LogActivityStatus();
@@ -261,6 +269,7 @@ public static class ResultTapExtensionsAsync
     public static async Task<Result> TapAsync(this Result result, Func<Task> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultTapExtensions.Tap));
         if (result.IsSuccess) await func().ConfigureAwait(false);
         result.LogActivityStatus();
         return result;
@@ -278,6 +287,7 @@ public static class ResultTapExtensionsAsync
     public static async ValueTask<Result> TapAsync(this Result result, Func<ValueTask> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultTapExtensions.Tap));
         if (result.IsSuccess) await func().ConfigureAwait(false);
         result.LogActivityStatus();
         return result;
@@ -318,6 +328,7 @@ public static class ResultTapErrorExtensionsAsync
     public static async Task<Result> TapErrorAsync(this Result result, Func<Error, Task> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultTapErrorExtensions.TapError));
         if (result.IsFailure) await func(result.Error).ConfigureAwait(false);
         result.LogActivityStatus();
         return result;
@@ -335,6 +346,7 @@ public static class ResultTapErrorExtensionsAsync
     public static async ValueTask<Result> TapErrorAsync(this Result result, Func<Error, ValueTask> func)
     {
         ArgumentNullException.ThrowIfNull(func);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultTapErrorExtensions.TapError));
         if (result.IsFailure) await func(result.Error).ConfigureAwait(false);
         result.LogActivityStatus();
         return result;
@@ -376,6 +388,7 @@ public static class ResultEnsureExtensionsAsync
     {
         ArgumentNullException.ThrowIfNull(predicate);
         ArgumentNullException.ThrowIfNull(error);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultEnsureExtensions.Ensure));
         if (result.IsFailure) return result;
         return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
     }
@@ -393,6 +406,7 @@ public static class ResultEnsureExtensionsAsync
     {
         ArgumentNullException.ThrowIfNull(predicate);
         ArgumentNullException.ThrowIfNull(error);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultEnsureExtensions.Ensure));
         if (result.IsFailure) return result;
         return await predicate().ConfigureAwait(false) ? Result.Ok() : Result.Fail(error);
     }
@@ -497,6 +511,7 @@ public static class ResultRecoverExtensionsAsync
     public static async Task<Result> RecoverAsync(this Result result, Func<Error, Task<Result>> recovery)
     {
         ArgumentNullException.ThrowIfNull(recovery);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultRecoverExtensions.Recover));
         if (result.IsSuccess) return result;
         var output = await recovery(result.Error).ConfigureAwait(false);
         output.LogActivityStatus();
@@ -515,6 +530,7 @@ public static class ResultRecoverExtensionsAsync
     public static async ValueTask<Result> RecoverAsync(this Result result, Func<Error, ValueTask<Result>> recovery)
     {
         ArgumentNullException.ThrowIfNull(recovery);
+        using var activity = RopTrace.ActivitySource.StartActivity(nameof(ResultRecoverExtensions.Recover));
         if (result.IsSuccess) return result;
         var output = await recovery(result.Error).ConfigureAwait(false);
         output.LogActivityStatus();

--- a/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
+++ b/Trellis.Results/src/Result/Extensions/Result.NonGeneric.Extensions.cs
@@ -43,7 +43,10 @@ public static class ResultMapExtensions
 public static class ResultMapExtensionsAsync
 {
     public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<TOut> func)
-        => (await resultTask.ConfigureAwait(false)).Map(func);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Map(func);
+    }
 
     public static async ValueTask<Result<TOut>> MapAsync<TOut>(this ValueTask<Result> resultTask, Func<TOut> func)
         => (await resultTask.ConfigureAwait(false)).Map(func);
@@ -58,6 +61,7 @@ public static class ResultMapExtensionsAsync
 
     public static async Task<Result<TOut>> MapAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MapAsync(func).ConfigureAwait(false);
     }
@@ -125,7 +129,10 @@ public static class ResultBindExtensionsAsync
 {
     // unit → unit
     public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Result> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
     public static async Task<Result> BindAsync(this Result result, Func<Task<Result>> func)
     {
@@ -139,6 +146,7 @@ public static class ResultBindExtensionsAsync
 
     public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Task<Result>> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
@@ -164,7 +172,10 @@ public static class ResultBindExtensionsAsync
 
     // unit → value
     public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Result<TOut>> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
     public static async Task<Result<TOut>> BindAsync<TOut>(this Result result, Func<Task<Result<TOut>>> func)
     {
@@ -178,6 +189,7 @@ public static class ResultBindExtensionsAsync
 
     public static async Task<Result<TOut>> BindAsync<TOut>(this Task<Result> resultTask, Func<Task<Result<TOut>>> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
@@ -203,7 +215,10 @@ public static class ResultBindExtensionsAsync
 
     // value → unit (cross-shape)
     public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Result> func)
-        => (await resultTask.ConfigureAwait(false)).Bind(func);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Bind(func);
+    }
 
     public static async Task<Result> BindAsync<TIn>(this Result<TIn> result, Func<TIn, Task<Result>> func)
     {
@@ -217,6 +232,7 @@ public static class ResultBindExtensionsAsync
 
     public static async Task<Result> BindAsync<TIn>(this Task<Result<TIn>> resultTask, Func<TIn, Task<Result>> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.BindAsync(func).ConfigureAwait(false);
     }
@@ -264,7 +280,10 @@ public static class ResultTapExtensions
 public static class ResultTapExtensionsAsync
 {
     public static async Task<Result> TapAsync(this Task<Result> resultTask, Action action)
-        => (await resultTask.ConfigureAwait(false)).Tap(action);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Tap(action);
+    }
 
     public static async Task<Result> TapAsync(this Result result, Func<Task> func)
     {
@@ -277,6 +296,7 @@ public static class ResultTapExtensionsAsync
 
     public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapAsync(func).ConfigureAwait(false);
     }
@@ -323,7 +343,10 @@ public static class ResultTapErrorExtensions
 public static class ResultTapErrorExtensionsAsync
 {
     public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Action<Error> action)
-        => (await resultTask.ConfigureAwait(false)).TapError(action);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).TapError(action);
+    }
 
     public static async Task<Result> TapErrorAsync(this Result result, Func<Error, Task> func)
     {
@@ -336,6 +359,7 @@ public static class ResultTapErrorExtensionsAsync
 
     public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<Error, Task> func)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.TapErrorAsync(func).ConfigureAwait(false);
     }
@@ -382,7 +406,10 @@ public static class ResultEnsureExtensions
 public static class ResultEnsureExtensionsAsync
 {
     public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<bool> predicate, Error error)
-        => (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Ensure(predicate, error);
+    }
 
     public static async Task<Result> EnsureAsync(this Result result, Func<Task<bool>> predicate, Error error)
     {
@@ -395,6 +422,7 @@ public static class ResultEnsureExtensionsAsync
 
     public static async Task<Result> EnsureAsync(this Task<Result> resultTask, Func<Task<bool>> predicate, Error error)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.EnsureAsync(predicate, error).ConfigureAwait(false);
     }
@@ -446,7 +474,10 @@ public static class ResultMatchExtensions
 public static class ResultMatchExtensionsAsync
 {
     public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<TOut> onSuccess, Func<Error, TOut> onFailure)
-        => (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Match(onSuccess, onFailure);
+    }
 
     public static async Task<TOut> MatchAsync<TOut>(this Result result, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
     {
@@ -459,6 +490,7 @@ public static class ResultMatchExtensionsAsync
 
     public static async Task<TOut> MatchAsync<TOut>(this Task<Result> resultTask, Func<Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.MatchAsync(onSuccess, onFailure).ConfigureAwait(false);
     }
@@ -506,7 +538,10 @@ public static class ResultRecoverExtensions
 public static class ResultRecoverExtensionsAsync
 {
     public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Result> recovery)
-        => (await resultTask.ConfigureAwait(false)).Recover(recovery);
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).Recover(recovery);
+    }
 
     public static async Task<Result> RecoverAsync(this Result result, Func<Error, Task<Result>> recovery)
     {
@@ -520,6 +555,7 @@ public static class ResultRecoverExtensionsAsync
 
     public static async Task<Result> RecoverAsync(this Task<Result> resultTask, Func<Error, Task<Result>> recovery)
     {
+        ArgumentNullException.ThrowIfNull(resultTask);
         var result = await resultTask.ConfigureAwait(false);
         return await result.RecoverAsync(recovery).ConfigureAwait(false);
     }
@@ -553,7 +589,10 @@ public static class ResultRecoverExtensionsAsync
 public static class ResultAsUnitExtensionsAsync
 {
     public static async Task<Result> AsUnitAsync<T>(this Task<Result<T>> resultTask)
-        => (await resultTask.ConfigureAwait(false)).AsUnit();
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        return (await resultTask.ConfigureAwait(false)).AsUnit();
+    }
 
     public static async ValueTask<Result> AsUnitAsync<T>(this ValueTask<Result<T>> resultTask)
         => (await resultTask.ConfigureAwait(false)).AsUnit();

--- a/Trellis.Results/src/Result/Extensions/Traverse.cs
+++ b/Trellis.Results/src/Result/Extensions/Traverse.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System.Diagnostics;
 

--- a/Trellis.Results/src/Result/Extensions/Traverse.cs
+++ b/Trellis.Results/src/Result/Extensions/Traverse.cs
@@ -207,4 +207,32 @@ public static class TraverseExtensions
 
         return Result.Ok<IReadOnlyList<TOut>>(results);
     }
+
+    /// <summary>
+    /// Asynchronously transforms a collection of items using a non-generic Result selector.
+    /// Short-circuits on the first failure. Returns a non-generic Result (no collected values).
+    /// </summary>
+    public static async Task<Result> TraverseAsync<TIn>(
+        this IEnumerable<TIn> source,
+        Func<TIn, CancellationToken, Task<Result>> selector,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(selector);
+
+        using var activity = RopTrace.ActivitySource.StartActivity();
+
+        foreach (var item in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = await selector(item, cancellationToken).ConfigureAwait(false);
+            if (result.IsFailure)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                return Result.Fail(result.Error);
+            }
+        }
+
+        return Result.Ok();
+    }
 }

--- a/Trellis.Results/src/Result/Result.cs
+++ b/Trellis.Results/src/Result/Result.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System;
 using System.Diagnostics;
@@ -142,7 +142,12 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     /// <summary>
     /// Creates a successful non-generic <see cref="Result"/> (no payload).
     /// </summary>
-    public static Result Ok() => default;
+    /// <remarks>
+    /// Goes through the constructor so that <see cref="Activity.Current"/> receives the success status,
+    /// matching the tracing behavior of <see cref="Ok{TValue}(TValue)"/>. Note that <c>default(Result)</c>
+    /// is still a valid success value (per the §3.5.1 default-state invariant) but will not tag any active activity.
+    /// </remarks>
+    public static Result Ok() => new(false, null);
 
     /// <summary>
     /// Creates a failed non-generic <see cref="Result"/> with the specified <paramref name="error"/>.

--- a/Trellis.Results/src/Result/Result.cs
+++ b/Trellis.Results/src/Result/Result.cs
@@ -1,54 +1,158 @@
 namespace Trellis;
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 /// <summary>
-/// Non-generic Result utility host containing factory and helper methods to construct <see cref="Result{TValue}"/> instances.
-/// NOTE: This struct is not intended to be instantiated; all members are static.
+/// Represents the outcome of an operation that has no success payload — either success or failure with an <see cref="Error"/>.
 /// </summary>
-public readonly partial struct Result
+/// <remarks>
+/// <para>
+/// Non-generic <see cref="Result"/> is the v2 replacement for <c>Result&lt;Unit&gt;</c>. Use it for operations that
+/// either succeed (no value) or fail (with an <see cref="Error"/>). The default value (<c>default(Result)</c>)
+/// represents success — matching the default-state invariant of <see cref="Result{TValue}"/>.
+/// </para>
+/// <para>
+/// This struct also hosts factory and helper methods to construct both <see cref="Result"/> and <see cref="Result{TValue}"/>
+/// instances (e.g. <see cref="Ok()"/>, <see cref="Fail(Error)"/>, <see cref="Ok{TValue}(TValue)"/>, <see cref="Try{T}(Func{T}, Func{Exception, Error}?)"/>).
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Error = {(_error is null ? \"<none>\" : _error.Code)}")]
+public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFactory<Result>
 {
+    private readonly Error? _error;
+
+    /// <summary>True when the result represents success.</summary>
+    public bool IsSuccess => !IsFailure;
+
+    /// <summary>True when the result represents failure.</summary>
+    public bool IsFailure { get; }
+
+    internal Result(bool isFailure, Error? error)
+    {
+        if (isFailure)
+        {
+            if (error is null)
+                throw new ArgumentException("If 'isFailure' is true, 'error' must not be null.", nameof(error));
+        }
+        else
+        {
+            if (error is not null)
+                throw new ArgumentException("If 'isFailure' is false, 'error' must be null.", nameof(error));
+        }
+
+        IsFailure = isFailure;
+        _error = error;
+
+        Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+
+        if (IsFailure && Activity.Current is { } act && error is not null)
+        {
+            act.SetTag("result.error.code", error.Code);
+        }
+    }
+
+    internal void LogActivityStatus() => Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+
+    /// <summary>
+    /// Internal accessor for in-assembly use, mirroring the <see cref="Result{TValue}"/> pattern.
+    /// External consumers must use <see cref="TryGetError(out Error)"/> or <see cref="Deconstruct(out bool, out Error?)"/>.
+    /// </summary>
+    internal Error Error =>
+        IsFailure
+            ? _error!
+            : throw new InvalidOperationException("Cannot access Error on a successful result.");
+
+    /// <summary>
+    /// Attempts to get the error without throwing.
+    /// </summary>
+    public bool TryGetError(out Error error)
+    {
+        if (IsFailure)
+        {
+            error = _error!;
+            return true;
+        }
+
+        error = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Deconstructs the result into its components for pattern matching.
+    /// </summary>
+    public void Deconstruct(out bool isSuccess, out Error? error)
+    {
+        isSuccess = IsSuccess;
+        error = _error;
+    }
+
+    /// <summary>
+    /// Creates a failure result wrapping the given error. Used by generic pipeline behaviors that need to construct
+    /// failure results polymorphically via <see cref="IFailureFactory{TSelf}"/>.
+    /// </summary>
+    public static Result CreateFailure(Error error) => Fail(error);
+
+    // ------------- Equality & hashing -------------
+
+    /// <inheritdoc />
+    public bool Equals(Result other)
+    {
+        if (IsFailure != other.IsFailure) return false;
+        if (IsFailure) return _error!.Equals(other._error);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Result other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        IsFailure
+            ? HashCode.Combine(true, _error)
+            : HashCode.Combine(false);
+
+    /// <summary>Determines whether two results are equal.</summary>
+    public static bool operator ==(Result left, Result right) => left.Equals(right);
+
+    /// <summary>Determines whether two results are not equal.</summary>
+    public static bool operator !=(Result left, Result right) => !left.Equals(right);
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        IsFailure
+            ? $"Failure({Error.Code}: {Error.Detail})"
+            : "Success";
+
+    // ------------- Factories -------------
+
     /// <summary>
     /// Creates a successful result wrapping the provided <paramref name="value"/>.
     /// </summary>
-    /// <typeparam name="TValue">Type of the Ok value.</typeparam>
-    /// <param name="value">Value to wrap in a successful result (may be null for reference types).</param>
-    /// <returns>A successful <see cref="Result{TValue}"/> containing <paramref name="value"/>.</returns>
     public static Result<TValue> Ok<TValue>(TValue value) =>
         new(false, value, default);
 
     /// <summary>
     /// Creates a failed result with the specified <paramref name="error"/>.
     /// </summary>
-    /// <typeparam name="TValue">Type of the (missing) Ok value.</typeparam>
-    /// <param name="error">Error describing the Fail.</param>
-    /// <returns>A failed <see cref="Result{TValue}"/>.</returns>
     public static Result<TValue> Fail<TValue>(Error error) =>
         new(true, default, error);
 
     /// <summary>
-    /// Creates a successful unit result (no payload).
+    /// Creates a successful non-generic <see cref="Result"/> (no payload).
     /// </summary>
-    /// <returns>A successful <see cref="Result{TValue}"/> of <see cref="Unit"/>.</returns>
-    public static Result<Unit> Ok() =>
-        new(false, default, default);
+    public static Result Ok() => default;
 
     /// <summary>
-    /// Creates a failed unit result with the specified <paramref name="error"/>.
+    /// Creates a failed non-generic <see cref="Result"/> with the specified <paramref name="error"/>.
     /// </summary>
-    /// <param name="error">Error describing the Fail.</param>
-    /// <returns>A failed <see cref="Result{TValue}"/> of <see cref="Unit"/>.</returns>
-    public static Result<Unit> Fail(Error error) =>
-        new(true, default, error);
+    public static Result Fail(Error error) => new(true, error);
 
     /// <summary>
-    /// Returns a Ok result if the flag is true; otherwise returns a Fail with the specified error.
+    /// Returns a successful <see cref="Result"/> if the flag is true; otherwise a failure with the specified error.
     /// </summary>
-    /// <param name="flag">The boolean condition to test.</param>
-    /// <param name="error">The error to return if the condition is false.</param>
-    /// <returns>A Ok result if flag is true; otherwise a Fail with the specified error.</returns>
-    public static Result<Unit> Ensure(bool flag, Error error)
+    public static Result Ensure(bool flag, Error error)
     {
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Ensure));
         var result = flag ? Ok() : Fail(error);
@@ -57,12 +161,9 @@ public readonly partial struct Result
     }
 
     /// <summary>
-    /// Returns a Ok result if the predicate is true; otherwise returns a Fail with the specified error.
+    /// Returns a successful <see cref="Result"/> if the predicate is true; otherwise a failure with the specified error.
     /// </summary>
-    /// <param name="predicate">The predicate to evaluate.</param>
-    /// <param name="error">The error to return if the predicate is false.</param>
-    /// <returns>A Ok result if predicate is true; otherwise a Fail with the specified error.</returns>
-    public static Result<Unit> Ensure(Func<bool> predicate, Error error)
+    public static Result Ensure(Func<bool> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(predicate);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Ensure));
@@ -72,12 +173,9 @@ public readonly partial struct Result
     }
 
     /// <summary>
-    /// Asynchronously evaluates the predicate and returns Ok if true; otherwise returns a Fail with the specified error.
+    /// Asynchronously evaluates the predicate and returns success if true; otherwise a failure with the specified error.
     /// </summary>
-    /// <param name="predicate">Async predicate producing true for Ok.</param>
-    /// <param name="error">The error to return if the predicate is false.</param>
-    /// <returns>A task producing a Ok or Fail Result of Unit.</returns>
-    public static async Task<Result<Unit>> EnsureAsync(Func<Task<bool>> predicate, Error error)
+    public static async Task<Result> EnsureAsync(Func<Task<bool>> predicate, Error error)
     {
         ArgumentNullException.ThrowIfNull(predicate);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(Ensure));
@@ -90,12 +188,8 @@ public readonly partial struct Result
     // --- Exception capture helpers --------------------------------------------------
 
     /// <summary>
-    /// Executes the function and converts exceptions to a failed result using the optional mapper (default maps to <see cref="Error.Unexpected(string, string?, string?)"/>).
+    /// Executes the function and converts exceptions to a failed result using the optional mapper (default Unexpected).
     /// </summary>
-    /// <typeparam name="T">Type of the produced value.</typeparam>
-    /// <param name="func">Function to execute.</param>
-    /// <param name="map">Optional exception-to-error mapper. If null, a default Unexpected error is used.</param>
-    /// <returns>A Ok result with the value or a Fail result if an exception was thrown.</returns>
     public static Result<T> Try<T>(Func<T> func, Func<Exception, Error>? map = null)
     {
         try
@@ -113,12 +207,8 @@ public readonly partial struct Result
     }
 
     /// <summary>
-    /// Executes the asynchronous function and converts exceptions to a failed result using the optional mapper (default maps to Unexpected).
+    /// Executes the asynchronous function and converts exceptions to a failed result.
     /// </summary>
-    /// <typeparam name="T">Type of the produced value.</typeparam>
-    /// <param name="func">Asynchronous function to execute.</param>
-    /// <param name="map">Optional exception-to-error mapper. If null, a default Unexpected error is used.</param>
-    /// <returns>A task producing either a Ok or Fail result.</returns>
     public static async Task<Result<T>> TryAsync<T>(Func<Task<T>> func, Func<Exception, Error>? map = null)
     {
         try
@@ -136,10 +226,50 @@ public readonly partial struct Result
     }
 
     /// <summary>
+    /// Executes the action and converts exceptions to a failed non-generic <see cref="Result"/> using the optional mapper.
+    /// </summary>
+    public static Result Try(Action work, Func<Exception, Error>? map = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        try
+        {
+            work();
+            return Ok();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Fail((map ?? DefaultExceptionMapper)(ex));
+        }
+    }
+
+    /// <summary>
+    /// Executes the asynchronous action and converts exceptions to a failed non-generic <see cref="Result"/>.
+    /// </summary>
+    public static async Task<Result> TryAsync(Func<Task> work, Func<Exception, Error>? map = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        try
+        {
+            await work().ConfigureAwait(false);
+            return Ok();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Fail((map ?? DefaultExceptionMapper)(ex));
+        }
+    }
+
+    /// <summary>
     /// Default mapper converting an exception into an <see cref="UnexpectedError"/>.
     /// </summary>
-    /// <param name="ex">Exception that occurred.</param>
-    /// <returns>An <see cref="UnexpectedError"/> containing the exception message.</returns>
     private static UnexpectedError DefaultExceptionMapper(Exception ex) =>
         Error.Unexpected(ex.Message);
 }

--- a/Trellis.Results/src/Result/Result{TValue}.cs
+++ b/Trellis.Results/src/Result/Result{TValue}.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 using System;
 using System.Diagnostics;

--- a/Trellis.Results/src/Result/Result{TValue}.cs
+++ b/Trellis.Results/src/Result/Result{TValue}.cs
@@ -223,6 +223,18 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     public static bool operator !=(Result<TValue> left, Result<TValue> right) => !left.Equals(right);
 
     /// <summary>
+    /// Converts this <see cref="Result{TValue}"/> to a non-generic <see cref="Result"/>, discarding the success value.
+    /// Failures preserve their <see cref="Error"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="AsUnit"/> when a pipeline returns a value but the next step only cares about success/failure
+    /// (e.g., bridging a value-producing operation into a void/Unit-shaped consumer). Replaces the v1 idiom
+    /// <c>result.Map(_ =&gt; Unit.Default)</c> / <c>Result&lt;Unit&gt;</c>.
+    /// </remarks>
+    /// <returns>A non-generic <see cref="Result"/> mirroring this result's success/failure state.</returns>
+    public Result AsUnit() => IsFailure ? Result.Fail(_error!) : Result.Ok();
+
+    /// <summary>
     /// Returns a string representation of the result.
     /// </summary>
     /// <returns>A string in the format "Success(value)" or "Failure(ErrorCode: detail)".</returns>

--- a/Trellis.Results/src/Result/Unit.cs
+++ b/Trellis.Results/src/Result/Unit.cs
@@ -1,94 +1,12 @@
 namespace Trellis;
 
 /// <summary>
-/// Represents the absence of a meaningful value, used for operations that have no return value.
-/// This is the functional programming equivalent of <c>void</c>, but as a proper type that can be used with generics.
+/// Internal sentinel type representing the absence of a meaningful value.
+/// Framework code uses this to provide generic implementations for non-generic <see cref="Result"/> operations.
+/// Consumer code should use the non-generic <see cref="Result"/> type directly.
 /// </summary>
-/// <remarks>
-/// <para>
-/// In functional programming, every function returns a value. When an operation doesn't have a meaningful
-/// return value (like <c>void</c> methods in imperative programming), we use <c>Unit</c> as a placeholder type.
-/// This allows <see cref="Result{TValue}"/> to represent both operations that return values and operations
-/// that only succeed or fail without returning data.
-/// </para>
-/// <para>
-/// Common use cases for <c>Unit</c>:
-/// <list type="bullet">
-/// <item>DELETE operations that either succeed or fail but don't return data</item>
-/// <item>State-changing operations (e.g., sending emails, updating records)</item>
-/// <item>Validation operations that only need to indicate success/failure</item>
-/// <item>Fire-and-forget side effects in a functional pipeline</item>
-/// </list>
-/// </para>
-/// <para>
-/// The <see cref="Result"/> class provides convenience methods for working with <c>Unit</c>:
-/// <list type="bullet">
-/// <item><see cref="Result.Ok()"/> - Creates a successful <c>Result&lt;Unit&gt;</c></item>
-/// <item><see cref="Result.Fail(Error)"/> - Creates a failed <c>Result&lt;Unit&gt;</c></item>
-/// </list>
-/// </para>
-/// <para>
-/// When converting <c>Result&lt;Unit&gt;</c> to HTTP responses, successful results automatically
-/// map to HTTP 204 No Content, indicating success without a response body.
-/// </para>
-/// </remarks>
-/// <example>
-/// Basic usage with Result:
-/// <code>
-/// // Operation that doesn't return a value
-/// public Result&lt;Unit&gt; DeleteUser(UserId userId)
-/// {
-///     var user = _repository.Find(userId);
-///     if (user == null)
-///         return Error.NotFound($"User {userId} not found");
-///     
-///     _repository.Delete(user);
-///     return Result.Ok(); // Returns Result&lt;Unit&gt;
-/// }
-/// 
-/// // Usage
-/// var result = DeleteUser(userId);
-/// if (result.IsSuccess)
-///     Console.WriteLine("User deleted successfully");
-/// </code>
-/// </example>
-/// <example>
-/// Chaining operations that don't return values:
-/// <code>
-/// public async Task&lt;Result&lt;Unit&gt;&gt; ProcessOrderAsync(Order order, CancellationToken ct)
-/// {
-///     return await ValidateOrder(order)          // Result&lt;Unit&gt;
-///         .BindAsync(() => ChargePaymentAsync(order, ct))   // Result&lt;Unit&gt;
-///         .TapAsync(() => SendConfirmationEmailAsync(order.Email, ct))
-///         .TapAsync(() => UpdateInventoryAsync(order.Items, ct));
-/// }
-/// </code>
-/// </example>
-/// <example>
-/// Converting to HTTP response:
-/// <code>
-/// app.MapDelete("/users/{id}", (Guid id, IUserService userService) =>
-///     UserId.TryCreate(id)
-///         .Bind(userService.DeleteUser)
-///         .ToHttpResult());
-/// // Returns 204 No Content on success, appropriate error status on failure
-/// </code>
-/// </example>
-/// <example>
-/// Combining Unit results with value results:
-/// <code>
-/// public Result&lt;User&gt; CreateAndNotify(CreateUserRequest request)
-/// {
-///     return FirstName.TryCreate(request.FirstName)
-///         .Combine(LastName.TryCreate(request.LastName))
-///         .Bind((first, last) => User.Create(first, last))
-///         .Combine(ValidateBusinessRules(request))  // Result&lt;Unit&gt; - just validates
-///         .Map((user, _) => user);  // Discard Unit, keep User
-/// }
-/// </code>
-/// </example>
 /// <seealso cref="Result"/>
 /// <seealso cref="Result{TValue}"/>
-public record struct Unit
+internal record struct Unit
 {
 }

--- a/Trellis.Results/src/Result/Unit.cs
+++ b/Trellis.Results/src/Result/Unit.cs
@@ -1,4 +1,4 @@
-namespace Trellis;
+﻿namespace Trellis;
 
 /// <summary>
 /// Internal sentinel type representing the absence of a meaningful value.

--- a/Trellis.Results/tests/Results/Extensions/CheckIfTests.cs
+++ b/Trellis.Results/tests/Results/Extensions/CheckIfTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Results.Tests.Results.Extensions;
+﻿namespace Trellis.Results.Tests.Results.Extensions;
 
 using Trellis.Testing;
 

--- a/Trellis.Results/tests/Results/Extensions/CheckIfTests.cs
+++ b/Trellis.Results/tests/Results/Extensions/CheckIfTests.cs
@@ -157,7 +157,7 @@ public class CheckIfTests
     {
         var result = Result.Ok(42);
 
-        var sut = result.CheckIf(v => v > 0, _ => Result.Fail<Unit>(CheckError));
+        var sut = result.CheckIf(v => v > 0, _ => Result.Fail(CheckError));
 
         sut.Should().BeFailure().Which.Should().Be(CheckError);
     }

--- a/Trellis.Results/tests/Results/Extensions/NonGenericResultTests.cs
+++ b/Trellis.Results/tests/Results/Extensions/NonGenericResultTests.cs
@@ -1,0 +1,184 @@
+﻿namespace Trellis.Results.Tests.Results.Extensions;
+
+using Trellis.Testing;
+
+/// <summary>
+/// Tests for the non-generic Result overloads added in PR5: Combine(Result, Result),
+/// TraverseAsync(IEnumerable, Func&lt;TIn, CancellationToken, Task&lt;Result&gt;&gt;), and
+/// RecoverOnFailureAsync(Task&lt;Result&gt;, ...). Each overload is exercised across the
+/// success path, failure path, and (where applicable) cancellation/short-circuit semantics.
+/// </summary>
+public class NonGenericResultTests : TestBase
+{
+    #region Combine(Result, Result)
+
+    [Fact]
+    public void Combine_NonGeneric_BothSuccess_ReturnsSuccess()
+    {
+        var combined = Result.Ok().Combine(Result.Ok());
+
+        combined.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void Combine_NonGeneric_FirstFailure_ReturnsFirstFailure()
+    {
+        var combined = Result.Fail(Error1).Combine(Result.Ok());
+
+        combined.Should().BeFailure().Which.Should().HaveCode(Error1.Code);
+    }
+
+    [Fact]
+    public void Combine_NonGeneric_SecondFailure_ReturnsSecondFailure()
+    {
+        var combined = Result.Ok().Combine(Result.Fail(Error1));
+
+        combined.Should().BeFailure().Which.Should().HaveCode(Error1.Code);
+    }
+
+    [Fact]
+    public void Combine_NonGeneric_BothFailure_AggregatesValidationFieldErrors()
+    {
+        var first = Result.Fail(Error.Validation("first failed", "f1"));
+        var second = Result.Fail(Error.Validation("second failed", "f2"));
+
+        var combined = first.Combine(second);
+
+        var validation = combined.Should().BeFailureOfType<ValidationError>().Which;
+        validation.FieldErrors.Should().HaveCount(2);
+        validation.FieldErrors.Select(fe => fe.FieldName).Should().BeEquivalentTo("f1", "f2");
+    }
+
+    #endregion
+
+    #region TraverseAsync (non-generic Result selector)
+
+    [Fact]
+    public async Task TraverseAsync_NonGeneric_AllSucceed_ReturnsSuccess()
+    {
+        var items = new[] { 1, 2, 3 };
+        var visited = new List<int>();
+        var ct = TestContext.Current.CancellationToken;
+
+        var result = await items.TraverseAsync((x, _) =>
+        {
+            visited.Add(x);
+            return Task.FromResult(Result.Ok());
+        }, ct);
+
+        result.Should().BeSuccess();
+        visited.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task TraverseAsync_NonGeneric_FirstFailure_ShortCircuitsAndReturnsThatError()
+    {
+        var items = new[] { 1, 2, 3, 4 };
+        var visited = new List<int>();
+        var ct = TestContext.Current.CancellationToken;
+
+        var result = await items.TraverseAsync((x, _) =>
+        {
+            visited.Add(x);
+            return Task.FromResult(x == 2 ? Result.Fail(Error1) : Result.Ok());
+        }, ct);
+
+        result.Should().BeFailure().Which.Should().HaveCode(Error1.Code);
+        visited.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task TraverseAsync_NonGeneric_Cancellation_StopsIterationAndThrows()
+    {
+        var items = new[] { 1, 2, 3 };
+        var visited = new List<int>();
+        using var cts = new CancellationTokenSource();
+
+#pragma warning disable xUnit1051 // Test deliberately uses its own CTS to trigger cancellation mid-iteration.
+        Func<Task> act = async () => await items.TraverseAsync((x, ct) =>
+        {
+            visited.Add(x);
+            if (x == 2) cts.Cancel();
+            return Task.FromResult(Result.Ok());
+        }, cts.Token);
+#pragma warning restore xUnit1051
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        visited.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task TraverseAsync_NonGeneric_EmptySource_ReturnsSuccess()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var result = await Array.Empty<int>().TraverseAsync((_, _) => Task.FromResult(Result.Ok()), ct);
+
+        result.Should().BeSuccess();
+    }
+
+    #endregion
+
+    #region RecoverOnFailureAsync(Task<Result>, ...)
+
+    [Fact]
+    public async Task RecoverOnFailureAsync_NonGeneric_Success_RecoveryNotInvoked()
+    {
+        var invoked = false;
+        Task<Result> input = Task.FromResult(Result.Ok());
+
+        var output = await input.RecoverOnFailureAsync(_ => true, () =>
+        {
+            invoked = true;
+            return Task.FromResult(Result.Ok());
+        });
+
+        invoked.Should().BeFalse();
+        output.Should().BeSuccess();
+    }
+
+    [Fact]
+    public async Task RecoverOnFailureAsync_NonGeneric_FailureMatchesPredicate_RecoveryInvoked()
+    {
+        var invoked = false;
+        Task<Result> input = Task.FromResult(Result.Fail(Error1));
+
+        var output = await input.RecoverOnFailureAsync(err => err.Code == Error1.Code, () =>
+        {
+            invoked = true;
+            return Task.FromResult(Result.Ok());
+        });
+
+        invoked.Should().BeTrue();
+        output.Should().BeSuccess();
+    }
+
+    [Fact]
+    public async Task RecoverOnFailureAsync_NonGeneric_FailurePredicateNotMatched_OriginalFailureReturned()
+    {
+        var invoked = false;
+        Task<Result> input = Task.FromResult(Result.Fail(Error1));
+
+        var output = await input.RecoverOnFailureAsync(err => err.Code == "Other", () =>
+        {
+            invoked = true;
+            return Task.FromResult(Result.Ok());
+        });
+
+        invoked.Should().BeFalse();
+        output.Should().BeFailure().Which.Should().HaveCode(Error1.Code);
+    }
+
+    [Fact]
+    public async Task RecoverOnFailureAsync_NonGeneric_NullResultTask_ThrowsArgumentNullException()
+    {
+        Task<Result> input = null!;
+
+        Func<Task<Result>> act = () => input.RecoverOnFailureAsync(_ => true, () => Task.FromResult(Result.Ok()));
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .Where(e => e.ParamName == "resultTask");
+    }
+
+    #endregion
+}

--- a/Trellis.Results/tests/Results/Extensions/NonGenericResultTests.cs
+++ b/Trellis.Results/tests/Results/Extensions/NonGenericResultTests.cs
@@ -181,4 +181,117 @@ public class NonGenericResultTests : TestBase
     }
 
     #endregion
+
+    #region AsUnit
+
+    [Fact]
+    public void AsUnit_Success_ReturnsNonGenericOk()
+    {
+        var source = Result.Ok(42);
+
+        var unit = source.AsUnit();
+
+        unit.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void AsUnit_Failure_PreservesError()
+    {
+        var source = Result.Fail<int>(Error1);
+
+        var unit = source.AsUnit();
+
+        var error = unit.Should().BeFailure().Which;
+        error.Code.Should().Be(Error1.Code);
+        error.Detail.Should().Be(Error1.Detail);
+        ReferenceEquals(error, Error1).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Result.Try (non-generic)
+
+    [Fact]
+    public void Try_Action_Success_ReturnsOk()
+    {
+        var ran = false;
+
+        var result = Result.Try(() => { ran = true; });
+
+        ran.Should().BeTrue();
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void Try_Action_WhenThrows_ReturnsUnexpectedFailure()
+    {
+        var result = Result.Try(() => throw new InvalidOperationException("Boom"));
+
+        var error = result.Should().BeFailure().Which;
+        error.Should().BeOfType<UnexpectedError>();
+        error.Detail.Should().Be("Boom");
+    }
+
+    [Fact]
+    public void Try_Action_WithCustomMapper_UsesMapper()
+    {
+        var result = Result.Try(
+            () => throw new InvalidOperationException("HideMe"),
+            ex => Error.BadRequest("Mapped"));
+
+        var error = result.Should().BeFailure().Which;
+        error.Should().BeOfType<BadRequestError>();
+        error.Detail.Should().Be("Mapped");
+    }
+
+    [Fact]
+    public void Try_Action_OperationCanceled_IsRethrown()
+    {
+        Action act = () => Result.Try(() => throw new OperationCanceledException("cancel"));
+
+        act.Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task TryAsync_Func_Success_ReturnsOk()
+    {
+        var ran = false;
+
+        var result = await Result.TryAsync(async () =>
+        {
+            await Task.Yield();
+            ran = true;
+        });
+
+        ran.Should().BeTrue();
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public async Task TryAsync_Func_WhenThrows_ReturnsUnexpectedFailure()
+    {
+        var result = await Result.TryAsync(async () =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("AsyncBoom");
+        });
+
+        var error = result.Should().BeFailure().Which;
+        error.Should().BeOfType<UnexpectedError>();
+        error.Detail.Should().Be("AsyncBoom");
+    }
+
+    [Fact]
+    public async Task TryAsync_Func_OperationCanceled_IsRethrown()
+    {
+        Func<Task> act = () => Result.TryAsync(async () =>
+        {
+            await Task.Yield();
+            throw new OperationCanceledException("cancel");
+        });
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    #endregion
 }

--- a/Trellis.Results/tests/Results/ResultEdgeCaseTests.cs
+++ b/Trellis.Results/tests/Results/ResultEdgeCaseTests.cs
@@ -557,7 +557,6 @@ public class ResultEdgeCaseTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(default(Unit));
     }
 
     [Fact]

--- a/Trellis.Results/tests/Results/ResultEdgeCaseTests.cs
+++ b/Trellis.Results/tests/Results/ResultEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Results.Tests;
+﻿namespace Trellis.Results.Tests;
 
 using Xunit;
 

--- a/Trellis.Results/tests/Results/ResultTests.cs
+++ b/Trellis.Results/tests/Results/ResultTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Results.Tests;
+﻿namespace Trellis.Results.Tests;
 
 using Trellis.Testing;
 

--- a/Trellis.Results/tests/Results/ResultTests.cs
+++ b/Trellis.Results/tests/Results/ResultTests.cs
@@ -29,8 +29,7 @@ public class ResultTests
         var result = Result.Ok();
 
         // Assert
-        result.Should().BeSuccess()
-            .Which.Should().Be(default(Unit));
+        result.Should().BeSuccess();
     }
 
     [Fact]

--- a/Trellis.Testing/src/Assertions/ResultAssertions.NonGeneric.cs
+++ b/Trellis.Testing/src/Assertions/ResultAssertions.NonGeneric.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Testing;
+﻿namespace Trellis.Testing;
 
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/Trellis.Testing/src/Assertions/ResultAssertions.NonGeneric.cs
+++ b/Trellis.Testing/src/Assertions/ResultAssertions.NonGeneric.cs
@@ -1,0 +1,137 @@
+namespace Trellis.Testing;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+/// <summary>
+/// Extension methods to enable FluentAssertions on the non-generic <see cref="Result"/>.
+/// </summary>
+public static class NonGenericResultAssertionsExtensions
+{
+    /// <summary>
+    /// Returns an assertions object for fluent assertions on a non-generic <see cref="Result"/>.
+    /// </summary>
+    public static NonGenericResultAssertions Should(this Result result) => new(result);
+}
+
+/// <summary>
+/// Contains assertion methods for the non-generic <see cref="Result"/> type.
+/// </summary>
+public class NonGenericResultAssertions : ReferenceTypeAssertions<Result, NonGenericResultAssertions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonGenericResultAssertions"/> class.
+    /// </summary>
+    public NonGenericResultAssertions(Result result)
+        : base(result)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override string Identifier => "result";
+
+    /// <summary>
+    /// Asserts that the result is a success.
+    /// </summary>
+    public AndConstraint<NonGenericResultAssertions> BeSuccess(
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Subject.TryGetError(out var error);
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject.IsSuccess)
+            .FailWith("Expected {context:result} to be success{reason}, but it failed with error: {0}",
+                error);
+
+        return new AndConstraint<NonGenericResultAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the result is a failure.
+    /// </summary>
+    public AndWhichConstraint<NonGenericResultAssertions, Error> BeFailure(
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject.IsFailure)
+            .FailWith("Expected {context:result} to be failure{reason}, but it succeeded.");
+
+        Subject.TryGetError(out var error);
+        return new AndWhichConstraint<NonGenericResultAssertions, Error>(this, error);
+    }
+
+    /// <summary>
+    /// Asserts that the result is a failure with a specific error type.
+    /// </summary>
+    public AndWhichConstraint<NonGenericResultAssertions, TError> BeFailureOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(error is TError)
+            .FailWith("Expected {context:result} error to be of type {0}{reason}, but found {1}",
+                typeof(TError).Name,
+                error?.GetType().Name);
+
+        return new AndWhichConstraint<NonGenericResultAssertions, TError>(
+            this,
+            (TError)error!);
+    }
+
+    /// <summary>
+    /// Asserts that the failure has a specific error code.
+    /// </summary>
+    public AndConstraint<NonGenericResultAssertions> HaveErrorCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error.Code.Should().Be(expectedCode, because, becauseArgs);
+
+        return new AndConstraint<NonGenericResultAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the failure has a specific error detail.
+    /// </summary>
+    public AndConstraint<NonGenericResultAssertions> HaveErrorDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error.Detail.Should().Be(expectedDetail, because, becauseArgs);
+
+        return new AndConstraint<NonGenericResultAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the failure error detail contains the specified substring.
+    /// </summary>
+    public AndConstraint<NonGenericResultAssertions> HaveErrorDetailContaining(
+        string substring,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error.Detail.Should().Contain(substring, because, becauseArgs);
+
+        return new AndConstraint<NonGenericResultAssertions>(this);
+    }
+}

--- a/Trellis.Testing/src/FakeRepository.cs
+++ b/Trellis.Testing/src/FakeRepository.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Testing;
+﻿namespace Trellis.Testing;
 
 using Trellis;
 

--- a/Trellis.Testing/src/FakeRepository.cs
+++ b/Trellis.Testing/src/FakeRepository.cs
@@ -77,7 +77,7 @@ public class FakeRepository<TAggregate, TId>
     /// <param name="aggregate">The aggregate to save.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A Result indicating success or failure.</returns>
-    public Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)
+    public Task<Result> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default)
     {
         var id = aggregate.Id;
 
@@ -89,7 +89,7 @@ public class FakeRepository<TAggregate, TId>
                 .FirstOrDefault(existing => !existing.Id.Equals(id) && Equals(constraint(existing), value));
 
             if (conflict is not null)
-                return Task.FromResult(Result.Fail<Unit>(
+                return Task.FromResult(Result.Fail(
                     Error.Conflict($"A {typeof(TAggregate).Name} with the same value already exists.")));
         }
 
@@ -105,12 +105,12 @@ public class FakeRepository<TAggregate, TId>
     /// <param name="id">The aggregate ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A Result indicating success or NotFoundError.</returns>
-    public Task<Result<Unit>> DeleteAsync(TId id, CancellationToken cancellationToken = default)
+    public Task<Result> DeleteAsync(TId id, CancellationToken cancellationToken = default)
     {
         if (_store.Remove(id))
             return Task.FromResult(Result.Ok());
 
-        return Task.FromResult(Result.Fail<Unit>(
+        return Task.FromResult(Result.Fail(
             Error.NotFound($"{typeof(TAggregate).Name} with ID {id} not found")));
     }
 

--- a/Trellis.Testing/src/UnwrapExtensions.cs
+++ b/Trellis.Testing/src/UnwrapExtensions.cs
@@ -48,6 +48,14 @@ public static class UnwrapExtensions
             : throw new UnwrapFailedException(
                 $"Called UnwrapError() on a successful Result<{typeof(T).Name}>.");
 
+    /// <summary>
+    /// Extracts the error from a failed non-generic result, or throws if success.
+    /// </summary>
+    public static Error UnwrapError(this Result result) =>
+        result.TryGetError(out var error)
+            ? error
+            : throw new UnwrapFailedException("Called UnwrapError() on a successful Result.");
+
     private static string BuildUnwrapErrorMessage<T>(Result<T> result)
     {
         // Caller (Unwrap) only invokes this when the result is known to be a failure.

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -232,7 +232,7 @@ graph TB
     
     subgraph Repository["Repository Layer"]
         QUERY[Query Methods<br/>return Maybe&lt;T&gt;]
-        COMMAND[Command Methods<br/>return Result&lt;Unit&gt;]
+        COMMAND[Command Methods<br/>return Result]
     end
     
     subgraph Database["Database"]


### PR DESCRIPTION
Introduce a first-class non-generic Result struct with full surface parity to Result<T> and remove Result<Unit> from the public API. The non-generic Result is the v2-correct representation of "operation succeeded or failed without a payload" -- it's discoverable, has default(Result)=Success per the §3.5.1 invariant, implements IResult and IFailureFactory<Result> so Mediator behaviors auto-register, and eliminates the awkward .Map(_ => Unit.Default) / Unit.Default idioms. Unit is now internal: framework code uses it only as a generic sentinel where shape collapse demands one.

Foundation: rewrite Result.cs with instance state, factories (Ok/Fail/Ensure/Try plus async forms), Activity tagging, equality and deconstruction. Add AsUnit() to Result<T> for cross-shape bridging. Add Result.NonGeneric.Extensions.cs with full verb surface (Map/Bind/Tap/TapError/Ensure/Match/Recover) and Bind cross-shape overload from Result<T> to Result. Add NonGenericResultAssertions for FluentAssertions parity.

Migrate consumers: Combine/CombineTs, Check/CheckIf (and Task/ValueTask variants), Traverse, RecoverOnFailure, HttpResult and ActionResult extensions (including 204 NoContent for non-generic Result), EfUnitOfWork/IUnitOfWork, RepositoryBase, FakeRepository, DbContextExtensions, MaybeInvariant; sample apps, examples, benchmarks, and all affected tests. Remove Result<Unit> overloads from Combine and CombineTs.g.cs. Internalize Unit and update stale doc-comment examples (IIdentifyResource, ActionResultExtensions, DIAGRAMS.md). Build clean (0 errors, 0 warnings); 4907 passed, 15 skipped, 0 failed (baseline preserved).