### PR TITLE
build(pack): disable symbol package for Trellis.Analyzers

### DIFF
--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -26,6 +26,14 @@
 
     <!-- Disable documentation requirement for analyzer project -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+    <!--
+      Analyzer-only package: the .dll ships under analyzers/dotnet/cs (see ItemGroup below)
+      with IncludeBuildOutput=false, so there is nothing under lib/ to symbolicate. Disable
+      symbol-package generation; otherwise SDK 10.0.203 fails with NU5017 ("Cannot create a
+      package that has no dependencies nor content") when producing the empty .snupkg.
+    -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->


### PR DESCRIPTION
The analyzer-only package ships its .dll under analyzers/dotnet/cs (with IncludeBuildOutput=false), so the symbol package has nothing under lib/ to symbolicate. SDK 10.0.203 surfaces this as a hard NU5017 error ("Cannot create a package that has no dependencies nor content") when producing the empty .snupkg, breaking the pack job on main:

  NU5017 [Trellis.Analyzers/src/Trellis.Analyzers.csproj]
  https://github.com/xavierjohn/Trellis/actions/runs/24936511885

Setting <IncludeSymbols>false</IncludeSymbols> on this project (it's inherited from Directory.Build.props) skips snupkg generation. The .nupkg itself still ships normally with the analyzer DLL packed under analyzers/dotnet/cs as before. Other Trellis packages keep their .snupkg because they have real lib/ content.

Verified locally: dotnet pack Trellis.Analyzers --no-build succeeds with just the .nupkg (no NU5017).