### PR TITLE
Spike: Page<T> + Cursor + Link-header pagination

### DIFF
--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -24,6 +24,7 @@
 #   Alice    | aaaaaaa1-0000-0000-0000-000000000000    | Checking | $1,000
 #   Alice    | aaaaaaa2-0000-0000-0000-000000000000    | Savings  | $5,000
 #   Bob      | bbbbbbb1-0000-0000-0000-000000000000    | Checking | $250
+#   (8 filler accounts cccccccc-0000-0000-0000-000000000001..8 — for pagination demo)
 #
 #   Customer IDs:
 #     Alice = 11111111-1111-1111-1111-111111111111
@@ -34,8 +35,21 @@
 # Accounts — list / get / open / freeze / unfreeze / close
 ###############################################################################
 
-### List all accounts
-GET {{host}}/api/accounts
+### List accounts — paginated (server hard-cap = 5)
+### Body envelope (`items`, `next`, `previous`, `requestedLimit`, `appliedLimit`,
+### `deliveredCount`, `wasCapped`) is co-emitted with an RFC 8288 `Link` header.
+### Behaviour is identical on both hosts (MVC and Minimal API).
+GET {{host}}/api/accounts?limit=10
+Accept: application/json
+
+### List accounts — follow the `next` cursor returned by the previous request.
+### Replace the placeholder below with the value of `next.cursor` from the
+### body (or just GET the URL from the `Link: <…>; rel="next"` header).
+GET {{host}}/api/accounts?limit=5&cursor=REPLACE_WITH_NEXT_CURSOR
+Accept: application/json
+
+### List accounts — malformed cursor (400 from Error.BadRequest("invalid_cursor"))
+GET {{host}}/api/accounts?cursor=not-a-real-cursor
 Accept: application/json
 
 ### Get account by id

--- a/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
+++ b/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
@@ -10,6 +10,14 @@ public interface IAccountRepository
     Result<BankAccount> GetById(AccountId id);
     void Add(BankAccount account);
     IReadOnlyList<BankAccount> All();
+
+    /// <summary>
+    /// Returns at most <paramref name="limit"/> accounts after <paramref name="cursor"/> (or
+    /// from the start when <paramref name="cursor"/> is <c>null</c>), ordered by
+    /// <see cref="AccountId"/> ascending. The server applies a hard cap of 5 regardless of
+    /// the requested limit. A malformed cursor produces <see cref="Error.BadRequest"/>.
+    /// </summary>
+    Result<Page<BankAccount>> GetPage(int limit, Cursor? cursor);
 }
 
 /// <summary>
@@ -50,5 +58,84 @@ public sealed class InMemoryAccountRepository : IAccountRepository
         {
             return _accounts.Values.ToList();
         }
+    }
+
+    private const int ServerCap = 5;
+
+    public Result<Page<BankAccount>> GetPage(int limit, Cursor? cursor)
+    {
+        var requestedLimit = limit <= 0 ? 10 : limit;
+        var appliedLimit = Math.Min(requestedLimit, ServerCap);
+
+        Guid? afterId = null;
+        if (cursor is { } c)
+        {
+            if (!TryDecodeCursor(c, out var decoded))
+            {
+                return Result.Fail<Page<BankAccount>>(
+                    new Error.BadRequest("invalid_cursor") { Detail = "Cursor is not a recognized token." });
+            }
+
+            afterId = decoded;
+        }
+
+        lock (_gate)
+        {
+            var ordered = _accounts.Values
+                .OrderBy(a => a.Id.Value)
+                .Where(a => afterId is not Guid g || a.Id.Value.CompareTo(g) > 0)
+                .Take(appliedLimit + 1)
+                .ToList();
+
+            var hasMore = ordered.Count > appliedLimit;
+            var items = hasMore ? ordered.Take(appliedLimit).ToList() : ordered;
+            Cursor? next = hasMore && items.Count > 0
+                ? new Cursor(EncodeCursor(items[^1].Id.Value))
+                : null;
+
+            return Result.Ok(new Page<BankAccount>(
+                Items: items,
+                Next: next,
+                Previous: null,
+                RequestedLimit: requestedLimit,
+                AppliedLimit: appliedLimit));
+        }
+    }
+
+    private static string EncodeCursor(Guid afterId)
+    {
+        var json = $"{{\"afterId\":\"{afterId}\"}}";
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        return Base64UrlEncode(bytes);
+    }
+
+    private static bool TryDecodeCursor(Cursor cursor, out Guid afterId)
+    {
+        afterId = default;
+        try
+        {
+            var bytes = Base64UrlDecode(cursor.Token);
+            using var doc = System.Text.Json.JsonDocument.Parse(bytes);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object) return false;
+            if (!doc.RootElement.TryGetProperty("afterId", out var prop)) return false;
+            return Guid.TryParse(prop.GetString(), out afterId);
+        }
+        catch (System.Text.Json.JsonException) { return false; }
+        catch (FormatException) { return false; }
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string token)
+    {
+        var s = token.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+
+        return Convert.FromBase64String(s);
     }
 }

--- a/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
+++ b/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
@@ -112,6 +112,8 @@ public sealed class InMemoryAccountRepository : IAccountRepository
     private static bool TryDecodeCursor(Cursor cursor, out Guid afterId)
     {
         afterId = default;
+        if (string.IsNullOrEmpty(cursor.Token))
+            return false;
         try
         {
             var bytes = Base64UrlDecode(cursor.Token);

--- a/Examples/Showcase/src/Showcase.Application/ShowcaseSeed.cs
+++ b/Examples/Showcase/src/Showcase.Application/ShowcaseSeed.cs
@@ -20,6 +20,11 @@ public static class ShowcaseSeed
     public static readonly AccountId AliceSavingsId = Required(AccountId.TryCreate(new Guid("aaaaaaa2-0000-0000-0000-000000000000")));
     public static readonly AccountId BobCheckingId = Required(AccountId.TryCreate(new Guid("bbbbbbb1-0000-0000-0000-000000000000")));
 
+    // Filler accounts so the cap=5 pagination demo yields multiple pages (8 extra → 11 total).
+    private static readonly AccountId[] FillerIds = Enumerable.Range(1, 8)
+        .Select(i => Required(AccountId.TryCreate(new Guid($"cccccccc-0000-0000-0000-{i:D12}"))))
+        .ToArray();
+
     public static void Apply(IAccountRepository repository, TimeProvider timeProvider)
     {
         var aliceChecking = BankAccount.Hydrate(AliceCheckingId, AliceId, AccountType.Checking, Money.Create(1000m, "USD"), Money.Create(500m, "USD"), Money.Create(0m, "USD"), AccountStatus.Active, timeProvider);
@@ -29,6 +34,13 @@ public static class ShowcaseSeed
         repository.Add(aliceChecking);
         repository.Add(aliceSavings);
         repository.Add(bobChecking);
+
+        foreach (var id in FillerIds)
+        {
+            repository.Add(BankAccount.Hydrate(id, AliceId, AccountType.Checking,
+                Money.Create(100m, "USD"), Money.Create(500m, "USD"), Money.Create(0m, "USD"),
+                AccountStatus.Active, timeProvider));
+        }
     }
 
     private static T Required<T>(Result<T> result) =>

--- a/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/AccountEndpoints.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Endpoints/AccountEndpoints.cs
@@ -18,8 +18,24 @@ public static class AccountEndpoints
     {
         var group = routes.MapGroup("/api/accounts").WithTags("Accounts");
 
-        group.MapGet("/", (IAccountRepository repo) =>
-            Results.Ok(repo.All().Select(AccountResponse.From).ToList()));
+        group.MapGet("/", (
+            int? limit,
+            string? cursor,
+            IAccountRepository repo,
+            LinkGenerator links,
+            HttpContext http) =>
+            {
+                var requestedLimit = limit is int l && l > 0 ? l : 10;
+                Cursor? cursorOpt = string.IsNullOrEmpty(cursor) ? null : new Cursor(cursor);
+                return repo.GetPage(requestedLimit, cursorOpt)
+                    .ToPagedHttpResult(
+                        nextUrlBuilder: (c, applied) =>
+                            links.GetUriByName(http, "Showcase_GetAccounts",
+                                values: new { limit = applied, cursor = c.Token })
+                            ?? throw new InvalidOperationException("Route 'Showcase_GetAccounts' not registered."),
+                        map: AccountResponse.From);
+            })
+            .WithName("Showcase_GetAccounts");
 
         group.MapGet("/{id:AccountId}", (AccountId id, IAccountRepository repo) =>
             repo.GetById(id)

--- a/Examples/Showcase/src/Showcase.Mvc/Controllers/AccountsController.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Controllers/AccountsController.cs
@@ -21,9 +21,24 @@ public class AccountsController : ControllerBase
         _workflow = workflow;
     }
 
-    [HttpGet]
-    public ActionResult<IReadOnlyList<AccountResponse>> List() =>
-        Ok(_repository.All().Select(AccountResponse.From).ToList());
+    [HttpGet(Name = "Showcase_GetAccounts")]
+    public ActionResult<PagedResponse<AccountResponse>> List(
+        [FromQuery] int? limit,
+        [FromQuery] string? cursor,
+        [FromServices] LinkGenerator links)
+    {
+        var requestedLimit = limit is int l && l > 0 ? l : 10;
+        Cursor? cursorOpt = string.IsNullOrEmpty(cursor) ? null : new Cursor(cursor);
+
+        return _repository.GetPage(requestedLimit, cursorOpt)
+            .ToPagedActionResult(
+                this,
+                nextUrlBuilder: (c, applied) =>
+                    links.GetUriByName(HttpContext, "Showcase_GetAccounts",
+                        values: new { limit = applied, cursor = c.Token })
+                    ?? throw new InvalidOperationException("Route 'Showcase_GetAccounts' not registered."),
+                map: AccountResponse.From);
+    }
 
     [HttpGet("{id:AccountId}", Name = "Showcase_GetAccount")]
     public ActionResult<AccountResponse> Get(AccountId id) =>

--- a/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
@@ -148,4 +148,98 @@ public class ShowcaseMinimalApiTests : IClassFixture<WebApplicationFactory<Progr
             "the framework should surface the curated TrellisJsonValidationException message instead of the generic placeholder");
         body.Should().Contain("negative", "the Money converter's curated message must reach the client");
     }
+
+    private sealed record PageEnvelope(
+        IReadOnlyList<AccountResponse> Items,
+        PageLinkDto? Next,
+        PageLinkDto? Previous,
+        int RequestedLimit,
+        int AppliedLimit,
+        int DeliveredCount,
+        bool WasCapped);
+
+    private sealed record PageLinkDto(string Cursor, string Href);
+
+    [Fact]
+    public async Task Paginated_list_caps_at_5_and_emits_next_cursor_plus_link_header()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts/?limit=10", UriKind.Relative), Ct);
+
+        response.EnsureSuccessStatusCode();
+        var page = await response.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        page.Should().NotBeNull();
+        page!.Items.Should().HaveCount(5);
+        page.RequestedLimit.Should().Be(10);
+        page.AppliedLimit.Should().Be(5);
+        page.WasCapped.Should().BeTrue();
+        page.DeliveredCount.Should().Be(5);
+        page.Next.Should().NotBeNull();
+        page.Next!.Cursor.Should().NotBeNullOrEmpty();
+
+        response.Headers.Should().ContainKey("Link");
+        var link = response.Headers.GetValues("Link").Single();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain($"cursor={page.Next.Cursor}");
+    }
+
+    [Fact]
+    public async Task Following_next_link_returns_subsequent_distinct_page()
+    {
+        var client = _factory.CreateClient();
+        var firstResp = await client.GetAsync(new Uri("/api/accounts/?limit=5", UriKind.Relative), Ct);
+        var first = await firstResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        first!.Next.Should().NotBeNull();
+
+        var secondResp = await client.GetAsync(new Uri(first.Next!.Href), Ct);
+        secondResp.EnsureSuccessStatusCode();
+        var second = await secondResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+
+        second!.Items.Should().NotBeEmpty();
+        var firstIds = first.Items.Select(a => a.Id).ToHashSet();
+        var secondIds = second.Items.Select(a => a.Id).ToHashSet();
+        firstIds.Overlaps(secondIds).Should().BeFalse("subsequent pages must contain distinct items");
+    }
+
+    [Fact]
+    public async Task Drain_to_last_page_returns_no_next_link_or_header()
+    {
+        var client = _factory.CreateClient();
+        var url = "/api/accounts/?limit=5";
+        PageEnvelope? page = null;
+        HttpResponseMessage? lastResp = null;
+        for (int i = 0; i < 10; i++)
+        {
+            lastResp = await client.GetAsync(new Uri(url, UriKind.RelativeOrAbsolute), Ct);
+            lastResp.EnsureSuccessStatusCode();
+            page = await lastResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+            if (page!.Next is null) break;
+            url = page.Next.Href;
+        }
+
+        page!.Next.Should().BeNull("after draining all pages, next must be absent");
+        lastResp!.Headers.Contains("Link").Should().BeFalse("last page must not emit a Link header");
+    }
+
+    [Fact]
+    public async Task Malformed_cursor_returns_400_problem_details()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts/?cursor=not-a-real-cursor", UriKind.Relative), Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Limit_zero_defaults_to_ten_and_caps_to_five()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts/?limit=0", UriKind.Relative), Ct);
+
+        response.EnsureSuccessStatusCode();
+        var page = await response.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        page!.RequestedLimit.Should().Be(10);
+        page.AppliedLimit.Should().Be(5);
+        page.Items.Should().HaveCount(5);
+    }
 }

--- a/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
@@ -116,4 +116,98 @@ public class ShowcaseApiTests : IClassFixture<WebApplicationFactory<Program>>
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
+
+    private sealed record PageEnvelope(
+        IReadOnlyList<AccountResponse> Items,
+        PageLinkDto? Next,
+        PageLinkDto? Previous,
+        int RequestedLimit,
+        int AppliedLimit,
+        int DeliveredCount,
+        bool WasCapped);
+
+    private sealed record PageLinkDto(string Cursor, string Href);
+
+    [Fact]
+    public async Task Paginated_list_caps_at_5_and_emits_next_cursor_plus_link_header()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts?limit=10", UriKind.Relative), Ct);
+
+        response.EnsureSuccessStatusCode();
+        var page = await response.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        page.Should().NotBeNull();
+        page!.Items.Should().HaveCount(5);
+        page.RequestedLimit.Should().Be(10);
+        page.AppliedLimit.Should().Be(5);
+        page.WasCapped.Should().BeTrue();
+        page.DeliveredCount.Should().Be(5);
+        page.Next.Should().NotBeNull();
+        page.Next!.Cursor.Should().NotBeNullOrEmpty();
+
+        response.Headers.Should().ContainKey("Link");
+        var link = response.Headers.GetValues("Link").Single();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain($"cursor={page.Next.Cursor}");
+    }
+
+    [Fact]
+    public async Task Following_next_link_returns_subsequent_distinct_page()
+    {
+        var client = _factory.CreateClient();
+        var firstResp = await client.GetAsync(new Uri("/api/accounts?limit=5", UriKind.Relative), Ct);
+        var first = await firstResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        first!.Next.Should().NotBeNull();
+
+        var secondResp = await client.GetAsync(new Uri(first.Next!.Href), Ct);
+        secondResp.EnsureSuccessStatusCode();
+        var second = await secondResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+
+        second!.Items.Should().NotBeEmpty();
+        var firstIds = first.Items.Select(a => a.Id).ToHashSet();
+        var secondIds = second.Items.Select(a => a.Id).ToHashSet();
+        firstIds.Overlaps(secondIds).Should().BeFalse("subsequent pages must contain distinct items");
+    }
+
+    [Fact]
+    public async Task Drain_to_last_page_returns_no_next_link_or_header()
+    {
+        var client = _factory.CreateClient();
+        var url = "/api/accounts?limit=5";
+        PageEnvelope? page = null;
+        HttpResponseMessage? lastResp = null;
+        for (int i = 0; i < 10; i++)
+        {
+            lastResp = await client.GetAsync(new Uri(url, UriKind.RelativeOrAbsolute), Ct);
+            lastResp.EnsureSuccessStatusCode();
+            page = await lastResp.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+            if (page!.Next is null) break;
+            url = page.Next.Href;
+        }
+
+        page!.Next.Should().BeNull("after draining all pages, next must be absent");
+        lastResp!.Headers.Contains("Link").Should().BeFalse("last page must not emit a Link header");
+    }
+
+    [Fact]
+    public async Task Malformed_cursor_returns_400_problem_details()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts?cursor=not-a-real-cursor", UriKind.Relative), Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Limit_zero_defaults_to_ten_and_caps_to_five()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/api/accounts?limit=0", UriKind.Relative), Ct);
+
+        response.EnsureSuccessStatusCode();
+        var page = await response.Content.ReadFromJsonAsync<PageEnvelope>(JsonOptions, Ct);
+        page!.RequestedLimit.Should().Be(10);
+        page.AppliedLimit.Should().Be(5);
+        page.Items.Should().HaveCount(5);
+    }
 }

--- a/Trellis.Asp/src/PageActionResultExtensions.cs
+++ b/Trellis.Asp/src/PageActionResultExtensions.cs
@@ -1,0 +1,92 @@
+namespace Trellis.Asp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// MVC counterpart of <see cref="PageHttpResultExtensions"/>. Maps
+/// <see cref="Result{T}"/> of <see cref="Page{T}"/> to an <see cref="ActionResult{TValue}"/>
+/// of <see cref="PagedResponse{TResponse}"/>, co-emitting an RFC 8288 <c>Link</c>
+/// header on the response.
+/// </summary>
+/// <remarks>
+/// Intentionally mirrors the Minimal-API overload surface so that MVC controllers and
+/// Minimal-API handlers produce byte-identical HTTP responses for the same domain result.
+/// Failure results delegate to <see cref="ActionResultExtensions.ToActionResult{TValue}(Error, ControllerBase)"/>;
+/// no <c>Link</c> header is emitted on the failure path.
+/// </remarks>
+public static class PageActionResultExtensions
+{
+    /// <summary>
+    /// Maps <c>Result&lt;Page&lt;T&gt;&gt;</c> to <c>200 OK</c> + paged envelope + <c>Link</c> header,
+    /// or to the standard error response on failure.
+    /// </summary>
+    /// <typeparam name="T">Domain item type carried by the page.</typeparam>
+    /// <typeparam name="TResponse">Wire DTO type to project items into.</typeparam>
+    /// <param name="result">The result containing a <see cref="Page{T}"/> on success.</param>
+    /// <param name="controller">The MVC controller — supplies HttpContext for header emission and error mapping.</param>
+    /// <param name="nextUrlBuilder">Builds the absolute URL for a cursor link given the cursor and the applied limit.</param>
+    /// <param name="map">Projection from domain item to wire DTO.</param>
+    public static ActionResult<PagedResponse<TResponse>> ToPagedActionResult<T, TResponse>(
+        this Result<Page<T>> result,
+        ControllerBase controller,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        ArgumentNullException.ThrowIfNull(nextUrlBuilder);
+        ArgumentNullException.ThrowIfNull(map);
+
+        if (result.TryGetError(out var error))
+            return error.ToActionResult<PagedResponse<TResponse>>(controller);
+
+        result.TryGetValue(out var page);
+
+        string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
+        string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
+
+        var envelope = new PagedResponse<TResponse>(
+            Items: page.Items.Select(map).ToList(),
+            Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
+            Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
+            RequestedLimit: page.RequestedLimit,
+            AppliedLimit: page.AppliedLimit,
+            DeliveredCount: page.DeliveredCount,
+            WasCapped: page.WasCapped);
+
+        var links = new List<string>(2);
+        if (nextHref is not null) links.Add($"<{nextHref}>; rel=\"next\"");
+        if (prevHref is not null) links.Add($"<{prevHref}>; rel=\"prev\"");
+        if (links.Count > 0)
+            controller.Response.Headers.Append("Link", string.Join(", ", links));
+
+        return controller.Ok(envelope);
+    }
+
+    /// <summary>Async <see cref="Task{TResult}"/> overload of <see cref="ToPagedActionResult{T, TResponse}"/>.</summary>
+    public static async Task<ActionResult<PagedResponse<TResponse>>> ToPagedActionResultAsync<T, TResponse>(
+        this Task<Result<Page<T>>> resultTask,
+        ControllerBase controller,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToPagedActionResult(controller, nextUrlBuilder, map);
+    }
+
+    /// <summary>Async <see cref="ValueTask{TResult}"/> overload of <see cref="ToPagedActionResult{T, TResponse}"/>.</summary>
+    public static async ValueTask<ActionResult<PagedResponse<TResponse>>> ToPagedActionResultAsync<T, TResponse>(
+        this ValueTask<Result<Page<T>>> resultTask,
+        ControllerBase controller,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToPagedActionResult(controller, nextUrlBuilder, map);
+    }
+}

--- a/Trellis.Asp/src/PageActionResultExtensions.cs
+++ b/Trellis.Asp/src/PageActionResultExtensions.cs
@@ -1,8 +1,6 @@
 namespace Trellis.Asp;
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -46,23 +44,9 @@ public static class PageActionResultExtensions
 
         result.TryGetValue(out var page);
 
-        string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
-        string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
-
-        var envelope = new PagedResponse<TResponse>(
-            Items: page.Items.Select(map).ToList(),
-            Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
-            Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
-            RequestedLimit: page.RequestedLimit,
-            AppliedLimit: page.AppliedLimit,
-            DeliveredCount: page.DeliveredCount,
-            WasCapped: page.WasCapped);
-
-        var links = new List<string>(2);
-        if (nextHref is not null) links.Add($"<{nextHref}>; rel=\"next\"");
-        if (prevHref is not null) links.Add($"<{prevHref}>; rel=\"prev\"");
-        if (links.Count > 0)
-            controller.Response.Headers.Append("Link", string.Join(", ", links));
+        var (envelope, linkHeader) = PagedResponseBuilder.Build(page, nextUrlBuilder, map);
+        if (linkHeader is not null)
+            controller.Response.Headers.Append("Link", linkHeader);
 
         return controller.Ok(envelope);
     }

--- a/Trellis.Asp/src/PageHttpResultExtensions.cs
+++ b/Trellis.Asp/src/PageHttpResultExtensions.cs
@@ -1,8 +1,6 @@
 namespace Trellis.Asp;
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -12,7 +10,7 @@ using Microsoft.AspNetCore.Http;
 /// <list type="bullet">
 ///   <item><c>200 OK</c> with a <see cref="PagedResponse{TResponse}"/> JSON envelope (items, next/prev cursor + href, requestedLimit, appliedLimit, deliveredCount, wasCapped).</item>
 ///   <item>Co-emitted <c>Link</c> header per RFC 8288 with <c>rel="next"</c> and/or <c>rel="prev"</c>.</item>
-///   <item>Failure results are delegated to the standard error mapper (<see cref="HttpResultExtensions.ToHttpResult{TValue}(Result{TValue}, TrellisAspOptions?)"/>) — no Link header emitted.</item>
+///   <item>Failure results are delegated to the standard error mapper (<see cref="HttpResultExtensions.ToHttpResult{TValue}(Result{TValue}, TrellisAspOptions)"/>) — no Link header emitted.</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -85,24 +83,9 @@ public static class PageHttpResultExtensions
         Func<Cursor, int, string> nextUrlBuilder,
         Func<T, TResponse> map)
     {
-        string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
-        string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
-
-        var envelope = new PagedResponse<TResponse>(
-            Items: page.Items.Select(map).ToList(),
-            Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
-            Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
-            RequestedLimit: page.RequestedLimit,
-            AppliedLimit: page.AppliedLimit,
-            DeliveredCount: page.DeliveredCount,
-            WasCapped: page.WasCapped);
-
+        var (envelope, linkHeader) = PagedResponseBuilder.Build(page, nextUrlBuilder, map);
         var ok = Results.Ok(envelope);
-
-        if (nextHref is null && prevHref is null)
-            return ok;
-
-        return new PagedHttpResult(ok, nextHref, prevHref);
+        return linkHeader is null ? ok : new PagedHttpResult(ok, linkHeader);
     }
 }
 
@@ -121,31 +104,23 @@ public sealed record PageLink(string Cursor, string Href);
 
 /// <summary>
 /// <see cref="IResult"/> wrapper that delegates to an inner result and also emits an
-/// RFC 8288 <c>Link</c> header with <c>rel="next"</c> / <c>rel="prev"</c> entries.
+/// RFC 8288 <c>Link</c> header containing pre-formatted <c>rel="next"</c> / <c>rel="prev"</c> entries.
 /// </summary>
 internal sealed class PagedHttpResult : IResult
 {
     private readonly IResult _inner;
-    private readonly string? _nextHref;
-    private readonly string? _previousHref;
+    private readonly string _linkHeader;
 
-    public PagedHttpResult(IResult inner, string? nextHref, string? previousHref)
+    public PagedHttpResult(IResult inner, string linkHeader)
     {
         _inner = inner;
-        _nextHref = nextHref;
-        _previousHref = previousHref;
+        _linkHeader = linkHeader;
     }
 
     public Task ExecuteAsync(HttpContext httpContext)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
-
-        var links = new List<string>(2);
-        if (_nextHref is not null) links.Add($"<{_nextHref}>; rel=\"next\"");
-        if (_previousHref is not null) links.Add($"<{_previousHref}>; rel=\"prev\"");
-        if (links.Count > 0)
-            httpContext.Response.Headers.Append("Link", string.Join(", ", links));
-
+        httpContext.Response.Headers.Append("Link", _linkHeader);
         return _inner.ExecuteAsync(httpContext);
     }
 }

--- a/Trellis.Asp/src/PageHttpResultExtensions.cs
+++ b/Trellis.Asp/src/PageHttpResultExtensions.cs
@@ -1,0 +1,151 @@
+namespace Trellis.Asp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Maps a <see cref="Result{T}"/> of <see cref="Page{T}"/> to an HTTP response that follows
+/// the Trellis pagination contract:
+/// <list type="bullet">
+///   <item><c>200 OK</c> with a <see cref="PagedResponse{TResponse}"/> JSON envelope (items, next/prev cursor + href, requestedLimit, appliedLimit, deliveredCount, wasCapped).</item>
+///   <item>Co-emitted <c>Link</c> header per RFC 8288 with <c>rel="next"</c> and/or <c>rel="prev"</c>.</item>
+///   <item>Failure results are delegated to the standard error mapper (<see cref="HttpResultExtensions.ToHttpResult{TValue}(Result{TValue}, TrellisAspOptions?)"/>) — no Link header emitted.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why an envelope AND a Link header?</b> The body envelope is AI/LLM-friendly (the cursor
+/// sits in the JSON the consumer already parsed) and matches OData / Microsoft Graph idioms.
+/// The Link header satisfies RFC-8288-aware tooling (HTTP middleware, crawlers, gateways) at
+/// near-zero cost. The two carry the same information.
+/// </para>
+/// <para>
+/// <b>Url builder responsibility:</b> the caller supplies a <c>nextUrlBuilder</c> that converts
+/// a <see cref="Cursor"/> + the applied limit into a fully-formed URL. The extension does NOT
+/// inspect the current request, build query strings, or URL-encode the cursor — the caller
+/// owns route construction.
+/// </para>
+/// </remarks>
+public static class PageHttpResultExtensions
+{
+    /// <summary>
+    /// Maps <c>Result&lt;Page&lt;T&gt;&gt;</c> to <c>200 OK</c> + envelope + <c>Link</c> header,
+    /// or to the standard error response on failure.
+    /// </summary>
+    /// <typeparam name="T">Domain item type carried by the page.</typeparam>
+    /// <typeparam name="TResponse">Wire DTO type to project items into.</typeparam>
+    /// <param name="result">The result containing a <see cref="Page{T}"/> on success.</param>
+    /// <param name="nextUrlBuilder">Builds the absolute URL for a cursor link given the cursor and the applied limit.</param>
+    /// <param name="map">Projection from domain item to wire DTO.</param>
+    /// <param name="options">Optional error-to-status mapping (defaults applied otherwise).</param>
+    public static IResult ToPagedHttpResult<T, TResponse>(
+        this Result<Page<T>> result,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map,
+        TrellisAspOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(nextUrlBuilder);
+        ArgumentNullException.ThrowIfNull(map);
+
+        if (result.TryGetError(out var error))
+            return error.ToHttpResult(options);
+
+        result.TryGetValue(out var page);
+        return BuildPagedResult(page, nextUrlBuilder, map);
+    }
+
+    /// <summary>Async <see cref="Task{TResult}"/> overload of <see cref="ToPagedHttpResult{T, TResponse}"/>.</summary>
+    public static async Task<IResult> ToPagedHttpResultAsync<T, TResponse>(
+        this Task<Result<Page<T>>> resultTask,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map,
+        TrellisAspOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToPagedHttpResult(nextUrlBuilder, map, options);
+    }
+
+    /// <summary>Async <see cref="ValueTask{TResult}"/> overload of <see cref="ToPagedHttpResult{T, TResponse}"/>.</summary>
+    public static async ValueTask<IResult> ToPagedHttpResultAsync<T, TResponse>(
+        this ValueTask<Result<Page<T>>> resultTask,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map,
+        TrellisAspOptions? options = null)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.ToPagedHttpResult(nextUrlBuilder, map, options);
+    }
+
+    private static IResult BuildPagedResult<T, TResponse>(
+        Page<T> page,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map)
+    {
+        string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
+        string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
+
+        var envelope = new PagedResponse<TResponse>(
+            Items: page.Items.Select(map).ToList(),
+            Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
+            Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
+            RequestedLimit: page.RequestedLimit,
+            AppliedLimit: page.AppliedLimit,
+            DeliveredCount: page.DeliveredCount,
+            WasCapped: page.WasCapped);
+
+        var ok = Results.Ok(envelope);
+
+        if (nextHref is null && prevHref is null)
+            return ok;
+
+        return new PagedHttpResult(ok, nextHref, prevHref);
+    }
+}
+
+/// <summary>JSON envelope wrapping a single page of items and its cursor links.</summary>
+public sealed record PagedResponse<TResponse>(
+    IReadOnlyList<TResponse> Items,
+    PageLink? Next,
+    PageLink? Previous,
+    int RequestedLimit,
+    int AppliedLimit,
+    int DeliveredCount,
+    bool WasCapped);
+
+/// <summary>A cursor + the absolute URL the client should follow to fetch the linked page.</summary>
+public sealed record PageLink(string Cursor, string Href);
+
+/// <summary>
+/// <see cref="IResult"/> wrapper that delegates to an inner result and also emits an
+/// RFC 8288 <c>Link</c> header with <c>rel="next"</c> / <c>rel="prev"</c> entries.
+/// </summary>
+internal sealed class PagedHttpResult : IResult
+{
+    private readonly IResult _inner;
+    private readonly string? _nextHref;
+    private readonly string? _previousHref;
+
+    public PagedHttpResult(IResult inner, string? nextHref, string? previousHref)
+    {
+        _inner = inner;
+        _nextHref = nextHref;
+        _previousHref = previousHref;
+    }
+
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var links = new List<string>(2);
+        if (_nextHref is not null) links.Add($"<{_nextHref}>; rel=\"next\"");
+        if (_previousHref is not null) links.Add($"<{_previousHref}>; rel=\"prev\"");
+        if (links.Count > 0)
+            httpContext.Response.Headers.Append("Link", string.Join(", ", links));
+
+        return _inner.ExecuteAsync(httpContext);
+    }
+}

--- a/Trellis.Asp/src/PagedResponseBuilder.cs
+++ b/Trellis.Asp/src/PagedResponseBuilder.cs
@@ -27,8 +27,10 @@ internal static class PagedResponseBuilder
         string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
         string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
 
+        var items = page.Items ?? (IReadOnlyList<T>)Array.Empty<T>();
+
         var envelope = new PagedResponse<TResponse>(
-            Items: page.Items.Select(map).ToList(),
+            Items: items.Select(map).ToList(),
             Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
             Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
             RequestedLimit: page.RequestedLimit,

--- a/Trellis.Asp/src/PagedResponseBuilder.cs
+++ b/Trellis.Asp/src/PagedResponseBuilder.cs
@@ -1,0 +1,46 @@
+namespace Trellis.Asp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Internal helper that builds the <see cref="PagedResponse{TResponse}"/> envelope and the
+/// matching RFC 8288 <c>Link</c> header value from a <see cref="Page{T}"/>. Used by both
+/// <see cref="PageHttpResultExtensions"/> (Minimal API) and <see cref="PageActionResultExtensions"/>
+/// (MVC) to guarantee byte-identical wire output across hosting styles.
+/// </summary>
+internal static class PagedResponseBuilder
+{
+    /// <summary>
+    /// Projects <paramref name="page"/> into a JSON envelope and the <c>Link</c> header value.
+    /// </summary>
+    /// <param name="page">The source page.</param>
+    /// <param name="nextUrlBuilder">Builds an absolute URL from a cursor and the applied limit.</param>
+    /// <param name="map">Projection from domain item to wire DTO.</param>
+    /// <returns>The envelope and the <c>Link</c> header value (null when neither cursor is present).</returns>
+    public static (PagedResponse<TResponse> Envelope, string? LinkHeader) Build<T, TResponse>(
+        Page<T> page,
+        Func<Cursor, int, string> nextUrlBuilder,
+        Func<T, TResponse> map)
+    {
+        string? nextHref = page.Next is { } next ? nextUrlBuilder(next, page.AppliedLimit) : null;
+        string? prevHref = page.Previous is { } prev ? nextUrlBuilder(prev, page.AppliedLimit) : null;
+
+        var envelope = new PagedResponse<TResponse>(
+            Items: page.Items.Select(map).ToList(),
+            Next: page.Next is { } n && nextHref is not null ? new PageLink(n.Token, nextHref) : null,
+            Previous: page.Previous is { } p && prevHref is not null ? new PageLink(p.Token, prevHref) : null,
+            RequestedLimit: page.RequestedLimit,
+            AppliedLimit: page.AppliedLimit,
+            DeliveredCount: page.DeliveredCount,
+            WasCapped: page.WasCapped);
+
+        var links = new List<string>(2);
+        if (nextHref is not null) links.Add($"<{nextHref}>; rel=\"next\"");
+        if (prevHref is not null) links.Add($"<{prevHref}>; rel=\"prev\"");
+        var linkHeader = links.Count > 0 ? string.Join(", ", links) : null;
+
+        return (envelope, linkHeader);
+    }
+}

--- a/Trellis.Asp/tests/PageActionResultExtensionsTests.cs
+++ b/Trellis.Asp/tests/PageActionResultExtensionsTests.cs
@@ -1,0 +1,168 @@
+namespace Trellis.Asp.Tests;
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Trellis;
+
+/// <summary>
+/// Unit tests for <see cref="PageActionResultExtensions"/>: envelope shape, Link header
+/// emission, error passthrough, and Task/ValueTask overloads.
+/// </summary>
+public class PageActionResultExtensionsTests
+{
+    private static readonly int[] OneItem = [1];
+    private static readonly int[] OneItemSeven = [7];
+    private static readonly int[] OneItemNine = [9];
+    private static readonly int[] OneTwoThree = [1, 2, 3];
+    private static readonly int[] OneTwo = [1, 2];
+
+    private sealed class TestController : ControllerBase { }
+
+    private static TestController CreateController()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory,
+            Microsoft.AspNetCore.Mvc.Infrastructure.DefaultProblemDetailsFactory>();
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions()));
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new ApiBehaviorOptions()));
+        var provider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = provider };
+        return new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private static string Build(Cursor cursor, int appliedLimit) =>
+        $"https://api.example.com/widgets?limit={appliedLimit}&cursor={cursor.Token}";
+
+    private static string MapToString(int x) => $"item-{x}";
+
+    [Fact]
+    public void Failure_result_returns_error_action_result_and_emits_no_link_header()
+    {
+        var controller = CreateController();
+        var result = Result.Fail<Page<int>>(new Error.NotFound(new ResourceRef("Widget", "x")));
+
+        var response = result.ToPagedActionResult(controller, Build, MapToString);
+
+        controller.Response.Headers.ContainsKey("Link").Should().BeFalse();
+        response.Result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Empty_page_with_no_cursors_returns_ok_envelope_and_no_link_header()
+    {
+        var controller = CreateController();
+        var page = Page.Empty<int>(requestedLimit: 10, appliedLimit: 5);
+
+        var response = Result.Ok(page).ToPagedActionResult(controller, Build, MapToString);
+
+        controller.Response.Headers.ContainsKey("Link").Should().BeFalse();
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<PagedResponse<string>>();
+    }
+
+    [Fact]
+    public void Page_with_next_cursor_emits_link_rel_next()
+    {
+        var controller = CreateController();
+        var page = new Page<int>(OneTwoThree, new Cursor("nxt-token"), null, RequestedLimit: 10, AppliedLimit: 3);
+
+        Result.Ok(page).ToPagedActionResult(controller, Build, MapToString);
+
+        var link = controller.Response.Headers["Link"].ToString();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain("cursor=nxt-token");
+        link.Should().Contain("limit=3");
+        link.Should().NotContain("rel=\"prev\"");
+    }
+
+    [Fact]
+    public void Page_with_both_cursors_emits_comma_separated_link_header()
+    {
+        var controller = CreateController();
+        var page = new Page<int>(OneItem, new Cursor("n"), new Cursor("p"), RequestedLimit: 5, AppliedLimit: 5);
+
+        Result.Ok(page).ToPagedActionResult(controller, Build, MapToString);
+
+        var link = controller.Response.Headers["Link"].ToString();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain("rel=\"prev\"");
+        link.Should().Contain(", ");
+    }
+
+    [Fact]
+    public void Url_builder_receives_applied_limit_not_requested()
+    {
+        var controller = CreateController();
+        int? observedLimit = null;
+        string Builder(Cursor c, int applied)
+        {
+            observedLimit = applied;
+            return $"u?{applied}";
+        }
+
+        var page = new Page<int>(OneItem, new Cursor("c"), null, RequestedLimit: 100, AppliedLimit: 5);
+
+        Result.Ok(page).ToPagedActionResult(controller, Builder, MapToString);
+
+        observedLimit.Should().Be(5);
+    }
+
+    [Fact]
+    public void Items_are_projected_via_map_into_envelope()
+    {
+        var controller = CreateController();
+        var page = new Page<int>(OneTwo, null, null, RequestedLimit: 10, AppliedLimit: 10);
+
+        var response = Result.Ok(page).ToPagedActionResult(controller, Build, MapToString);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = ok.Value.Should().BeOfType<PagedResponse<string>>().Subject;
+        envelope.Items.Should().Equal("item-1", "item-2");
+        envelope.RequestedLimit.Should().Be(10);
+        envelope.AppliedLimit.Should().Be(10);
+        envelope.DeliveredCount.Should().Be(2);
+        envelope.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Task_overload_awaits_and_delegates_correctly()
+    {
+        var controller = CreateController();
+        var page = new Page<int>(OneItemSeven, new Cursor("t"), null, 10, 1);
+        Task<Result<Page<int>>> task = Task.FromResult(Result.Ok(page));
+
+        await task.ToPagedActionResultAsync(controller, Build, MapToString);
+
+        controller.Response.Headers["Link"].ToString().Should().Contain("cursor=t");
+    }
+
+    [Fact]
+    public async Task ValueTask_overload_awaits_and_delegates_correctly()
+    {
+        var controller = CreateController();
+        var page = new Page<int>(OneItemNine, new Cursor("v"), null, 10, 1);
+        ValueTask<Result<Page<int>>> task = new ValueTask<Result<Page<int>>>(Result.Ok(page));
+
+        await task.ToPagedActionResultAsync(controller, Build, MapToString);
+
+        controller.Response.Headers["Link"].ToString().Should().Contain("cursor=v");
+    }
+
+    [Fact]
+    public void Null_controller_throws_argument_null_exception()
+    {
+        var page = new Page<int>(OneItem, null, null, 10, 10);
+        var act = () => Result.Ok(page).ToPagedActionResult<int, string>(null!, Build, MapToString);
+
+        act.Should().Throw<System.ArgumentNullException>().WithParameterName("controller");
+    }
+}

--- a/Trellis.Asp/tests/PageHttpResultExtensionsTests.cs
+++ b/Trellis.Asp/tests/PageHttpResultExtensionsTests.cs
@@ -1,0 +1,190 @@
+namespace Trellis.Asp.Tests;
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Trellis;
+
+/// <summary>
+/// Unit tests for <see cref="PageHttpResultExtensions"/>: envelope shape, Link header
+/// emission, error passthrough, and Task/ValueTask overloads.
+/// </summary>
+public class PageHttpResultExtensionsTests
+{
+    private static readonly int[] OneItem = [1];
+    private static readonly int[] OneItemSeven = [7];
+    private static readonly int[] OneItemNine = [9];
+    private static readonly int[] OneTwoThree = [1, 2, 3];
+    private static readonly int[] OneTwo = [1, 2];
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider(),
+        };
+        context.Response.Body = new System.IO.MemoryStream();
+        return context;
+    }
+
+    private static string Build(Cursor cursor, int appliedLimit) =>
+        $"https://api.example.com/widgets?limit={appliedLimit}&cursor={cursor.Token}";
+
+    private static string MapToString(int x) => $"item-{x}";
+
+    [Fact]
+    public async Task Failure_result_returns_error_response_and_emits_no_link_header()
+    {
+        var httpContext = CreateHttpContext();
+        var result = Result.Fail<Page<int>>(new Error.NotFound(new ResourceRef("Widget", "x")));
+
+        var response = result.ToPagedHttpResult(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        httpContext.Response.Headers.ContainsKey("Link").Should().BeFalse();
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task Empty_page_with_no_cursors_returns_ok_envelope_and_no_link_header()
+    {
+        var httpContext = CreateHttpContext();
+        var page = Page.Empty<int>(requestedLimit: 10, appliedLimit: 5);
+        var result = Result.Ok(page);
+
+        var response = result.ToPagedHttpResult(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        httpContext.Response.Headers.ContainsKey("Link").Should().BeFalse();
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.Should().BeOfType<Ok<PagedResponse<string>>>();
+    }
+
+    [Fact]
+    public async Task Page_with_next_cursor_emits_link_rel_next()
+    {
+        var httpContext = CreateHttpContext();
+        var page = new Page<int>(
+            Items: OneTwoThree,
+            Next: new Cursor("nxt-token"),
+            Previous: null,
+            RequestedLimit: 10,
+            AppliedLimit: 3);
+        var result = Result.Ok(page);
+
+        var response = result.ToPagedHttpResult(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        var link = httpContext.Response.Headers["Link"].ToString();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain("cursor=nxt-token");
+        link.Should().Contain("limit=3");
+        link.Should().NotContain("rel=\"prev\"");
+    }
+
+    [Fact]
+    public async Task Page_with_both_cursors_emits_comma_separated_link_header()
+    {
+        var httpContext = CreateHttpContext();
+        var page = new Page<int>(
+            Items: OneItem,
+            Next: new Cursor("n"),
+            Previous: new Cursor("p"),
+            RequestedLimit: 5,
+            AppliedLimit: 5);
+
+        var response = Result.Ok(page).ToPagedHttpResult(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        var link = httpContext.Response.Headers["Link"].ToString();
+        link.Should().Contain("rel=\"next\"");
+        link.Should().Contain("rel=\"prev\"");
+        link.Should().Contain(", "); // RFC 8288 comma-joined values
+    }
+
+    [Fact]
+    public async Task Url_builder_receives_applied_limit_not_requested()
+    {
+        var httpContext = CreateHttpContext();
+        int? observedLimit = null;
+        string Builder(Cursor c, int applied)
+        {
+            observedLimit = applied;
+            return $"u?{applied}";
+        }
+
+        var page = new Page<int>(OneItem, new Cursor("c"), null, RequestedLimit: 100, AppliedLimit: 5);
+
+        await Result.Ok(page).ToPagedHttpResult(Builder, MapToString).ExecuteAsync(httpContext);
+
+        observedLimit.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task Items_are_projected_via_map_into_envelope()
+    {
+        var httpContext = CreateHttpContext();
+        var page = new Page<int>(OneTwo, null, null, RequestedLimit: 10, AppliedLimit: 10);
+
+        var response = Result.Ok(page).ToPagedHttpResult(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        var typed = response.Should().BeOfType<Ok<PagedResponse<string>>>().Subject;
+        typed.Value!.Items.Should().Equal("item-1", "item-2");
+        typed.Value.RequestedLimit.Should().Be(10);
+        typed.Value.AppliedLimit.Should().Be(10);
+        typed.Value.DeliveredCount.Should().Be(2);
+        typed.Value.WasCapped.Should().BeFalse();
+        typed.Value.Next.Should().BeNull();
+        typed.Value.Previous.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Task_overload_awaits_and_delegates_correctly()
+    {
+        var httpContext = CreateHttpContext();
+        var page = new Page<int>(OneItemSeven, new Cursor("t"), null, 10, 1);
+        Task<Result<Page<int>>> task = Task.FromResult(Result.Ok(page));
+
+        var response = await task.ToPagedHttpResultAsync(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        httpContext.Response.Headers["Link"].ToString().Should().Contain("cursor=t");
+    }
+
+    [Fact]
+    public async Task ValueTask_overload_awaits_and_delegates_correctly()
+    {
+        var httpContext = CreateHttpContext();
+        var page = new Page<int>(OneItemNine, new Cursor("v"), null, 10, 1);
+        ValueTask<Result<Page<int>>> task = new ValueTask<Result<Page<int>>>(Result.Ok(page));
+
+        var response = await task.ToPagedHttpResultAsync(Build, MapToString);
+        await response.ExecuteAsync(httpContext);
+
+        httpContext.Response.Headers["Link"].ToString().Should().Contain("cursor=v");
+    }
+
+    [Fact]
+    public void Null_url_builder_throws_argument_null_exception()
+    {
+        var page = new Page<int>(OneItem, null, null, 10, 10);
+        var act = () => Result.Ok(page).ToPagedHttpResult<int, string>(null!, MapToString);
+
+        act.Should().Throw<System.ArgumentNullException>().WithParameterName("nextUrlBuilder");
+    }
+
+    [Fact]
+    public void Null_map_throws_argument_null_exception()
+    {
+        var page = new Page<int>(OneItem, null, null, 10, 10);
+        var act = () => Result.Ok(page).ToPagedHttpResult<int, string>(Build, null!);
+
+        act.Should().Throw<System.ArgumentNullException>().WithParameterName("map");
+    }
+}

--- a/Trellis.Results/src/Pagination/Cursor.cs
+++ b/Trellis.Results/src/Pagination/Cursor.cs
@@ -1,0 +1,39 @@
+namespace Trellis;
+
+using System;
+
+/// <summary>
+/// Opaque pagination cursor exchanged between server and client. Servers MUST treat the
+/// <see cref="Token"/> contents as their own private encoding; clients MUST treat it as a
+/// black box and only echo it back on the next request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cursors are the canonical "continue from here" primitive for collection pagination
+/// in Trellis (see <see cref="Page{T}"/>). They are intentionally opaque to keep the
+/// server free to change its sort order, encoding, signing, or skip strategy without
+/// breaking clients.
+/// </para>
+/// <para>
+/// Absence of a cursor is represented by <c>null</c> at the use site
+/// (<c>Cursor?</c> or <c>Page&lt;T&gt;.Next is null</c>). There is no "empty cursor"
+/// — a constructed <see cref="Cursor"/> always carries a non-empty token.
+/// </para>
+/// </remarks>
+public readonly record struct Cursor
+{
+    /// <summary>
+    /// Creates a cursor with the supplied opaque token.
+    /// </summary>
+    /// <param name="token">The opaque continuation token. Must be non-null and non-empty.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="token"/> is null or empty.</exception>
+    public Cursor(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            throw new ArgumentException("Cursor token must be a non-empty string.", nameof(token));
+        Token = token;
+    }
+
+    /// <summary>The opaque continuation token. Server-defined encoding; never parsed by the client.</summary>
+    public string Token { get; }
+}

--- a/Trellis.Results/src/Pagination/Page.cs
+++ b/Trellis.Results/src/Pagination/Page.cs
@@ -26,15 +26,51 @@ using System.Collections.Generic;
 /// makes server-side clamping observable without the client having to compare counts.
 /// </para>
 /// </remarks>
-public readonly record struct Page<T>(
-    IReadOnlyList<T> Items,
-    Cursor? Next,
-    Cursor? Previous,
-    int RequestedLimit,
-    int AppliedLimit)
+public readonly record struct Page<T>
 {
-    /// <summary>The number of items actually returned in this page (always equal to <c>Items.Count</c>).</summary>
-    public int DeliveredCount => Items.Count;
+    /// <summary>Constructs a validated page. Use <see cref="Page.Empty{T}(int, int)"/> for empty pages.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="Items"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">A limit is non-positive, or <paramref name="AppliedLimit"/> exceeds <paramref name="RequestedLimit"/>.</exception>
+    public Page(
+        IReadOnlyList<T> Items,
+        Cursor? Next,
+        Cursor? Previous,
+        int RequestedLimit,
+        int AppliedLimit)
+    {
+        ArgumentNullException.ThrowIfNull(Items);
+        if (RequestedLimit <= 0)
+            throw new ArgumentOutOfRangeException(nameof(RequestedLimit), "Limit must be positive.");
+        if (AppliedLimit <= 0)
+            throw new ArgumentOutOfRangeException(nameof(AppliedLimit), "Limit must be positive.");
+        if (AppliedLimit > RequestedLimit)
+            throw new ArgumentOutOfRangeException(nameof(AppliedLimit), "AppliedLimit cannot exceed RequestedLimit.");
+
+        this.Items = Items;
+        this.Next = Next;
+        this.Previous = Previous;
+        this.RequestedLimit = RequestedLimit;
+        this.AppliedLimit = AppliedLimit;
+    }
+
+    /// <summary>The items returned for this page (never null when constructed via the public ctor).</summary>
+    public IReadOnlyList<T> Items { get; }
+
+    /// <summary>Cursor for the next page, or null when this is the last page.</summary>
+    public Cursor? Next { get; }
+
+    /// <summary>Cursor for the previous page, or null when this is the first page (or the source doesn't support reverse).</summary>
+    public Cursor? Previous { get; }
+
+    /// <summary>The limit the client requested.</summary>
+    public int RequestedLimit { get; }
+
+    /// <summary>The limit the server actually applied (after server-side cap).</summary>
+    public int AppliedLimit { get; }
+
+    /// <summary>The number of items actually returned in this page.</summary>
+    /// <remarks>Defensive against <c>default(Page&lt;T&gt;)</c>: returns 0 when <see cref="Items"/> is null.</remarks>
+    public int DeliveredCount => Items?.Count ?? 0;
 
     /// <summary>True when the server applied a smaller limit than the client requested.</summary>
     public bool WasCapped => AppliedLimit < RequestedLimit;

--- a/Trellis.Results/src/Pagination/Page.cs
+++ b/Trellis.Results/src/Pagination/Page.cs
@@ -1,0 +1,53 @@
+namespace Trellis;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// A single page of items from a paginated collection together with the cursors needed to
+/// fetch adjacent pages. The canonical Trellis primitive for server-driven pagination.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>Wire shape:</b> Trellis projects <see cref="Page{T}"/> to <c>200 OK</c> with a JSON
+/// body envelope and a co-emitted <c>Link</c> header (RFC 8288). See
+/// <c>Trellis.Asp.PageHttpResultExtensions.ToPagedHttpResult</c>.
+/// </para>
+/// <para>
+/// <b>Why not 206 Partial Content?</b> RFC 9110 §14 was designed for byte-range transfer
+/// of a single octet stream; collection pagination has no IANA-registered range unit and
+/// no proxy/CDN ecosystem support. Use <see cref="Page{T}"/> for collections; reserve
+/// <c>206</c> for actual byte-range GETs.
+/// </para>
+/// <para>
+/// <b>Cap visibility:</b> <see cref="RequestedLimit"/> records what the client asked for and
+/// <see cref="AppliedLimit"/> records what the server actually used. <see cref="WasCapped"/>
+/// makes server-side clamping observable without the client having to compare counts.
+/// </para>
+/// </remarks>
+public readonly record struct Page<T>(
+    IReadOnlyList<T> Items,
+    Cursor? Next,
+    Cursor? Previous,
+    int RequestedLimit,
+    int AppliedLimit)
+{
+    /// <summary>The number of items actually returned in this page (always equal to <c>Items.Count</c>).</summary>
+    public int DeliveredCount => Items.Count;
+
+    /// <summary>True when the server applied a smaller limit than the client requested.</summary>
+    public bool WasCapped => AppliedLimit < RequestedLimit;
+}
+
+/// <summary>
+/// Non-generic factory companion for <see cref="Page{T}"/>. Mirrors the <c>Result</c> /
+/// <c>Result&lt;T&gt;</c> split: factory methods live on the non-generic type to keep
+/// generic-type surface minimal (CA1000) and to allow type inference at the call site.
+/// </summary>
+public static class Page
+{
+    /// <summary>An empty page (no items, no cursors) for the supplied limits.</summary>
+    public static Page<T> Empty<T>(int requestedLimit, int appliedLimit) =>
+        new(Array.Empty<T>(), null, null, requestedLimit, appliedLimit);
+}

--- a/Trellis.Results/tests/Pagination/CursorTests.cs
+++ b/Trellis.Results/tests/Pagination/CursorTests.cs
@@ -1,0 +1,48 @@
+namespace Trellis.Results.Tests.Pagination;
+
+using System;
+
+/// <summary>
+/// Unit tests for the <see cref="Cursor"/> opaque pagination token.
+/// </summary>
+public class CursorTests
+{
+    [Fact]
+    public void Constructor_with_non_empty_token_round_trips_value()
+    {
+        var cursor = new Cursor("abc123");
+
+        cursor.Token.Should().Be("abc123");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Constructor_rejects_null_or_empty_token(string? token)
+    {
+        var act = () => new Cursor(token!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName(nameof(token));
+    }
+
+    [Fact]
+    public void Default_struct_has_null_token_and_is_distinct_from_constructed_cursor()
+    {
+        var defaulted = default(Cursor);
+        var constructed = new Cursor("x");
+
+        defaulted.Token.Should().BeNull();
+        defaulted.Should().NotBe(constructed);
+    }
+
+    [Fact]
+    public void Cursors_with_same_token_are_equal()
+    {
+        var a = new Cursor("token-1");
+        var b = new Cursor("token-1");
+
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/Trellis.Results/tests/Pagination/PageTests.cs
+++ b/Trellis.Results/tests/Pagination/PageTests.cs
@@ -1,0 +1,48 @@
+namespace Trellis.Results.Tests.Pagination;
+
+using System;
+
+/// <summary>
+/// Unit tests for the <see cref="Page{T}"/> pagination envelope.
+/// </summary>
+public class PageTests
+{
+    [Fact]
+    public void DeliveredCount_equals_items_count()
+    {
+        var items = new[] { 1, 2, 3 };
+        var page = new Page<int>(items, Next: null, Previous: null, RequestedLimit: 10, AppliedLimit: 5);
+
+        page.DeliveredCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void WasCapped_true_when_applied_less_than_requested()
+    {
+        var page = new Page<int>(Array.Empty<int>(), null, null, RequestedLimit: 10, AppliedLimit: 5);
+
+        page.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WasCapped_false_when_applied_equals_requested()
+    {
+        var page = new Page<int>(Array.Empty<int>(), null, null, RequestedLimit: 10, AppliedLimit: 10);
+
+        page.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_factory_returns_zero_items_and_no_cursors()
+    {
+        var page = Page.Empty<int>(requestedLimit: 25, appliedLimit: 10);
+
+        page.Items.Should().BeEmpty();
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+        page.RequestedLimit.Should().Be(25);
+        page.AppliedLimit.Should().Be(10);
+        page.DeliveredCount.Should().Be(0);
+        page.WasCapped.Should().BeTrue();
+    }
+}

--- a/Trellis.Results/tests/Pagination/PageTests.cs
+++ b/Trellis.Results/tests/Pagination/PageTests.cs
@@ -45,4 +45,44 @@ public class PageTests
         page.DeliveredCount.Should().Be(0);
         page.WasCapped.Should().BeTrue();
     }
+
+    [Fact]
+    public void Default_struct_returns_zero_for_derived_properties()
+    {
+        Page<int> def = default;
+        def.DeliveredCount.Should().Be(0);
+        def.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_items()
+    {
+        var act = () => new Page<int>(null!, null, null, 10, 10);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("Items");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_rejects_non_positive_requested_limit(int requested)
+    {
+        var act = () => new Page<int>(Array.Empty<int>(), null, null, requested, 1);
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("RequestedLimit");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_rejects_non_positive_applied_limit(int applied)
+    {
+        var act = () => new Page<int>(Array.Empty<int>(), null, null, 10, applied);
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("AppliedLimit");
+    }
+
+    [Fact]
+    public void Constructor_rejects_applied_greater_than_requested()
+    {
+        var act = () => new Page<int>(Array.Empty<int>(), null, null, 5, 10);
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("AppliedLimit");
+    }
 }


### PR DESCRIPTION
Validates the redesign §0.7.4 decision: business APIs return a `PagedResponse<T>` body envelope **and** co-emit an RFC 8288 `Link` header. Bytes / `Range` / `206 Partial Content` stays reserved for media (per the same section).
 
 ## Why
 
 Today the Showcase has no story for "client asks for N, server caps to M and continues" — and the framework's only paging primitive (`PartialContentResult` + `items {from}-{to}/{total}`) misuses 206 for collections. This spike implements the proposed shape end-to-end on both hosting styles to prove the design 
is ergonomic and host-agnostic before promoting it into PR-PAGE.
 
 ## Surface added
 
 | Assembly | Type / API |
 |---|---|
 | `Trellis.Results` | `Cursor` (opaque record-struct, ctor enforces non-empty) |
 | `Trellis.Results` | `Page<T>` record-struct: `Items`, `Next`, `Previous`, `RequestedLimit`, `AppliedLimit` (+ derived `DeliveredCount`, `WasCapped`) |
 | `Trellis.Results` | non-generic `Page.Empty<T>(req, app)` factory (CA1000-compliant) |
 | `Trellis.Asp` | `ToPagedHttpResult<T,TResponse>(...)` — Minimal API, sync + Task + ValueTask |
 | `Trellis.Asp` | `ToPagedActionResult<T,TResponse>(...)` — MVC, sync + Task + ValueTask |
 | `Trellis.Asp` | Envelope DTOs: `PagedResponse<T>`, `PageLink` |
 
 **Failure path:** delegates to the standard error mapper (`ToHttpResult` / `ToActionResult`); no `Link` header is emitted on failure or on an empty page.
 **Caller responsibility:** the `nextUrlBuilder: Func<Cursor, int, string>` receives the *applied* limit (so links never echo a bad/zero raw limit) and owns route construction — the extension does not inspect the current request.
 
 ## Wire format
 
 `GET /api/accounts?limit=10`
 
 ```json
 {
   "items": [ /* … 5 items … */ ],
   "next":     { "cursor": "eyJhZnRlcklkI…", "href": "https://…?limit=5&cursor=eyJhZnRlcklkI…" },
   "previous": null,
   "requestedLimit": 10,
   "appliedLimit":   5,
   "deliveredCount": 5,
   "wasCapped":      true
 }

 Link: <https://…?limit=5&cursor=eyJhZnRlcklkI…>; rel="next"

Showcase end-to-end (proves both hosts behave identically)

 - IAccountRepository.GetPage(int limit, Cursor?) — server hard cap = 5, ordered by AccountId.Value ascending, base64url(JSON {"afterId":"<guid>"}) cursor; malformed cursor → Error.BadRequest("invalid_cursor") →
  400.
 - ShowcaseSeed adds 8 filler accounts (3 named → 11 total) so cap=5 yields 3 pages.
 - Showcase.MinimalApi GET /api/accounts and Showcase.Mvc AccountsController.List both call the same repository and produce byte-identical envelopes + headers (route name Showcase_GetAccounts on both).
 - api.http exercises the happy path (cap demo), follow-cursor, and malformed cursor against either host environment.