### PR TITLE
docs(docfx): fix broken xref after Trellis.Results->Trellis.Core rename

### DIFF
--- a/docs/docfx_project/api/index.md
+++ b/docs/docfx_project/api/index.md
@@ -122,7 +122,7 @@ Each integration has its own namespace and pulls in the relevant third-party dep
 
 ## Observability
 
-Built-in OpenTelemetry tracing via [`ResultsTraceProviderBuilderExtensions`](xref:Trellis.CoreTraceProviderBuilderExtensions) and [`PrimitiveValueObjectTraceProviderBuilderExtensions`](xref:Trellis.PrimitiveValueObjectTraceProviderBuilderExtensions). Automatic span creation for pipeline operations and value object creation boundaries.
+Built-in OpenTelemetry tracing via [`ResultsTraceProviderBuilderExtensions`](xref:Trellis.ResultsTraceProviderBuilderExtensions) and [`PrimitiveValueObjectTraceProviderBuilderExtensions`](xref:Trellis.PrimitiveValueObjectTraceProviderBuilderExtensions). Automatic span creation for pipeline operations and value object creation boundaries.
 
 > Learn more: [Observability & Monitoring](~/articles/integration-observability.md)
 


### PR DESCRIPTION
## Summary
Fix a docfx xref that the bulk regex in #401 corrupted.

The rename rewrote `Trellis.Results` -> `Trellis.Core` repo-wide. The
regex did not anchor at a word boundary, so it also matched the prefix
of the CLR type `Trellis.ResultsTraceProviderBuilderExtensions`,
turning the xref UID into `Trellis.CoreTraceProviderBuilderExtensions`.
That UID does not exist (the type itself was untouched), so the docfx
link broke.

## Fix
Restore the xref UID to `Trellis.ResultsTraceProviderBuilderExtensions`
in `docs/docfx_project/api/index.md`.

A type rename (`ResultsTraceProviderBuilderExtensions` -> `CoreTraceProviderBuilderExtensions`)
to align the public API with the new package name is a deliberate
API-surface decision and is **not** done here.

## Verification
Verified there is exactly one such corruption in the tree
(`rg ""Trellis\.Core[A-Z]\w+""`).

Found via Copilot PR review on #401.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>