### PR TITLE
fix: framework review hardening (RFC 6901, null-guard, paramName)

### DIFF
--- a/Trellis.Core/src/Errors/InputPointer.cs
+++ b/Trellis.Core/src/Errors/InputPointer.cs
@@ -28,10 +28,25 @@ public readonly record struct InputPointer(string Path)
     /// </summary>
     /// <param name="propertyName">A simple property name or full JSON Pointer.</param>
     /// <returns>An <see cref="InputPointer"/>.</returns>
-    public static InputPointer ForProperty(string propertyName) =>
-        string.IsNullOrEmpty(propertyName)
-            ? Root
-            : new(propertyName.StartsWith('/') ? propertyName : "/" + propertyName);
+    /// <remarks>
+    /// When the input is a simple property name (does not start with <c>'/'</c>), the special
+    /// characters defined by RFC 6901 §3 are escaped: <c>'~'</c> becomes <c>"~0"</c> and
+    /// <c>'/'</c> becomes <c>"~1"</c>. The order is significant — <c>'~'</c> is escaped first
+    /// so that an already-introduced <c>"~1"</c> from a slash escape is not re-escaped as
+    /// <c>"~01"</c>. Inputs that already start with <c>'/'</c> are assumed to be a fully-formed
+    /// JSON Pointer (e.g. produced by <c>JsonPointerNormalizer</c>) and are passed through unchanged.
+    /// </remarks>
+    public static InputPointer ForProperty(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return Root;
+        if (propertyName.StartsWith('/'))
+            return new(propertyName);
+
+        var escaped = propertyName.Replace("~", "~0", StringComparison.Ordinal)
+                                  .Replace("/", "~1", StringComparison.Ordinal);
+        return new("/" + escaped);
+    }
 
     /// <inheritdoc />
     public override string ToString() => Path;

--- a/Trellis.Core/src/Result/Extensions/EnsureAll.cs
+++ b/Trellis.Core/src/Result/Extensions/EnsureAll.cs
@@ -42,10 +42,10 @@ public static class EnsureAllExtensions
             var (predicate, error) = checks[i];
 
             if (predicate is null)
-                throw new ArgumentNullException($"checks[{i}].predicate");
+                throw new ArgumentNullException(nameof(checks), $"checks[{i}].predicate is null.");
 
             if (error is null)
-                throw new ArgumentNullException($"checks[{i}].error");
+                throw new ArgumentNullException(nameof(checks), $"checks[{i}].error is null.");
 
             if (!predicate(result.Value))
                 accumulated = accumulated.Combine(error);

--- a/Trellis.Core/tests/Errors/InputPointerTests.cs
+++ b/Trellis.Core/tests/Errors/InputPointerTests.cs
@@ -1,0 +1,46 @@
+namespace Trellis.Core.Tests.Errors;
+
+/// <summary>
+/// Tests for <see cref="InputPointer"/>'s RFC 6901 (JSON Pointer) compliance.
+/// RFC 6901 §3 requires that the special characters '~' and '/' inside a property name
+/// be escaped as "~0" and "~1" respectively (and the order matters: '~' must be escaped
+/// FIRST, otherwise '/' → '~1' would be re-escaped as '~01').
+/// </summary>
+public class InputPointerTests
+{
+    [Fact]
+    public void ForProperty_with_simple_name_prepends_slash() =>
+        InputPointer.ForProperty("Email").Path.Should().Be("/Email");
+
+    [Fact]
+    public void ForProperty_with_empty_returns_root() =>
+        InputPointer.ForProperty("").Should().Be(InputPointer.Root);
+
+    [Fact]
+    public void ForProperty_with_null_returns_root() =>
+        InputPointer.ForProperty(null!).Should().Be(InputPointer.Root);
+
+    [Fact]
+    public void ForProperty_with_existing_pointer_does_not_double_escape() =>
+        // Caller passing a fully-formed pointer (e.g. from JsonPointerNormalizer) must be preserved.
+        InputPointer.ForProperty("/Lines/0/Memo").Path.Should().Be("/Lines/0/Memo");
+
+    [Fact]
+    public void ForProperty_escapes_tilde_per_rfc_6901() =>
+        // RFC 6901 §3: '~' must be escaped as '~0' so the pointer can roundtrip.
+        InputPointer.ForProperty("data~field").Path.Should().Be("/data~0field");
+
+    [Fact]
+    public void ForProperty_escapes_slash_in_property_name_per_rfc_6901() =>
+        // RFC 6901 §3: '/' inside a property name must be escaped as '~1'.
+        // Otherwise "email/work" would parse back as a nested pointer (/email then /work)
+        // rather than a single property literally named "email/work".
+        InputPointer.ForProperty("email/work").Path.Should().Be("/email~1work");
+
+    [Fact]
+    public void ForProperty_escapes_tilde_before_slash_per_rfc_6901_order() =>
+        // RFC 6901 §3 mandates the escape order: '~' first, then '/'. Otherwise
+        // '/' → '~1' would be re-escaped as '~01' on the second pass.
+        // Input: "~/" should produce "/~0~1", NOT "/~01".
+        InputPointer.ForProperty("~/").Path.Should().Be("/~0~1");
+}

--- a/Trellis.Core/tests/Results/Extensions/EnsureAllTests.cs
+++ b/Trellis.Core/tests/Results/Extensions/EnsureAllTests.cs
@@ -10,6 +10,36 @@ public class EnsureAllTests
     #region Sync
 
     [Fact]
+    public void EnsureAll_with_null_predicate_in_array_throws_with_correct_paramName_and_index()
+    {
+        var sut = Result.Ok("Hello");
+
+        var act = () => sut.EnsureAll(
+            (s => s.Length > 0, new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty)),
+            (null!, new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty)));
+
+        // ArgumentNullException.ParamName must be the actual parameter name ("checks") so callers
+        // catching by ParamName work, and the message must identify the offending index/field.
+        act.Should().Throw<ArgumentNullException>()
+            .Where(ex => ex.ParamName == "checks")
+            .And.Message.Should().Contain("checks[1]").And.Contain("predicate");
+    }
+
+    [Fact]
+    public void EnsureAll_with_null_error_in_array_throws_with_correct_paramName_and_index()
+    {
+        var sut = Result.Ok("Hello");
+
+        var act = () => sut.EnsureAll(
+            (s => s.Length > 0, new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty)),
+            (s => s.Length > 0, null!));
+
+        act.Should().Throw<ArgumentNullException>()
+            .Where(ex => ex.ParamName == "checks")
+            .And.Message.Should().Contain("checks[1]").And.Contain("error");
+    }
+
+    [Fact]
     public void EnsureAll_WithNullChecks_ShouldThrowArgumentNullException()
     {
         var sut = Result.Ok("Hello");

--- a/Trellis.Mediator/src/ServiceCollectionExtensions.cs
+++ b/Trellis.Mediator/src/ServiceCollectionExtensions.cs
@@ -183,6 +183,11 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(assemblies);
         if (assemblies.Length == 0)
             throw new ArgumentException("At least one assembly must be provided.", nameof(assemblies));
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            if (assemblies[i] is null)
+                throw new ArgumentException($"Assembly at index [{i}] is null.", nameof(assemblies));
+        }
 
         var authorizeResourceDef = typeof(IAuthorizeResource<>);
         var loaderDef = typeof(IResourceLoader<,>);

--- a/Trellis.Mediator/tests/AddResourceLoadersTests.cs
+++ b/Trellis.Mediator/tests/AddResourceLoadersTests.cs
@@ -204,6 +204,21 @@ public class AddResourceAuthorizationScanTests
     #region Discovers IAuthorizeResource<T> command and registers behavior
 
     [Fact]
+    public void AddResourceAuthorization_with_null_assembly_element_throws_with_index()
+    {
+        // Mirrors the guard already present in AddTrellisFluentValidation: a null entry in
+        // the params Assembly[] must surface as ArgumentException pointing at the offending
+        // index, NOT a NullReferenceException from Assembly.GetTypes() inside GetLoadableTypes.
+        var services = new ServiceCollection();
+
+        var act = () => services.AddResourceAuthorization(typeof(ScanTestCommand).Assembly, null!);
+
+        act.Should().Throw<ArgumentException>()
+            .Where(ex => ex.ParamName == "assemblies")
+            .And.Message.Should().Contain("[1]");
+    }
+
+    [Fact]
     public void AddResourceAuthorization_Assembly_RegistersBehaviorForCommand()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Framework-wide review hardening (3 fixes)

After PR #410/#411 merged, I ran a high-signal code review across all 13 framework packages (5 parallel  + "code-review" +  agents). Six findings surfaced; this PR ships the three that reproduced under TDD.

### Fixes (each commit is one finding, red-then-green)

| # | Commit | Severity | What |
|---|---|---|---|
| 1 | a64b619 | P0 |  + "InputPointer.ForProperty" +  now escapes  + "~" + → + "~0" +  then  + "/" + → + "~1" +  per RFC 6901 §3 |
| 2 | 114c819 | P0 |  + "AddResourceAuthorization(params Assembly[])" +  guards null elements (sister bug to one already fixed in  + "AddTrellisFluentValidation" + ) |
| 3 | 55395f3 | P1 |  + "EnsureAll" +  ArgumentNullException now uses  + "
ameof(checks)" +  as paramName (path moved to message) |

Each commit is fully self-contained with TDD tests written first (red) then implementation (green).

### Findings dropped (with reasoning)

- **#3  + "FieldViolation.ArgsHash" +  XOR-determinism** — theoretical bug that does not reproduce.  + "FieldViolation.Args" +  is strictly  + "ImmutableDictionary<string,string>?" +  whose AVL iteration is deterministic for a given key set. Three TDD tests all passed against the unmodified code. Not a real defect.
- **#6  + "MaybeAssertions.HaveValue" +  AssertionScope safety** — theoretical bug that does not reproduce. The proposed-bug code path ( + "Subject.Value" +  after a failed  + "FailWith" +  inside a scope) does not throw  + "InvalidOperationException" +  against current FluentAssertions. Test passed against unmodified code; cannot construct a failing repro.

### Deferred

- **#5  + "ScalarValueJsonConverterGenerator" +  AOT-incompatible default branch** — real but theoretical (only triggers for value objects wrapping non-default primitives like  + "TimeSpan" +  /  + "Uri" +  / custom structs). Needs a new TRLSGEN diagnostic ID and behavior change (emit diagnostic + skip generation, or use  + "JsonTypeInfo" +  lookup). Filing a follow-up issue.

### Verification

-  + "dotnet build Trellis.slnx -c Release" +  → 0 warnings, 0 errors.
-  + "Trellis.Core.Tests" + ,  + "Trellis.Mediator.Tests" + ,  + "Trellis.Testing.Tests" +  → all pass (no regressions).
- 9 new tests added across the three fixes.
