### PR TITLE
Default-state invariants for Result/Maybe + TRLS029 analyzer

### DIFF
--- a/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
+++ b/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
@@ -1,0 +1,89 @@
+﻿namespace Trellis.Analyzers;
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+/// <summary>
+/// TRLS029 — flags explicit <c>default(Result)</c>, <c>default(Result&lt;T&gt;)</c>, and
+/// <c>default(Maybe&lt;T&gt;)</c> at use sites. Per ADR-002 §3.5.1, default-initialized
+/// <see cref="Trellis.Result"/> and <see cref="Trellis.Result{TValue}"/> represent a typed
+/// failure (<see cref="Trellis.Error.Unexpected"/> sentinel), and <c>default(Maybe&lt;T&gt;)</c>
+/// is semantically <c>Maybe&lt;T&gt;.None</c>; in both cases the explicit literal obscures
+/// intent and is a known footgun.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Detection uses <see cref="OperationKind.DefaultValue"/> to cover all surface forms:
+/// <list type="bullet">
+///   <item><c>default(Result)</c>, <c>default(Result&lt;T&gt;)</c>, <c>default(Maybe&lt;T&gt;)</c> (typeof-style)</item>
+///   <item>Target-typed <c>default</c> in <c>return default;</c>, parameter defaults, etc.</item>
+///   <item><c>default!</c> with the null-suppressing operator</item>
+/// </list>
+/// </para>
+/// <para>
+/// To suppress: use <c>[SuppressMessage("Trellis", "TRLS029", Justification = "...")]</c>
+/// on the enclosing member, or <c>#pragma warning disable TRLS029</c> on the offending span.
+/// Both are sanctioned by the ADR for legitimate sentinel/test-helper sites.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DefaultResultOrMaybeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.DefaultResultOrMaybe];
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeDefaultValue, OperationKind.DefaultValue);
+    }
+
+    private static void AnalyzeDefaultValue(OperationAnalysisContext context)
+    {
+        var op = (IDefaultValueOperation)context.Operation;
+        if (op.Type is not INamedTypeSymbol type)
+            return;
+
+        // Match by metadata name + containing namespace to avoid string-display fragility.
+        var ns = type.ContainingNamespace?.ToDisplayString();
+        if (ns != "Trellis")
+            return;
+
+        var original = type.OriginalDefinition;
+        var metadataName = original.MetadataName; // "Result", "Result`1", "Maybe`1"
+
+        string typeDisplay;
+        string suggestion;
+        switch (metadataName)
+        {
+            case "Result" when original.TypeKind == TypeKind.Struct && !original.IsGenericType:
+                typeDisplay = "Result";
+                suggestion = "Result.Ok() or Result.Fail(...)";
+                break;
+
+            case "Result`1":
+                typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                suggestion = "Result.Ok(...) or Result.Fail<T>(...)";
+                break;
+
+            case "Maybe`1":
+                typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                suggestion = "Maybe<T>.None";
+                break;
+
+            default:
+                return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.DefaultResultOrMaybe,
+            op.Syntax.GetLocation(),
+            typeDisplay,
+            suggestion));
+    }
+}

--- a/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
+++ b/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
@@ -49,35 +49,26 @@ public sealed class DefaultResultOrMaybeAnalyzer : DiagnosticAnalyzer
         if (op.Type is not INamedTypeSymbol type)
             return;
 
-        // Match by metadata name + containing namespace to avoid string-display fragility.
-        var ns = type.ContainingNamespace?.ToDisplayString();
-        if (ns != "Trellis")
-            return;
-
-        var original = type.OriginalDefinition;
-        var metadataName = original.MetadataName; // "Result", "Result`1", "Maybe`1"
-
         string typeDisplay;
         string suggestion;
-        switch (metadataName)
+        if (type.IsNonGenericResultType())
         {
-            case "Result" when original.TypeKind == TypeKind.Struct && !original.IsGenericType:
-                typeDisplay = "Result";
-                suggestion = "Result.Ok() or Result.Fail(...)";
-                break;
-
-            case "Result`1":
-                typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                suggestion = "Result.Ok(...) or Result.Fail<T>(...)";
-                break;
-
-            case "Maybe`1":
-                typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                suggestion = "Maybe<T>.None or Maybe.From(...)";
-                break;
-
-            default:
-                return;
+            typeDisplay = "Result";
+            suggestion = "Result.Ok() or Result.Fail(...)";
+        }
+        else if (type.IsResultType())
+        {
+            typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            suggestion = "Result.Ok(...) or Result.Fail<T>(...)";
+        }
+        else if (type.IsMaybeType())
+        {
+            typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            suggestion = "Maybe<T>.None or Maybe.From(...)";
+        }
+        else
+        {
+            return;
         }
 
         context.ReportDiagnostic(Diagnostic.Create(

--- a/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
+++ b/Trellis.Analyzers/src/DefaultResultOrMaybeAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed class DefaultResultOrMaybeAnalyzer : DiagnosticAnalyzer
 
             case "Maybe`1":
                 typeDisplay = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                suggestion = "Maybe<T>.None";
+                suggestion = "Maybe<T>.None or Maybe.From(...)";
                 break;
 
             default:

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -340,4 +340,22 @@ public static class DiagnosticDescriptors
         description: "Property patterns like 'result switch { { Value: var v } => ... }' or 'result is { Value: ... }' evaluate Result<T>.Value, which throws when the result is a failure. " +
                      "Use Match, or pattern-match on the discriminator first: 'result.Error is { } e ? handle(e) : use(result.Value)' or check IsSuccess explicitly.",
         helpLinkUri: HelpLinkBase + "TRLS025");
+
+    /// <summary>
+    /// TRLS029: Explicit default(Result), default(Result&lt;T&gt;), or default(Maybe&lt;T&gt;) at a use site.
+    /// </summary>
+    public static readonly DiagnosticDescriptor DefaultResultOrMaybe = new(
+        id: "TRLS029",
+        title: "Avoid default(Result), default(Result<T>), and default(Maybe<T>)",
+        messageFormat: "Explicit 'default' of '{0}' is a known footgun. Use {1} instead.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Per ADR-002 §3.5.1, default(Result) and default(Result<T>) are typed failures carrying " +
+                     "the Error.Unexpected(\"default_initialized\") sentinel — never a silent success. " +
+                     "default(Maybe<T>) equals Maybe<T>.None but the explicit literal obscures intent. " +
+                     "Always construct via Result.Ok(...)/Result.Fail(...) or Maybe<T>.None / Maybe.From(...). " +
+                     "Suppress with [SuppressMessage(\"Trellis\", \"TRLS029\")] or '#pragma warning disable TRLS029' " +
+                     "for sanctioned sentinel/test-helper sites.",
+        helpLinkUri: HelpLinkBase + "TRLS029");
 }

--- a/Trellis.Analyzers/src/TypeSymbolExtensions.cs
+++ b/Trellis.Analyzers/src/TypeSymbolExtensions.cs
@@ -8,6 +8,13 @@ using Microsoft.CodeAnalysis;
 internal static class TypeSymbolExtensions
 {
     /// <summary>
+    /// Checks if the type is the non-generic <c>Result</c> struct from the Trellis namespace.
+    /// </summary>
+    internal static bool IsNonGenericResultType(this ITypeSymbol? typeSymbol) =>
+        typeSymbol is INamedTypeSymbol { Name: "Result", IsGenericType: false, TypeKind: TypeKind.Struct } namedType &&
+        namedType.ContainingNamespace?.ToDisplayString() == "Trellis";
+
+    /// <summary>
     /// Checks if the type is Result&lt;T&gt; from Trellis namespace.
     /// </summary>
     internal static bool IsResultType(this ITypeSymbol? typeSymbol) =>

--- a/Trellis.Analyzers/tests/AnalyzerTestHelper.cs
+++ b/Trellis.Analyzers/tests/AnalyzerTestHelper.cs
@@ -73,6 +73,7 @@ public static class AnalyzerTestHelper
     /// Stub source code for Trellis types used in analyzer tests.
     /// </summary>
     private const string TrellisStubSource = """
+        #pragma warning disable TRLS029 // stub returns intentional defaults — not subject to TRLS029
         namespace Trellis
         {
             using System;
@@ -165,9 +166,15 @@ public static class AnalyzerTestHelper
                 public NotFoundError(string message) : base(message) { }
             }
 
-            // Static Result factory class
-            public static class Result
+            // Non-generic Result struct + static Result factory class (combined as a struct so 'default(Result)' compiles).
+            public readonly struct Result
             {
+                public bool IsSuccess { get; }
+                public bool IsFailure => !IsSuccess;
+                public Error Error => IsFailure ? default! : throw new InvalidOperationException();
+
+                public static Result Ok() => default;
+                public static Result Fail(Error error) => default;
                 public static Result<T> Ok<T>(T value) => value;
                 public static Result<T> Fail<T>(Error error) => error;
 

--- a/Trellis.Analyzers/tests/DefaultResultOrMaybeAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/DefaultResultOrMaybeAnalyzerTests.cs
@@ -1,0 +1,248 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="DefaultResultOrMaybeAnalyzer"/> (TRLS029) — flags explicit
+/// <c>default(Result)</c>, <c>default(Result&lt;T&gt;)</c>, and <c>default(Maybe&lt;T&gt;)</c>
+/// per ADR-002 §3.5.1.
+/// </summary>
+public class DefaultResultOrMaybeAnalyzerTests
+{
+    [Fact]
+    public async Task Default_of_NonGenericResult_ReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Result Run()
+                {
+                    return default(Result);
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 16)
+                .WithArguments("Result", "Result.Ok() or Result.Fail(...)"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Default_of_GenericResult_ReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Result<int> Run()
+                {
+                    return default(Result<int>);
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 16)
+                .WithArguments("Result<int>", "Result.Ok(...) or Result.Fail<T>(...)"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Default_of_Maybe_ReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Maybe<int> Run()
+                {
+                    return default(Maybe<int>);
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 16)
+                .WithArguments("Maybe<int>", "Maybe<T>.None"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TargetTyped_Default_ResultReturn_ReportsDiagnostic()
+    {
+        // 'return default;' inferred to Result<int>.
+        const string source = """
+            public class TestClass
+            {
+                public Result<int> Run()
+                {
+                    return default;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 16)
+                .WithArguments("Result<int>", "Result.Ok(...) or Result.Fail<T>(...)"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task DefaultBangSuppressed_StillReportsDiagnostic()
+    {
+        // 'default!' bypasses nullable warnings but the underlying default value remains.
+        const string source = """
+            public class TestClass
+            {
+                public Result<string> Run()
+                {
+                    return default!;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 16)
+                .WithArguments("Result<string>", "Result.Ok(...) or Result.Fail<T>(...)"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task LocalDefaultAssignment_ReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int Run()
+                {
+                    Result<int> r = default;
+                    return r.IsSuccess ? r.Value : 0;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<DefaultResultOrMaybeAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
+                .WithLocation(11, 25)
+                .WithArguments("Result<int>", "Result.Ok(...) or Result.Fail<T>(...)"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task DefaultOfUnrelatedStruct_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int Run()
+                {
+                    var x = default(int);
+                    return x;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ResultOk_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Result<int> Run() => Result.Ok(42);
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MaybeNone_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Maybe<int> Run() => Maybe<int>.None;
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task DefaultInsideNameof_NoDiagnostic()
+    {
+        // nameof(default(...)) is illegal; cover the broader "default token isn't an expression" case
+        // via typeof(Result<int>) which is a different operation kind.
+        const string source = """
+            public class TestClass
+            {
+                public string Run() => typeof(Result<int>).Name;
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task SuppressMessageAttribute_SilencesDiagnostic()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            public class TestClass
+            {
+                [SuppressMessage("Trellis", "TRLS029", Justification = "Sentinel for testing.")]
+                public Result<int> Run()
+                {
+                    return default;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task PragmaDisable_SilencesDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public Result<int> Run()
+                {
+            #pragma warning disable TRLS029
+                    return default;
+            #pragma warning restore TRLS029
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<DefaultResultOrMaybeAnalyzer>(source);
+        await test.RunAsync();
+    }
+}

--- a/Trellis.Analyzers/tests/DefaultResultOrMaybeAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/DefaultResultOrMaybeAnalyzerTests.cs
@@ -71,7 +71,7 @@ public class DefaultResultOrMaybeAnalyzerTests
             source,
             AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.DefaultResultOrMaybe)
                 .WithLocation(11, 16)
-                .WithArguments("Maybe<int>", "Maybe<T>.None"));
+                .WithArguments("Maybe<int>", "Maybe<T>.None or Maybe.From(...)"));
 
         await test.RunAsync();
     }

--- a/Trellis.Asp/src/TrellisAspOptions.cs
+++ b/Trellis.Asp/src/TrellisAspOptions.cs
@@ -16,7 +16,7 @@ using Trellis;
 ///         <term>Error Type</term>
 ///         <description>Default HTTP Status</description>
 ///     </listheader>
-///     <item><term><see cref="Error.UnprocessableContent"/></term><description>400 Bad Request</description></item>
+///     <item><term><see cref="Error.UnprocessableContent"/></term><description>422 Unprocessable Entity</description></item>
 ///     <item><term><see cref="Error.BadRequest"/></term><description>400 Bad Request</description></item>
 ///     <item><term><see cref="Error.Unauthorized"/></term><description>401 Unauthorized</description></item>
 ///     <item><term><see cref="Error.Forbidden"/></term><description>403 Forbidden</description></item>
@@ -24,7 +24,6 @@ using Trellis;
 ///     <item><term><see cref="Error.Conflict"/></term><description>409 Conflict</description></item>
 ///     <item><term><see cref="Error.PreconditionFailed"/></term><description>412 Precondition Failed</description></item>
 ///     <item><term><see cref="Error.PreconditionRequired"/></term><description>428 Precondition Required</description></item>
-///     <item><term><see cref="Error.Conflict"/></term><description>422 Unprocessable Entity</description></item>
 ///     <item><term><see cref="Error.TooManyRequests"/></term><description>429 Too Many Requests</description></item>
 ///     <item><term><see cref="Error.InternalServerError"/></term><description>500 Internal Server Error</description></item>
 ///     <item><term><see cref="Error.Unexpected"/></term><description>500 Internal Server Error</description></item>

--- a/Trellis.Asp/src/TrellisAspOptions.cs
+++ b/Trellis.Asp/src/TrellisAspOptions.cs
@@ -27,6 +27,7 @@ using Trellis;
 ///     <item><term><see cref="Error.Conflict"/></term><description>422 Unprocessable Entity</description></item>
 ///     <item><term><see cref="Error.TooManyRequests"/></term><description>429 Too Many Requests</description></item>
 ///     <item><term><see cref="Error.InternalServerError"/></term><description>500 Internal Server Error</description></item>
+///     <item><term><see cref="Error.Unexpected"/></term><description>500 Internal Server Error</description></item>
 ///     <item><term><see cref="Error.ServiceUnavailable"/></term><description>503 Service Unavailable</description></item>
 /// </list>
 /// </para>
@@ -79,6 +80,7 @@ public sealed class TrellisAspOptions
         [typeof(Error.PreconditionRequired)] = StatusCodes.Status428PreconditionRequired,
         [typeof(Error.TooManyRequests)] = StatusCodes.Status429TooManyRequests,
         [typeof(Error.InternalServerError)] = StatusCodes.Status500InternalServerError,
+        [typeof(Error.Unexpected)] = StatusCodes.Status500InternalServerError,
         [typeof(Error.NotImplemented)] = StatusCodes.Status501NotImplemented,
         [typeof(Error.ServiceUnavailable)] = StatusCodes.Status503ServiceUnavailable,
     };

--- a/Trellis.Core/src/Errors/Error.cs
+++ b/Trellis.Core/src/Errors/Error.cs
@@ -332,6 +332,28 @@ public abstract record Error
         public override string Code => FaultId;
     }
 
+    /// <summary>
+    /// HTTP 500 — an "shouldn't happen" condition. Used for default-initialized <see cref="Result"/>/<see cref="Result{TValue}"/>
+    /// (per ADR-002 §3.5.1), exhausted match arms, or other internal invariant violations whose root cause
+    /// is a programming error rather than a documented server-side fault.
+    /// </summary>
+    /// <param name="ReasonCode">A stable, machine-readable identifier of the invariant that was violated
+    /// (e.g. <c>"default_initialized"</c>, <c>"invariant_violation"</c>). Distinct per logical cause; not a per-incident id.</param>
+    /// <remarks>
+    /// Distinct from <see cref="InternalServerError"/>: that case carries an opaque per-incident <c>FaultId</c>
+    /// for correlating with telemetry. <see cref="Unexpected"/> identifies the *kind* of unexpected condition.
+    /// Both map to HTTP 500 at the ASP boundary, but only <see cref="InternalServerError"/> attaches a
+    /// <c>faultId</c> extension to the problem-details payload.
+    /// </remarks>
+    public sealed record Unexpected(string ReasonCode) : Error
+    {
+        /// <inheritdoc />
+        public override string Kind => "unexpected";
+
+        /// <inheritdoc />
+        public override string Code => ReasonCode;
+    }
+
     /// <summary>HTTP 501 — the requested feature is not implemented.</summary>
     /// <param name="Feature">Identifier of the feature that is not implemented.</param>
     public sealed record NotImplemented(string Feature) : Error

--- a/Trellis.Core/src/Errors/Error.cs
+++ b/Trellis.Core/src/Errors/Error.cs
@@ -333,7 +333,7 @@ public abstract record Error
     }
 
     /// <summary>
-    /// HTTP 500 — an "shouldn't happen" condition. Used for default-initialized <see cref="Result"/>/<see cref="Result{TValue}"/>
+    /// HTTP 500 — a "shouldn't happen" condition. Used for default-initialized <see cref="Result"/>/<see cref="Result{TValue}"/>
     /// (per ADR-002 §3.5.1), exhausted match arms, or other internal invariant violations whose root cause
     /// is a programming error rather than a documented server-side fault.
     /// </summary>

--- a/Trellis.Core/src/Result/Result.cs
+++ b/Trellis.Core/src/Result/Result.cs
@@ -10,26 +10,36 @@ using System.Threading.Tasks;
 /// <remarks>
 /// <para>
 /// Non-generic <see cref="Result"/> is the v2 replacement for <c>Result&lt;Unit&gt;</c>. Use it for operations that
-/// either succeed (no value) or fail (with an <see cref="Error"/>). The default value (<c>default(Result)</c>)
-/// represents success — matching the default-state invariant of <see cref="Result{TValue}"/>.
+/// either succeed (no value) or fail (with an <see cref="Error"/>).
+/// </para>
+/// <para>
+/// Per ADR-002 §3.5.1, <c>default(Result)</c> represents a <em>failure</em> carrying a sentinel
+/// <see cref="Trellis.Error.Unexpected"/> with <c>ReasonCode = "default_initialized"</c>. This makes
+/// uninitialized state a typed failure rather than a silent success. Always construct via
+/// <see cref="Ok()"/> or <see cref="Fail(Error)"/>; analyzer <c>TRLS029</c> flags explicit
+/// <c>default(Result)</c> at call sites.
 /// </para>
 /// <para>
 /// This struct also hosts factory and helper methods to construct both <see cref="Result"/> and <see cref="Result{TValue}"/>
 /// instances (e.g. <see cref="Ok()"/>, <see cref="Fail(Error)"/>, <see cref="Ok{TValue}(TValue)"/>, <see cref="Try{T}(Func{T}, Func{Exception, Error}?)"/>).
 /// </para>
 /// </remarks>
-[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Error = {(_error is null ? \"<none>\" : _error.Code)}")]
+[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Error = {(IsSuccess ? \"<none>\" : EffectiveError().Code)}")]
 public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFactory<Result>
 {
+    private readonly bool _isOk;
     private readonly Error? _error;
 
     /// <summary>True when the result represents success.</summary>
     [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(Error))]
-    public bool IsSuccess => !IsFailure;
+    public bool IsSuccess => _isOk;
 
     /// <summary>True when the result represents failure.</summary>
+    /// <remarks>
+    /// <c>default(Result).IsFailure</c> is <see langword="true"/> per ADR-002 §3.5.1.
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(Error))]
-    public bool IsFailure { get; }
+    public bool IsFailure => !_isOk;
 
     internal Result(bool isFailure, Error? error)
     {
@@ -44,7 +54,7 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
                 throw new ArgumentException("If 'isFailure' is false, 'error' must be null.", nameof(error));
         }
 
-        IsFailure = isFailure;
+        _isOk = !isFailure;
         _error = error;
 
         Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
@@ -58,12 +68,20 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     internal void LogActivityStatus() => Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
 
     /// <summary>
+    /// Returns the failure-side error, routing default-initialized failures through the shared
+    /// <see cref="ResultDefaults.Sentinel"/>. Caller is responsible for checking <see cref="IsFailure"/> first.
+    /// </summary>
+    private Error EffectiveError() => _error ?? ResultDefaults.Sentinel;
+
+    /// <summary>
     /// Gets the error when this result is a failure, or <see langword="null"/> when it is a success.
     /// </summary>
     /// <remarks>
     /// Reading this property never throws. The nullable return type is the discriminator: a non-null
     /// <see cref="Trellis.Error"/> means the result is a failure; <see langword="null"/> means success.
-    /// Pattern-match on the value to handle individual error cases.
+    /// For <c>default(Result)</c>, returns the shared <see cref="Trellis.Error.Unexpected"/> sentinel
+    /// (per ADR-002 §3.5.1) so default-initialized failures are observationally equivalent to
+    /// <c>Result.Fail(Error.Unexpected("default_initialized"))</c>.
     /// </remarks>
     /// <example>
     /// <code>
@@ -75,7 +93,7 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     ///     };
     /// </code>
     /// </example>
-    public Error? Error => _error;
+    public Error? Error => _isOk ? null : EffectiveError();
 
     /// <summary>
     /// Attempts to get the error without throwing. Companion to <see cref="Error"/> for callers
@@ -85,8 +103,14 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     /// <returns><see langword="true"/> if the result is a failure; otherwise <see langword="false"/>.</returns>
     public bool TryGetError([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Error? error)
     {
-        error = _error;
-        return error is not null;
+        if (_isOk)
+        {
+            error = null;
+            return false;
+        }
+
+        error = EffectiveError();
+        return true;
     }
 
     /// <summary>
@@ -95,7 +119,7 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     public void Deconstruct(out bool isSuccess, out Error? error)
     {
         isSuccess = IsSuccess;
-        error = _error;
+        error = _isOk ? null : EffectiveError();
     }
 
     /// <summary>
@@ -109,9 +133,9 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     /// <inheritdoc />
     public bool Equals(Result other)
     {
-        if (IsFailure != other.IsFailure) return false;
-        if (IsFailure) return _error!.Equals(other._error);
-        return true;
+        if (_isOk != other._isOk) return false;
+        if (_isOk) return true;
+        return EffectiveError().Equals(other.EffectiveError());
     }
 
     /// <inheritdoc />
@@ -119,9 +143,9 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
 
     /// <inheritdoc />
     public override int GetHashCode() =>
-        IsFailure
-            ? HashCode.Combine(true, _error)
-            : HashCode.Combine(false);
+        _isOk
+            ? HashCode.Combine(false)
+            : HashCode.Combine(true, EffectiveError());
 
     /// <summary>Determines whether two results are equal.</summary>
     public static bool operator ==(Result left, Result right) => left.Equals(right);
@@ -130,10 +154,12 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     public static bool operator !=(Result left, Result right) => !left.Equals(right);
 
     /// <inheritdoc />
-    public override string ToString() =>
-        _error is { } error
-            ? $"Failure({error.Code}: {error.Detail})"
-            : "Success";
+    public override string ToString()
+    {
+        if (_isOk) return "Success";
+        var error = EffectiveError();
+        return $"Failure({error.Code}: {error.Detail})";
+    }
 
     // ------------- Factories -------------
 
@@ -154,8 +180,9 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     /// </summary>
     /// <remarks>
     /// Goes through the constructor so that <see cref="Activity.Current"/> receives the success status,
-    /// matching the tracing behavior of <see cref="Ok{TValue}(TValue)"/>. Note that <c>default(Result)</c>
-    /// is still a valid success value (per the §3.5.1 default-state invariant) but will not tag any active activity.
+    /// matching the tracing behavior of <see cref="Ok{TValue}(TValue)"/>. Always prefer this factory over
+    /// <c>default(Result)</c>: per ADR-002 §3.5.1, <c>default(Result)</c> represents <em>failure</em> with
+    /// the <see cref="Trellis.Error.Unexpected"/> sentinel, not success.
     /// </remarks>
     public static Result Ok() => new(false, null);
 

--- a/Trellis.Core/src/Result/Result.cs
+++ b/Trellis.Core/src/Result/Result.cs
@@ -81,7 +81,7 @@ public readonly partial struct Result : IResult, IEquatable<Result>, IFailureFac
     /// <see cref="Trellis.Error"/> means the result is a failure; <see langword="null"/> means success.
     /// For <c>default(Result)</c>, returns the shared <see cref="Trellis.Error.Unexpected"/> sentinel
     /// (per ADR-002 §3.5.1) so default-initialized failures are observationally equivalent to
-    /// <c>Result.Fail(Error.Unexpected("default_initialized"))</c>.
+    /// <c>Result.Fail(new Error.Unexpected("default_initialized"))</c>.
     /// </remarks>
     /// <example>
     /// <code>

--- a/Trellis.Core/src/Result/ResultDefaults.cs
+++ b/Trellis.Core/src/Result/ResultDefaults.cs
@@ -1,0 +1,19 @@
+﻿namespace Trellis;
+
+/// <summary>
+/// Internal default-state sentinel for <see cref="Result"/> and <see cref="Result{TValue}"/>.
+/// Single shared allocation across all closed generic instantiations of <see cref="Result{TValue}"/>.
+/// Per ADR-002 §3.5.1, <c>default(Result)</c> and <c>default(Result&lt;T&gt;)</c> are observationally
+/// equivalent to <c>Result.Fail(<see cref="Sentinel"/>)</c> / <c>Result.Fail&lt;T&gt;(<see cref="Sentinel"/>)</c>.
+/// </summary>
+internal static class ResultDefaults
+{
+    /// <summary>
+    /// The single shared <see cref="Trellis.Error.Unexpected"/> instance returned by
+    /// <see cref="Result.Error"/> / <see cref="Result{TValue}.Error"/> when the result was default-initialized.
+    /// </summary>
+    internal static readonly Error Sentinel = new Error.Unexpected("default_initialized")
+    {
+        Detail = "Result was default-initialized; use Result.Ok(...) or Result.Fail(...) instead.",
+    };
+}

--- a/Trellis.Core/src/Result/Result{TValue}.cs
+++ b/Trellis.Core/src/Result/Result{TValue}.cs
@@ -138,7 +138,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// <see cref="Trellis.Error"/> means the result is a failure; <see langword="null"/> means success.
     /// For <c>default(Result&lt;T&gt;)</c>, returns the shared <see cref="Trellis.Error.Unexpected"/>
     /// sentinel (per ADR-002 §3.5.1) so default-initialized failures are observationally equivalent to
-    /// <c>Result.Fail&lt;T&gt;(Error.Unexpected("default_initialized"))</c>.
+    /// <c>Result.Fail&lt;T&gt;(new Error.Unexpected("default_initialized"))</c>.
     /// </remarks>
     /// <example>
     /// <code>

--- a/Trellis.Core/src/Result/Result{TValue}.cs
+++ b/Trellis.Core/src/Result/Result{TValue}.cs
@@ -8,9 +8,18 @@ using System.Diagnostics;
 /// </summary>
 /// <typeparam name="TValue">Success value type.</typeparam>
 /// <remarks>
+/// <para>
 /// Result is the core type for Railway Oriented Programming. It forces explicit handling of both
 /// success and failure cases, making error handling visible in the type system. Use Result when
 /// an operation can fail in a predictable way that should be handled by the caller.
+/// </para>
+/// <para>
+/// Per ADR-002 §3.5.1, <c>default(Result&lt;T&gt;)</c> represents a <em>failure</em> carrying a sentinel
+/// <see cref="Trellis.Error.Unexpected"/> with <c>ReasonCode = "default_initialized"</c>. This makes
+/// uninitialized state a typed failure rather than a silent success that would hide a programming error.
+/// Always construct via <see cref="Result.Ok{T}(T)"/> or <see cref="Result.Fail{T}(Error)"/>; analyzer
+/// <c>TRLS029</c> flags explicit <c>default(Result&lt;T&gt;)</c> at call sites.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>
@@ -34,7 +43,7 @@ using System.Diagnostics;
 ///     .Map(user => user.Name);
 /// </code>
 /// </example>
-[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Value = {(_value is null ? \"<null>\" : _value)}, Error = {(_error is null ? \"<none>\" : _error.Code)}")]
+[DebuggerDisplay("{IsSuccess ? \"Success\" : \"Failure\"}, Value = {(_value is null ? \"<null>\" : _value)}, Error = {(IsSuccess ? \"<none>\" : EffectiveError().Code)}")]
 [DebuggerTypeProxy(typeof(ResultDebugView<>))]
 public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>, IFailureFactory<Result<TValue>>
 {
@@ -43,14 +52,17 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// </summary>
     /// <value>True if successful; otherwise false.</value>
     [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(Error))]
-    public bool IsSuccess => !IsFailure;
+    public bool IsSuccess => _isOk;
 
     /// <summary>
     /// True when the result represents failure.
     /// </summary>
     /// <value>True if failed; otherwise false.</value>
+    /// <remarks>
+    /// <c>default(Result&lt;T&gt;).IsFailure</c> is <see langword="true"/> per ADR-002 §3.5.1.
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(Error))]
-    public bool IsFailure { get; }
+    public bool IsFailure => !_isOk;
 
     /// <summary>
     /// Creates a failure result wrapping the given error.
@@ -76,7 +88,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
                 throw new ArgumentException("If 'isFailure' is false, 'error' must be null.", nameof(error));
         }
 
-        IsFailure = isFailure;
+        _isOk = !isFailure;
         _error = error;
         _value = ok;
 
@@ -91,8 +103,15 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
 
     internal void LogActivityStatus() => Activity.Current?.SetStatus(IsFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
 
+    private readonly bool _isOk;
     private readonly TValue? _value;
     private readonly Error? _error;
+
+    /// <summary>
+    /// Returns the failure-side error, routing default-initialized failures through the shared
+    /// <see cref="ResultDefaults.Sentinel"/>. Caller is responsible for checking <see cref="IsFailure"/> first.
+    /// </summary>
+    private Error EffectiveError() => _error ?? ResultDefaults.Sentinel;
 
     // ------------- Public accessors -------------
 
@@ -117,7 +136,9 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// <remarks>
     /// Reading this property never throws. The nullable return type is the discriminator: a non-null
     /// <see cref="Trellis.Error"/> means the result is a failure; <see langword="null"/> means success.
-    /// Pattern-match on the value to handle individual error cases.
+    /// For <c>default(Result&lt;T&gt;)</c>, returns the shared <see cref="Trellis.Error.Unexpected"/>
+    /// sentinel (per ADR-002 §3.5.1) so default-initialized failures are observationally equivalent to
+    /// <c>Result.Fail&lt;T&gt;(Error.Unexpected("default_initialized"))</c>.
     /// </remarks>
     /// <example>
     /// <code>
@@ -129,7 +150,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     ///     };
     /// </code>
     /// </example>
-    public Error? Error => _error;
+    public Error? Error => _isOk ? null : EffectiveError();
 
     // ------------- Convenience / ergonomic APIs ------------
 
@@ -161,8 +182,14 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// <returns><see langword="true"/> if the result is a failure; otherwise <see langword="false"/>.</returns>
     public bool TryGetError([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Error? error)
     {
-        error = _error;
-        return error is not null;
+        if (_isOk)
+        {
+            error = null;
+            return false;
+        }
+
+        error = EffectiveError();
+        return true;
     }
 
     /// <summary>
@@ -184,7 +211,7 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     {
         isSuccess = IsSuccess;
         value = _value;
-        error = _error;
+        error = _isOk ? null : EffectiveError();
     }
 
     // ------------- Equality & hashing -------------
@@ -196,12 +223,15 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// <returns>True if the specified result is equal to the current result; otherwise false.</returns>
     /// <remarks>
     /// Two results are equal if they have the same success/failure state and equal values/errors.
+    /// Default-initialized failures use the shared sentinel <see cref="Trellis.Error.Unexpected"/>
+    /// per ADR-002 §3.5.1, so two <c>default(Result&lt;T&gt;)</c> values are equal, and a default
+    /// equals an explicit <c>Result.Fail&lt;T&gt;(...)</c> with the same sentinel.
     /// </remarks>
     public bool Equals(Result<TValue> other)
     {
-        if (IsFailure != other.IsFailure) return false;
-        if (IsFailure) return _error!.Equals(other._error);
-        return EqualityComparer<TValue>.Default.Equals(_value, other._value);
+        if (_isOk != other._isOk) return false;
+        if (_isOk) return EqualityComparer<TValue>.Default.Equals(_value, other._value);
+        return EffectiveError().Equals(other.EffectiveError());
     }
 
     /// <summary>
@@ -216,9 +246,9 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// </summary>
     /// <returns>A hash code for the current result.</returns>
     public override int GetHashCode() =>
-        IsFailure
-            ? HashCode.Combine(true, _error)
-            : HashCode.Combine(false, _value);
+        _isOk
+            ? HashCode.Combine(false, _value)
+            : HashCode.Combine(true, EffectiveError());
 
     /// <summary>
     /// Determines whether two results are equal.
@@ -243,17 +273,21 @@ public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValu
     /// <remarks>
     /// Use <see cref="AsUnit"/> when a pipeline returns a value but the next step only cares about success/failure
     /// (e.g., bridging a value-producing operation into a void/Unit-shaped consumer). Replaces the v1 idiom
-    /// <c>result.Map(_ =&gt; Unit.Default)</c> / <c>Result&lt;Unit&gt;</c>.
+    /// <c>result.Map(_ =&gt; Unit.Default)</c> / <c>Result&lt;Unit&gt;</c>. For default-initialized failures
+    /// the returned non-generic <see cref="Result"/> is constructed via <see cref="Result.Fail(Error)"/> with
+    /// the shared sentinel — never returns <c>default(Result)</c>.
     /// </remarks>
     /// <returns>A non-generic <see cref="Result"/> mirroring this result's success/failure state.</returns>
-    public Result AsUnit() => IsFailure ? Result.Fail(_error!) : Result.Ok();
+    public Result AsUnit() => _isOk ? Result.Ok() : Result.Fail(EffectiveError());
 
     /// <summary>
     /// Returns a string representation of the result.
     /// </summary>
     /// <returns>A string in the format "Success(value)" or "Failure(ErrorCode: detail)".</returns>
-    public override string ToString() =>
-        _error is { } error
-            ? $"Failure({error.Code}: {error.Detail})"
-            : $"Success({(_value is null ? "<null>" : _value)})";
+    public override string ToString()
+    {
+        if (_isOk) return $"Success({(_value is null ? "<null>" : _value)})";
+        var error = EffectiveError();
+        return $"Failure({error.Code}: {error.Detail})";
+    }
 }

--- a/Trellis.Core/tests/Errors/UnexpectedErrorTests.cs
+++ b/Trellis.Core/tests/Errors/UnexpectedErrorTests.cs
@@ -1,0 +1,136 @@
+namespace Trellis.Core.Tests.Errors;
+
+using Trellis.Testing;
+
+/// <summary>
+/// Tests for <see cref="Error.Unexpected"/>, the closed-ADT case used for "this shouldn't have happened"
+/// situations. Most prominent use: the sentinel error returned by <c>default(Result)</c> /
+/// <c>default(Result&lt;T&gt;)</c> per ADR-002 §3.5.1.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="Error.InternalServerError"/>:
+/// <list type="bullet">
+///   <item><description><see cref="Error.InternalServerError"/> = a documented server-side fault with a tracking <c>FaultId</c>.</description></item>
+///   <item><description><see cref="Error.Unexpected"/> = a "shouldn't happen" condition (default-init, exhausted match, internal invariant violation) carrying a stable <c>ReasonCode</c>.</description></item>
+/// </list>
+/// Both map to HTTP 500 at the ASP boundary, but only <see cref="Error.InternalServerError"/> attaches a <c>faultId</c> extension.
+/// </remarks>
+public class UnexpectedErrorTests
+{
+    [Fact]
+    public void Construct_with_ReasonCode_sets_ReasonCode_property()
+    {
+        var error = new Error.Unexpected("default_initialized");
+
+        error.ReasonCode.Should().Be("default_initialized");
+    }
+
+    [Fact]
+    public void Kind_is_unexpected()
+    {
+        var error = new Error.Unexpected("default_initialized");
+
+        error.Kind.Should().Be("unexpected");
+    }
+
+    [Fact]
+    public void Code_overrides_to_ReasonCode()
+    {
+        var error = new Error.Unexpected("internal_invariant_violated");
+
+        error.Code.Should().Be("internal_invariant_violated");
+    }
+
+    [Fact]
+    public void Detail_init_property_inherited_from_base()
+    {
+        var error = new Error.Unexpected("default_initialized")
+        {
+            Detail = "Result was default-initialized; use Result.Ok(...) or Result.Fail<T>(...).",
+        };
+
+        error.Detail.Should().Be("Result was default-initialized; use Result.Ok(...) or Result.Fail<T>(...).");
+    }
+
+    [Fact]
+    public void GetDisplayMessage_prefers_Detail_when_set()
+    {
+        var error = new Error.Unexpected("default_initialized")
+        {
+            Detail = "human-readable detail",
+        };
+
+        error.GetDisplayMessage().Should().Be("human-readable detail");
+    }
+
+    [Fact]
+    public void GetDisplayMessage_falls_back_to_Code_when_Detail_null()
+    {
+        var error = new Error.Unexpected("invariant_violation");
+
+        error.GetDisplayMessage().Should().Be("invariant_violation");
+    }
+
+    [Fact]
+    public void Two_Unexpected_with_same_ReasonCode_are_equal()
+    {
+        var a = new Error.Unexpected("default_initialized");
+        var b = new Error.Unexpected("default_initialized");
+
+        a.Should().Be(b);
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Two_Unexpected_with_different_ReasonCode_are_not_equal()
+    {
+        var a = new Error.Unexpected("default_initialized");
+        var b = new Error.Unexpected("invariant_violation");
+
+        a.Equals(b).Should().BeFalse();
+        (a == b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Unexpected_does_not_equal_InternalServerError_with_matching_payload()
+    {
+        var unexpected = new Error.Unexpected("fault-123");
+        var ise = new Error.InternalServerError("fault-123");
+
+        ((Error)unexpected).Equals((Error)ise).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cause_init_property_inherited_and_chained()
+    {
+        var inner = new Error.Unexpected("inner");
+        var outer = new Error.Unexpected("outer") { Cause = inner };
+
+        outer.Cause.Should().BeSameAs(inner);
+    }
+
+    [Fact]
+    public void Switch_pattern_matches_as_distinct_case()
+    {
+        Error error = new Error.Unexpected("default_initialized");
+
+        var matched = error switch
+        {
+            Error.InternalServerError => "ise",
+            Error.Unexpected u => $"unexpected:{u.ReasonCode}",
+            _ => "other",
+        };
+
+        matched.Should().Be("unexpected:default_initialized");
+    }
+
+    [Fact]
+    public void ToString_includes_Kind_and_Code()
+    {
+        var error = new Error.Unexpected("invariant_violation");
+
+        error.ToString().Should().Contain("unexpected");
+        error.ToString().Should().Contain("invariant_violation");
+    }
+}

--- a/Trellis.Core/tests/Results/DefaultStateInvariantTests.cs
+++ b/Trellis.Core/tests/Results/DefaultStateInvariantTests.cs
@@ -9,8 +9,8 @@ using Trellis.Testing;
 /// <remarks>
 /// <para>
 /// <c>default(Result)</c> and <c>default(Result&lt;T&gt;)</c> must be observationally
-/// equivalent to <c>Result.Fail(Error.Unexpected("default_initialized"))</c> /
-/// <c>Result.Fail&lt;T&gt;(...)</c>. This means every failure-facing API
+/// equivalent to <c>Result.Fail(new Error.Unexpected("default_initialized"))</c> /
+/// <c>Result.Fail&lt;T&gt;(new Error.Unexpected("default_initialized"))</c>. This means every failure-facing API
 /// (<see cref="Result.Error"/>, <c>TryGetError</c>, <c>Deconstruct</c>, <c>Equals</c>,
 /// <c>GetHashCode</c>, <c>ToString</c>, <c>AsUnit</c>) must route through the same
 /// effective-error helper so that callers cannot distinguish the two forms.

--- a/Trellis.Core/tests/Results/DefaultStateInvariantTests.cs
+++ b/Trellis.Core/tests/Results/DefaultStateInvariantTests.cs
@@ -1,0 +1,269 @@
+namespace Trellis.Core.Tests.Results;
+
+using Trellis.Testing;
+
+/// <summary>
+/// Invariants for the default-state of <see cref="Result"/> and <see cref="Result{TValue}"/>
+/// per ADR-002 §3.5.1.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>default(Result)</c> and <c>default(Result&lt;T&gt;)</c> must be observationally
+/// equivalent to <c>Result.Fail(Error.Unexpected("default_initialized"))</c> /
+/// <c>Result.Fail&lt;T&gt;(...)</c>. This means every failure-facing API
+/// (<see cref="Result.Error"/>, <c>TryGetError</c>, <c>Deconstruct</c>, <c>Equals</c>,
+/// <c>GetHashCode</c>, <c>ToString</c>, <c>AsUnit</c>) must route through the same
+/// effective-error helper so that callers cannot distinguish the two forms.
+/// </para>
+/// </remarks>
+public class DefaultStateInvariantTests
+{
+    private static Error.Unexpected MakeSentinel() => new Error.Unexpected("default_initialized")
+    {
+        Detail = "Result was default-initialized; use Result.Ok(...) or Result.Fail(...) instead.",
+    };
+
+    // ── default(Result) — non-generic ────────────────────────────────────────
+
+    [Fact]
+    public void Default_Result_is_failure()
+    {
+        Result r = default;
+
+        r.IsFailure.Should().BeTrue();
+        r.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_Result_Error_is_Unexpected_default_initialized()
+    {
+        Result r = default;
+
+        r.Error!.Should().NotBeNull();
+        r.Error!.Should().BeOfType<Error.Unexpected>();
+        ((Error.Unexpected)r.Error!).ReasonCode.Should().Be("default_initialized");
+    }
+
+    [Fact]
+    public void Default_Result_TryGetError_returns_true_with_sentinel()
+    {
+        Result r = default;
+
+        r.TryGetError(out var error).Should().BeTrue();
+        error!.Should().BeOfType<Error.Unexpected>();
+    }
+
+    [Fact]
+    public void Default_Result_Deconstruct_yields_failure_and_sentinel()
+    {
+        Result r = default;
+
+        var (isSuccess, error) = r;
+
+        isSuccess.Should().BeFalse();
+        error!.Should().BeOfType<Error.Unexpected>();
+    }
+
+    [Fact]
+    public void Default_Result_equals_explicit_Fail_with_sentinel()
+    {
+        Result a = default;
+        Result b = Result.Fail(MakeSentinel());
+
+        a.Equals(b).Should().BeTrue();
+        b.Equals(a).Should().BeTrue();
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Two_default_Results_are_equal()
+    {
+        Result a = default;
+        Result b = default;
+
+        a.Equals(b).Should().BeTrue();
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Default_Result_does_not_equal_Result_Ok()
+    {
+        Result a = default;
+        Result b = Result.Ok();
+
+        a.Equals(b).Should().BeFalse();
+        (a == b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_Result_ToString_does_not_say_Success()
+    {
+        Result r = default;
+
+        r.ToString().Should().NotContain("Success");
+        r.ToString().Should().Contain("Failure");
+    }
+
+    // ── default(Result<T>) — generic ─────────────────────────────────────────
+
+    [Fact]
+    public void Default_ResultT_is_failure()
+    {
+        Result<int> r = default;
+
+        r.IsFailure.Should().BeTrue();
+        r.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_ResultT_Error_is_Unexpected_default_initialized()
+    {
+        Result<string> r = default;
+
+        r.Error!.Should().NotBeNull();
+        r.Error!.Should().BeOfType<Error.Unexpected>();
+        ((Error.Unexpected)r.Error!).ReasonCode.Should().Be("default_initialized");
+    }
+
+    [Fact]
+    public void Default_ResultT_TryGetError_returns_true_with_sentinel()
+    {
+        Result<int> r = default;
+
+        r.TryGetError(out var error).Should().BeTrue();
+        error!.Should().BeOfType<Error.Unexpected>();
+    }
+
+    [Fact]
+    public void Default_ResultT_Deconstruct_yields_failure_default_value_and_sentinel()
+    {
+        Result<int> r = default;
+
+        var (isSuccess, value, error) = r;
+
+        isSuccess.Should().BeFalse();
+        value.Should().Be(0);
+        error!.Should().BeOfType<Error.Unexpected>();
+    }
+
+    [Fact]
+    public void Default_ResultT_Value_throws()
+    {
+        Result<int> r = default;
+
+        var act = () => _ = r.Value;
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Default_ResultT_TryGetValue_returns_false()
+    {
+        Result<int> r = default;
+
+        r.TryGetValue(out var value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public void Default_ResultT_equals_explicit_Fail_with_sentinel()
+    {
+        Result<int> a = default;
+        Result<int> b = Result.Fail<int>(MakeSentinel());
+
+        a.Equals(b).Should().BeTrue();
+        b.Equals(a).Should().BeTrue();
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Two_default_ResultT_are_equal_no_NRE()
+    {
+        Result<int> a = default;
+        Result<int> b = default;
+
+        // pre-fix: this NRE'd inside Equals because both _error fields were null
+        a.Equals(b).Should().BeTrue();
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Default_ResultT_does_not_equal_Ok_value()
+    {
+        Result<int> a = default;
+        Result<int> b = Result.Ok(0);
+
+        a.Equals(b).Should().BeFalse();
+        (a == b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_ResultT_ToString_does_not_say_Success()
+    {
+        Result<int> r = default;
+
+        r.ToString().Should().NotContain("Success");
+        r.ToString().Should().Contain("Failure");
+    }
+
+    // ── AsUnit observational equivalence ─────────────────────────────────────
+
+    [Fact]
+    public void Default_ResultT_AsUnit_returns_explicit_failure_not_default()
+    {
+        Result<int> r = default;
+
+        Result asUnit = r.AsUnit();
+
+        // Must NOT be `default(Result)` — must be an explicit Fail with the sentinel.
+        // We assert observational equivalence via Equals(explicit Fail).
+        asUnit.IsFailure.Should().BeTrue();
+        asUnit.Error!.Should().BeOfType<Error.Unexpected>();
+        asUnit.Equals(Result.Fail(MakeSentinel())).Should().BeTrue();
+    }
+
+    // ── Maybe<T> default = None (already correct, regression guard) ──────────
+
+    [Fact]
+    public void Default_MaybeT_is_None()
+    {
+        Maybe<int> m = default;
+
+        m.HasValue.Should().BeFalse();
+        m.Equals(Maybe<int>.None).Should().BeTrue();
+    }
+
+    // ── Sentinel sharing — single allocation across closed generics ──────────
+
+    [Fact]
+    public void Sentinel_is_shared_across_closed_generic_Result_types()
+    {
+        Result<int> ri = default;
+        Result<string> rs = default;
+        Result rn = default;
+
+        // Same Error reference (single shared sentinel allocation per program).
+        ReferenceEquals(ri.Error, rs.Error).Should().BeTrue();
+        ReferenceEquals(ri.Error, rn.Error).Should().BeTrue();
+    }
+
+    // ── Activity status tagging is best-effort and NOT required for default ──
+
+    [Fact]
+    public void Default_Result_does_not_throw_when_observed_under_no_activity()
+    {
+        // Just construct + observe — confirms no NRE / no required init path.
+        Result r = default;
+        Result<int> rt = default;
+
+        _ = r.Error;
+        _ = r.IsFailure;
+        _ = r.ToString();
+        _ = rt.Error;
+        _ = rt.IsFailure;
+        _ = rt.ToString();
+    }
+}

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -32,7 +32,7 @@
 | `TRLS022` | Warning | Wrong [StringLength] or [Range] attribute namespace | Trellis [StringLength] and [Range] attributes share names with System.ComponentModel.DataAnnotations versions. Using the wrong namespace compiles silently but the Trellis source generator ignores them, resulting in value objects without the expected validation constraints. Use the Trellis versions (namespace Trellis) instead. |
 | `TRLS024` | Warning | Unsafe Result deconstruction | Reading the value position of a `Result<T>` deconstruction (`var (success, value, error) = result;`) without first checking `success`/`error` returns the default value when the result is in failure. Gate the read with the success bool, an `error is null` check, or an early return on failure. |
 | `TRLS025` | Warning | Unsafe property pattern over Result.Value | Property patterns such as `result is { Value: ... }` or `result switch { { Value: var v } => ... }` evaluate `Result<T>.Value`, which throws `InvalidOperationException` on failure results. Pattern-match on `IsSuccess`/`IsFailure` first, or use `Match` / explicit guard. |
-| `TRLS029` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | Per ADR-002 §3.5.1, `default(Result)` and `default(Result<T>)` are typed failures carrying the `Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", "TRLS029")]` or `#pragma warning disable TRLS029` for sanctioned sentinel/test-helper sites. |
+| `TRLS029` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | Per ADR-002 §3.5.1, `default(Result)` and `default(Result<T>)` are typed failures carrying the `new Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", "TRLS029")]` or `#pragma warning disable TRLS029` for sanctioned sentinel/test-helper sites. |
 
 ## Analyzer classes
 
@@ -237,7 +237,7 @@ result.Match(
   - `default(T)` typeof-style: `return default(Result<int>);`
   - Target-typed `default`: `return default;` in a `Result<T>`-returning method, parameter defaults, etc.
   - Null-suppressed `default!`: `return default!;` is treated identically — the null-suppressing operator does not change the underlying value.
-- Per ADR-002 §3.5.1, `default(Result)`/`default(Result<T>)` represent typed failures carrying the shared `Error.Unexpected("default_initialized")` sentinel — *never* silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` (semantically correct) but the explicit literal obscures intent.
+- Per ADR-002 §3.5.1, `default(Result)`/`default(Result<T>)` represent typed failures carrying the shared `new Error.Unexpected("default_initialized")` sentinel — *never* silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` (semantically correct) but the explicit literal obscures intent.
 - Suggested replacements:
   - `Result` → `Result.Ok()` or `Result.Fail(error)`
   - `Result<T>` → `Result.Ok(value)` or `Result.Fail<T>(error)`

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -32,6 +32,7 @@
 | `TRLS022` | Warning | Wrong [StringLength] or [Range] attribute namespace | Trellis [StringLength] and [Range] attributes share names with System.ComponentModel.DataAnnotations versions. Using the wrong namespace compiles silently but the Trellis source generator ignores them, resulting in value objects without the expected validation constraints. Use the Trellis versions (namespace Trellis) instead. |
 | `TRLS024` | Warning | Unsafe Result deconstruction | Reading the value position of a `Result<T>` deconstruction (`var (success, value, error) = result;`) without first checking `success`/`error` returns the default value when the result is in failure. Gate the read with the success bool, an `error is null` check, or an early return on failure. |
 | `TRLS025` | Warning | Unsafe property pattern over Result.Value | Property patterns such as `result is { Value: ... }` or `result switch { { Value: var v } => ... }` evaluate `Result<T>.Value`, which throws `InvalidOperationException` on failure results. Pattern-match on `IsSuccess`/`IsFailure` first, or use `Match` / explicit guard. |
+| `TRLS029` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | Per ADR-002 §3.5.1, `default(Result)` and `default(Result<T>)` are typed failures carrying the `Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", "TRLS029")]` or `#pragma warning disable TRLS029` for sanctioned sentinel/test-helper sites. |
 
 ## Analyzer classes
 
@@ -229,6 +230,20 @@ result.Match(
 - Triggers on `is`-patterns, `switch` statements, and `switch` expressions.
 - Property patterns evaluate `Result<T>.Value`, which throws `InvalidOperationException` on failure results — `{ Value: ... }` against a failure result throws at runtime instead of safely matching. Use a discriminator (`IsSuccess`/`IsFailure`) before inspecting `Value`, or use `TryGetValue`/`Match`.
 - No code fix.
+
+#### `DefaultResultOrMaybeAnalyzer` — `TRLS029`
+- Flags explicit `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` expressions at use sites.
+- Uses `IDefaultValueOperation` (operation-based, not syntax-based) so it covers all surface forms equivalently:
+  - `default(T)` typeof-style: `return default(Result<int>);`
+  - Target-typed `default`: `return default;` in a `Result<T>`-returning method, parameter defaults, etc.
+  - Null-suppressed `default!`: `return default!;` is treated identically — the null-suppressing operator does not change the underlying value.
+- Per ADR-002 §3.5.1, `default(Result)`/`default(Result<T>)` represent typed failures carrying the shared `Error.Unexpected("default_initialized")` sentinel — *never* silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` (semantically correct) but the explicit literal obscures intent.
+- Suggested replacements:
+  - `Result` → `Result.Ok()` or `Result.Fail(error)`
+  - `Result<T>` → `Result.Ok(value)` or `Result.Fail<T>(error)`
+  - `Maybe<T>` → `Maybe<T>.None` or `Maybe.From(value)`
+- For sanctioned sentinel/test-helper sites, suppress with `[SuppressMessage("Trellis", "TRLS029", Justification = "...")]` on the enclosing member or `#pragma warning disable TRLS029` around the offending span.
+- No code fix (the appropriate replacement depends on intent — success vs. failure for `Result`, value vs. None for `Maybe`).
 
 ## Code fix providers
 

--- a/docs/api_reference/trellis-api-core.md
+++ b/docs/api_reference/trellis-api-core.md
@@ -115,7 +115,7 @@ None.
 Static factory and helper surface for `Result<TValue>` and the non-generic `Result` (success/failure for void flows).
 
 > **Default-state invariant (ADR-002 §3.5.1).** `default(Result)` represents a **failure** carrying the
-> shared `Error.Unexpected("default_initialized")` sentinel — *not* success. This makes uninitialized
+> shared `new Error.Unexpected("default_initialized")` sentinel — *not* success. This makes uninitialized
 > state a typed failure rather than a silent success that would hide a programming error. Always
 > construct via `Result.Ok()` or `Result.Fail(error)`. Analyzer **`TRLS029`** flags explicit
 > `default(Result)` at call sites.
@@ -152,10 +152,10 @@ None.
 Represents either a successful `TValue` or a failure `Error`.
 
 > **Default-state invariant (ADR-002 §3.5.1).** `default(Result<T>)` represents a **failure** carrying
-> the shared `Error.Unexpected("default_initialized")` sentinel — *not* success with `default(T)`.
+> the shared `new Error.Unexpected("default_initialized")` sentinel — *not* success with `default(T)`.
 > All failure-facing APIs (`Error`, `TryGetError`, `Deconstruct`, `Equals`, `GetHashCode`, `ToString`,
 > `AsUnit`) route through this sentinel so that `default(Result<T>)` is observationally equivalent to
-> `Result.Fail<T>(Error.Unexpected("default_initialized"))`. Always construct via `Result.Ok(value)`
+> `Result.Fail<T>(new Error.Unexpected("default_initialized"))`. Always construct via `Result.Ok(value)`
 > or `Result.Fail<T>(error)`. Analyzer **`TRLS029`** flags explicit `default(Result<T>)` at call sites.
 
 #### Properties

--- a/docs/api_reference/trellis-api-core.md
+++ b/docs/api_reference/trellis-api-core.md
@@ -114,6 +114,12 @@ None.
 
 Static factory and helper surface for `Result<TValue>` and the non-generic `Result` (success/failure for void flows).
 
+> **Default-state invariant (ADR-002 §3.5.1).** `default(Result)` represents a **failure** carrying the
+> shared `Error.Unexpected("default_initialized")` sentinel — *not* success. This makes uninitialized
+> state a typed failure rather than a silent success that would hide a programming error. Always
+> construct via `Result.Ok()` or `Result.Fail(error)`. Analyzer **`TRLS029`** flags explicit
+> `default(Result)` at call sites.
+
 #### Properties
 
 None.
@@ -145,6 +151,13 @@ None.
 
 Represents either a successful `TValue` or a failure `Error`.
 
+> **Default-state invariant (ADR-002 §3.5.1).** `default(Result<T>)` represents a **failure** carrying
+> the shared `Error.Unexpected("default_initialized")` sentinel — *not* success with `default(T)`.
+> All failure-facing APIs (`Error`, `TryGetError`, `Deconstruct`, `Equals`, `GetHashCode`, `ToString`,
+> `AsUnit`) route through this sentinel so that `default(Result<T>)` is observationally equivalent to
+> `Result.Fail<T>(Error.Unexpected("default_initialized"))`. Always construct via `Result.Ok(value)`
+> or `Result.Fail<T>(error)`. Analyzer **`TRLS029`** flags explicit `default(Result<T>)` at call sites.
+
 #### Properties
 
 | Name | Type | Notes |
@@ -160,8 +173,9 @@ Represents either a successful `TValue` or a failure `Error`.
 | --- | --- |
 | `public static Result<TValue> CreateFailure(Error error)` | Implements `IFailureFactory<Result<TValue>>` |
 | `public bool TryGetValue(out TValue value)` | Non-throwing success extractor |
-| `public bool TryGetError(out Error error)` | Non-throwing failure extractor |
+| `public bool TryGetError(out Error error)` | Non-throwing failure extractor; on `default(Result<T>)` returns `true` with the `Error.Unexpected` sentinel |
 | `public void Deconstruct(out bool isSuccess, out TValue? value, out Error? error)` | Deconstruction support |
+| `public Result AsUnit()` | Discards the success value, returning a non-generic `Result`. On a default-initialized failure, returns an explicit `Result.Fail(sentinel)` (never another `default`). |
 | `public bool Equals(Result<TValue> other)` | Value equality |
 | `public override bool Equals(object? obj)` | Object equality |
 | `public override int GetHashCode()` | Hash code |
@@ -254,6 +268,11 @@ MaybeInvariant.ExactlyOne(command.Email, command.Phone, "email", "phone");
 ### `public readonly struct Maybe<T> where T : notnull`
 
 Optional value container for domain optionality.
+
+> **Default-state invariant.** `default(Maybe<T>)` equals `Maybe<T>.None` (the type already uses an
+> `_isValueSet` discriminator). Although correct, prefer the explicit `Maybe<T>.None` for readability.
+> Analyzer **`TRLS029`** flags explicit `default(Maybe<T>)` at call sites and recommends `Maybe<T>.None`
+> instead.
 
 #### Properties
 
@@ -399,6 +418,7 @@ Eighteen nested `sealed record` cases under `Error`. Each case constructor is `i
 | `Error.PreconditionRequired` | `(PreconditionKind Condition)` | 428 | Missing concurrency token on PUT. |
 | `Error.TooManyRequests` | `(RetryAfterValue? RetryAfter = null)` | 429 | |
 | `Error.InternalServerError` | `(string FaultId)` | 500 | `Code` returns `FaultId`. **Never holds a live `Exception`**; the `FaultId` indexes into the logging/telemetry layer. |
+| `Error.Unexpected` | `(string ReasonCode)` | 500 | "Shouldn't happen" condition: default-initialized `Result`/`Result<T>` (per §3.5.1), exhausted match arms, internal invariant violations. `Code` returns `ReasonCode` (e.g. `"default_initialized"`). Distinct from `InternalServerError`: no opaque per-incident `FaultId`, and the ASP boundary does **not** attach a `faultId` extension. |
 | `Error.NotImplemented` | `(string Feature)` | 501 | `Code` returns `Feature`. |
 | `Error.ServiceUnavailable` | `(RetryAfterValue? RetryAfter = null)` | 503 | |
 | `Error.Aggregate` | `(EquatableArray<Error> Errors)` | 207 / `extensions.errors` | Composition node. **Disallows `Cause`** (pure composition). Auto-flattens nested `Aggregate` instances at construction. |
@@ -731,6 +751,7 @@ For tuple-enabled families, generated overloads cover the declared arity ranges 
 | `Error.PreconditionRequired` | `(PreconditionKind Condition)` | `precondition-required` | 428 |
 | `Error.TooManyRequests` | `(RetryAfterValue? RetryAfter = null)` | `too-many-requests` | 429 |
 | `Error.InternalServerError` | `(string FaultId)` | `FaultId` | 500 |
+| `Error.Unexpected` | `(string ReasonCode)` | `ReasonCode` | 500 |
 | `Error.NotImplemented` | `(string Feature)` | `Feature` | 501 |
 | `Error.ServiceUnavailable` | `(RetryAfterValue? RetryAfter = null)` | `service-unavailable` | 503 |
 | `Error.Aggregate` | `(EquatableArray<Error> Errors)` | `aggregate` | depends on contained errors; serialized via `ProblemDetails.Extensions["errors"]` (RFC 9457) |

--- a/docs/api_reference/trellis-api-core.md
+++ b/docs/api_reference/trellis-api-core.md
@@ -173,7 +173,7 @@ Represents either a successful `TValue` or a failure `Error`.
 | --- | --- |
 | `public static Result<TValue> CreateFailure(Error error)` | Implements `IFailureFactory<Result<TValue>>` |
 | `public bool TryGetValue(out TValue value)` | Non-throwing success extractor |
-| `public bool TryGetError(out Error error)` | Non-throwing failure extractor; on `default(Result<T>)` returns `true` with the `Error.Unexpected` sentinel |
+| `public bool TryGetError(out Error? error)` | Non-throwing failure extractor; on `default(Result<T>)` returns `true` with the `Error.Unexpected` sentinel |
 | `public void Deconstruct(out bool isSuccess, out TValue? value, out Error? error)` | Deconstruction support |
 | `public Result AsUnit()` | Discards the success value, returning a non-generic `Result`. On a default-initialized failure, returns an explicit `Result.Fail(sentinel)` (never another `default`). |
 | `public bool Equals(Result<TValue> other)` | Value equality |

--- a/docs/docfx_project/articles/analyzers/TRLS029.md
+++ b/docs/docfx_project/articles/analyzers/TRLS029.md
@@ -1,0 +1,84 @@
+# TRLS029 — Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)`
+
+- **Severity:** Warning
+- **Category:** Trellis
+
+## What it detects
+
+Flags explicit `default` expressions whose type is `Trellis.Result`, `Trellis.Result<T>`, or `Trellis.Maybe<T>`. Detection is operation-based (`IDefaultValueOperation`), so all surface forms are covered:
+
+- `default(Result)`, `default(Result<int>)`, `default(Maybe<string>)` (typeof-style)
+- Target-typed `default` (e.g. `return default;` in a method returning `Result<T>`)
+- Null-suppressed `default!`
+
+## Why it matters
+
+Per [ADR-002 §3.5.1](../../../adr/ADR-002-v2-redesign-plan.md), `default(Result)` and `default(Result<T>)` are typed **failures** carrying the shared `Error.Unexpected("default_initialized")` sentinel. They are observationally equivalent to `Result.Fail(sentinel)` / `Result.Fail<T>(sentinel)`. The explicit `default` literal at a call site obscures intent — readers see `default` and assume "the zero value of this type", but the runtime semantics are *failure*.
+
+`default(Maybe<T>)` happens to equal `Maybe<T>.None` (the type uses an `_isValueSet` discriminator that defaults to `false`). The runtime behavior is correct, but writing `default(Maybe<T>)` instead of `Maybe<T>.None` is poor style: the explicit `None` factory communicates intent.
+
+> [!IMPORTANT]
+> Never use `default(Result<T>)` to "convert" a failure short-circuit. The result is a typed failure with a sentinel, not a placeholder. Use `Result.Fail<T>(error)` with a meaningful `Error` case so downstream consumers can pattern-match on the actual problem.
+
+## Bad examples
+
+```csharp
+// Misleading: looks like a "no-op" but actually returns Result.Fail(sentinel)
+public Result<User> Lookup(Guid id)
+{
+    if (id == Guid.Empty)
+        return default;                       // TRLS029
+    return _repo.Get(id);
+}
+
+// Same problem in a typeof form
+public Result Save() => default(Result);      // TRLS029
+
+// Style violation on Maybe
+public Maybe<int> First() => default(Maybe<int>);   // TRLS029
+```
+
+## Good examples
+
+```csharp
+public Result<User> Lookup(Guid id)
+{
+    if (id == Guid.Empty)
+        return Result.Fail<User>(new Error.BadRequest("id-empty") { Detail = "id is required" });
+    return _repo.Get(id);
+}
+
+public Result Save() => Result.Ok();
+
+public Maybe<int> First() => Maybe<int>.None;
+```
+
+## Code fix available
+
+No. The right replacement depends on intent — success vs. failure for `Result`, value vs. `None` for `Maybe`. The analyzer cannot guess which one is correct.
+
+## Configuration
+
+Standard Roslyn configuration applies.
+
+```ini
+dotnet_diagnostic.TRLS029.severity = none
+```
+
+For sanctioned sentinel/test-helper sites — for example, an analyzer test stub that intentionally returns `default` for shape-only methods — use a targeted suppression rather than disabling the rule globally:
+
+```csharp
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Trellis", "TRLS029",
+    Justification = "Shape-only test stub; returned value is never observed.")]
+public static Result<T> StubFail<T>() => default;
+```
+
+```csharp
+#pragma warning disable TRLS029 // Sentinel for default-state regression test.
+Result<int> r = default;
+#pragma warning restore TRLS029
+```
+
+> [!TIP]
+> If you are migrating from v1 where `default(Result<T>)` was a silent success, search for `return default;` in `Result`-returning methods first. Most should become `Result.Ok(...)` (intentional success) or `Result.Fail<T>(...)` (intentional failure with a meaningful `Error` case).

--- a/docs/docfx_project/articles/analyzers/TRLS029.md
+++ b/docs/docfx_project/articles/analyzers/TRLS029.md
@@ -13,7 +13,7 @@ Flags explicit `default` expressions whose type is `Trellis.Result`, `Trellis.Re
 
 ## Why it matters
 
-Per [ADR-002 §3.5.1](../../../adr/ADR-002-v2-redesign-plan.md), `default(Result)` and `default(Result<T>)` are typed **failures** carrying the shared `Error.Unexpected("default_initialized")` sentinel. They are observationally equivalent to `Result.Fail(sentinel)` / `Result.Fail<T>(sentinel)`. The explicit `default` literal at a call site obscures intent — readers see `default` and assume "the zero value of this type", but the runtime semantics are *failure*.
+Per [ADR-002 §3.5.1](../../../adr/ADR-002-v2-redesign-plan.md), `default(Result)` and `default(Result<T>)` are typed **failures** carrying the shared `new Error.Unexpected("default_initialized")` sentinel. They are observationally equivalent to `Result.Fail(sentinel)` / `Result.Fail<T>(sentinel)`. The explicit `default` literal at a call site obscures intent — readers see `default` and assume "the zero value of this type", but the runtime semantics are *failure*.
 
 `default(Maybe<T>)` happens to equal `Maybe<T>.None` (the type uses an `_isValueSet` discriminator that defaults to `false`). The runtime behavior is correct, but writing `default(Maybe<T>)` instead of `Maybe<T>.None` is poor style: the explicit `None` factory communicates intent.
 

--- a/docs/docfx_project/articles/analyzers/toc.yml
+++ b/docs/docfx_project/articles/analyzers/toc.yml
@@ -44,3 +44,5 @@
   href: TRLS021.md
 - name: TRLS022 - Wrong attribute namespace
   href: TRLS022.md
+- name: TRLS029 - Avoid default(Result/Maybe)
+  href: TRLS029.md


### PR DESCRIPTION
 Implements ADR-002 §3.5.1 so that default(Result) / default(Result<T>) are no longer silent successes, plus a new
  analyzer (TRLS029) that flags explicit default(...) of these types at consumer call sites.

  Why

  Pre-v2, Result.IsFailure was an auto-property defaulting to false, so default(Result<T>) impersonated success with 
  default(T) — a known footgun that hid programming errors (uninitialized struct fields, exhausted match arms, etc.).
  ADR-002 §3.5.1 specifies the invariant: a default-initialized Result is a typed failure carrying a shared 
  Error.Unexpected sentinel.

  What changed

  1. Error.Unexpected(string ReasonCode) ADT case (9ad1f8e)

   - New nested record under Error for "shouldn't happen" conditions: default-initialized results, exhausted match 
  arms, internal invariant violations.
   - Code returns the ReasonCode (e.g. "default_initialized").
   - ASP boundary maps to HTTP 500 but — unlike InternalServerError — does not attach an opaque faultId extension.

  2. Result / Result<T> default-state flip (1e8f108)

   - Replaced IsFailure { get; } auto-property with an _isOk field so the default ctor produces false for success.
   - Added shared sentinel in ResultDefaults.cs: Error.Unexpected("default_initialized") with explanatory Detail.
   - All failure-facing APIs (Error, TryGetError, Deconstruct, Equals, GetHashCode, ToString, AsUnit) routed through 
  EffectiveError() so default(Result<T>) is observationally equivalent to Result.Fail<T>(sentinel).
   - Fixed Equals NRE on two defaults; AsUnit() now returns an explicit Result.Fail(sentinel) (never another default).
   - 23 new tests in DefaultStateInvariantTests.cs.

  3. DefaultResultOrMaybeAnalyzer — TRLS029 (1499ff3)

   - Operation-based (IDefaultValueOperation) so it covers default(T), target-typed default, and default! uniformly.
   - Single Warning descriptor with type-aware messages:
    - Result → Result.Ok() or Result.Fail(error)
    - Result<T> → Result.Ok(value) or Result.Fail<T>(error)
    - Maybe<T> → Maybe<T>.None or Maybe.From(value)
   - No code fix (replacement depends on intent).
   - Suppression via [SuppressMessage("Trellis", "TRLS029")] or #pragma warning disable TRLS029 for sanctioned 
  sentinel/test-helper sites.
   - Stub Result in AnalyzerTestHelper converted from static class → readonly struct so default(Result) compiles in 
  tests; #pragma warning disable TRLS029 added to stub preamble so existing 274 analyzer tests don't regress.
   - 12 new tests covering all surface forms + suppression paths.

  4. Documentation (8986ac6)

   - trellis-api-core.md: default-state invariant callouts on Result/Result<T>/Maybe<T>; new Error.Unexpected rows in 
  concrete-error-cases and wire-mapping tables; clarified TryGetError and AsUnit semantics.
   - trellis-api-analyzers.md: TRLS029 row + dedicated section.
   - New per-rule page docs/docfx_project/articles/analyzers/TRLS029.md (TRLS022.md template).
   - Analyzers toc.yml updated.