### PR TITLE
Showcase: opt-in route constraints for AccountId

### DIFF
--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -46,6 +46,14 @@ Accept: application/json
 GET {{host}}/api/accounts/00000000-0000-0000-0000-000000000099
 Accept: application/json
 
+### Get account — malformed id (404 from Trellis route constraint).
+### Both hosts register `AddTrellisRouteConstraint<AccountId>()`, so the
+### `{id:AccountId}` template rejects any value that fails AccountId.TryParse
+### before the request ever reaches the endpoint. The response is a routing
+### 404 — no handler is invoked, no model-binding error is produced.
+GET {{host}}/api/accounts/not-a-guid
+Accept: application/json
+
 ### Open new account (201 Created)
 POST {{host}}/api/accounts
 Content-Type: application/json

--- a/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/AccountEndpoints.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/AccountEndpoints.cs
@@ -21,7 +21,7 @@ public static class AccountEndpoints
         group.MapGet("/", (IAccountRepository repo) =>
             Results.Ok(repo.All().Select(AccountResponse.From).ToList()));
 
-        group.MapGet("/{id}", (AccountId id, IAccountRepository repo) =>
+        group.MapGet("/{id:AccountId}", (AccountId id, IAccountRepository repo) =>
             repo.GetById(id)
                 .Map(AccountResponse.From)
                 .ToHttpResult())
@@ -35,41 +35,41 @@ public static class AccountEndpoints
                     map: AccountResponse.From))
             .WithScalarValueValidation();
 
-        group.MapPost("/{id}/deposit", (AccountId id, DepositRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/deposit", (AccountId id, DepositRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.DepositAsync(account, request.Amount, request.Description, ct))
                 .MapAsync(AccountResponse.From)
                 .ToHttpResultAsync())
             .WithScalarValueValidation();
 
-        group.MapPost("/{id}/withdraw", (AccountId id, WithdrawRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/withdraw", (AccountId id, WithdrawRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.WithdrawAsync(account, request.Amount, request.Description, ct))
                 .MapAsync(AccountResponse.From)
                 .ToHttpResultAsync())
             .WithScalarValueValidation();
 
-        group.MapPost("/{id}/secure-withdraw", (AccountId id, SecureWithdrawRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/secure-withdraw", (AccountId id, SecureWithdrawRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.SecureWithdrawAsync(account, request.Amount, request.VerificationCode, ct))
                 .MapAsync(AccountResponse.From)
                 .ToHttpResultAsync())
             .WithScalarValueValidation();
 
-        group.MapPost("/{id}/freeze", (AccountId id, FreezeRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/freeze", (AccountId id, FreezeRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.FreezeAsync(account, request.Reason, ct))
                 .MapAsync(AccountResponse.From)
                 .ToHttpResultAsync())
             .WithScalarValueValidation();
 
-        group.MapPost("/{id}/unfreeze", (AccountId id, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/unfreeze", (AccountId id, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.UnfreezeAsync(account, ct))
                 .MapAsync(AccountResponse.From)
                 .ToHttpResultAsync());
 
-        group.MapPost("/{id}/close", (AccountId id, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{id:AccountId}/close", (AccountId id, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)
                 .BindAsync(account => workflow.CloseAsync(account, ct))
                 .MapAsync(AccountResponse.From)

--- a/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/InterestEndpoints.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/InterestEndpoints.cs
@@ -11,7 +11,7 @@ public static class InterestEndpoints
 {
     public static IEndpointRouteBuilder MapInterestEndpoints(this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("/api/accounts/{id}/interest").WithTags("Interest");
+        var group = routes.MapGroup("/api/accounts/{id:AccountId}/interest").WithTags("Interest");
 
         group.MapPost("/", (AccountId id, InterestRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(id)

--- a/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/TransferEndpoints.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/TransferEndpoints.cs
@@ -13,7 +13,7 @@ public static class TransferEndpoints
     {
         var group = routes.MapGroup("/api/transfers").WithTags("Transfers");
 
-        group.MapPost("/{fromId}", (AccountId fromId, TransferRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
+        group.MapPost("/{fromId:AccountId}", (AccountId fromId, TransferRequest request, IAccountRepository repo, BankingWorkflow workflow, CancellationToken ct) =>
             repo.GetById(fromId)
                 .Combine(repo.GetById(request.ToAccountId))
                 .BindAsync(pair => workflow.TransferAsync(pair.Item1, pair.Item2, request.Amount, request.Description, ct))

--- a/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
@@ -2,15 +2,18 @@ using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 using Trellis.Asp;
 using Trellis.Asp.Authorization;
+using Trellis.Asp.Routing;
 using Trellis.Showcase.Application;
 using Trellis.Showcase.Application.Persistence;
 using Trellis.Showcase.Application.Services;
 using Trellis.Showcase.Application.Workflows;
+using Trellis.Showcase.Domain.ValueObjects;
 using Trellis.Showcase.MinimalApi.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddScalarValueValidationForMinimalApi();
+builder.Services.AddTrellisRouteConstraint<AccountId>();
 builder.Services.ConfigureHttpJsonOptions(o =>
     o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddOpenApi();

--- a/Examples/Showcase/src/Showcase.Mvc/Controllers/AccountsController.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Controllers/AccountsController.cs
@@ -25,7 +25,7 @@ public class AccountsController : ControllerBase
     public ActionResult<IReadOnlyList<AccountResponse>> List() =>
         Ok(_repository.All().Select(AccountResponse.From).ToList());
 
-    [HttpGet("{id}", Name = "Showcase_GetAccount")]
+    [HttpGet("{id:AccountId}", Name = "Showcase_GetAccount")]
     public ActionResult<AccountResponse> Get(AccountId id) =>
         _repository.GetById(id)
             .Map(AccountResponse.From)
@@ -37,42 +37,42 @@ public class AccountsController : ControllerBase
             .MapAsync(AccountResponse.From)
             .ToCreatedAtActionResultAsync(this, actionName: nameof(Get), routeValues: a => new { id = a.Id });
 
-    [HttpPost("{id}/deposit")]
+    [HttpPost("{id:AccountId}/deposit")]
     public Task<ActionResult<AccountResponse>> Deposit(AccountId id, [FromBody] DepositRequest request, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.DepositAsync(account, request.Amount, request.Description, cancellationToken))
             .MapAsync(AccountResponse.From)
             .ToActionResultAsync(this);
 
-    [HttpPost("{id}/withdraw")]
+    [HttpPost("{id:AccountId}/withdraw")]
     public Task<ActionResult<AccountResponse>> Withdraw(AccountId id, [FromBody] WithdrawRequest request, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.WithdrawAsync(account, request.Amount, request.Description, cancellationToken))
             .MapAsync(AccountResponse.From)
             .ToActionResultAsync(this);
 
-    [HttpPost("{id}/secure-withdraw")]
+    [HttpPost("{id:AccountId}/secure-withdraw")]
     public Task<ActionResult<AccountResponse>> SecureWithdraw(AccountId id, [FromBody] SecureWithdrawRequest request, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.SecureWithdrawAsync(account, request.Amount, request.VerificationCode, cancellationToken))
             .MapAsync(AccountResponse.From)
             .ToActionResultAsync(this);
 
-    [HttpPost("{id}/freeze")]
+    [HttpPost("{id:AccountId}/freeze")]
     public Task<ActionResult<AccountResponse>> Freeze(AccountId id, [FromBody] FreezeRequest request, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.FreezeAsync(account, request.Reason, cancellationToken))
             .MapAsync(AccountResponse.From)
             .ToActionResultAsync(this);
 
-    [HttpPost("{id}/unfreeze")]
+    [HttpPost("{id:AccountId}/unfreeze")]
     public Task<ActionResult<AccountResponse>> Unfreeze(AccountId id, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.UnfreezeAsync(account, cancellationToken))
             .MapAsync(AccountResponse.From)
             .ToActionResultAsync(this);
 
-    [HttpPost("{id}/close")]
+    [HttpPost("{id:AccountId}/close")]
     public Task<ActionResult<AccountResponse>> Close(AccountId id, CancellationToken cancellationToken) =>
         _repository.GetById(id)
             .BindAsync(account => _workflow.CloseAsync(account, cancellationToken))

--- a/Examples/Showcase/src/Showcase.Mvc/Controllers/InterestController.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Controllers/InterestController.cs
@@ -8,7 +8,7 @@ using Trellis.Showcase.Application.Workflows;
 using Trellis.Showcase.Domain.ValueObjects;
 
 [ApiController]
-[Route("api/accounts/{id}/interest")]
+[Route("api/accounts/{id:AccountId}/interest")]
 public class InterestController : ControllerBase
 {
     private readonly IAccountRepository _repository;

--- a/Examples/Showcase/src/Showcase.Mvc/Controllers/TransfersController.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Controllers/TransfersController.cs
@@ -21,7 +21,7 @@ public class TransfersController : ControllerBase
         _workflow = workflow;
     }
 
-    [HttpPost("{fromId}")]
+    [HttpPost("{fromId:AccountId}")]
     public Task<ActionResult<AccountResponse>> Transfer(AccountId fromId, [FromBody] TransferRequest request, CancellationToken cancellationToken) =>
         _repository.GetById(fromId)
             .Combine(_repository.GetById(request.ToAccountId))

--- a/Examples/Showcase/src/Showcase.Mvc/Program.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Program.cs
@@ -2,10 +2,12 @@ using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 using Trellis.Asp;
 using Trellis.Asp.Authorization;
+using Trellis.Asp.Routing;
 using Trellis.Showcase.Application;
 using Trellis.Showcase.Application.Persistence;
 using Trellis.Showcase.Application.Services;
 using Trellis.Showcase.Application.Workflows;
+using Trellis.Showcase.Domain.ValueObjects;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +15,8 @@ builder.Services
     .AddControllers()
     .AddScalarValueValidation()
     .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+builder.Services.AddTrellisRouteConstraint<AccountId>();
 
 builder.Services.AddOpenApi();
 


### PR DESCRIPTION
## Summary

Demonstrates the new `AddTrellisRouteConstraint<T>` extension and `{id:AccountId}` route templates introduced in #398. Both Showcase.MinimalApi and Showcase.Mvc now register a strongly-typed route constraint for `AccountId`, so malformed account ids fail routing with 404 before reaching the endpoint instead of bubbling out as model-binding errors.

## Changes

- `Showcase.MinimalApi/Program.cs` and `Showcase.Mvc/Program.cs`: register `AddTrellisRouteConstraint<AccountId>()` and import `Trellis.Asp.Routing`.
- Updated route templates in `AccountEndpoints`, `TransferEndpoints`, `InterestEndpoints` (Minimal API) and `AccountsController`, `TransfersController`, `InterestController` (MVC) to use `{id:AccountId}` / `{fromId:AccountId}`.

## Validation

- `dotnet build Trellis.slnx -c Release` — 0 warnings / 0 errors
- `Showcase.MinimalApi.Tests` 8/8 passed
- `Showcase.Tests` 29/29 passed
