### PR TITLE
feat: G4-G7 review hardening + TRLS020/TRLS021 analyzers + Trellis.ServiceDefaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,9 @@ Phase status as of last update:
 
 ## Before Writing Code That Uses Trellis APIs
 
-Always read the relevant API reference files in `docs/api_reference/` **before** writing or generating code that uses Trellis types:
+Always read the relevant cookbook recipe and API reference files in `docs/api_reference/` **before** writing or generating code that uses Trellis types.
+
+Start with the task lookup table at the top of `docs/api_reference/trellis-api-cookbook.md`. If the current work matches a row (aggregate, handler, pagination, endpoint, DTO-to-VO mapping, resource authorization, EF `Maybe<T>`, optional fields, state machine, tests, domain events, analyzer warnings, or composition root), read the listed recipe before writing code. Then read the package reference files below for exact signatures.
 
 | When using... | Read first |
 |--------------|------------|

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,7 @@ Each integration package gets its own namespace because it pulls in a third-part
 | `Trellis.Asp.Authorization` | API layer only | ASP.NET actor providers (Claims, Entra, Development) |
 | `Trellis.Asp` | API layer only | Result-to-HTTP response mapping |
 | `Trellis.Http` | ACL layer only | HttpClient → Result extensions |
+| `Trellis.ServiceDefaults` | API/Composition root only | Opinionated Trellis service wiring builder |
 | `Trellis.StateMachine` | Domain layer (when needed) | Stateless state machine integration |
 | `Trellis.FluentValidation` | Domain layer (when needed) | FluentValidation integration |
 | `Trellis.Testing` | Test projects only | FluentAssertions extensions for Result/Maybe |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Start with the task lookup table at the top of `docs/api_reference/trellis-api-c
 | Mediator pipeline behaviors | `docs/api_reference/trellis-api-mediator.md` |
 | State machine integration | `docs/api_reference/trellis-api-statemachine.md` |
 | Testing helpers | `docs/api_reference/trellis-api-testing-reference.md` |
-| Analyzer rules (TRLS001-TRLS020) | `docs/api_reference/trellis-api-analyzers.md` |
+| Analyzer rules (TRLS001-TRLS021) | `docs/api_reference/trellis-api-analyzers.md` |
 
 These files document the exact method signatures, overloads, and usage patterns. Do not assume APIs based on naming conventions — read the reference first.
 
@@ -158,7 +158,7 @@ Analyzers (`Trellis.Analyzers`) and the bundled source generators emit diagnosti
 
 | Range | Owner | Example |
 |-------|-------|---------|
-| `TRLS001`–`TRLS020` | `Trellis.Analyzers` | `TRLS003` — Unsafe access to `Maybe.Value` |
+| `TRLS001`–`TRLS021` | `Trellis.Analyzers` | `TRLS003` — Unsafe access to `Maybe.Value` |
 | `TRLS031`–`TRLS034` | `Trellis.Core.Generator` (Primitives) | `TRLS032` — `MinimumLength` exceeds `MaximumLength` |
 | `TRLS035`–`TRLS038` | `Trellis.EntityFrameworkCore.Generator` | `TRLS035` — `Maybe<T>` property should be `partial` |
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Start with the task lookup table at the top of `docs/api_reference/trellis-api-c
 | Mediator pipeline behaviors | `docs/api_reference/trellis-api-mediator.md` |
 | State machine integration | `docs/api_reference/trellis-api-statemachine.md` |
 | Testing helpers | `docs/api_reference/trellis-api-testing-reference.md` |
-| Analyzer rules (TRLS001-TRLS019) | `docs/api_reference/trellis-api-analyzers.md` |
+| Analyzer rules (TRLS001-TRLS020) | `docs/api_reference/trellis-api-analyzers.md` |
 
 These files document the exact method signatures, overloads, and usage patterns. Do not assume APIs based on naming conventions — read the reference first.
 
@@ -157,7 +157,7 @@ Analyzers (`Trellis.Analyzers`) and the bundled source generators emit diagnosti
 
 | Range | Owner | Example |
 |-------|-------|---------|
-| `TRLS001`–`TRLS019` | `Trellis.Analyzers` | `TRLS003` — Unsafe access to `Maybe.Value` |
+| `TRLS001`–`TRLS020` | `Trellis.Analyzers` | `TRLS003` — Unsafe access to `Maybe.Value` |
 | `TRLS031`–`TRLS034` | `Trellis.Core.Generator` (Primitives) | `TRLS032` — `MinimumLength` exceeds `MaximumLength` |
 | `TRLS035`–`TRLS038` | `Trellis.EntityFrameworkCore.Generator` | `TRLS035` — `Maybe<T>` property should be `partial` |
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,70 +78,103 @@ jobs:
           /p:PublishAot=true \
           /p:TreatWarningsAsErrors=true
 
-    - name: AOT runtime smoke test (Showcase.MinimalApi)
-      # Proves the AOT-published binary actually serves traffic. Catches runtime
-      # regressions that publish-time IL analysis cannot see — e.g., anonymous
+    - name: Showcase runtime smoke tests (AOT MinimalApi + JIT MVC)
+      # Proves both Showcase samples actually serve traffic. Catches runtime
+      # regressions that build/publish-time analysis cannot see — e.g., anonymous
       # types in ProblemDetails extensions, missing JsonSerializerContext entries,
-      # reflection inside [UnconditionalSuppressMessage] blocks. Exercises both a
-      # success path (JSON serialization) and a 4xx path (ResponseFailureWriter
-      # rules array) so a regression in either fails CI.
+      # reflection inside [UnconditionalSuppressMessage] blocks, MVC formatter
+      # misconfiguration. Exercises both a success path (JSON serialization) and
+      # a 4xx path (ResponseFailureWriter rules array) for each sample so a
+      # regression in either fails CI.
       shell: bash
       run: |
         set -euo pipefail
-        BIN=Examples/Showcase/src/Showcase.MinimalApi/bin/Release/net10.0/linux-x64/publish/Showcase.MinimalApi
-        test -x "$BIN" || { echo "AOT binary not found: $BIN"; ls -la "$(dirname "$BIN")" || true; exit 1; }
 
-        ASPNETCORE_URLS=http://127.0.0.1:5099 ASPNETCORE_ENVIRONMENT=Production "$BIN" > aot-smoke.log 2>&1 &
-        APP_PID=$!
-        trap 'kill $APP_PID 2>/dev/null || true; echo "--- app log ---"; cat aot-smoke.log || true' EXIT
+        # --- Reusable smoke probe: launch a sample, assert one happy + one failure path ---
+        # Args: <label> <port> <log-file> <launch-command...>
+        run_smoke() {
+          local LABEL=$1 PORT=$2 LOG=$3
+          shift 3
+          echo "==================== ${LABEL} ===================="
 
-        echo "Waiting for AOT host (pid $APP_PID) to accept connections..."
-        for i in $(seq 1 60); do
-          if curl -fsS -o /dev/null --max-time 1 http://127.0.0.1:5099/api/accounts/ 2>/dev/null; then
-            echo "  up after ${i} attempt(s)"
-            break
+          ASPNETCORE_URLS="http://127.0.0.1:${PORT}" ASPNETCORE_ENVIRONMENT=Production "$@" > "$LOG" 2>&1 &
+          local APP_PID=$!
+          # Ensure cleanup even on assertion failure.
+          trap "kill ${APP_PID} 2>/dev/null || true; echo '--- ${LABEL} log ---'; cat ${LOG} || true" RETURN
+
+          echo "Waiting for ${LABEL} (pid ${APP_PID}) on port ${PORT}..."
+          local i
+          for i in $(seq 1 60); do
+            if curl -fsS -o /dev/null --max-time 1 "http://127.0.0.1:${PORT}/api/accounts/" 2>/dev/null; then
+              echo "  up after ${i} attempt(s)"
+              break
+            fi
+            if ! kill -0 ${APP_PID} 2>/dev/null; then
+              echo "${LABEL} host exited before becoming ready"
+              return 1
+            fi
+            sleep 0.5
+          done
+
+          echo "--- Happy path: GET /api/accounts/ ---"
+          local HAPPY_STATUS
+          HAPPY_STATUS=$(curl -s -o "${LABEL}-happy.json" -w '%{http_code}' "http://127.0.0.1:${PORT}/api/accounts/")
+          if [ "$HAPPY_STATUS" != "200" ]; then
+            echo "Expected 200, got ${HAPPY_STATUS}"
+            cat "${LABEL}-happy.json" || true
+            return 1
           fi
-          if ! kill -0 $APP_PID 2>/dev/null; then
-            echo "AOT host exited before becoming ready"
-            exit 1
-          fi
-          sleep 0.5
-        done
+          echo "  200 OK; body head: $(head -c 200 ${LABEL}-happy.json)"
 
-        echo "=== Happy path: GET /api/accounts/ ==="
-        HAPPY_STATUS=$(curl -s -o happy.json -w '%{http_code}' http://127.0.0.1:5099/api/accounts/)
-        if [ "$HAPPY_STATUS" != "200" ]; then
-          echo "Expected 200, got $HAPPY_STATUS"
-          cat happy.json || true
+          echo "--- Failure path: POST /api/accounts/ with empty body -> 4xx ProblemDetails ---"
+          local FAIL_STATUS
+          FAIL_STATUS=$(curl -s -o "${LABEL}-fail.json" -w '%{http_code}' \
+            -H 'content-type: application/json' \
+            -X POST --data '{}' "http://127.0.0.1:${PORT}/api/accounts/")
+          case "$FAIL_STATUS" in
+            400|422) ;;
+            *)
+              echo "Expected 400 or 422, got ${FAIL_STATUS}"
+              cat "${LABEL}-fail.json" || true
+              return 1
+              ;;
+          esac
+          # Body must be non-empty JSON ProblemDetails. Catches missing
+          # JsonSerializerContext entries (would yield empty body) and
+          # ResponseFailureWriter regressions (anonymous-type rules array).
+          if ! grep -qE '"(title|detail|errors|rules|status)"' "${LABEL}-fail.json"; then
+            echo "${LABEL} failure response lacks ProblemDetails fields:"
+            cat "${LABEL}-fail.json"
+            return 1
+          fi
+          echo "  ${FAIL_STATUS} OK; body head: $(head -c 300 ${LABEL}-fail.json)"
+
+          kill ${APP_PID} 2>/dev/null || true
+          wait ${APP_PID} 2>/dev/null || true
+          trap - RETURN
+          echo "=== ${LABEL} smoke test passed ==="
+        }
+
+        # --- AOT MinimalApi: published native binary ---
+        AOT_BIN=Examples/Showcase/src/Showcase.MinimalApi/bin/Release/net10.0/linux-x64/publish/Showcase.MinimalApi
+        if [ ! -x "$AOT_BIN" ]; then
+          echo "AOT binary not found: $AOT_BIN"
+          ls -la "$(dirname "$AOT_BIN")" || true
           exit 1
         fi
-        echo "  200 OK; body head: $(head -c 200 happy.json)"
+        run_smoke "MinimalApi-AOT" 5099 minimalapi-aot.log "$AOT_BIN"
 
-        echo "=== Failure path: POST /api/accounts/ with empty body -> expect 4xx with ProblemDetails ==="
-        FAIL_STATUS=$(curl -s -o fail.json -w '%{http_code}' \
-          -H 'content-type: application/json' \
-          -X POST --data '{}' http://127.0.0.1:5099/api/accounts/)
-        case "$FAIL_STATUS" in
-          400|422) ;;
-          *)
-            echo "Expected 400 or 422, got $FAIL_STATUS"
-            cat fail.json || true
-            exit 1
-            ;;
-        esac
-        # Body must be non-empty JSON ProblemDetails. Catches missing JsonSerializerContext
-        # entries (would yield empty body) and ResponseFailureWriter regressions.
-        if ! grep -qE '"(title|detail|errors|rules|status)"' fail.json; then
-          echo "Failure response body lacks ProblemDetails fields:"
-          cat fail.json
+        # --- JIT MVC: managed binary from the existing Release build ---
+        # MVC is intentionally not AOT-published (controller binding + filter
+        # pipeline are not currently AOT-supported). The smoke test runs the
+        # JIT-compiled assembly to prove the sample actually serves traffic.
+        MVC_DLL=Examples/Showcase/src/Showcase.Mvc/bin/Release/net10.0/Showcase.Mvc.dll
+        if [ ! -f "$MVC_DLL" ]; then
+          echo "MVC assembly not found: $MVC_DLL"
+          ls -la "$(dirname "$MVC_DLL")" || true
           exit 1
         fi
-        echo "  $FAIL_STATUS OK; body head: $(head -c 300 fail.json)"
-
-        kill $APP_PID 2>/dev/null || true
-        wait $APP_PID 2>/dev/null || true
-        trap - EXIT
-        echo "=== AOT smoke test passed ==="
+        run_smoke "Mvc-JIT" 5100 mvc-jit.log dotnet "$MVC_DLL"
 
     - name: Update doc tools
       run: dotnet tool update -g docfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,11 +97,14 @@ jobs:
           shift 3
           echo "==================== ${LABEL} ===================="
 
+          local APP_PID=""
           ASPNETCORE_URLS="http://127.0.0.1:${PORT}" ASPNETCORE_ENVIRONMENT=Production "$@" > "$LOG" 2>&1 &
-          local APP_PID=$!
+          APP_PID=$!
           cleanup_smoke() {
-            kill "${APP_PID}" 2>/dev/null || true
-            wait "${APP_PID}" 2>/dev/null || true
+            if [ -n "${APP_PID:-}" ]; then
+              kill "${APP_PID}" 2>/dev/null || true
+              wait "${APP_PID}" 2>/dev/null || true
+            fi
             echo "--- ${LABEL} log ---"
             cat "${LOG}" || true
           }
@@ -115,7 +118,7 @@ jobs:
               echo "  up after ${i} attempt(s)"
               break
             fi
-            if ! kill -0 ${APP_PID} 2>/dev/null; then
+            if ! kill -0 "${APP_PID}" 2>/dev/null; then
               echo "${LABEL} host exited before becoming ready"
               return 1
             fi
@@ -132,11 +135,12 @@ jobs:
           fi
           echo "  200 OK; body head: $(head -c 200 ${LABEL}-happy.json)"
 
-          echo "--- Failure path: POST /api/accounts/ with empty body -> 4xx ProblemDetails ---"
+          echo "--- Failure path: POST /api/accounts/{id}/deposit with zero amount -> 4xx ProblemDetails ---"
           local FAIL_STATUS
           FAIL_STATUS=$(curl -s -o "${LABEL}-fail.json" -w '%{http_code}' \
             -H 'content-type: application/json' \
-            -X POST --data '{}' "http://127.0.0.1:${PORT}/api/accounts/")
+            -X POST --data '{"amount":{"amount":0,"currency":"USD"}}' \
+            "http://127.0.0.1:${PORT}/api/accounts/aaaaaaa1-0000-0000-0000-000000000000/deposit")
           case "$FAIL_STATUS" in
             400|422) ;;
             *)
@@ -155,8 +159,9 @@ jobs:
           fi
           echo "  ${FAIL_STATUS} OK; body head: $(head -c 300 ${LABEL}-fail.json)"
 
-          kill ${APP_PID} 2>/dev/null || true
-          wait ${APP_PID} 2>/dev/null || true
+          kill "${APP_PID}" 2>/dev/null || true
+          wait "${APP_PID}" 2>/dev/null || true
+          APP_PID=""
           trap - RETURN EXIT
           echo "=== ${LABEL} smoke test passed ==="
         }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,14 @@ jobs:
 
           ASPNETCORE_URLS="http://127.0.0.1:${PORT}" ASPNETCORE_ENVIRONMENT=Production "$@" > "$LOG" 2>&1 &
           local APP_PID=$!
-          # Ensure cleanup even on assertion failure.
-          trap "kill ${APP_PID} 2>/dev/null || true; echo '--- ${LABEL} log ---'; cat ${LOG} || true" RETURN
+          cleanup_smoke() {
+            kill "${APP_PID}" 2>/dev/null || true
+            wait "${APP_PID}" 2>/dev/null || true
+            echo "--- ${LABEL} log ---"
+            cat "${LOG}" || true
+          }
+          # Ensure cleanup even when set -e exits the script before the function returns.
+          trap cleanup_smoke RETURN EXIT
 
           echo "Waiting for ${LABEL} (pid ${APP_PID}) on port ${PORT}..."
           local i
@@ -151,7 +157,7 @@ jobs:
 
           kill ${APP_PID} 2>/dev/null || true
           wait ${APP_PID} 2>/dev/null || true
-          trap - RETURN
+          trap - RETURN EXIT
           echo "=== ${LABEL} smoke test passed ==="
         }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,71 @@ jobs:
           /p:PublishAot=true \
           /p:TreatWarningsAsErrors=true
 
+    - name: AOT runtime smoke test (Showcase.MinimalApi)
+      # Proves the AOT-published binary actually serves traffic. Catches runtime
+      # regressions that publish-time IL analysis cannot see — e.g., anonymous
+      # types in ProblemDetails extensions, missing JsonSerializerContext entries,
+      # reflection inside [UnconditionalSuppressMessage] blocks. Exercises both a
+      # success path (JSON serialization) and a 4xx path (ResponseFailureWriter
+      # rules array) so a regression in either fails CI.
+      shell: bash
+      run: |
+        set -euo pipefail
+        BIN=Examples/Showcase/src/Showcase.MinimalApi/bin/Release/net10.0/linux-x64/publish/Showcase.MinimalApi
+        test -x "$BIN" || { echo "AOT binary not found: $BIN"; ls -la "$(dirname "$BIN")" || true; exit 1; }
+
+        ASPNETCORE_URLS=http://127.0.0.1:5099 ASPNETCORE_ENVIRONMENT=Production "$BIN" > aot-smoke.log 2>&1 &
+        APP_PID=$!
+        trap 'kill $APP_PID 2>/dev/null || true; echo "--- app log ---"; cat aot-smoke.log || true' EXIT
+
+        echo "Waiting for AOT host (pid $APP_PID) to accept connections..."
+        for i in $(seq 1 60); do
+          if curl -fsS -o /dev/null --max-time 1 http://127.0.0.1:5099/api/accounts/ 2>/dev/null; then
+            echo "  up after ${i} attempt(s)"
+            break
+          fi
+          if ! kill -0 $APP_PID 2>/dev/null; then
+            echo "AOT host exited before becoming ready"
+            exit 1
+          fi
+          sleep 0.5
+        done
+
+        echo "=== Happy path: GET /api/accounts/ ==="
+        HAPPY_STATUS=$(curl -s -o happy.json -w '%{http_code}' http://127.0.0.1:5099/api/accounts/)
+        if [ "$HAPPY_STATUS" != "200" ]; then
+          echo "Expected 200, got $HAPPY_STATUS"
+          cat happy.json || true
+          exit 1
+        fi
+        echo "  200 OK; body head: $(head -c 200 happy.json)"
+
+        echo "=== Failure path: POST /api/accounts/ with empty body -> expect 4xx with ProblemDetails ==="
+        FAIL_STATUS=$(curl -s -o fail.json -w '%{http_code}' \
+          -H 'content-type: application/json' \
+          -X POST --data '{}' http://127.0.0.1:5099/api/accounts/)
+        case "$FAIL_STATUS" in
+          400|422) ;;
+          *)
+            echo "Expected 400 or 422, got $FAIL_STATUS"
+            cat fail.json || true
+            exit 1
+            ;;
+        esac
+        # Body must be non-empty JSON ProblemDetails. Catches missing JsonSerializerContext
+        # entries (would yield empty body) and ResponseFailureWriter regressions.
+        if ! grep -qE '"(title|detail|errors|rules|status)"' fail.json; then
+          echo "Failure response body lacks ProblemDetails fields:"
+          cat fail.json
+          exit 1
+        fi
+        echo "  $FAIL_STATUS OK; body head: $(head -c 300 fail.json)"
+
+        kill $APP_PID 2>/dev/null || true
+        wait $APP_PID 2>/dev/null || true
+        trap - EXIT
+        echo "=== AOT smoke test passed ==="
+
     - name: Update doc tools
       run: dotnet tool update -g docfx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ The `Examples/` folder was rewritten end-to-end so every kept sample passes the 
 
 **SampleUserLibrary, SampleMinimalApi (`Examples/SampleWeb/*`):**
 - The standalone Minimal API sample and the shared `SampleUserLibrary` were folded into `Examples/Showcase/src/Showcase.MinimalApi`, which now hosts the same banking domain as `Showcase.Mvc` over identical DTOs. The shared-VO-library teaching is preserved by Showcase's `Showcase.Domain` / `Showcase.Application` split.
-- AOT publish for the Minimal API host is **deferred to a follow-up PR**. The current `ScalarValueValidationMiddleware` parses exception text to extract field names, which doesn't survive AOT trimming; the follow-up PR will replace the exception-text path with a typed contract.
+- `ScalarValueValidationMiddleware` no longer parses `BadHttpRequestException.Message` to extract field names or invalid values for Minimal API scalar route/query binding failures. It now uses endpoint parameter metadata plus route/query raw values and re-runs Trellis scalar validation for `IScalarValue<,>` / `Maybe<TScalar>` parameters.
 
 **ConditionalRequestExample:**
 - Route templates use `{id:ProductId}` (not `{id:guid}`). Handler signatures bind `ProductId id` directly (generator-emitted `IParsable`).

--- a/Examples/Showcase/README.md
+++ b/Examples/Showcase/README.md
@@ -34,8 +34,8 @@ the two hosting styles side-by-side over a single, identical contract.
 > - `AddTrellisUnitOfWork<TContext>()` + `TransactionalCommandBehavior` (no `DbContext` here).
 > - Resource authorization (`IAuthorizeResource<T>` + `IResourceLoader<,>`).
 > - Assembly-scanning `AddTrellisFluentValidation(typeof(...).Assembly)` overload.
-> - `<PublishAot>true</PublishAot>` end-to-end (blocked on EF Core AOT readiness and the
->   scalar-VO middleware rewrite).
+> - EF Core-backed `<PublishAot>true</PublishAot>` end-to-end (blocked on EF Core AOT readiness;
+>   the Minimal API host already publishes with AOT for non-EF Trellis.Asp/Mediator/FluentValidation paths).
 
 ## Project layout
 

--- a/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
@@ -12,10 +12,13 @@ using Trellis.Showcase.Application.Persistence;
 using Trellis.Showcase.Application.Services;
 using Trellis.Showcase.Application.Workflows;
 using Trellis.Showcase.Domain.ValueObjects;
+using Trellis.Showcase.MinimalApi;
 using Trellis.Showcase.MinimalApi.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.ConfigureHttpJsonOptions(options =>
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, ShowcaseJsonSerializerContext.Default));
 builder.Services.AddScalarValueValidationForMinimalApi();
 builder.Services.AddTrellisRouteConstraint<AccountId>();
 // AccountType, AccountStatus, and TransactionType are RequiredEnum<TSelf> value objects;

--- a/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/Program.cs
@@ -18,7 +18,10 @@ using Trellis.Showcase.MinimalApi.Endpoints;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.ConfigureHttpJsonOptions(options =>
-    options.SerializerOptions.TypeInfoResolverChain.Insert(0, ShowcaseJsonSerializerContext.Default));
+{
+    options.SerializerOptions.RespectRequiredConstructorParameters = true;
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, ShowcaseJsonSerializerContext.Default);
+});
 builder.Services.AddScalarValueValidationForMinimalApi();
 builder.Services.AddTrellisRouteConstraint<AccountId>();
 // AccountType, AccountStatus, and TransactionType are RequiredEnum<TSelf> value objects;

--- a/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
@@ -1,0 +1,33 @@
+namespace Trellis.Showcase.MinimalApi;
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Trellis.Asp;
+using Trellis.Showcase.Application.Features.SubmitBatchTransfers;
+using Trellis.Showcase.Application.Models;
+using Trellis.Showcase.MinimalApi.Endpoints;
+
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(OpenAccountRequest))]
+[JsonSerializable(typeof(DepositRequest))]
+[JsonSerializable(typeof(WithdrawRequest))]
+[JsonSerializable(typeof(SecureWithdrawRequest))]
+[JsonSerializable(typeof(TransferRequest))]
+[JsonSerializable(typeof(FreezeRequest))]
+[JsonSerializable(typeof(InterestRequest))]
+[JsonSerializable(typeof(BatchTransferEndpoints.BatchTransferRequest))]
+[JsonSerializable(typeof(BatchMetadata))]
+[JsonSerializable(typeof(BatchTransferLine))]
+[JsonSerializable(typeof(AccountResponse))]
+[JsonSerializable(typeof(PagedResponse<AccountResponse>))]
+[JsonSerializable(typeof(PageLink))]
+[JsonSerializable(typeof(BatchTransferReceipt))]
+[JsonSerializable(typeof(ProblemDetails))]
+[JsonSerializable(typeof(HttpValidationProblemDetails))]
+[JsonSerializable(typeof(Dictionary<string, string[]>))]
+[JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(object[]))]
+[JsonSerializable(typeof(RuleViolationProblemDetail[]))]
+internal sealed partial class ShowcaseJsonSerializerContext : JsonSerializerContext;

--- a/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Showcase.MinimalApi;
+﻿namespace Trellis.Showcase.MinimalApi;
 
 using System.Collections.Generic;
 using System.Text.Json;

--- a/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
+++ b/Examples/Showcase/src/Showcase.MinimalApi/ShowcaseJsonSerializerContext.cs
@@ -9,7 +9,7 @@ using Trellis.Showcase.Application.Features.SubmitBatchTransfers;
 using Trellis.Showcase.Application.Models;
 using Trellis.Showcase.MinimalApi.Endpoints;
 
-[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web, RespectRequiredConstructorParameters = true)]
 [JsonSerializable(typeof(OpenAccountRequest))]
 [JsonSerializable(typeof(DepositRequest))]
 [JsonSerializable(typeof(WithdrawRequest))]

--- a/Examples/Showcase/src/Showcase.Mvc/Program.cs
+++ b/Examples/Showcase/src/Showcase.Mvc/Program.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 using Trellis.Asp;
 using Trellis.Asp.Authorization;
@@ -14,13 +14,20 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services
     .AddControllers()
     .AddScalarValueValidation()
-    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+    .AddJsonOptions(o =>
+    {
+        o.JsonSerializerOptions.RespectRequiredConstructorParameters = true;
+        o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 
 // Trellis' ToHttpResponse() returns IResult, which executes via HttpContext and
 // reads ConfigureHttpJsonOptions (not MVC's AddJsonOptions). Configure both so
 // MVC formatters and IResult-based responses serialize enums identically.
 builder.Services.ConfigureHttpJsonOptions(o =>
-    o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+{
+    o.SerializerOptions.RespectRequiredConstructorParameters = true;
+    o.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 
 builder.Services.AddTrellisRouteConstraint<AccountId>();
 

--- a/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Showcase.MinimalApi.Tests;
+﻿namespace Trellis.Showcase.MinimalApi.Tests;
 
 using System.Net;
 using System.Net.Http.Json;
@@ -116,6 +116,20 @@ public class ShowcaseMinimalApiTests : IClassFixture<WebApplicationFactory<Progr
             Ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Open_account_with_missing_body_properties_returns_400_not_500()
+    {
+        var client = _factory.CreateClient();
+        using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(
+            new Uri("/api/accounts", UriKind.Relative),
+            content,
+            Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Showcase.Tests.Api;
+﻿namespace Trellis.Showcase.Tests.Api;
 
 using System.Net;
 using System.Net.Http.Json;
@@ -115,6 +115,20 @@ public class ShowcaseApiTests : IClassFixture<WebApplicationFactory<Program>>
             Ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Open_account_with_missing_body_properties_returns_400_not_500()
+    {
+        var client = _factory.CreateClient();
+        using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(
+            new Uri("/api/accounts", UriKind.Relative),
+            content,
+            Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     private sealed record PageEnvelope(

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ using Trellis.Primitives;
 
 return EmailAddress.TryCreate(request.Email)
     .Map(email => new User(email))
-    .ToHttpResult();
+    .ToHttpResponse();
 ```
 
 ## What You Get
@@ -85,6 +85,7 @@ var result = Result.Ok("ada@example.com")
 | [Trellis.Mediator](https://www.nuget.org/packages/Trellis.Mediator) | Result-aware pipeline behaviors for [Mediator](https://github.com/martinothamar/Mediator) |
 | [Trellis.FluentValidation](https://www.nuget.org/packages/Trellis.FluentValidation) | FluentValidation output converted into Trellis results |
 | [Trellis.EntityFrameworkCore](https://www.nuget.org/packages/Trellis.EntityFrameworkCore) | EF Core conventions, converters, Maybe queries, and safe save helpers (bundles the `Maybe<T>` / owned value-object source generator) |
+| [Trellis.ServiceDefaults](https://www.nuget.org/packages/Trellis.ServiceDefaults) | Opinionated composition builder for wiring Trellis web-service modules in the canonical order |
 | [Trellis.StateMachine](https://www.nuget.org/packages/Trellis.StateMachine) | Stateless transitions that return `Result<TState>` |
 | [Trellis.Testing](https://www.nuget.org/packages/Trellis.Testing) | FluentAssertions extensions for `Result<T>` and `Maybe<T>` |
 

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -23,6 +23,7 @@ var result = Parse("abc")
 ## Key Features
 - Flags unsafe `Maybe.Value` access (TRLS003).
 - Catches async misuse, double-wrapped results, and common ROP anti-patterns.
+- Flags composite value objects exposed through request/response DTOs without `CompositeValueObjectJsonConverter<T>` (TRLS020).
 - Includes fixes for Trellis-specific issues such as `SaveChangesAsync` vs. `SaveChangesResultAsync`.
 
 ## Documentation

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -24,6 +24,7 @@ var result = Parse("abc")
 - Flags unsafe `Maybe.Value` access (TRLS003).
 - Catches async misuse, double-wrapped results, and common ROP anti-patterns.
 - Flags composite value objects exposed through request/response DTOs without `CompositeValueObjectJsonConverter<T>` (TRLS020).
+- Flags redundant EF Core `HasConversion`, `OwnsOne`, and `Ignore` mappings for Trellis convention-owned properties (TRLS021).
 - Includes fixes for Trellis-specific issues such as `SaveChangesAsync` vs. `SaveChangesResultAsync`.
 
 ## Documentation

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -23,6 +23,7 @@ var result = Parse("abc")
 ## Key Features
 - Flags unsafe `Maybe.Value` access (TRLS003).
 - Catches async misuse, double-wrapped results, and common ROP anti-patterns.
+- Flags composite value objects exposed through request/response DTOs without `CompositeValueObjectJsonConverter<T>` (TRLS020).
 - Includes fixes for Trellis-specific issues such as `SaveChangesAsync` vs. `SaveChangesResultAsync`.
 
 ## Documentation

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -24,6 +24,7 @@ var result = Parse("abc")
 - Flags unsafe `Maybe.Value` access (TRLS003).
 - Catches async misuse, double-wrapped results, and common ROP anti-patterns.
 - Flags composite value objects exposed through request/response DTOs without `CompositeValueObjectJsonConverter<T>` (TRLS020).
+- Flags redundant EF Core `HasConversion`, `OwnsOne`, and `Ignore` mappings for Trellis convention-owned properties (TRLS021).
 - Includes fixes for Trellis-specific issues such as `SaveChangesAsync` vs. `SaveChangesResultAsync`.
 
 ## Documentation

--- a/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
+++ b/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
@@ -1,0 +1,263 @@
+﻿namespace Trellis.Analyzers;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+/// <summary>
+/// Analyzer that detects composite value objects exposed by request/response DTOs without
+/// <c>CompositeValueObjectJsonConverter&lt;T&gt;</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static compilationContext =>
+        {
+            var reportedProperties = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+            compilationContext.RegisterSymbolAction(
+                symbolContext => AnalyzeMethod(symbolContext, reportedProperties),
+                SymbolKind.Method);
+
+            compilationContext.RegisterSymbolAction(
+                symbolContext => AnalyzeMessageType(symbolContext, reportedProperties),
+                SymbolKind.NamedType);
+
+            compilationContext.RegisterOperationAction(
+                operationContext => AnalyzeEndpointMappingInvocation(operationContext, reportedProperties),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context, ISet<ISymbol> reportedProperties)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+        var isControllerMethod = IsControllerMethod(method);
+
+        foreach (var parameter in method.Parameters)
+        {
+            if (!isControllerMethod && !HasAttribute(parameter, "FromBodyAttribute", "Microsoft.AspNetCore.Mvc"))
+                continue;
+
+            if (parameter.Type is not INamedTypeSymbol dtoType)
+                continue;
+
+            AnalyzeDtoType(dtoType, context.ReportDiagnostic, reportedProperties);
+        }
+
+        if (isControllerMethod)
+        {
+            foreach (var dtoType in GetCandidateDtoTypes(method.ReturnType))
+                AnalyzeDtoType(dtoType, context.ReportDiagnostic, reportedProperties);
+        }
+    }
+
+    private static void AnalyzeMessageType(SymbolAnalysisContext context, ISet<ISymbol> reportedProperties)
+    {
+        if (context.Symbol is not INamedTypeSymbol type || !IsMediatorMessageType(type))
+            return;
+
+        AnalyzeDtoType(type, context.ReportDiagnostic, reportedProperties);
+    }
+
+    private static void AnalyzeEndpointMappingInvocation(OperationAnalysisContext context, ISet<ISymbol> reportedProperties)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        if (!IsEndpointMappingMethod(invocation.TargetMethod))
+            return;
+
+        foreach (var argument in invocation.Arguments)
+        {
+            var handlerMethod = GetEndpointHandlerMethod(argument.Value);
+            if (handlerMethod is null)
+                continue;
+
+            foreach (var parameter in handlerMethod.Parameters)
+            {
+                if (parameter.Type is INamedTypeSymbol dtoType)
+                    AnalyzeDtoType(dtoType, context.ReportDiagnostic, reportedProperties);
+            }
+        }
+    }
+
+    private static IMethodSymbol? GetEndpointHandlerMethod(IOperation operation) =>
+        operation switch
+        {
+            IAnonymousFunctionOperation anonymousFunction => anonymousFunction.Symbol,
+            IMethodReferenceOperation methodReference => methodReference.Method,
+            IDelegateCreationOperation { Target: var target } => GetEndpointHandlerMethod(target),
+            IConversionOperation { Operand: var operand } => GetEndpointHandlerMethod(operand),
+            _ => null,
+        };
+
+    private static void AnalyzeDtoType(
+        INamedTypeSymbol dtoType,
+        Action<Diagnostic> reportDiagnostic,
+        ISet<ISymbol> reportedProperties)
+    {
+        foreach (var member in dtoType.GetMembers())
+        {
+            if (member is not IPropertySymbol property)
+                continue;
+
+            if (property.IsStatic)
+                continue;
+
+            if (property.Type is not INamedTypeSymbol propertyType)
+                continue;
+
+            if (!IsOwnedCompositeValueObject(propertyType))
+                continue;
+
+            if (HasCompositeValueObjectJsonConverter(propertyType))
+                continue;
+
+            if (!TryMarkReported(property, reportedProperties))
+                continue;
+
+            reportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter,
+                GetDiagnosticLocation(property, dtoType),
+                propertyType.Name,
+                $"{dtoType.Name}.{property.Name}"));
+        }
+    }
+
+    private static Location GetDiagnosticLocation(IPropertySymbol property, INamedTypeSymbol dtoType)
+    {
+        if (property.Locations.Length > 0)
+            return property.Locations[0];
+
+        return dtoType.Locations.Length > 0 ? dtoType.Locations[0] : Location.None;
+    }
+
+    private static bool TryMarkReported(IPropertySymbol property, ISet<ISymbol> reportedProperties)
+    {
+        lock (reportedProperties)
+        {
+            return reportedProperties.Add(property);
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetCandidateDtoTypes(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+            yield break;
+
+        if (namedType.Name is "Task" or "ValueTask" && namedType.TypeArguments.Length == 1)
+        {
+            foreach (var candidate in GetCandidateDtoTypes(namedType.TypeArguments[0]))
+                yield return candidate;
+
+            yield break;
+        }
+
+        if (namedType.Name is "ActionResult" or "Result" && namedType.TypeArguments.Length == 1)
+        {
+            foreach (var candidate in GetCandidateDtoTypes(namedType.TypeArguments[0]))
+                yield return candidate;
+        }
+
+        yield return namedType;
+
+        foreach (var typeArgument in namedType.TypeArguments)
+        {
+            foreach (var candidate in GetCandidateDtoTypes(typeArgument))
+                yield return candidate;
+        }
+    }
+
+    private static bool IsControllerMethod(IMethodSymbol method) =>
+        method.MethodKind == MethodKind.Ordinary &&
+        method.ContainingType is not null &&
+        (InheritsFrom(method.ContainingType, "ControllerBase", "Microsoft.AspNetCore.Mvc") ||
+         HasAttribute(method.ContainingType, "ApiControllerAttribute", "Microsoft.AspNetCore.Mvc"));
+
+    private static bool IsMediatorMessageType(INamedTypeSymbol type)
+    {
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            if (interfaceType.Name is "IRequest" or "ICommand" or "IQuery" &&
+                IsMediatorNamespace(interfaceType.ContainingNamespace))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsMediatorNamespace(INamespaceSymbol? namespaceSymbol)
+    {
+        var namespaceName = namespaceSymbol?.ToDisplayString();
+        return namespaceName == "Mediator" || namespaceName?.EndsWith(".Mediator", StringComparison.Ordinal) == true;
+    }
+
+    private static bool IsEndpointMappingMethod(IMethodSymbol method) =>
+        method.Name is "MapPost" or "MapPut" or "MapPatch" or "MapDelete";
+
+    private static bool IsOwnedCompositeValueObject(INamedTypeSymbol type) =>
+        HasAttribute(type, "OwnedEntityAttribute", "Trellis.EntityFrameworkCore") &&
+        InheritsFrom(type, "ValueObject", "Trellis");
+
+    private static bool HasCompositeValueObjectJsonConverter(INamedTypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            if (!IsAttribute(attribute.AttributeClass, "JsonConverterAttribute", "System.Text.Json.Serialization"))
+                continue;
+
+            if (attribute.ConstructorArguments.Length != 1)
+                continue;
+
+            if (attribute.ConstructorArguments[0].Value is not INamedTypeSymbol converterType)
+                continue;
+
+            if (converterType.Name != "CompositeValueObjectJsonConverter" ||
+                converterType.ContainingNamespace?.ToDisplayString() != "Trellis.Primitives" ||
+                converterType.TypeArguments.Length != 1)
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(converterType.TypeArguments[0], type))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool InheritsFrom(INamedTypeSymbol type, string baseTypeName, string baseTypeNamespace)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == baseTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == baseTypeNamespace)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeName, string attributeNamespace)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (IsAttribute(attribute.AttributeClass, attributeName, attributeNamespace))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsAttribute(INamedTypeSymbol? attributeType, string attributeName, string attributeNamespace) =>
+        attributeType is not null &&
+        attributeType.Name == attributeName &&
+        attributeType.ContainingNamespace?.ToDisplayString() == attributeNamespace;
+}

--- a/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
+++ b/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
@@ -201,8 +201,30 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
         return namespaceName == "Mediator" || namespaceName?.EndsWith(".Mediator", StringComparison.Ordinal) == true;
     }
 
-    private static bool IsEndpointMappingMethod(IMethodSymbol method) =>
-        method.Name is "MapPost" or "MapPut" or "MapPatch" or "MapDelete";
+    private static bool IsEndpointMappingMethod(IMethodSymbol method)
+    {
+        var endpointMethod = method.ReducedFrom ?? method;
+        if (method.Name is not ("MapPost" or "MapPut" or "MapPatch" or "MapDelete") &&
+            endpointMethod.Name is not ("MapPost" or "MapPut" or "MapPatch" or "MapDelete"))
+            return false;
+
+        return IsAspNetCoreEndpointMappingContainer(method.ContainingType) ||
+               IsAspNetCoreEndpointMappingContainer(endpointMethod.ContainingType) ||
+               IsAspNetCoreBuilderNamespace(method.ContainingNamespace) ||
+               IsAspNetCoreBuilderNamespace(endpointMethod.ContainingNamespace);
+    }
+
+    private static bool IsAspNetCoreEndpointMappingContainer(INamedTypeSymbol? containingType) =>
+        containingType is not null &&
+        containingType.Name is "EndpointRouteBuilderExtensions" or "RouteHandlerBuilderExtensions" &&
+        IsAspNetCoreBuilderNamespace(containingType.ContainingNamespace);
+
+    private static bool IsAspNetCoreBuilderNamespace(INamespaceSymbol? namespaceSymbol)
+    {
+        var namespaceName = namespaceSymbol?.ToDisplayString();
+        return namespaceName == "Microsoft.AspNetCore.Builder" ||
+               namespaceName?.EndsWith(".Microsoft.AspNetCore.Builder", StringComparison.Ordinal) == true;
+    }
 
     private static bool IsOwnedCompositeValueObject(INamedTypeSymbol type) =>
         HasAttribute(type, "OwnedEntityAttribute", "Trellis.EntityFrameworkCore") &&

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -301,4 +301,18 @@ public static class DiagnosticDescriptors
                      "[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]. Without it, System.Text.Json can " +
                      "fall back to default construction and bypass TryCreate validation.",
         helpLinkUri: HelpLinkBase + "TRLS020");
+
+    /// <summary>
+    /// TRLS021: EF configuration duplicates Trellis conventions for Maybe&lt;T&gt; or [OwnedEntity].
+    /// </summary>
+    public static readonly DiagnosticDescriptor RedundantEfConfiguration = new(
+        id: TrellisDiagnosticIds.RedundantEfConfiguration,
+        title: "EF configuration duplicates Trellis conventions",
+        messageFormat: "'{0}' manually configures '{1}', but ApplyTrellisConventions is already wired. Remove the redundant mapping and let Trellis conventions own Maybe<T> and [OwnedEntity] properties.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When ApplyTrellisConventions or ApplyTrellisConventionsFor<TContext>() is wired, manual HasConversion, OwnsOne, or Ignore configuration for Maybe<T> and [OwnedEntity] properties can override or conflict with Trellis EF conventions. " +
+                     "Remove the redundant mapping so the convention-generated storage and ownership model stay authoritative.",
+        helpLinkUri: HelpLinkBase + "TRLS021");
 }

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -286,4 +286,19 @@ public static class DiagnosticDescriptors
                      "Suppress with [SuppressMessage(\"Trellis\", \"TRLS019\")] or '#pragma warning disable TRLS019' " +
                      "for sanctioned sentinel/test-helper sites.",
         helpLinkUri: HelpLinkBase + "TRLS019");
+
+    /// <summary>
+    /// TRLS020: Composite value object DTO property is missing CompositeValueObjectJsonConverter.
+    /// </summary>
+    public static readonly DiagnosticDescriptor CompositeValueObjectDtoMissingJsonConverter = new(
+        id: TrellisDiagnosticIds.CompositeValueObjectDtoMissingJsonConverter,
+        title: "Composite value object DTO property is missing JSON converter",
+        messageFormat: "Composite value object '{0}' is exposed by DTO property '{1}' without CompositeValueObjectJsonConverter<T>. Model binding may bypass TryCreate validation.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Composite value objects exposed through request/response DTOs must carry " +
+                     "[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]. Without it, System.Text.Json can " +
+                     "fall back to default construction and bypass TryCreate validation.",
+        helpLinkUri: HelpLinkBase + "TRLS020");
 }

--- a/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
+++ b/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -41,12 +40,16 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
             // Per-compilation state:
             //   wired  — set to 1 when a Trellis-conventions call is confirmed via semantic model
             //   pending — candidate diagnostics collected before the wiring tree is analyzed
-            var wired = new StrongBox<int>(0);
+            var wired = new int[1]; // wired[0]: 0 = not confirmed, 1 = confirmed
             var pending = new ConcurrentBag<Diagnostic>();
 
             // Semantic-model pass: resolve each candidate invocation and set wired flag.
             compilationContext.RegisterSemanticModelAction(semanticModelContext =>
             {
+                // Short-circuit if another tree already confirmed the wiring.
+                if (Volatile.Read(ref wired[0]) == 1)
+                    return;
+
                 var root = semanticModelContext.SemanticModel.SyntaxTree
                     .GetRoot(semanticModelContext.CancellationToken);
 
@@ -64,7 +67,7 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
                     if (containingType is not null &&
                         TrellisConventionContainingTypes.Contains(containingType))
                     {
-                        Interlocked.Exchange(ref wired.Value, 1);
+                        Interlocked.Exchange(ref wired[0], 1);
                         return;
                     }
                 }
@@ -76,10 +79,10 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
                 nodeContext => CollectCandidates(nodeContext, pending),
                 SyntaxKind.InvocationExpression);
 
-            // Drain pending diagnostics only when all trees have been walked and wired == 1.
+            // Drain pending diagnostics only when all trees have been walked and wired[0] == 1.
             compilationContext.RegisterCompilationEndAction(endContext =>
             {
-                if (Volatile.Read(ref wired.Value) == 0)
+                if (Volatile.Read(ref wired[0]) == 0)
                     return;
 
                 foreach (var diagnostic in pending)

--- a/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
+++ b/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
@@ -16,14 +16,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
 {
-    // The two canonical types that own the ApplyTrellisConventions / ApplyTrellisConventionsFor
-    // extension methods.  Any call that resolves to a *different* containing type is user code
-    // and must NOT enable the analyzer.
-    private static readonly ImmutableHashSet<string> TrellisConventionContainingTypes =
-        ImmutableHashSet.Create(
-            "Trellis.EntityFrameworkCore.ModelConfigurationBuilderExtensions",
-            "Trellis.EntityFrameworkCore.GeneratedTrellisConventions");
-
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         [DiagnosticDescriptors.RedundantEfConfiguration];
 
@@ -37,77 +29,32 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
             if (compilationContext.Compilation.GetTypeByMetadataName("Trellis.EntityFrameworkCore.MaybeConvention") is null)
                 return;
 
-            // Per-compilation state:
-            //   wired  — set to 1 when a Trellis-conventions call is confirmed via semantic model
-            //   pending — candidate diagnostics collected before the wiring tree is analyzed
-            var wired = new int[1]; // wired[0]: 0 = not confirmed, 1 = confirmed
-            var pending = new ConcurrentBag<Diagnostic>();
+            var conventionsAreWired = 0;
+            var pendingDiagnostics = new ConcurrentQueue<Diagnostic>();
 
-            // Semantic-model pass: resolve each candidate invocation and set wired flag.
-            compilationContext.RegisterSemanticModelAction(semanticModelContext =>
-            {
-                // Short-circuit if another tree already confirmed the wiring.
-                if (Volatile.Read(ref wired[0]) == 1)
-                    return;
-
-                var root = semanticModelContext.SemanticModel.SyntaxTree
-                    .GetRoot(semanticModelContext.CancellationToken);
-
-                foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
-                {
-                    if (!IsCandidateConventionsName(invocation))
-                        continue;
-
-                    if (semanticModelContext.SemanticModel
-                            .GetSymbolInfo(invocation, semanticModelContext.CancellationToken)
-                            .Symbol is not IMethodSymbol method)
-                        continue;
-
-                    var containingType = method.ContainingType?.ToDisplayString();
-                    if (containingType is not null &&
-                        TrellisConventionContainingTypes.Contains(containingType))
-                    {
-                        Interlocked.Exchange(ref wired[0], 1);
-                        return;
-                    }
-                }
-            });
-
-            // Syntax-node pass: collect candidate diagnostics (deferred — the wiring call
-            // may live in a tree that has not yet been semantically analyzed).
             compilationContext.RegisterSyntaxNodeAction(
-                nodeContext => CollectCandidates(nodeContext, pending),
+                context =>
+                {
+                    var invocation = (InvocationExpressionSyntax)context.Node;
+                    if (IsTrellisConventionsInvocation(context.SemanticModel, invocation))
+                        Interlocked.Exchange(ref conventionsAreWired, 1);
+
+                    AnalyzeInvocation(context, pendingDiagnostics.Enqueue);
+                },
                 SyntaxKind.InvocationExpression);
 
-            // Drain pending diagnostics only when all trees have been walked and wired[0] == 1.
-            compilationContext.RegisterCompilationEndAction(endContext =>
+            compilationContext.RegisterCompilationEndAction(context =>
             {
-                if (Volatile.Read(ref wired[0]) == 0)
+                if (Volatile.Read(ref conventionsAreWired) == 0)
                     return;
 
-                foreach (var diagnostic in pending)
-                    endContext.ReportDiagnostic(diagnostic);
+                while (pendingDiagnostics.TryDequeue(out var diagnostic))
+                    context.ReportDiagnostic(diagnostic);
             });
         });
     }
 
-    // Returns true when the invocation's method name looks like a Trellis-conventions call.
-    // Actual symbol resolution happens in RegisterSemanticModelAction.
-    private static bool IsCandidateConventionsName(InvocationExpressionSyntax invocation)
-    {
-        var methodName = invocation.Expression switch
-        {
-            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => id.Identifier.Text,
-            MemberAccessExpressionSyntax { Name: GenericNameSyntax gen } => gen.Identifier.Text,
-            IdentifierNameSyntax id => id.Identifier.Text,
-            GenericNameSyntax gen => gen.Identifier.Text,
-            _ => null
-        };
-
-        return methodName is "ApplyTrellisConventions" or "ApplyTrellisConventionsFor";
-    }
-
-    private static void CollectCandidates(SyntaxNodeAnalysisContext context, ConcurrentBag<Diagnostic> pending)
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, Action<Diagnostic> reportDiagnostic)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
@@ -123,20 +70,20 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         switch (methodName)
         {
             case "HasConversion":
-                CollectHasConversionCandidate(context, invocation, memberAccess, pending);
+                AnalyzeHasConversion(context, invocation, memberAccess, reportDiagnostic);
                 break;
             case "OwnsOne":
             case "Ignore":
-                CollectEntityTypeBuilderCandidate(context, invocation, memberAccess, methodName, pending);
+                AnalyzeEntityTypeBuilderConfiguration(context, invocation, memberAccess, methodName, reportDiagnostic);
                 break;
         }
     }
 
-    private static void CollectHasConversionCandidate(
+    private static void AnalyzeHasConversion(
         SyntaxNodeAnalysisContext context,
         InvocationExpressionSyntax invocation,
         MemberAccessExpressionSyntax memberAccess,
-        ConcurrentBag<Diagnostic> pending)
+        Action<Diagnostic> reportDiagnostic)
     {
         if (!IsPropertyBuilderMethod(context, invocation))
             return;
@@ -148,15 +95,15 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         if (!TryGetConfiguredProperty(context, propertyInvocation, out var property))
             return;
 
-        EnqueueIfTrellisConventionProperty(memberAccess.Name.GetLocation(), "HasConversion", property, pending);
+        ReportIfTrellisConventionProperty(reportDiagnostic, memberAccess.Name.GetLocation(), "HasConversion", property);
     }
 
-    private static void CollectEntityTypeBuilderCandidate(
+    private static void AnalyzeEntityTypeBuilderConfiguration(
         SyntaxNodeAnalysisContext context,
         InvocationExpressionSyntax invocation,
         MemberAccessExpressionSyntax memberAccess,
         string methodName,
-        ConcurrentBag<Diagnostic> pending)
+        Action<Diagnostic> reportDiagnostic)
     {
         if (!IsEntityTypeBuilderMethod(context, invocation, methodName))
             return;
@@ -164,7 +111,7 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         if (!TryGetConfiguredProperty(context, invocation, out var property))
             return;
 
-        EnqueueIfTrellisConventionProperty(memberAccess.Name.GetLocation(), methodName, property, pending);
+        ReportIfTrellisConventionProperty(reportDiagnostic, memberAccess.Name.GetLocation(), methodName, property);
     }
 
     private static bool TryGetConfiguredProperty(
@@ -199,16 +146,16 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static void EnqueueIfTrellisConventionProperty(
+    private static void ReportIfTrellisConventionProperty(
+        Action<Diagnostic> reportDiagnostic,
         Location location,
         string methodName,
-        IPropertySymbol property,
-        ConcurrentBag<Diagnostic> pending)
+        IPropertySymbol property)
     {
         if (!property.Type.IsMaybeType() && !HasOwnedEntityAttribute(property.Type))
             return;
 
-        pending.Add(Diagnostic.Create(
+        reportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.RedundantEfConfiguration,
             location,
             methodName,
@@ -283,5 +230,25 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsTrellisConventionsInvocation(SemanticModel semanticModel, InvocationExpressionSyntax invocation)
+    {
+        if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
+            return false;
+
+        var originalMethod = method.ReducedFrom ?? method;
+        var containingType = originalMethod.ContainingType;
+        if (containingType?.ContainingNamespace?.ToDisplayString() != "Trellis.EntityFrameworkCore")
+            return false;
+
+        return originalMethod.Name switch
+        {
+            "ApplyTrellisConventions" =>
+                containingType.Name == "ModelConfigurationBuilderExtensions",
+            "ApplyTrellisConventionsFor" =>
+                containingType.Name is "ModelConfigurationBuilderExtensions" or "GeneratedTrellisConventions",
+            _ => false
+        };
     }
 }

--- a/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
+++ b/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
@@ -1,0 +1,249 @@
+namespace Trellis.Analyzers;
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Analyzer that detects manual EF configuration that duplicates Trellis EF conventions.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.RedundantEfConfiguration];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            if (compilationContext.Compilation.GetTypeByMetadataName("Trellis.EntityFrameworkCore.MaybeConvention") is null)
+                return;
+
+            var conventionsAreWired = new Lazy<bool>(() => HasTrellisConventions(compilationContext.Compilation));
+
+            compilationContext.RegisterSyntaxNodeAction(
+                context =>
+                {
+                    if (!conventionsAreWired.Value)
+                        return;
+
+                    AnalyzeInvocation(context);
+                },
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var methodName = memberAccess.Name switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            _ => null
+        };
+
+        switch (methodName)
+        {
+            case "HasConversion":
+                AnalyzeHasConversion(context, invocation, memberAccess);
+                break;
+            case "OwnsOne":
+            case "Ignore":
+                AnalyzeEntityTypeBuilderConfiguration(context, invocation, memberAccess, methodName);
+                break;
+        }
+    }
+
+    private static void AnalyzeHasConversion(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        MemberAccessExpressionSyntax memberAccess)
+    {
+        if (!IsPropertyBuilderMethod(context, invocation))
+            return;
+
+        var propertyInvocation = FindPropertyInvocation(context, memberAccess.Expression);
+        if (propertyInvocation is null)
+            return;
+
+        if (!TryGetConfiguredProperty(context, propertyInvocation, out var property))
+            return;
+
+        ReportIfTrellisConventionProperty(context, memberAccess.Name.GetLocation(), "HasConversion", property);
+    }
+
+    private static void AnalyzeEntityTypeBuilderConfiguration(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        MemberAccessExpressionSyntax memberAccess,
+        string methodName)
+    {
+        if (!IsEntityTypeBuilderMethod(context, invocation, methodName))
+            return;
+
+        if (!TryGetConfiguredProperty(context, invocation, out var property))
+            return;
+
+        ReportIfTrellisConventionProperty(context, memberAccess.Name.GetLocation(), methodName, property);
+    }
+
+    private static bool TryGetConfiguredProperty(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        out IPropertySymbol property)
+    {
+        property = null!;
+
+        if (invocation.ArgumentList.Arguments.Count == 0)
+            return false;
+
+        if (invocation.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda)
+            return false;
+
+        var lambdaParameter = LambdaSyntaxHelpers.GetLambdaParameter(lambda);
+        if (lambdaParameter is null)
+            return false;
+
+        foreach (var memberAccess in lambda.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (!LambdaSyntaxHelpers.IsAccessOnParameter(memberAccess, lambdaParameter))
+                continue;
+
+            if (context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol is not IPropertySymbol propertySymbol)
+                continue;
+
+            property = propertySymbol;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void ReportIfTrellisConventionProperty(
+        SyntaxNodeAnalysisContext context,
+        Location location,
+        string methodName,
+        IPropertySymbol property)
+    {
+        if (!property.Type.IsMaybeType() && !HasOwnedEntityAttribute(property.Type))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.RedundantEfConfiguration,
+            location,
+            methodName,
+            $"{property.ContainingType.Name}.{property.Name}"));
+    }
+
+    private static bool IsEntityTypeBuilderMethod(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        string expectedMethodName)
+    {
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol methodSymbol)
+            return false;
+
+        if (methodSymbol.Name != expectedMethodName)
+            return false;
+
+        return IsEntityTypeBuilder(methodSymbol.ContainingType);
+    }
+
+    private static bool IsPropertyBuilderMethod(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+    {
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol methodSymbol)
+            return false;
+
+        var containingType = methodSymbol.ContainingType;
+        return containingType?.Name.IndexOf("PropertyBuilder", StringComparison.Ordinal) >= 0 &&
+               containingType.ContainingNamespace?.ToDisplayString() == "Microsoft.EntityFrameworkCore.Metadata.Builders";
+    }
+
+    private static InvocationExpressionSyntax? FindPropertyInvocation(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax expression)
+    {
+        if (expression is InvocationExpressionSyntax invocation &&
+            IsEntityTypeBuilderMethod(context, invocation, "Property"))
+            return invocation;
+
+        foreach (var descendantInvocation in expression.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (IsEntityTypeBuilderMethod(context, descendantInvocation, "Property"))
+                return descendantInvocation;
+        }
+
+        return null;
+    }
+
+    private static bool IsEntityTypeBuilder(INamedTypeSymbol? type)
+    {
+        while (type is not null)
+        {
+            if (type.Name == "EntityTypeBuilder" &&
+                type.ContainingNamespace?.ToDisplayString() == "Microsoft.EntityFrameworkCore.Metadata.Builders")
+                return true;
+
+            type = type.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool HasOwnedEntityAttribute(ITypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            if (attribute.AttributeClass is
+                {
+                    Name: "OwnedEntityAttribute",
+                    ContainingNamespace: var ns
+                } && ns?.ToDisplayString() == "Trellis.EntityFrameworkCore")
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasTrellisConventions(Compilation compilation)
+    {
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            foreach (var invocation in syntaxTree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (!IsTrellisConventionsInvocation(invocation))
+                    continue;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTrellisConventionsInvocation(InvocationExpressionSyntax invocation)
+    {
+        var methodName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax identifier } => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } => generic.Identifier.Text,
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            _ => null
+        };
+
+        return methodName is "ApplyTrellisConventions" or "ApplyTrellisConventionsFor";
+    }
+}

--- a/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
+++ b/Trellis.Analyzers/src/RedundantEfConfigurationAnalyzer.cs
@@ -1,8 +1,11 @@
-namespace Trellis.Analyzers;
+﻿namespace Trellis.Analyzers;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,6 +17,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
 {
+    // The two canonical types that own the ApplyTrellisConventions / ApplyTrellisConventionsFor
+    // extension methods.  Any call that resolves to a *different* containing type is user code
+    // and must NOT enable the analyzer.
+    private static readonly ImmutableHashSet<string> TrellisConventionContainingTypes =
+        ImmutableHashSet.Create(
+            "Trellis.EntityFrameworkCore.ModelConfigurationBuilderExtensions",
+            "Trellis.EntityFrameworkCore.GeneratedTrellisConventions");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         [DiagnosticDescriptors.RedundantEfConfiguration];
 
@@ -27,21 +38,73 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
             if (compilationContext.Compilation.GetTypeByMetadataName("Trellis.EntityFrameworkCore.MaybeConvention") is null)
                 return;
 
-            var conventionsAreWired = new Lazy<bool>(() => HasTrellisConventions(compilationContext.Compilation));
+            // Per-compilation state:
+            //   wired  — set to 1 when a Trellis-conventions call is confirmed via semantic model
+            //   pending — candidate diagnostics collected before the wiring tree is analyzed
+            var wired = new StrongBox<int>(0);
+            var pending = new ConcurrentBag<Diagnostic>();
 
-            compilationContext.RegisterSyntaxNodeAction(
-                context =>
+            // Semantic-model pass: resolve each candidate invocation and set wired flag.
+            compilationContext.RegisterSemanticModelAction(semanticModelContext =>
+            {
+                var root = semanticModelContext.SemanticModel.SyntaxTree
+                    .GetRoot(semanticModelContext.CancellationToken);
+
+                foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
                 {
-                    if (!conventionsAreWired.Value)
-                        return;
+                    if (!IsCandidateConventionsName(invocation))
+                        continue;
 
-                    AnalyzeInvocation(context);
-                },
+                    if (semanticModelContext.SemanticModel
+                            .GetSymbolInfo(invocation, semanticModelContext.CancellationToken)
+                            .Symbol is not IMethodSymbol method)
+                        continue;
+
+                    var containingType = method.ContainingType?.ToDisplayString();
+                    if (containingType is not null &&
+                        TrellisConventionContainingTypes.Contains(containingType))
+                    {
+                        Interlocked.Exchange(ref wired.Value, 1);
+                        return;
+                    }
+                }
+            });
+
+            // Syntax-node pass: collect candidate diagnostics (deferred — the wiring call
+            // may live in a tree that has not yet been semantically analyzed).
+            compilationContext.RegisterSyntaxNodeAction(
+                nodeContext => CollectCandidates(nodeContext, pending),
                 SyntaxKind.InvocationExpression);
+
+            // Drain pending diagnostics only when all trees have been walked and wired == 1.
+            compilationContext.RegisterCompilationEndAction(endContext =>
+            {
+                if (Volatile.Read(ref wired.Value) == 0)
+                    return;
+
+                foreach (var diagnostic in pending)
+                    endContext.ReportDiagnostic(diagnostic);
+            });
         });
     }
 
-    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    // Returns true when the invocation's method name looks like a Trellis-conventions call.
+    // Actual symbol resolution happens in RegisterSemanticModelAction.
+    private static bool IsCandidateConventionsName(InvocationExpressionSyntax invocation)
+    {
+        var methodName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => id.Identifier.Text,
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax gen } => gen.Identifier.Text,
+            IdentifierNameSyntax id => id.Identifier.Text,
+            GenericNameSyntax gen => gen.Identifier.Text,
+            _ => null
+        };
+
+        return methodName is "ApplyTrellisConventions" or "ApplyTrellisConventionsFor";
+    }
+
+    private static void CollectCandidates(SyntaxNodeAnalysisContext context, ConcurrentBag<Diagnostic> pending)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
@@ -57,19 +120,20 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         switch (methodName)
         {
             case "HasConversion":
-                AnalyzeHasConversion(context, invocation, memberAccess);
+                CollectHasConversionCandidate(context, invocation, memberAccess, pending);
                 break;
             case "OwnsOne":
             case "Ignore":
-                AnalyzeEntityTypeBuilderConfiguration(context, invocation, memberAccess, methodName);
+                CollectEntityTypeBuilderCandidate(context, invocation, memberAccess, methodName, pending);
                 break;
         }
     }
 
-    private static void AnalyzeHasConversion(
+    private static void CollectHasConversionCandidate(
         SyntaxNodeAnalysisContext context,
         InvocationExpressionSyntax invocation,
-        MemberAccessExpressionSyntax memberAccess)
+        MemberAccessExpressionSyntax memberAccess,
+        ConcurrentBag<Diagnostic> pending)
     {
         if (!IsPropertyBuilderMethod(context, invocation))
             return;
@@ -81,14 +145,15 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         if (!TryGetConfiguredProperty(context, propertyInvocation, out var property))
             return;
 
-        ReportIfTrellisConventionProperty(context, memberAccess.Name.GetLocation(), "HasConversion", property);
+        EnqueueIfTrellisConventionProperty(memberAccess.Name.GetLocation(), "HasConversion", property, pending);
     }
 
-    private static void AnalyzeEntityTypeBuilderConfiguration(
+    private static void CollectEntityTypeBuilderCandidate(
         SyntaxNodeAnalysisContext context,
         InvocationExpressionSyntax invocation,
         MemberAccessExpressionSyntax memberAccess,
-        string methodName)
+        string methodName,
+        ConcurrentBag<Diagnostic> pending)
     {
         if (!IsEntityTypeBuilderMethod(context, invocation, methodName))
             return;
@@ -96,7 +161,7 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         if (!TryGetConfiguredProperty(context, invocation, out var property))
             return;
 
-        ReportIfTrellisConventionProperty(context, memberAccess.Name.GetLocation(), methodName, property);
+        EnqueueIfTrellisConventionProperty(memberAccess.Name.GetLocation(), methodName, property, pending);
     }
 
     private static bool TryGetConfiguredProperty(
@@ -131,16 +196,16 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static void ReportIfTrellisConventionProperty(
-        SyntaxNodeAnalysisContext context,
+    private static void EnqueueIfTrellisConventionProperty(
         Location location,
         string methodName,
-        IPropertySymbol property)
+        IPropertySymbol property,
+        ConcurrentBag<Diagnostic> pending)
     {
         if (!property.Type.IsMaybeType() && !HasOwnedEntityAttribute(property.Type))
             return;
 
-        context.ReportDiagnostic(Diagnostic.Create(
+        pending.Add(Diagnostic.Create(
             DiagnosticDescriptors.RedundantEfConfiguration,
             location,
             methodName,
@@ -215,35 +280,5 @@ public sealed class RedundantEfConfigurationAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    private static bool HasTrellisConventions(Compilation compilation)
-    {
-        foreach (var syntaxTree in compilation.SyntaxTrees)
-        {
-            foreach (var invocation in syntaxTree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>())
-            {
-                if (!IsTrellisConventionsInvocation(invocation))
-                    continue;
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsTrellisConventionsInvocation(InvocationExpressionSyntax invocation)
-    {
-        var methodName = invocation.Expression switch
-        {
-            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax identifier } => identifier.Identifier.Text,
-            MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } => generic.Identifier.Text,
-            IdentifierNameSyntax identifier => identifier.Identifier.Text,
-            GenericNameSyntax generic => generic.Identifier.Text,
-            _ => null
-        };
-
-        return methodName is "ApplyTrellisConventions" or "ApplyTrellisConventionsFor";
     }
 }

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -14,7 +14,7 @@
 ///     Justification = "guarded by HasValue check earlier in the pipeline")]
 /// </code>
 /// <para>
-/// IDs in the <c>TRLS001</c>–<c>TRLS020</c> range are emitted by the
+/// IDs in the <c>TRLS001</c>–<c>TRLS021</c> range are emitted by the
 /// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS038</c>
 /// range are emitted by the bundled source generators
 /// (<c>Trellis.Core.Generator</c> and <c>Trellis.EntityFrameworkCore.Generator</c>).
@@ -87,6 +87,9 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS020 — Composite value object DTO property is missing <c>CompositeValueObjectJsonConverter&lt;T&gt;</c>.</summary>
     public const string CompositeValueObjectDtoMissingJsonConverter = "TRLS020";
+
+    /// <summary>TRLS021 — EF configuration duplicates Trellis conventions for <c>Maybe&lt;T&gt;</c> or <c>[OwnedEntity]</c>.</summary>
+    public const string RedundantEfConfiguration = "TRLS021";
 
     // ---- Generator IDs (Trellis.Core.Generator / Trellis.EntityFrameworkCore.Generator) ----
     // Renumbered from TRLSGEN### to TRLS### in v2 (see ADR-002 §3.5). Mapping:

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -14,7 +14,7 @@
 ///     Justification = "guarded by HasValue check earlier in the pipeline")]
 /// </code>
 /// <para>
-/// IDs in the <c>TRLS001</c>–<c>TRLS019</c> range are emitted by the
+/// IDs in the <c>TRLS001</c>–<c>TRLS020</c> range are emitted by the
 /// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS038</c>
 /// range are emitted by the bundled source generators
 /// (<c>Trellis.Core.Generator</c> and <c>Trellis.EntityFrameworkCore.Generator</c>).
@@ -84,6 +84,9 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS019 — Avoid <c>default(Result)</c>, <c>default(Result&lt;T&gt;)</c>, and <c>default(Maybe&lt;T&gt;)</c>.</summary>
     public const string DefaultResultOrMaybe = "TRLS019";
+
+    /// <summary>TRLS020 — Composite value object DTO property is missing <c>CompositeValueObjectJsonConverter&lt;T&gt;</c>.</summary>
+    public const string CompositeValueObjectDtoMissingJsonConverter = "TRLS020";
 
     // ---- Generator IDs (Trellis.Core.Generator / Trellis.EntityFrameworkCore.Generator) ----
     // Renumbered from TRLSGEN### to TRLS### in v2 (see ADR-002 §3.5). Mapping:

--- a/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
@@ -136,9 +136,11 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
 
             namespace Microsoft.AspNetCore.Builder
             {
+                public delegate void CreateCustomerRequestHandler(global::TestNamespace.CreateCustomerRequest request);
+
                 public static class EndpointRouteBuilderExtensions
                 {
-                    public static void MapPost<TDelegate>(this object builder, string pattern, TDelegate handler) { }
+                    public static void MapPost(this object builder, string pattern, CreateCustomerRequestHandler handler) { }
                 }
             }
 
@@ -167,7 +169,7 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
         var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
             source,
             AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
-                .WithLocation(32, 60)
+                .WithLocation(34, 60)
                 .WithArguments("ShippingAddress", "CreateCustomerRequest.ShippingAddress"));
         test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
 
@@ -184,9 +186,11 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
 
             namespace Microsoft.AspNetCore.Builder
             {
+                public delegate void CreateCustomerRequestHandler(global::TestNamespace.CreateCustomerRequest request);
+
                 public static class EndpointRouteBuilderExtensions
                 {
-                    public static void MapPost<TDelegate>(this object builder, string pattern, TDelegate handler) { }
+                    public static void MapPost(this object builder, string pattern, CreateCustomerRequestHandler handler) { }
                 }
             }
 
@@ -217,7 +221,7 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
         var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
             source,
             AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
-                .WithLocation(32, 60)
+                .WithLocation(34, 60)
                 .WithArguments("ShippingAddress", "CreateCustomerRequest.ShippingAddress"));
         test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
 
@@ -295,6 +299,50 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
             {
                 [HttpPost]
                 public void Create([FromBody] CreateCustomerRequest request) { }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(source);
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task UnrelatedMapPostMethod_WithOwnedValueObjectRequest_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+            using MyCompany.Routing;
+
+            namespace MyCompany.Routing
+            {
+                public static class RouteBuilderExtensions
+                {
+                    public static void MapPost<TDelegate>(this object builder, string pattern, TDelegate handler) { }
+                }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerRequest(ShippingAddress ShippingAddress);
+
+            public static class CustomerEndpoints
+            {
+                public static void Map(object app) =>
+                    app.MapPost("/customers", (CreateCustomerRequest request) => { });
             }
             """;
 

--- a/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
@@ -1,0 +1,338 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+/// <summary>
+/// Tests for the composite value object DTO converter analyzer.
+/// </summary>
+public class CompositeValueObjectDtoConverterAnalyzerTests
+{
+    private const string AspAndTrellisStubSource = """
+        namespace Microsoft.AspNetCore.Mvc
+        {
+            public sealed class ApiControllerAttribute : System.Attribute { }
+            public sealed class RouteAttribute : System.Attribute
+            {
+                public RouteAttribute(string template) { }
+            }
+            public sealed class HttpPostAttribute : System.Attribute { }
+            public sealed class FromBodyAttribute : System.Attribute { }
+            public sealed class ActionResult<T> { }
+            public abstract class ControllerBase { }
+        }
+
+        namespace Trellis
+        {
+            using System.Collections.Generic;
+
+            public abstract class ValueObject
+            {
+                protected abstract IEnumerable<System.IComparable?> GetEqualityComponents();
+            }
+        }
+
+        namespace Trellis.EntityFrameworkCore
+        {
+            public sealed class OwnedEntityAttribute : System.Attribute { }
+        }
+
+        namespace Trellis.Primitives
+        {
+            public sealed class CompositeValueObjectJsonConverter<T> { }
+        }
+        """;
+
+    [Fact]
+    public async Task FromBodyDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Microsoft.AspNetCore.Mvc;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerRequest(ShippingAddress ShippingAddress);
+
+            [ApiController]
+            [Route("customers")]
+            public sealed class CustomersController : ControllerBase
+            {
+                [HttpPost]
+                public void Create([FromBody] CreateCustomerRequest request) { }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(24, 60)
+                .WithArguments("ShippingAddress", "CreateCustomerRequest.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ControllerResponseDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Microsoft.AspNetCore.Mvc;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CustomerResponse(ShippingAddress ShippingAddress);
+
+            [ApiController]
+            [Route("customers")]
+            public sealed class CustomersController : ControllerBase
+            {
+                public ActionResult<CustomerResponse> Get() => default!;
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(24, 55)
+                .WithArguments("ShippingAddress", "CustomerResponse.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MinimalApiRequestDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Microsoft.AspNetCore.Builder;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            namespace Microsoft.AspNetCore.Builder
+            {
+                public static class EndpointRouteBuilderExtensions
+                {
+                    public static void MapPost<TDelegate>(this object builder, string pattern, TDelegate handler) { }
+                }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerRequest(ShippingAddress ShippingAddress);
+
+            public static class CustomerEndpoints
+            {
+                public static void Map(object app) =>
+                    app.MapPost("/customers", (CreateCustomerRequest request) => { });
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(32, 60)
+                .WithArguments("ShippingAddress", "CreateCustomerRequest.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MinimalApiMethodGroupRequestDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Microsoft.AspNetCore.Builder;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            namespace Microsoft.AspNetCore.Builder
+            {
+                public static class EndpointRouteBuilderExtensions
+                {
+                    public static void MapPost<TDelegate>(this object builder, string pattern, TDelegate handler) { }
+                }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerRequest(ShippingAddress ShippingAddress);
+
+            public static class CustomerEndpoints
+            {
+                public static void Map(object app) =>
+                    app.MapPost("/customers", Create);
+
+                private static void Create(CreateCustomerRequest request) { }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(32, 60)
+                .WithArguments("ShippingAddress", "CreateCustomerRequest.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MediatorRequestDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Mediator;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            namespace Mediator
+            {
+                public interface ICommand<TResponse> { }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerCommand(ShippingAddress ShippingAddress) : ICommand<Result>;
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(29, 60)
+                .WithArguments("ShippingAddress", "CreateCustomerCommand.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task FromBodyDto_WithOwnedValueObjectAndConverter_NoDiagnostic()
+    {
+        const string source = """
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Json.Serialization;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+            using Trellis.Primitives;
+
+            [OwnedEntity]
+            [JsonConverter(typeof(CompositeValueObjectJsonConverter<ShippingAddress>))]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed record CreateCustomerRequest(ShippingAddress ShippingAddress);
+
+            [ApiController]
+            [Route("customers")]
+            public sealed class CustomersController : ControllerBase
+            {
+                [HttpPost]
+                public void Create([FromBody] CreateCustomerRequest request) { }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(source);
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task PlainDomainType_NotUsedAsFromBodyDto_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            public sealed class Customer
+            {
+                public ShippingAddress ShippingAddress { get; set; } = default!;
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(source);
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+}

--- a/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
@@ -1,0 +1,354 @@
+namespace Trellis.Analyzers.Tests;
+
+using Xunit;
+
+/// <summary>
+/// Tests for RedundantEfConfigurationAnalyzer (TRLS021).
+/// </summary>
+public class RedundantEfConfigurationAnalyzerTests
+{
+    private const string EfCoreBuilderStubSource = """
+        namespace Microsoft.EntityFrameworkCore
+        {
+            public class ModelConfigurationBuilder
+            {
+            }
+        }
+
+        namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+        {
+            using System;
+            using System.Linq.Expressions;
+
+            public class EntityTypeBuilder<TEntity> where TEntity : class
+            {
+                public virtual PropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
+                    => new PropertyBuilder<TProperty>();
+
+                public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
+                    Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
+                    where TRelatedEntity : class
+                    => new OwnedNavigationBuilder<TEntity, TRelatedEntity>();
+
+                public virtual EntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object?>> propertyExpression)
+                    => this;
+
+                public virtual EntityTypeBuilder<TEntity> Ignore(string propertyName)
+                    => this;
+            }
+
+            public class PropertyBuilder<TProperty>
+            {
+                public virtual PropertyBuilder<TProperty> HasConversion<TProvider>()
+                    => this;
+
+                public virtual PropertyBuilder<TProperty> HasMaxLength(int maxLength)
+                    => this;
+            }
+
+            public class OwnedNavigationBuilder<TEntity, TRelatedEntity>
+                where TEntity : class
+                where TRelatedEntity : class
+            {
+            }
+        }
+
+        namespace Trellis.EntityFrameworkCore
+        {
+            using System;
+            using Microsoft.EntityFrameworkCore;
+
+            public class MaybeConvention
+            {
+            }
+
+            [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+            public sealed class OwnedEntityAttribute : Attribute
+            {
+            }
+
+            public static class ModelConfigurationBuilderExtensions
+            {
+                public static ModelConfigurationBuilder ApplyTrellisConventions(
+                    this ModelConfigurationBuilder configurationBuilder,
+                    params System.Reflection.Assembly[] assemblies)
+                    => configurationBuilder;
+
+                public static ModelConfigurationBuilder ApplyTrellisConventionsFor<TContext>(
+                    this ModelConfigurationBuilder configurationBuilder)
+                    => configurationBuilder;
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task HasConversion_OnMaybeProperty_WithTrellisConventions_ProducesWarning()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Property(e => e.PhoneNumber).HasConversion<string>();
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions(typeof(Order).Assembly);
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<RedundantEfConfigurationAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.RedundantEfConfiguration)
+                .WithLocation(21, 46)
+                .WithArguments("HasConversion", "Order.PhoneNumber"));
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnsOne_OnOwnedEntityProperty_WithTrellisConventionsFor_ProducesWarning()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Money Total { get; set; } = null!;
+            }
+
+            [OwnedEntity]
+            public class Money
+            {
+                public decimal Amount { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.OwnsOne(e => e.Total);
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<RedundantEfConfigurationAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.RedundantEfConfiguration)
+                .WithLocation(27, 17)
+                .WithArguments("OwnsOne", "Order.Total"));
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Ignore_OnMaybeProperty_WithTrellisConventions_ProducesWarning()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Ignore(e => e.PhoneNumber);
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<RedundantEfConfigurationAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.RedundantEfConfiguration)
+                .WithLocation(21, 17)
+                .WithArguments("Ignore", "Order.PhoneNumber"));
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task HasConversion_OnMaybeProperty_WithoutTrellisConventions_NoDiagnostic()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Property(e => e.PhoneNumber).HasConversion<string>();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ChainedHasConversion_OnMaybeProperty_WithTrellisConventions_ProducesWarning()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Property(e => e.PhoneNumber).HasMaxLength(20).HasConversion<string>();
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<RedundantEfConfigurationAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.RedundantEfConfiguration)
+                .WithLocation(21, 63)
+                .WithArguments("HasConversion", "Order.PhoneNumber"));
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Ignore_StringOverload_NoDiagnostic()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Ignore("PhoneNumber");
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task HasConversion_OnRegularProperty_WithTrellisConventions_NoDiagnostic()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public string Status { get; set; } = "";
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Property(e => e.Status).HasConversion<string>();
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+}

--- a/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
@@ -473,4 +473,67 @@ public class RedundantEfConfigurationAnalyzerTests
 
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task TrellisAndUserDefinedApplyTrellisConventions_TrellisCallEnablesAnalyzer()
+    {
+        // When both the Trellis-owned extension and a user-defined method with the same name
+        // exist in scope, and the TRELLIS-owned overload is called, TRLS021 must fire.
+        // This confirms the symbol-resolution correctly distinguishes between the two.
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+            using MyCompany.Data;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Ignore(e => e.PhoneNumber);
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    // Calls the TRELLIS-owned overload (takes assemblies); user method takes none.
+                    configurationBuilder.ApplyTrellisConventions(typeof(Order).Assembly);
+                }
+            }
+            """;
+
+        // User-defined extension has a different signature (no args) to avoid CS0121 ambiguity.
+        // The call above is unambiguously resolved to the Trellis-owned overload.
+        const string userConventionsStub = """
+            namespace MyCompany.Data
+            {
+                using Microsoft.EntityFrameworkCore;
+
+                public static class MyConventions
+                {
+                    public static ModelConfigurationBuilder ApplyTrellisConventions(
+                        this ModelConfigurationBuilder configurationBuilder)
+                        => configurationBuilder;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<RedundantEfConfigurationAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.RedundantEfConfiguration)
+                .WithLocation(22, 17)
+                .WithArguments("Ignore", "Order.PhoneNumber"));
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+        test.TestState.Sources.Add(("UserConventionsStub.cs", userConventionsStub));
+
+        await test.RunAsync();
+    }
 }

--- a/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
@@ -238,6 +238,53 @@ public class RedundantEfConfigurationAnalyzerTests
     }
 
     [Fact]
+    public async Task HasConversion_OnMaybeProperty_WithUnrelatedApplyTrellisConventionsName_NoDiagnostic()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using MyCompany.EntityFrameworkCore;
+
+            namespace MyCompany.EntityFrameworkCore
+            {
+                public static class ModelConfigurationBuilderExtensions
+                {
+                    public static ModelConfigurationBuilder ApplyTrellisConventions(
+                        this ModelConfigurationBuilder configurationBuilder)
+                        => configurationBuilder;
+                }
+            }
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Property(e => e.PhoneNumber).HasConversion<string>();
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
+        test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task ChainedHasConversion_OnMaybeProperty_WithTrellisConventions_ProducesWarning()
     {
         const string source = """

--- a/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/RedundantEfConfigurationAnalyzerTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Analyzers.Tests;
+﻿namespace Trellis.Analyzers.Tests;
 
 using Xunit;
 
@@ -348,6 +348,128 @@ public class RedundantEfConfigurationAnalyzerTests
 
         var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
         test.TestState.Sources.Add(("EfCoreBuilderStubs.cs", EfCoreBuilderStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task UserDefinedApplyTrellisConventions_DoesNotEnableAnalyzer()
+    {
+        // A user-defined extension method with the same name as the Trellis convention
+        // wiring methods must NOT enable TRLS021.  The analyzer must resolve the symbol
+        // and confirm it belongs to a Trellis-owned containing type before firing.
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.EntityFrameworkCore.Metadata.Builders;
+            using Trellis.EntityFrameworkCore;
+            using MyCompany.Data;
+
+            public class Order
+            {
+                public int Id { get; set; }
+                public Maybe<string> PhoneNumber { get; set; }
+            }
+
+            public class OrderConfig
+            {
+                public void Configure(EntityTypeBuilder<Order> builder)
+                {
+                    builder.Ignore(e => e.PhoneNumber);
+                }
+            }
+
+            public class AppDbContext
+            {
+                protected void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                {
+                    // Calls user-defined ApplyTrellisConventions — NOT the Trellis extension.
+                    configurationBuilder.ApplyTrellisConventions();
+                }
+            }
+            """;
+
+        // User-defined extension that lives in a different containing type.
+        const string userConventionsStub = """
+            namespace MyCompany.Data
+            {
+                using Microsoft.EntityFrameworkCore;
+
+                public static class MyConventions
+                {
+                    public static ModelConfigurationBuilder ApplyTrellisConventions(
+                        this ModelConfigurationBuilder configurationBuilder)
+                        => configurationBuilder;
+                }
+            }
+            """;
+
+        // The stub source here omits ModelConfigurationBuilderExtensions so the only
+        // ApplyTrellisConventions in scope is the user-defined one.
+        const string efStubWithoutTrellisExtension = """
+            namespace Microsoft.EntityFrameworkCore
+            {
+                public class ModelConfigurationBuilder
+                {
+                }
+            }
+
+            namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+            {
+                using System;
+                using System.Linq.Expressions;
+
+                public class EntityTypeBuilder<TEntity> where TEntity : class
+                {
+                    public virtual PropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
+                        => new PropertyBuilder<TProperty>();
+
+                    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
+                        Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
+                        where TRelatedEntity : class
+                        => new OwnedNavigationBuilder<TEntity, TRelatedEntity>();
+
+                    public virtual EntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object?>> propertyExpression)
+                        => this;
+
+                    public virtual EntityTypeBuilder<TEntity> Ignore(string propertyName)
+                        => this;
+                }
+
+                public class PropertyBuilder<TProperty>
+                {
+                    public virtual PropertyBuilder<TProperty> HasConversion<TProvider>()
+                        => this;
+
+                    public virtual PropertyBuilder<TProperty> HasMaxLength(int maxLength)
+                        => this;
+                }
+
+                public class OwnedNavigationBuilder<TEntity, TRelatedEntity>
+                    where TEntity : class
+                    where TRelatedEntity : class
+                {
+                }
+            }
+
+            namespace Trellis.EntityFrameworkCore
+            {
+                using System;
+                using Microsoft.EntityFrameworkCore;
+
+                public class MaybeConvention
+                {
+                }
+
+                [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+                public sealed class OwnedEntityAttribute : Attribute
+                {
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<RedundantEfConfigurationAnalyzer>(source);
+        test.TestState.Sources.Add(("EfStubWithoutTrellisExtension.cs", efStubWithoutTrellisExtension));
+        test.TestState.Sources.Add(("UserConventionsStub.cs", userConventionsStub));
 
         await test.RunAsync();
     }

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -114,9 +114,14 @@ public static class ServiceCollectionExtensions
         var existingResolver = options.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver();
         options.TypeInfoResolver = existingResolver.WithAddedModifier(ModifyTypeInfo);
 
-        // Add factories for direct serialization scenarios
-        options.Converters.Add(new ValidatingJsonConverterFactory());
-        options.Converters.Add(new MaybeScalarValueJsonConverterFactory());
+        // Add factories for direct serialization scenarios in reflection-enabled apps.
+        // Native AOT source-generated contexts cannot expand reflection-created converter factories;
+        // AOT consumers should make scalar roots reachable through their JsonSerializerContext.
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            options.Converters.Add(new ValidatingJsonConverterFactory());
+            options.Converters.Add(new MaybeScalarValueJsonConverterFactory());
+        }
     }
 
     /// <summary>

--- a/Trellis.Asp/src/Response/ResponseFailureWriter.cs
+++ b/Trellis.Asp/src/Response/ResponseFailureWriter.cs
@@ -83,15 +83,16 @@ internal static class ResponseFailureWriter
         if (rules.Items.Length > 0)
         {
             ext["rules"] = rules.Items
-                .Select(rv => (object)new
-                {
-                    code = rv.ReasonCode,
-                    detail = rv.Detail,
-                    fields = rv.Fields.Items.Select(p => p.Path).ToArray(),
-                })
+                .Select(rv => new RuleViolationProblemDetail(
+                    rv.ReasonCode,
+                    rv.Detail,
+                    rv.Fields.Items.Select(p => p.Path).ToArray()))
                 .ToArray();
         }
 
         return ext;
     }
 }
+
+/// <summary>JSON shape used for rule violations in ProblemDetails extensions.</summary>
+public sealed record RuleViolationProblemDetail(string Code, string? Detail, string[] Fields);

--- a/Trellis.Asp/src/Routing/RouteConstraintRegistrationExtensions.cs
+++ b/Trellis.Asp/src/Routing/RouteConstraintRegistrationExtensions.cs
@@ -99,7 +99,10 @@ public static class RouteConstraintRegistrationExtensions
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Caller registers a known constraint type at compile time.")]
-    private static void ConfigureSingle(RouteOptions options, string name, Type constraintType)
+    private static void ConfigureSingle(
+        RouteOptions options,
+        string name,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type constraintType)
     {
         // Match the assembly-scanning variant: preserve any existing entry under the same name.
         if (!options.ConstraintMap.ContainsKey(name))

--- a/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
@@ -114,7 +114,11 @@ internal static class ScalarValueTypeHelper
             null);
 
         if (stringTryCreateMethod is not null)
-            return InvokeTryCreate(stringTryCreateMethod, [rawValue, parameterName], parameterName);
+        {
+            var stringErrors = InvokeTryCreate(stringTryCreateMethod, [rawValue, parameterName], parameterName);
+            if (stringErrors is not null || GetPrimitiveType(scalarValueType) == typeof(string))
+                return stringErrors;
+        }
 
         var primitiveType = GetPrimitiveType(scalarValueType);
         if (primitiveType is null)
@@ -217,9 +221,16 @@ internal static class ScalarValueTypeHelper
         if (conversionResult is null)
             return null;
 
-        var tryGetValue = conversionResult.GetType().GetMethod(
-            "TryGetValue",
-            BindingFlags.Public | BindingFlags.Instance);
+        var tryGetValue = conversionResult.GetType()
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(method =>
+            {
+                if (method.Name != "TryGetValue")
+                    return false;
+
+                var parameters = method.GetParameters();
+                return parameters.Length == 1 && parameters[0].ParameterType.IsByRef;
+            });
 
         if (tryGetValue is null)
             return null;

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp;
+﻿namespace Trellis.Asp;
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿namespace Trellis.Asp;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Trellis;
@@ -59,7 +60,7 @@ public sealed class ScalarValueValidationMiddleware
             }
             catch (BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status400BadRequest)
             {
-                if (IsParameterReadFailureMessage(ex.Message))
+                if (ex.InnerException is JsonException)
                 {
                     // Handle JSON body deserialization failures (e.g., missing required properties)
                     await WriteJsonDeserializationErrorAsync(context, ex).ConfigureAwait(false);
@@ -95,10 +96,6 @@ public sealed class ScalarValueValidationMiddleware
         var result = Results.ValidationProblem(errors);
         await result.ExecuteAsync(context).ConfigureAwait(false);
     }
-
-    private static bool IsParameterReadFailureMessage(string message) =>
-        message.StartsWith("Failed to read parameter ", StringComparison.Ordinal) &&
-        message.EndsWith(" from the request body as JSON.", StringComparison.Ordinal);
 
     [UnconditionalSuppressMessage("AOT", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
         Justification = "The type check for IScalarValue interfaces is safe - we only check interface implementation, not instantiate or invoke members.")]

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -1,7 +1,6 @@
-﻿namespace Trellis.Asp;
+namespace Trellis.Asp;
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Trellis;
@@ -35,17 +34,9 @@ using Trellis.Asp.Validation;
 /// app.MapControllers();
 /// </code>
 /// </example>
-public sealed partial class ScalarValueValidationMiddleware
+public sealed class ScalarValueValidationMiddleware
 {
     private readonly RequestDelegate _next;
-
-    // Regex to parse: Failed to bind parameter "TypeName paramName" from "value".
-    // The type name may include namespaces or nested type separators (e.g., Namespace.Type or Outer+Inner).
-    [GeneratedRegex("""^Failed to bind parameter "(.+?)\s+([^"\s]+)" from "(.*)".$""")]
-    private static partial Regex ParameterBindingFailedRegex();
-
-    [GeneratedRegex("""^Failed to read parameter ".+" from the request body as JSON\.$""")]
-    private static partial Regex ParameterReadFailedRegex();
 
     /// <summary>
     /// Creates a new instance of <see cref="ScalarValueValidationMiddleware"/>.
@@ -68,29 +59,20 @@ public sealed partial class ScalarValueValidationMiddleware
             }
             catch (BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status400BadRequest)
             {
-                // Use StatusCode as the primary check; regex is a secondary detail extractor.
-                if (TryParseBindingFailureMessage(ex.Message, out var parameterName, out var typeName, out var invalidValue))
-                {
-                    // Only handle binding failures for IScalarValue types
-                    var scalarValueType = GetScalarValueParameterType(context, parameterName);
-                    if (scalarValueType is not null)
-                    {
-                        // Call TryCreate to get the real validation error (e.g., with valid values list)
-                        var errors = ScalarValueTypeHelper.GetValidationErrors(scalarValueType, invalidValue, parameterName)
-                            ?? CreateFallbackErrors(parameterName, invalidValue);
-
-                        await WriteValidationProblemAsync(context, errors).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        // Re-throw for non-scalar value types (e.g., int, Guid, DateTime)
-                        throw;
-                    }
-                }
-                else if (IsParameterReadFailureMessage(ex.Message))
+                if (IsParameterReadFailureMessage(ex.Message))
                 {
                     // Handle JSON body deserialization failures (e.g., missing required properties)
                     await WriteJsonDeserializationErrorAsync(context, ex).ConfigureAwait(false);
+                }
+                else if (TryCreateScalarBindingErrors(context, out var errors))
+                {
+                    await WriteValidationProblemAsync(context, errors).ConfigureAwait(false);
+                }
+                else if (HasEndpointParameterMetadata(context))
+                {
+                    // Endpoint binding failed, but Trellis could not map it to a scalar-value parameter.
+                    // Let ASP.NET Core's normal BadHttpRequestException handling deal with non-Trellis parameters.
+                    throw;
                 }
                 else
                 {
@@ -115,27 +97,16 @@ public sealed partial class ScalarValueValidationMiddleware
     }
 
     private static bool IsParameterReadFailureMessage(string message) =>
-        ParameterReadFailedRegex().IsMatch(message);
+        message.StartsWith("Failed to read parameter ", StringComparison.Ordinal) &&
+        message.EndsWith(" from the request body as JSON.", StringComparison.Ordinal);
 
     [UnconditionalSuppressMessage("AOT", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
         Justification = "The type check for IScalarValue interfaces is safe - we only check interface implementation, not instantiate or invoke members.")]
     [UnconditionalSuppressMessage("AOT", "IL2073:Return type does not satisfy 'DynamicallyAccessedMembersAttribute' requirements.",
         Justification = "The returned type comes from ParameterInfo.ParameterType which preserves type metadata at runtime.")]
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)]
-    private static Type? GetScalarValueParameterType(HttpContext context, string parameterName)
+    private static Type? GetScalarValueParameterType(IParameterBindingMetadata parameterMetadata)
     {
-        var endpoint = context.GetEndpoint();
-        if (endpoint is null)
-            return null;
-
-        // Get the parameter binding metadata from the endpoint
-        var parameterMetadata = endpoint.Metadata
-            .OfType<IParameterBindingMetadata>()
-            .FirstOrDefault(p => p.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase));
-
-        if (parameterMetadata is null)
-            return null;
-
         // Check if the parameter type implements IScalarValue<,>
         var parameterType = parameterMetadata.ParameterInfo.ParameterType;
 
@@ -150,6 +121,54 @@ public sealed partial class ScalarValueValidationMiddleware
             ? maybeInnerType
             : null;
     }
+
+    private static bool TryCreateScalarBindingErrors(
+        HttpContext context,
+        out IDictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        foreach (var parameterMetadata in GetEndpointParameterMetadata(context))
+        {
+            var parameterName = parameterMetadata.Name;
+            if (string.IsNullOrWhiteSpace(parameterName))
+                continue;
+
+            var scalarValueType = GetScalarValueParameterType(parameterMetadata);
+            if (scalarValueType is null)
+                continue;
+
+            var rawValue = GetRawParameterValue(context, parameterName);
+            if (rawValue is null)
+                continue;
+
+            var parameterErrors = ScalarValueTypeHelper.GetValidationErrors(scalarValueType, rawValue, parameterName);
+            if (parameterErrors is null)
+                continue;
+
+            foreach (var (fieldName, details) in parameterErrors)
+                errors[fieldName] = details;
+        }
+
+        return errors.Count > 0;
+    }
+
+    private static string? GetRawParameterValue(HttpContext context, string parameterName)
+    {
+        if (context.Request.RouteValues.TryGetValue(parameterName, out var routeValue))
+            return routeValue?.ToString();
+
+        if (context.Request.Query.TryGetValue(parameterName, out var queryValue))
+            return queryValue.ToString();
+
+        return null;
+    }
+
+    private static bool HasEndpointParameterMetadata(HttpContext context) =>
+        GetEndpointParameterMetadata(context).Any();
+
+    private static IEnumerable<IParameterBindingMetadata> GetEndpointParameterMetadata(HttpContext context) =>
+        context.GetEndpoint()?.Metadata.OfType<IParameterBindingMetadata>() ?? [];
 
     private static async Task WriteValidationProblemAsync(
         HttpContext context,
@@ -183,39 +202,4 @@ public sealed partial class ScalarValueValidationMiddleware
         await result.ExecuteAsync(context).ConfigureAwait(false);
     }
 
-    private static Dictionary<string, string[]> CreateFallbackErrors(
-        string parameterName,
-        string invalidValue)
-    {
-        var errorMessage = string.IsNullOrEmpty(invalidValue)
-            ? $"'{parameterName}' is required."
-            : $"'{parameterName}' has an invalid value.";
-
-        return new Dictionary<string, string[]>
-        {
-            [parameterName] = [errorMessage]
-        };
-    }
-
-    private static bool TryParseBindingFailureMessage(
-        string message,
-        out string parameterName,
-        out string typeName,
-        out string invalidValue)
-    {
-        // Try to parse: Failed to bind parameter "TypeName paramName" from "value".
-        var match = ParameterBindingFailedRegex().Match(message);
-        if (match.Success)
-        {
-            typeName = match.Groups[1].Value;
-            parameterName = match.Groups[2].Value;
-            invalidValue = match.Groups[3].Value;
-            return true;
-        }
-
-        parameterName = string.Empty;
-        typeName = string.Empty;
-        invalidValue = string.Empty;
-        return false;
-    }
 }

--- a/Trellis.Asp/tests/ScalarValueTypeHelperTests.cs
+++ b/Trellis.Asp/tests/ScalarValueTypeHelperTests.cs
@@ -464,14 +464,16 @@ public class ScalarValueTypeHelperTests
     public void GetValidationErrors_TypeWithoutStringTryCreate_ParseablePrimitive_ReturnsValidationErrors()
     {
         // Arrange - InterfaceOnlyValidated has TryCreate(string, string) that throws NotImplementedException,
-        // so GetValidationErrors will return null (exception is caught and swallowed).
+        // so GetValidationErrors falls through to TryCreate(int, string).
         var type = typeof(InterfaceOnlyValidated);
 
         // Act
         var errors = ScalarValueTypeHelper.GetValidationErrors(type, "0", "param");
 
-        // Assert - returns null because the string TryCreate throws NotImplementedException
-        errors.Should().BeNull();
+        // Assert
+        errors.Should().NotBeNull();
+        errors!.Should().ContainKey("param");
+        errors["param"].Should().Contain("Must be positive.");
     }
 
     [Fact]

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
@@ -343,7 +343,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(ScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "INVALID");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "OrderCode code" from "INVALID".""", 400));
@@ -367,7 +367,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(ScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "INVALID");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "Trellis.Asp.Tests.OrderCode code" from "INVALID".""", 400));
@@ -391,7 +391,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(ScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "INVALID");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "ScalarValueValidationMiddlewareTests+OrderCode code" from "INVALID".""", 400));
@@ -415,7 +415,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(MaybeScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "INVALID");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "Maybe<OrderCode> code" from "INVALID".""", 400));
@@ -439,7 +439,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(NonScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "id");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "id", "abc");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "Int32 id" from "abc".""", 400));
@@ -452,7 +452,7 @@ public class ScalarValueValidationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_NoEndpoint_Rethrows()
+    public async Task InvokeAsync_BindingFailure_NoEndpoint_ReturnsGeneric400()
     {
         // Arrange - no endpoint set on context
         var context = CreateHttpContextWithServices();
@@ -461,21 +461,25 @@ public class ScalarValueValidationMiddlewareTests
             throw new BadHttpRequestException("""Failed to bind parameter "OrderCode code" from "INVALID".""", 400));
 
         // Act
-        var act = async () => await middleware.InvokeAsync(context);
+        await middleware.InvokeAsync(context);
 
         // Assert
-        await act.Should().ThrowAsync<BadHttpRequestException>();
+        context.Response.StatusCode.Should().Be(400);
+        var body = await ReadResponseBodyAsync(context);
+        var problem = JsonSerializer.Deserialize<JsonElement>(body);
+        problem.GetProperty("errors").GetProperty("$")[0].GetString()
+            .Should().Be("The request was invalid.");
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_MessageContainsSubstringButDoesNotMatchFormat_ReturnsGeneric400()
+    public async Task InvokeAsync_BindingFailure_DoesNotDependOnExceptionMessageFormat_ReturnsRichErrors()
     {
         // Arrange
         var paramInfo = typeof(ScalarValueValidationMiddlewareTests)
             .GetMethod(nameof(ScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "INVALID");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("Proxy error: Failed to bind parameter happened upstream before request processing.", 400));
@@ -487,8 +491,8 @@ public class ScalarValueValidationMiddlewareTests
         context.Response.StatusCode.Should().Be(400);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
-        problem.GetProperty("errors").GetProperty("$")[0].GetString()
-            .Should().Be("The request was invalid.", "should not leak ex.Message to clients");
+        problem.GetProperty("errors").GetProperty("code")[0].GetString()
+            .Should().Contain("ORD-", "endpoint metadata and raw route values should drive validation");
     }
 
     [Fact]
@@ -637,7 +641,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(ScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "code");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "code", "BAD");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "OrderCode code" from "BAD".""", 400));
@@ -658,7 +662,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(IntOnlyScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "val");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "val", "0");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "IntOnlyScalarValue val" from "0".""", 400));
@@ -666,12 +670,12 @@ public class ScalarValueValidationMiddlewareTests
         // Act
         await middleware.InvokeAsync(context);
 
-        // Assert - falls back to generic error since string TryCreate throws NotImplementedException
+        // Assert - falls through from the unusable string overload to primitive TryCreate.
         context.Response.StatusCode.Should().Be(400);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("val")[0].GetString()
-            .Should().Be("'val' has an invalid value.");
+            .Should().Be("Must be positive.");
     }
 
     [Fact]
@@ -682,7 +686,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(IntOnlyScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "val");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "val", "");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "IntOnlyScalarValue val" from "".""", 400));
@@ -735,7 +739,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(IntOnlyScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "val");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "val", "<script>alert('xss')</script>");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "IntOnlyScalarValue val" from "<script>alert('xss')</script>".""", 400));
@@ -758,7 +762,7 @@ public class ScalarValueValidationMiddlewareTests
             .GetMethod(nameof(IntOnlyScalarValueParam), BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
-        var context = CreateContextWithEndpointMetadata(paramInfo, "val");
+        var context = CreateContextWithEndpointMetadata(paramInfo, "val", "bad");
 
         var middleware = new ScalarValueValidationMiddleware(_ =>
             throw new BadHttpRequestException("""Failed to bind parameter "IntOnlyScalarValue val" from "bad".""", 400));
@@ -776,7 +780,10 @@ public class ScalarValueValidationMiddlewareTests
 
     #region Helper Methods
 
-    private static DefaultHttpContext CreateContextWithEndpointMetadata(ParameterInfo paramInfo, string paramName)
+    private static DefaultHttpContext CreateContextWithEndpointMetadata(
+        ParameterInfo paramInfo,
+        string paramName,
+        string? rawValue = null)
     {
         var mockMetadata = new Mock<IParameterBindingMetadata>();
         mockMetadata.Setup(m => m.Name).Returns(paramName);
@@ -788,6 +795,9 @@ public class ScalarValueValidationMiddlewareTests
             displayName: "TestEndpoint");
 
         var context = CreateHttpContextWithServices();
+        if (rawValue is not null)
+            context.Request.RouteValues[paramName] = rawValue;
+
         context.SetEndpoint(endpoint);
         return context;
     }

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using System.IO;
@@ -516,7 +516,7 @@ public class ScalarValueValidationMiddlewareTests
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("$")[0].GetString()
-            .Should().Contain("invalid JSON");
+            .Should().Be("The request body contains invalid JSON.");
     }
 
     [Fact]
@@ -590,7 +590,7 @@ public class ScalarValueValidationMiddlewareTests
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("$")[0].GetString()
-            .Should().Contain("invalid JSON");
+            .Should().Be("The request was invalid.");
     }
 
     [Fact]

--- a/Trellis.EntityFrameworkCore/NUGET_README.md
+++ b/Trellis.EntityFrameworkCore/NUGET_README.md
@@ -18,7 +18,7 @@ using Trellis.EntityFrameworkCore;
 protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
     configurationBuilder.ApplyTrellisConventions(typeof(AppDbContext).Assembly);
 
-// AOT-friendly alternative — generated at compile time, no reflection scan:
+// Reflection-free alternative — generated at compile time, no assembly scan:
 //   configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
 
 Maybe<Customer> customer = await dbContext.Customers.FirstOrDefaultMaybeAsync(cancellationToken);

--- a/Trellis.EntityFrameworkCore/README.md
+++ b/Trellis.EntityFrameworkCore/README.md
@@ -27,7 +27,7 @@ using Trellis.EntityFrameworkCore;
 protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
     configurationBuilder.ApplyTrellisConventions(typeof(AppDbContext).Assembly);
 
-// AOT-friendly alternative — generated at compile time, no reflection scan:
+// Reflection-free alternative — generated at compile time, no assembly scan:
 //   configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
 
 Maybe<Customer> customer = await dbContext.Customers.FirstOrDefaultMaybeAsync(cancellationToken);

--- a/Trellis.EntityFrameworkCore/generator/ApplyTrellisConventionsForGenerator.cs
+++ b/Trellis.EntityFrameworkCore/generator/ApplyTrellisConventionsForGenerator.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 /// </para>
 /// <para>
 /// The runtime API uses reflection-based assembly scanning; the generated path is a
-/// drop-in replacement for AOT/trim scenarios where reflection over arbitrary
+    /// drop-in replacement for scenarios where reflection over arbitrary
 /// assemblies is undesirable. See ADR-002 §8.1.
 /// </para>
 /// </remarks>
@@ -365,7 +365,7 @@ public sealed class ApplyTrellisConventionsForGenerator : IIncrementalGenerator
         sb.AppendLine("{");
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Registers Trellis value object converters and conventions for the specified");
-        sb.AppendLine("    /// <typeparamref name=\"TContext\"/>. Reflection-free, AOT-clean alternative to");
+        sb.AppendLine("    /// <typeparamref name=\"TContext\"/>. Reflection-free alternative to");
         sb.AppendLine("    /// <see cref=\"ModelConfigurationBuilderExtensions.ApplyTrellisConventions(ModelConfigurationBuilder, System.Reflection.Assembly[])\"/>.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    /// <typeparam name=\"TContext\">A concrete <see cref=\"DbContext\"/>-derived type defined in the current compilation.</typeparam>");

--- a/Trellis.EntityFrameworkCore/src/ModelConfigurationBuilderExtensions.cs
+++ b/Trellis.EntityFrameworkCore/src/ModelConfigurationBuilderExtensions.cs
@@ -118,7 +118,7 @@ public static class ModelConfigurationBuilderExtensions
     /// <typeparamref name="TClr"/> properties that round-trip to <typeparamref name="TProvider"/>.
     /// </summary>
     /// <remarks>
-    /// AOT/trim-friendly: no calls to <see cref="Type.MakeGenericType(Type[])"/> or other
+    /// Reflection-free: no calls to <see cref="Type.MakeGenericType(Type[])"/> or other
     /// runtime reflection. Intended for source-generated convention registration.
     /// </remarks>
     /// <typeparam name="TClr">The Trellis scalar value object CLR type (e.g. <c>CustomerId</c>).</typeparam>
@@ -141,7 +141,7 @@ public static class ModelConfigurationBuilderExtensions
     /// <c>AggregateTransientPropertyConvention</c>, and <c>ValueObjectMappingGuardConvention</c>.
     /// </summary>
     /// <remarks>
-    /// AOT/trim-friendly: no calls to <see cref="Type.MakeGenericType(Type[])"/>. The
+    /// Reflection-free: no calls to <see cref="Type.MakeGenericType(Type[])"/>. The
     /// <paramref name="composites"/> argument carries already-closed <see cref="Type"/> tokens
     /// supplied by the caller (typically the source generator).
     /// </remarks>

--- a/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
+++ b/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
@@ -273,15 +273,15 @@ public sealed class CompositeValueObjectJsonConverter<
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
             Type type)
         {
-            var properties = type
+            var discoveredProperties = type
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                 .Where(p =>
                     p.GetMethod is not null &&
                     p.GetIndexParameters().Length == 0 &&
                     (p.SetMethod is null || !p.SetMethod.IsPublic))
-                .OrderBy(TryGetMetadataToken)
-                .ThenBy(p => p.Name, StringComparer.Ordinal)
                 .ToList();
+
+            var properties = OrderProperties(type, discoveredProperties);
 
             var props = new List<PropertyMetadata>(properties.Count);
             foreach (var p in properties)
@@ -326,15 +326,59 @@ public sealed class CompositeValueObjectJsonConverter<
             return propertyType;
         }
 
-        private static int TryGetMetadataToken(MemberInfo member)
+        private static List<PropertyInfo> OrderProperties(Type type, List<PropertyInfo> properties)
+        {
+            var withTokens = new List<(PropertyInfo Property, int Token)>(properties.Count);
+            foreach (var property in properties)
+            {
+                if (!TryGetMetadataToken(property, out var token))
+                    return OrderPropertiesWithoutMetadataTokens(type, properties);
+
+                withTokens.Add((property, token));
+            }
+
+            return withTokens
+                .OrderBy(p => p.Token)
+                .Select(p => p.Property)
+                .ToList();
+        }
+
+        [UnconditionalSuppressMessage("Trimming", "IL2072",
+            Justification = "Property types are discovered from a rooted composite value object. The fallback only inspects interfaces to reject unsafe duplicate primitive shapes before any value conversion occurs.")]
+        private static List<PropertyInfo> OrderPropertiesWithoutMetadataTokens(Type type, List<PropertyInfo> properties)
+        {
+            var duplicatePrimitiveTypes = properties
+                .GroupBy(p => GetPrimitiveType(p.PropertyType))
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            if (duplicatePrimitiveTypes.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"CompositeValueObjectJsonConverter<{type.Name}> cannot determine a safe property order because metadata tokens are unavailable " +
+                    $"and multiple properties share the same primitive type(s): {string.Join(", ", duplicatePrimitiveTypes)}. " +
+                    "Use a hand-written converter for this composite value object.");
+            }
+
+            return properties
+                .OrderBy(p => GetPrimitiveType(p.PropertyType).Name, StringComparer.Ordinal)
+                .ThenBy(p => p.Name, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        private static bool TryGetMetadataToken(MemberInfo member, out int metadataToken)
         {
             try
             {
-                return member.MetadataToken;
+                metadataToken = member.MetadataToken;
+                return true;
             }
             catch (InvalidOperationException)
             {
-                return int.MaxValue;
+                metadataToken = 0;
+                return false;
             }
         }
 

--- a/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
+++ b/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
@@ -41,11 +41,13 @@ using Trellis;
 /// message on failure.
 /// </para>
 /// <para>
-/// This converter uses reflection at first use (results are cached). It is not Native AOT compatible.
-/// For AOT scenarios, hand-write a converter and register it with <see cref="JsonConverterAttribute"/>.
+/// This converter uses reflection at first use (results are cached). Native AOT apps must root the
+/// closed converter type through <see cref="JsonConverterAttribute"/> or a source-generated context.
 /// </para>
 /// </remarks>
-public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
+public sealed class CompositeValueObjectJsonConverter<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+    T> : JsonConverter<T>
     where T : ValueObject
 {
     private static readonly CompositeMetadata Metadata = CompositeMetadata.Build(typeof(T));
@@ -189,7 +191,9 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
 
         if (primitiveType == typeof(string))
         {
-            writer.WriteString(jsonName, (string)raw);
+            writer.WriteString(jsonName, raw is string text
+                ? text
+                : Convert.ToString(raw, System.Globalization.CultureInfo.InvariantCulture));
         }
         else if (primitiveType == typeof(decimal))
         {
@@ -263,9 +267,11 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
 
         public required Func<object?[], Result<T>> Invoke { get; init; }
 
-        [UnconditionalSuppressMessage("Trimming", "IL2070",
-            Justification = "Composite VO converter discovers properties on T via reflection by design. The class XML doc directs AOT consumers to hand-write a converter and register it with [JsonConverter]; the source-generator extension for composite VOs is tracked as a follow-up.")]
-        public static CompositeMetadata Build(Type type)
+        [UnconditionalSuppressMessage("Trimming", "IL2072",
+            Justification = "Composite VO public properties are preserved by the converter generic parameter annotation; property type interface annotations are not expressible through PropertyInfo.")]
+        public static CompositeMetadata Build(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+            Type type)
         {
             var properties = type
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
@@ -273,7 +279,8 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
                     p.GetMethod is not null &&
                     p.GetIndexParameters().Length == 0 &&
                     (p.SetMethod is null || !p.SetMethod.IsPublic))
-                .OrderBy(p => p.MetadataToken)
+                .OrderBy(TryGetMetadataToken)
+                .ThenBy(p => p.Name, StringComparer.Ordinal)
                 .ToList();
 
             var props = new List<PropertyMetadata>(properties.Count);
@@ -304,9 +311,11 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
             };
         }
 
-        [UnconditionalSuppressMessage("Trimming", "IL2070",
-            Justification = "Composite VO converter discovers IScalarValue<,> implementation by reflection. The class XML doc directs AOT consumers to hand-write a converter; the source-generator extension is tracked as a follow-up.")]
-        private static Type GetPrimitiveType(Type propertyType)
+        [UnconditionalSuppressMessage("Trimming", "IL2072",
+            Justification = "Property types are discovered from a rooted composite value object. Scalar value object interfaces are preserved by their generated converter/model-binding surface.")]
+        private static Type GetPrimitiveType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+            Type propertyType)
         {
             foreach (var iface in propertyType.GetInterfaces())
             {
@@ -317,8 +326,20 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
             return propertyType;
         }
 
+        private static int TryGetMetadataToken(MemberInfo member)
+        {
+            try
+            {
+                return member.MetadataToken;
+            }
+            catch (InvalidOperationException)
+            {
+                return int.MaxValue;
+            }
+        }
+
         [UnconditionalSuppressMessage("Trimming", "IL2075",
-            Justification = "Composite VO converter inspects the property's 'Value' member by reflection. The class XML doc directs AOT consumers to hand-write a converter; the source-generator extension is tracked as a follow-up.")]
+            Justification = "Property types are discovered from a rooted composite value object. Scalar value object Value members are part of the public Trellis scalar contract.")]
         private static Func<T, object?> BuildPrimitiveGetter(PropertyInfo propInfo, Type primitiveType)
         {
             var instance = Expression.Parameter(typeof(T), "v");
@@ -349,9 +370,10 @@ public sealed class CompositeValueObjectJsonConverter<T> : JsonConverter<T>
 
         [UnconditionalSuppressMessage("AOT", "IL3050",
             Justification = "Result<T> is constructed via MakeGenericType to match the TryCreate factory's return type. T is the converter's owning type and is reachable through JsonConverter<T>. The class XML doc directs AOT consumers to hand-write a converter; the source-generator extension is tracked as a follow-up.")]
-        [UnconditionalSuppressMessage("Trimming", "IL2070",
-            Justification = "TryCreate factory is discovered on T via reflection. The class XML doc directs AOT consumers to hand-write a converter; the source-generator extension is tracked as a follow-up.")]
-        private static Func<object?[], Result<T>> BuildInvoker(Type type, List<PropertyMetadata> props)
+        private static Func<object?[], Result<T>> BuildInvoker(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            Type type,
+            List<PropertyMetadata> props)
         {
             var resultType = typeof(Result<>).MakeGenericType(type);
             var primitiveTypes = props.Select(p => p.PrimitiveType).ToArray();

--- a/Trellis.Primitives/tests/CompositeValueObjectJsonConverterTests.cs
+++ b/Trellis.Primitives/tests/CompositeValueObjectJsonConverterTests.cs
@@ -1,7 +1,8 @@
-using Trellis.Testing;
+﻿using Trellis.Testing;
 
 namespace Trellis.Primitives.Tests;
 
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Trellis;
@@ -69,6 +70,20 @@ public class CompositeValueObjectJsonConverterTests
         rt.Should().NotBeNull();
         rt!.Amount.Should().Be(99.99m);
         rt.Currency.Value.Should().Be("USD");
+    }
+
+    [Fact]
+    public void Roundtrip_same_typed_properties_preserves_declaration_order()
+    {
+        var address = SameTypedPropertiesVo.Create("123 Main St", "Springfield");
+
+        var json = JsonSerializer.Serialize(address);
+
+        json.Should().Be("{\"street\":\"123 Main St\",\"city\":\"Springfield\"}");
+        var rt = JsonSerializer.Deserialize<SameTypedPropertiesVo>("{\"street\":\"1 High St\",\"city\":\"London\"}");
+        rt.Should().NotBeNull();
+        rt!.Street.Should().Be("1 High St");
+        rt.City.Should().Be("London");
     }
 
     #endregion
@@ -238,6 +253,26 @@ public class CompositeValueObjectJsonConverterTests
             .WithMessage("*found multiple ambiguous 'TryCreate' overloads*");
     }
 
+    [Fact]
+    public void Metadata_token_fallback_rejects_same_typed_properties()
+    {
+        var metadataType = typeof(CompositeValueObjectJsonConverter<>)
+            .GetNestedType("CompositeMetadata", BindingFlags.NonPublic);
+        metadataType = metadataType!.MakeGenericType(typeof(SameTypedPropertiesVo));
+        var fallbackMethod = metadataType?.GetMethod(
+            "OrderPropertiesWithoutMetadataTokens",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var properties = typeof(SameTypedPropertiesVo)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .ToList();
+
+        Action act = () => fallbackMethod!.Invoke(null, [typeof(SameTypedPropertiesVo), properties]);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<InvalidOperationException>()
+            .WithMessage("*cannot determine a safe property order*String*");
+    }
+
     #endregion
 
     // --- Test fixtures ---
@@ -262,6 +297,23 @@ public class CompositeValueObjectJsonConverterTests
 
         public static Result<IntStringVo> TryCreate(int number, string label, string? fieldName = null) =>
             Result.Ok(new IntStringVo(number, label));
+    }
+
+    [JsonConverter(typeof(CompositeValueObjectJsonConverter<SameTypedPropertiesVo>))]
+    public class SameTypedPropertiesVo : TestVo
+    {
+        public string Street { get; private set; } = string.Empty;
+
+        public string City { get; private set; } = string.Empty;
+
+        private SameTypedPropertiesVo() { }
+
+        private SameTypedPropertiesVo(string street, string city) { Street = street; City = city; }
+
+        public static SameTypedPropertiesVo Create(string street, string city) => new(street, city);
+
+        public static Result<SameTypedPropertiesVo> TryCreate(string street, string city, string? fieldName = null) =>
+            Result.Ok(new SameTypedPropertiesVo(street, city));
     }
 
     [JsonConverter(typeof(CompositeValueObjectJsonConverter<AllPrimitivesVo>))]

--- a/Trellis.ServiceDefaults/NUGET_README.md
+++ b/Trellis.ServiceDefaults/NUGET_README.md
@@ -1,0 +1,28 @@
+# Trellis.ServiceDefaults
+
+[![NuGet Package](https://img.shields.io/nuget/v/Trellis.ServiceDefaults.svg)](https://www.nuget.org/packages/Trellis.ServiceDefaults)
+
+Opinionated composition defaults for Trellis web services.
+
+## Installation
+```bash
+dotnet add package Trellis.ServiceDefaults
+```
+
+## Quick Example
+```csharp
+using Trellis.ServiceDefaults;
+
+builder.Services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator()
+    .UseFluentValidation(typeof(Program).Assembly)
+    .UseClaimsActorProvider()
+    .UseResourceAuthorization(typeof(Program).Assembly)
+    .UseEntityFrameworkUnitOfWork<AppDbContext>());
+```
+
+`UseEntityFrameworkUnitOfWork<TContext>()` is always applied last so the transactional command behavior runs innermost. `AddDbContext<TContext>(...)` and `AddMediator(...)` remain application-owned registrations.
+
+## Part of Trellis
+This package is part of the [Trellis](https://github.com/xavierjohn/Trellis) framework.

--- a/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
+++ b/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Opinionated service composition defaults for Trellis web services. Provides a tiered builder that wires ASP integration, Mediator behaviors, FluentValidation, resource authorization, actor providers, and EF Core Unit of Work in canonical order.</Description>

--- a/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
+++ b/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+    <Description>Opinionated service composition defaults for Trellis web services. Provides a tiered builder that wires ASP integration, Mediator behaviors, FluentValidation, resource authorization, actor providers, and EF Core Unit of Work in canonical order.</Description>
+    <PackageTags>trellis;service-defaults;composition;aspnetcore;cqrs;mediator;entity-framework-core;fluentvalidation</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>servicedefaults</TrellisApiRefName>
+    <IsAotCompatible>false</IsAotCompatible>
+    <IsTrimmable>false</IsTrimmable>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />
+    <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\src\Trellis.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\Trellis.FluentValidation\src\Trellis.FluentValidation.csproj" />
+    <ProjectReference Include="..\..\Trellis.Mediator\src\Trellis.Mediator.csproj" />
+  </ItemGroup>
+</Project>

--- a/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
@@ -1,4 +1,4 @@
-namespace Trellis.ServiceDefaults;
+﻿namespace Trellis.ServiceDefaults;
 
 using System;
 using System.Collections.Generic;

--- a/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
@@ -153,7 +153,7 @@ public sealed class TrellisServiceBuilder
 
     private void SetActorProvider(ActorProviderKind kind, Action<IServiceCollection> registration)
     {
-        if (_actorProviderKind != ActorProviderKind.None && _actorProviderKind != kind)
+        if (_actorProviderKind != ActorProviderKind.None)
             throw new InvalidOperationException(
                 $"Only one actor provider can be selected. '{_actorProviderKind}' is already configured.");
 

--- a/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
@@ -1,0 +1,194 @@
+namespace Trellis.ServiceDefaults;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp;
+using Trellis.Asp.Authorization;
+using Trellis.EntityFrameworkCore;
+using Trellis.FluentValidation;
+using Trellis.Mediator;
+
+/// <summary>
+/// Collects requested Trellis integration modules and applies them in canonical order.
+/// </summary>
+public sealed class TrellisServiceBuilder
+{
+    private readonly IServiceCollection _services;
+    private readonly List<Assembly> _fluentValidationAssemblies = [];
+    private readonly List<Assembly> _resourceAuthorizationAssemblies = [];
+    private Action<TrellisAspOptions>? _configureAsp;
+    private Action<TrellisMediatorTelemetryOptions>? _configureMediatorTelemetry;
+    private Action<IServiceCollection>? _actorProviderRegistration;
+    private Action<IServiceCollection>? _unitOfWorkRegistration;
+    private bool _useAsp;
+    private bool _useMediator;
+    private bool _useFluentValidation;
+    private ActorProviderKind _actorProviderKind;
+
+    internal TrellisServiceBuilder(IServiceCollection services) =>
+        _services = services;
+
+    /// <summary>
+    /// Registers Trellis ASP.NET Core integration.
+    /// </summary>
+    public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)
+    {
+        _useAsp = true;
+        if (configure is not null)
+            _configureAsp = Combine(_configureAsp, configure);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers the Trellis Mediator pipeline behaviors.
+    /// </summary>
+    public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)
+    {
+        _useMediator = true;
+        if (configureTelemetry is not null)
+            _configureMediatorTelemetry = Combine(_configureMediatorTelemetry, configureTelemetry);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers the FluentValidation adapter and optionally scans validator assemblies.
+    /// Implies <see cref="UseMediator"/>.
+    /// </summary>
+    public TrellisServiceBuilder UseFluentValidation(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+        if (assemblies.Length > 0)
+            AddAssemblies(_fluentValidationAssemblies, assemblies, nameof(assemblies));
+
+        _useFluentValidation = true;
+        _useMediator = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers resource authorization behaviors and resource loaders discovered in assemblies.
+    /// Implies <see cref="UseMediator"/>.
+    /// </summary>
+    public TrellisServiceBuilder UseResourceAuthorization(params Assembly[] assemblies)
+    {
+        AddAssemblies(_resourceAuthorizationAssemblies, assemblies, nameof(assemblies));
+        _useMediator = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers <see cref="ClaimsActorProvider"/> as the scoped actor provider.
+    /// </summary>
+    public TrellisServiceBuilder UseClaimsActorProvider(Action<ClaimsActorOptions>? configure = null)
+    {
+        SetActorProvider(ActorProviderKind.Claims, services => services.AddClaimsActorProvider(configure));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers <see cref="EntraActorProvider"/> as the scoped actor provider.
+    /// </summary>
+    public TrellisServiceBuilder UseEntraActorProvider(Action<EntraActorOptions>? configure = null)
+    {
+        SetActorProvider(ActorProviderKind.Entra, services => services.AddEntraActorProvider(configure));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers <see cref="DevelopmentActorProvider"/> as the scoped actor provider.
+    /// </summary>
+    public TrellisServiceBuilder UseDevelopmentActorProvider(Action<DevelopmentActorOptions>? configure = null)
+    {
+        SetActorProvider(ActorProviderKind.Development, services => services.AddDevelopmentActorProvider(configure));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers EF Core Unit of Work and the transactional command behavior.
+    /// Implies <see cref="UseMediator"/> and is always applied after all other behavior registrations.
+    /// </summary>
+    public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>()
+        where TContext : DbContext
+    {
+        _useMediator = true;
+        _unitOfWorkRegistration = services => services.AddTrellisUnitOfWork<TContext>();
+        return this;
+    }
+
+    internal void Apply()
+    {
+        if (_useAsp)
+        {
+            if (_configureAsp is null)
+                _services.AddTrellisAsp();
+            else
+                _services.AddTrellisAsp(_configureAsp);
+        }
+
+        _actorProviderRegistration?.Invoke(_services);
+
+        if (_useMediator)
+        {
+            if (_configureMediatorTelemetry is null)
+                _services.AddTrellisBehaviors();
+            else
+                _services.AddTrellisBehaviors(_configureMediatorTelemetry);
+        }
+
+        if (_resourceAuthorizationAssemblies.Count > 0)
+            _services.AddResourceAuthorization([.. _resourceAuthorizationAssemblies]);
+
+        if (_useFluentValidation && _fluentValidationAssemblies.Count == 0)
+            _services.AddTrellisFluentValidation();
+        else if (_fluentValidationAssemblies.Count > 0)
+            _services.AddTrellisFluentValidation([.. _fluentValidationAssemblies]);
+
+        _unitOfWorkRegistration?.Invoke(_services);
+    }
+
+    private void SetActorProvider(ActorProviderKind kind, Action<IServiceCollection> registration)
+    {
+        if (_actorProviderKind != ActorProviderKind.None && _actorProviderKind != kind)
+            throw new InvalidOperationException(
+                $"Only one actor provider can be selected. '{_actorProviderKind}' is already configured.");
+
+        _actorProviderKind = kind;
+        _actorProviderRegistration = registration;
+    }
+
+    private static void AddAssemblies(List<Assembly> target, Assembly[] assemblies, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+        if (assemblies.Length == 0)
+            throw new ArgumentException("At least one assembly must be provided.", parameterName);
+
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            if (assemblies[i] is null)
+                throw new ArgumentException($"Assembly at index [{i}] is null.", parameterName);
+
+            if (!target.Contains(assemblies[i]))
+                target.Add(assemblies[i]);
+        }
+    }
+
+    private static Action<T> Combine<T>(Action<T>? existing, Action<T> next) =>
+        existing is null ? next : value =>
+        {
+            existing(value);
+            next(value);
+        };
+
+    private enum ActorProviderKind
+    {
+        None,
+        Claims,
+        Entra,
+        Development,
+    }
+}

--- a/Trellis.ServiceDefaults/src/TrellisServiceCollectionExtensions.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+namespace Trellis.ServiceDefaults;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for applying opinionated Trellis service composition defaults.
+/// </summary>
+public static class TrellisServiceCollectionExtensions
+{
+    /// <summary>
+    /// Applies Trellis integration modules in canonical order.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configures the Trellis service modules to apply.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <remarks>
+    /// This method only wires Trellis integration services. Application-owned services such as
+    /// <c>AddDbContext&lt;TContext&gt;(...)</c> and <c>AddMediator(...)</c> stay explicit.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddTrellis(options => options
+    ///     .UseAsp()
+    ///     .UseMediator()
+    ///     .UseFluentValidation(typeof(Program).Assembly)
+    ///     .UseEntityFrameworkUnitOfWork&lt;AppDbContext&gt;());
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddTrellis(
+        this IServiceCollection services,
+        Action<TrellisServiceBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = new TrellisServiceBuilder(services);
+        configure(builder);
+        builder.Apply();
+        return services;
+    }
+}

--- a/Trellis.ServiceDefaults/src/TrellisServiceCollectionExtensions.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-namespace Trellis.ServiceDefaults;
+﻿namespace Trellis.ServiceDefaults;
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
+++ b/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\src\Trellis.ServiceDefaults.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+  </ItemGroup>
+</Project>

--- a/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
+++ b/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Trellis.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
+++ b/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.ServiceDefaults.Tests;
+﻿namespace Trellis.ServiceDefaults.Tests;
 
 using System.Linq;
 using global::Mediator;

--- a/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
+++ b/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
@@ -1,0 +1,107 @@
+namespace Trellis.ServiceDefaults.Tests;
+
+using System.Linq;
+using global::Mediator;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp;
+using Trellis.Authorization;
+using Trellis.EntityFrameworkCore;
+using Trellis.Mediator;
+
+/// <summary>
+/// Tests for <see cref="TrellisServiceBuilder"/>.
+/// </summary>
+public class TrellisServiceBuilderTests
+{
+    [Fact]
+    public void UseEntityFrameworkUnitOfWork_AppliesTransactionalBehaviorLast()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options
+            .UseMediator()
+            .UseEntityFrameworkUnitOfWork<TestDbContext>());
+
+        var behaviorTypes = services
+            .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>))
+            .Select(d => d.ImplementationType)
+            .ToList();
+
+        behaviorTypes.Should().EndWith(typeof(TransactionalCommandBehavior<,>));
+        services.Should().ContainSingle(d =>
+            d.ServiceType == typeof(IUnitOfWork) &&
+            d.ImplementationType == typeof(EfUnitOfWork<TestDbContext>));
+    }
+
+    [Fact]
+    public void UseFluentValidation_ImpliedMediatorAndRegistersAdapter()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options
+            .UseFluentValidation(typeof(TrellisServiceBuilderTests).Assembly));
+
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(IPipelineBehavior<,>) &&
+            d.ImplementationType == typeof(ValidationBehavior<,>));
+        services.Count(d =>
+            d.ServiceType == typeof(IMessageValidator<>) &&
+            d.ImplementationType?.Name == "FluentValidationMessageValidatorAdapter`1").Should().Be(1);
+    }
+
+    [Fact]
+    public void UseFluentValidation_WithoutAssemblies_RegistersAdapterOnly()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options.UseFluentValidation());
+
+        services.Count(d =>
+            d.ServiceType == typeof(IMessageValidator<>) &&
+            d.ImplementationType?.Name == "FluentValidationMessageValidatorAdapter`1").Should().Be(1);
+    }
+
+    [Fact]
+    public void UseAsp_RegistersTrellisAspOptionsAndScalarValidationInfrastructure()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options.UseAsp());
+
+        services.Should().ContainSingle(d => d.ServiceType == typeof(TrellisAspOptions));
+    }
+
+    [Fact]
+    public void MultipleActorProviders_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddTrellis(options => options
+            .UseClaimsActorProvider()
+            .UseEntraActorProvider());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Only one actor provider*");
+    }
+
+    [Fact]
+    public void UseClaimsActorProvider_RegistersActorProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options.UseClaimsActorProvider());
+
+        services.Count(d =>
+            d.ServiceType == typeof(IActorProvider) &&
+            d.ImplementationType?.Name == "ClaimsActorProvider").Should().Be(1);
+    }
+
+    private sealed class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}

--- a/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
+++ b/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
@@ -86,6 +86,19 @@ public class TrellisServiceBuilderTests
     }
 
     [Fact]
+    public void SameActorProviderConfiguredTwice_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddTrellis(options => options
+            .UseClaimsActorProvider()
+            .UseClaimsActorProvider());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Only one actor provider*");
+    }
+
+    [Fact]
     public void UseClaimsActorProvider_RegistersActorProvider()
     {
         var services = new ServiceCollection();

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -107,6 +107,10 @@
     <Project Path="Trellis.Core/src/Trellis.Core.csproj" />
     <Project Path="Trellis.Core/tests/Trellis.Core.Tests.csproj" />
   </Folder>
+  <Folder Name="/Trellis.ServiceDefaults/">
+    <Project Path="Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj" />
+    <Project Path="Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj" />
+  </Folder>
   <Folder Name="/Trellis.StateMachine/">
     <Project Path="Trellis.StateMachine/src/Trellis.StateMachine.csproj" />
     <Project Path="Trellis.StateMachine/tests/Trellis.StateMachine.Tests.csproj" />

--- a/docs/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/adr/ADR-002-v2-redesign-plan.md
@@ -992,12 +992,12 @@ The v1 promise of "no assembly scanning ever" is dropped — it's a 6-month proj
 `RepositoryBase<TAggregate, TId>` keeps its current shape — it's good. Changes:
 - `SaveChangesResultAsync` and `SaveChangesResultUnitAsync` stay as `DbContext` extensions for non-pipeline scenarios.
 - `IUnitOfWork.CommitAsync()` is the canonical commit for pipeline scenarios.
-- `TRLS020` (warning today: prefer `SaveChangesResultAsync` over `SaveChangesAsync`) is **kept as warning**, not escalated to error. Some scenarios legitimately call `SaveChangesAsync`.
+- `TRLS015` (warning today: prefer `SaveChangesResultAsync` over `SaveChangesAsync`) is **kept as warning**, not escalated to error. Some scenarios legitimately call `SaveChangesAsync`.
 
 ### 8.3 Maybe properties + indexes
 
 `HasIndex(x => x.MaybeProp)` magic rewriting is **dropped** (per critique: low ROI, high fragility). Instead:
-- `TRLS021` (current warning) stays, telling users to use `HasTrellisIndex` or string-based `HasIndex`.
+- `TRLS016` (current warning) stays, telling users to use `HasTrellisIndex` or string-based `HasIndex`.
 - The `HasTrellisIndex` extension is the recommended path, documented prominently.
 
 ### 8.4 Diagnostics retained

--- a/docs/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/adr/ADR-002-v2-redesign-plan.md
@@ -373,7 +373,7 @@ If two methods do the same thing under different names (`SuccessIf` ≈ `Ensure`
 **Decision (2026-04-20):** every async-returning extension is named `…Async` (`MapAsync`, `BindAsync`, `TapAsync`, `TapOnFailureAsync`, `EnsureAsync`, `MatchAsync`, `RecoverAsync`). This follows the BCL guideline for `Task`/`ValueTask`-returning methods and matches every async API the user already reads (`Task.WhenAllAsync`, `HttpClient.SendAsync`, `DbContext.SaveChangesAsync`). The earlier "async invisible" framing has been **rescinded** because it created two avoidable problems: (1) overload ambiguity between sync `Map` and `Task<Result<T>>.Map`, and (2) no visible signal at the call site that an `await` is required. The §3.3 overload matrix is updated accordingly: `Map` is one overload (sync × sync), `MapAsync` covers the five async permutations.
 
 ### C. **No tuple-arity ceilings in user-facing validation APIs.**
-A builder pattern (`Validate.Field(a).And(b).And(c)…`) replaces fixed-arity `Combine` for **validation aggregation** (no ceiling). For heterogeneous value combination (different value types, first-failure-wins semantics), `Result.Combine<T1..T9>` stays — it's already T4-generated, costs nothing, and is genuinely cleaner than chained `Bind`s. `TRLS019` (max 9 hard-error) stays for `Combine` with a clearer message: "Group into a record or use `Validate.Field(...).Build()` if these are validation results."
+A builder pattern (`Validate.Field(a).And(b).And(c)…`) replaces fixed-arity `Combine` for **validation aggregation** (no ceiling). For heterogeneous value combination (different value types, first-failure-wins semantics), `Result.Combine<T1..T9>` stays — it's already T4-generated, costs nothing, and is genuinely cleaner than chained `Bind`s. `TRLS014` (max 9 hard-error) stays for `Combine` with a clearer message: "Group into a record or use `Validate.Field(...).Build()` if these are validation results."
 
 ### D. **Errors are a closed-by-convention catalog, not an open hierarchy.**
 We **do not** claim compiler exhaustiveness — C# does not provide it for record hierarchies. Instead:
@@ -396,7 +396,7 @@ The per-package `docs/api_reference/trellis-api-*.md` is the canonical surface; 
 ### I. **Diagnostics complement — not replace — boundary adapters.**
 We keep `Result.Try(Func<T>, Func<Exception, Error>?)` and `Result.TryAsync` as explicit boundary adapters for foreign code (EF, HttpClient, BCL parsing, third-party). Analyzers (`TRLS015`) catch unguarded `throw` *inside* a chain — but they cannot catch exceptions from foreign code, which is exactly what `Try` exists for. Removing `Try` would force the AI to reinvent it badly.
 
-### J. **AOT-clean by default. No reflection in hot paths.**
+### J. **AOT-clean where supported. No reflection in hot paths.**
 Source generators do the work. The redesign treats AOT as a target, not a bonus.
 
 ---
@@ -690,7 +690,7 @@ var result = Result.Combine(orderResult, customerResult, productResult)
 - Error position is deterministic (first argument's failure wins).
 - Subsequent results not evaluated for error aggregation; their value is observed only for parallel async via `Result.ParallelAsync`.
 - T1..T9 surface kept (T4-generated, zero cost).
-- `TRLS019` (T10 hard-error) **stays** with a clearer message steering users to record-grouping or `Validate`.
+- `TRLS014` (T10 hard-error) **stays** with a clearer message steering users to record-grouping or `Validate`.
 
 #### `Result.ParallelAsync<T1..T9>` — parallel async fan-in
 
@@ -983,7 +983,7 @@ The `HandleFailureAsync<TContext>(...)` overloads with their `(response, ctx, ct
 
 A **new** source generator emits `ApplyTrellisConventionsFor<TContext>()` that walks the `DbContext`'s `DbSet<>` properties at compile time and emits explicit converter registrations. Users can pick either:
 - `ApplyTrellisConventions(typeof(MyDbContext).Assembly)` — runtime scan (works today; ergonomic; reflection cost at startup only)
-- `ApplyTrellisConventionsFor<MyDbContext>()` — generated, reflection-free, AOT-clean
+- `ApplyTrellisConventionsFor<MyDbContext>()` — generated, reflection-free convention registration; EF Core itself remains outside Trellis' NativeAOT support promise
 
 The v1 promise of "no assembly scanning ever" is dropped — it's a 6-month project to do it well across all real EF scenarios. This dual-path is honest.
 
@@ -1177,7 +1177,7 @@ Stated once for the whole framework so individual packages don't re-decide:
 v2 framework code is **AOT-friendly and trim-safe**. No runtime reflection in hot paths — Mediator pipeline behaviors, the `Result` pipeline, EFCore conventions, and analyzer/generator outputs all rely on source-generators or compile-time wiring. Specifically:
 
 - **No `Activator.CreateInstance`, no `Type.GetMethod(...).Invoke` in request paths.** If a future feature appears to need it, the answer is "ship a source-generator instead", which is also the rationale for the optional Phase 7 `Trellis.Mediator.Dispatcher`.
-- **Every framework package declares `<IsTrimmable>true</IsTrimmable>` and `<IsAotCompatible>true</IsAotCompatible>`.** CI fails if a package emits IL2026/IL2070/IL3050 trim/AOT warnings.
+- **Every non-EF runtime package declares `<IsTrimmable>true</IsTrimmable>` and `<IsAotCompatible>true</IsAotCompatible>`.** `Trellis.EntityFrameworkCore` explicitly opts out because EF Core NativeAOT support is still experimental. CI fails if an AOT-supported package emits IL2026/IL2070/IL3050 trim/AOT warnings.
 - **Ban on `dynamic`, `[Obsolete]`-after-v2.0, and unconstrained generic reflection in hot paths.** Tested via a custom analyzer in Phase 5a (`TRLS028`).
 
 This is an AI-correctness positive: the model has fewer "does this method exist at runtime?" mysteries to model. It is also a future-proofing positive: modern .NET hosting (Native AOT, single-file, container slimming) is fully supported without per-package retrofits.
@@ -1220,7 +1220,7 @@ All six questions in v2 are now decided. The per-package implementation plans bu
 | 2 | Remove `Result<T>.Value` and `Result<T>.Error` properties entirely? | **Yes — remove entirely** | They are the single biggest source of `TRLS003`/`TRLS004` warnings. `TryGetValue` / `TryGetError` / `Deconstruct` / `Match` cover every legitimate use. AI generates safer code by default when the unsafe path doesn't exist. |
 | 3 | Move HTTP-protocol value types out of core? | **Split by observed usage in `TrellisAspTemplate`:** `RepresentationMetadata` moves to `Trellis.Asp` (constructed only in controllers). **`EntityTagValue` and `RetryAfterValue` stay in `Trellis.Core`** — the template's `UpdateTodoCommand.IfMatchETags : EntityTagValue[]?` and `OptionalETag(...)` handler call show `EntityTagValue` flowing through the Application layer; `RetryAfterValue` is a property of error records the ACL constructs. HTTP-specific *parsing* (`ETagHelper.ParseIfMatch`) and *header formatting* (`RetryAfterValue.ToHttpHeaderValue`) are extensions in `Trellis.Asp`. `IAggregate.ETag` stays as `string` in `Trellis.Core` (after the Phase 2 DDD merge). | The template is the canonical AI starting point — its layer usage is the design constraint. Conditional preconditions are an Application-layer concern (commands declare their own preconditions); response shape is an API concern. See §12.2 for the full layer rules. |
 | 4 | `Trellis.StateMachine` — wrap or abstract Stateless? | **Thin wrapper, rename only. No `IStateMachine<TState, TTrigger>` abstraction.** | Reimplementing state machines is a trap. Abstracting Stateless either becomes a giant reimplementation or a crippled abstraction users escape. Document the Stateless types in user code. |
-| 5 | Keep `Result.Combine` arity? | **Keep T1..T9 with first-failure-wins semantics. `Validate` builder for validation aggregation (no ceiling). `TRLS019` (T10 hard-error) stays with a clearer message.** | The two operations have **different semantics**: `Validate` accumulates field errors into a single `ValidationError` (validation-shaped failures only); `Combine` combines heterogeneous `Result<T1>..<T9>` with first-failure-wins (any error type). T1..T9 is already T4-generated, costs nothing, and `Combine(a,b,c,d).Bind((a,b,c,d) => ...)` is genuinely cleaner than chained `Bind`s. No `AggregateError` — there is no useful HTTP/UX mapping for "multiple unrelated errors at once". `Result.ParallelAsync` retained for parallel async with first-failure-wins (and OpenTelemetry on both branches). |
+| 5 | Keep `Result.Combine` arity? | **Keep T1..T9 with first-failure-wins semantics. `Validate` builder for validation aggregation (no ceiling). `TRLS014` (T10 hard-error) stays with a clearer message.** | The two operations have **different semantics**: `Validate` accumulates field errors into a single `ValidationError` (validation-shaped failures only); `Combine` combines heterogeneous `Result<T1>..<T9>` with first-failure-wins (any error type). T1..T9 is already T4-generated, costs nothing, and `Combine(a,b,c,d).Bind((a,b,c,d) => ...)` is genuinely cleaner than chained `Bind`s. No `AggregateError` — there is no useful HTTP/UX mapping for "multiple unrelated errors at once". `Result.ParallelAsync` retained for parallel async with first-failure-wins (and OpenTelemetry on both branches). |
 | 6 | `MaybeInvariant` location? | **Keep separate from `Validate` builder, in `Trellis.Core`** | Different semantics. `Validate` accumulates field errors per source field. `MaybeInvariant` enforces *cross-field* rules between optionals (`AllOrNone`, `Requires`, `MutuallyExclusive`, `ExactlyOne`, `AtLeastOne`). Folding them together would conflate two distinct concepts and harm AI clarity. |
 
 ### Decision implications for the redesign
@@ -1296,11 +1296,11 @@ Every framework `.nupkg` produced by Phases 1a–5a satisfies the following befo
 | **Error model** | 6 | 8 | +2 | Concrete-subtype factory returns; protocol-bearing payloads kept; aggregation via `Validate` not `AggregateError`. `RetryAfterValue`/`EntityTagValue` placement now justified by layer usage. |
 | **Async ergonomics** | 5 | 7 | +2 | Left/Right/Both file-naming noise gone from user surface; ~6 overloads per verb internal. Cap: `Task`↔`ValueTask` mixing still needs explicit conversion. |
 | **ASP integration** | 6 | 8 | +2 | One `ToHttpResponse` verb collapses today's 4 quartets. Protocol semantics (Vary, conditional, Prefer, Range, RetryAfter) preserved via opts. Cap: opts-builder discoverability is unproven. |
-| **EF integration** | 7 | 7 | 0 | Already solid. New: AOT-clean generated path is additive, not replacement. Honest: `RepositoryBase` shape unchanged; magic index rewriting *not* added. |
+| **EF integration** | 7 | 7 | 0 | Already solid. New: reflection-free generated convention path is additive, not replacement. Honest: `RepositoryBase` shape unchanged; magic index rewriting *not* added. |
 | **Tooling (analyzers + generators)** | 6 | 8 | +2 | Unified `TRLS001…099`; new `TRLS023/024/025/026/027`; analyzer + generator co-shipped. |
 | **Documentation** | 7 | 8 | +1 | Per-package `trellis-api-*.md` shipping in nupkg today (already good). New: template-anchored docs as canonical AI surface; reduces drift. |
 | **Testability** | 8 | 8 | 0 | Already strong. New helpers (`ShouldHaveFieldError`, `ShouldHaveRaised<T>`) are additive. |
-| **AOT readiness** | 6 | 7 | +1 | Source-gen-first culture; explicit AOT-clean EF path; Mediator wrapping caps gains. |
+| **AOT readiness** | 6 | 7 | +1 | Source-gen-first culture for AOT-supported packages; explicit EF opt-out; Mediator wrapping caps gains. |
 | **Internal consistency / "one way"** | 5 | 8 | +3 | The most-violated current axis (aliases everywhere). New: aliases banned by analyzer; `Result.Ok`/`Fail`/`Try` is the entire factory surface. |
 | **Combinator power** | 6 | 7 | +1 | `Validate` builder removes arity ceiling for validation; `Combine T1..T9` + `ParallelAsync` retained for heterogeneous combination. |
 | **Migration cost / risk** | n/a | n/a | — | The redesign is whole-package replacement across 8 phases (1a–7) — real cost. The v2-canary sample in Phase 5a (§15.1) mitigates "no consumer before GA" risk but does not eliminate it. Counted as a risk, not a score. |

--- a/docs/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/adr/ADR-002-v2-redesign-plan.md
@@ -1203,7 +1203,7 @@ Three perennial debates closed off so the template (Phase 6) and framework (Phas
 | Packages | 17 | **12** (11 runtime + 1 tooling) — `Trellis.AspTemplate` continues to ship from its own repo |
 | ASP entry points for happy-path response | `ToActionResult` / `ToHttpResult` / `ToCreatedHttpResult` / `ToUpdatedHttpResult` / `WriteOutcome.ToHttpResult` / `PartialContentHttpResult` × sync/async | **1** (`ToHttpResponse` with options) |
 | HTTP-client status helpers | ~16 method names × 4 input shapes (~60 overloads) | **5 named methods**, single `statusMap` parameter on the generic one |
-| Combine arity ceiling | 9 (hard error TRLS019) | **`Validate` builder: no ceiling** for validation aggregation; **`Combine<T1..T9>`: T1..T9 retained** for heterogeneous combination (first-failure-wins); TRLS019 stays at T10 with clearer message |
+| Combine arity ceiling | 9 (hard error TRLS014) | **`Validate` builder: no ceiling** for validation aggregation; **`Combine<T1..T9>`: T1..T9 retained** for heterogeneous combination (first-failure-wins); TRLS014 stays at T10 with clearer message |
 | VO base classes the AI must distinguish | scalar / symbolic / composite / optionality wrapper | **2** (`Scalar`, `Composite`) — symbolic is `Scalar<T,Enum>`; optionality is `Maybe<T>` |
 | Tracing / OTel surface | rich, dispersed | **same surface**, documented as canonical (no loss) |
 | Resource authorization | `IAuthorize` + `IAuthorizeResource<T>` + `IIdentifyResource<,>` + `IResourceLoader<,>` | **same model** + attribute sugar for the simple case (no loss) |

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -29,6 +29,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 | `TRLS017` | Warning | Wrong [StringLength] or [Range] attribute namespace | Trellis [StringLength] and [Range] attributes share names with System.ComponentModel.DataAnnotations versions. Using the wrong namespace compiles silently but the Trellis source generator ignores them, resulting in value objects without the expected validation constraints. Use the Trellis versions (namespace Trellis) instead. |
 | `TRLS018` | Warning | Result<T> deconstruction reads value without success gate | Reading the value position of a `Result<T>` deconstruction (`var (success, value, error) = result;`) without first checking `success`/`error` returns the default value when the result is in failure. Gate the read with the success bool, an `error is null` check, or an early return on failure. |
 | `TRLS019` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | Per ADR-002 §3.5.1, `default(Result)` and `default(Result<T>)` are typed failures carrying the `new Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", TrellisDiagnosticIds.DefaultResultOrMaybe)]` or `#pragma warning disable TRLS019` for sanctioned sentinel/test-helper sites. |
+| `TRLS020` | Warning | Composite value object DTO property is missing JSON converter | Composite `[OwnedEntity]` value objects exposed through request/response DTO surfaces must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` so JSON binding round-trips through `TryCreate`. |
 | `TRLS031` | Warning | Unsupported base type for `RequiredPartialClassGenerator` | Emitted by the Primitives source generator when a `Required*`-derived value object inherits from an unsupported base. Supported bases: `RequiredGuid`, `RequiredString`, `RequiredInt`, `RequiredDecimal`, `RequiredLong`, `RequiredBool`, `RequiredDateTime`, `RequiredEnum`. *(formerly `TRLSGEN001`)* |
 | `TRLS032` | Error | `MinimumLength` exceeds `MaximumLength` | Emitted by the Primitives source generator when a `[StringLength]` attribute has `MinimumLength > MaximumLength`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN002`)* |
 | `TRLS033` | Error | `Range` minimum exceeds maximum | Emitted by the Primitives source generator when a `[Range]` attribute on `int`/`long`/`decimal` has `Min > Max`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN003`)* |
@@ -109,6 +110,7 @@ The public static class `Trellis.Analyzers.DiagnosticDescriptors` exposes one `p
 | `WrongAttributeNamespace` | `TRLS017` | Warning | Trellis.Primitives |
 | `UnsafeResultDeconstruction` | `TRLS018` | Warning | Trellis.Result |
 | `DefaultResultOrMaybe` | `TRLS019` | Warning | Trellis.Result |
+| `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | Warning | Trellis.Asp |
 
 > **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS038`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
 
@@ -316,6 +318,13 @@ This analyzer was deleted in v2. The `result.IsSuccess ? result.Value : fallback
   - `Maybe<T>` → `Maybe<T>.None` or `Maybe.From(value)`
 - For sanctioned sentinel/test-helper sites, suppress with `[SuppressMessage("Trellis", "TRLS019", Justification = "...")]` on the enclosing member or `#pragma warning disable TRLS019` around the offending span.
 - No code fix (the appropriate replacement depends on intent — success vs. failure for `Result`, value vs. None for `Maybe`).
+
+#### `CompositeValueObjectDtoConverterAnalyzer` — `TRLS020`
+- Flags ASP.NET controller request/response DTOs, Minimal API handler request DTOs, and Mediator `IRequest<T>`/`ICommand<T>`/`IQuery<T>` message DTOs with properties whose type is an `[OwnedEntity]` Trellis `ValueObject` missing `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]`.
+- This catches the silent JSON-binding failure where System.Text.Json can default-construct the composite value object and bypass `TryCreate` validation.
+- Does not flag domain model properties that are not exposed through DTO surfaces.
+- Does not flag composite value-object types that carry the matching `CompositeValueObjectJsonConverter<T>` attribute.
+- No code fix.
 
 ## Code fix providers
 

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -30,6 +30,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 | `TRLS018` | Warning | Result<T> deconstruction reads value without success gate | Reading the value position of a `Result<T>` deconstruction (`var (success, value, error) = result;`) without first checking `success`/`error` returns the default value when the result is in failure. Gate the read with the success bool, an `error is null` check, or an early return on failure. |
 | `TRLS019` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | Per ADR-002 §3.5.1, `default(Result)` and `default(Result<T>)` are typed failures carrying the `new Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", TrellisDiagnosticIds.DefaultResultOrMaybe)]` or `#pragma warning disable TRLS019` for sanctioned sentinel/test-helper sites. |
 | `TRLS020` | Warning | Composite value object DTO property is missing JSON converter | Composite `[OwnedEntity]` value objects exposed through request/response DTO surfaces must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` so JSON binding round-trips through `TryCreate`. |
+| `TRLS021` | Warning | EF configuration duplicates Trellis conventions | Flags `HasConversion`, `OwnsOne`, and `Ignore` calls on `Maybe<T>` or `[OwnedEntity]` properties when `ApplyTrellisConventions(...)` / `ApplyTrellisConventionsFor<TContext>()` is wired. Remove the manual mapping and let Trellis conventions own the property. |
 | `TRLS031` | Warning | Unsupported base type for `RequiredPartialClassGenerator` | Emitted by the Primitives source generator when a `Required*`-derived value object inherits from an unsupported base. Supported bases: `RequiredGuid`, `RequiredString`, `RequiredInt`, `RequiredDecimal`, `RequiredLong`, `RequiredBool`, `RequiredDateTime`, `RequiredEnum`. *(formerly `TRLSGEN001`)* |
 | `TRLS032` | Error | `MinimumLength` exceeds `MaximumLength` | Emitted by the Primitives source generator when a `[StringLength]` attribute has `MinimumLength > MaximumLength`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN002`)* |
 | `TRLS033` | Error | `Range` minimum exceeds maximum | Emitted by the Primitives source generator when a `[Range]` attribute on `int`/`long`/`decimal` has `Min > Max`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN003`)* |
@@ -76,6 +77,8 @@ Every `public const string` field on `TrellisDiagnosticIds`, the diagnostic ID i
 | `WrongAttributeNamespace` | `TRLS017` | `WrongAttributeNamespaceAnalyzer` |
 | `UnsafeResultDeconstruction` | `TRLS018` | `UnsafeResultDeconstructionAnalyzer` |
 | `DefaultResultOrMaybe` | `TRLS019` | `DefaultResultOrMaybeAnalyzer` |
+| `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | `CompositeValueObjectDtoConverterAnalyzer` |
+| `RedundantEfConfiguration` | `TRLS021` | `RedundantEfConfigurationAnalyzer` |
 | `UnsupportedRequiredBaseType` | `TRLS031` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `InvalidStringLengthRange` | `TRLS032` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `InvalidRangeMinExceedsMax` | `TRLS033` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
@@ -111,6 +114,7 @@ The public static class `Trellis.Analyzers.DiagnosticDescriptors` exposes one `p
 | `UnsafeResultDeconstruction` | `TRLS018` | Warning | Trellis.Result |
 | `DefaultResultOrMaybe` | `TRLS019` | Warning | Trellis.Result |
 | `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | Warning | Trellis.Asp |
+| `RedundantEfConfiguration` | `TRLS021` | Warning | Trellis.EntityFrameworkCore |
 
 > **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS038`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
 
@@ -324,6 +328,16 @@ This analyzer was deleted in v2. The `result.IsSuccess ? result.Value : fallback
 - This catches the silent JSON-binding failure where System.Text.Json can default-construct the composite value object and bypass `TryCreate` validation.
 - Does not flag domain model properties that are not exposed through DTO surfaces.
 - Does not flag composite value-object types that carry the matching `CompositeValueObjectJsonConverter<T>` attribute.
+- No code fix.
+
+#### `RedundantEfConfigurationAnalyzer` — `TRLS021`
+- Activates only when the compilation references `Trellis.EntityFrameworkCore.MaybeConvention`.
+- Reports only when the source also wires Trellis conventions via `ApplyTrellisConventions(...)` or generated `ApplyTrellisConventionsFor<TContext>()`.
+- Flags manual EF configuration for convention-owned properties:
+  - `builder.Property(e => e.MaybeProperty).HasConversion(...)`
+  - `builder.OwnsOne(e => e.OwnedEntityValueObject)`
+  - `builder.Ignore(e => e.MaybeOrOwnedEntityProperty)`
+- Targets `Maybe<T>` and types annotated with `Trellis.EntityFrameworkCore.OwnedEntityAttribute`.
 - No code fix.
 
 ## Code fix providers

--- a/docs/api_reference/trellis-api-asp.md
+++ b/docs/api_reference/trellis-api-asp.md
@@ -652,13 +652,13 @@ public sealed class ScalarValueValidationEndpointFilter : IEndpointFilter
 **Declaration**
 
 ```csharp
-public sealed partial class ScalarValueValidationMiddleware
+public sealed class ScalarValueValidationMiddleware
 ```
 
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public ScalarValueValidationMiddleware(RequestDelegate next)` | — | Wraps each request in `ValidationErrorsContext.BeginScope()`. |
-| `public Task InvokeAsync(HttpContext context)` | `Task` | Begins a validation scope, invokes the next middleware, and converts scalar-value `BadHttpRequestException` binding failures into validation problem responses. |
+| `public Task InvokeAsync(HttpContext context)` | `Task` | Begins a validation scope, invokes the next middleware, and converts scalar-value `BadHttpRequestException` binding failures into validation problem responses using endpoint parameter metadata plus route/query raw values. |
 
 ### `ValidationErrorsContext`
 
@@ -689,6 +689,7 @@ public static class ValidationErrorsContext
 - **`CreatedAtAction` is not AOT-safe.** It depends on MVC's `ControllerLinkGeneratorExtensions`. The builder method, the writer's `ResolveActionLocation` private, and the `LocationKind.Action` branch are annotated `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`. Use `CreatedAtRoute` with a named route for trim/AOT scenarios; `ResolveActionLocation` throws `NotSupportedException` when `RuntimeFeature.IsDynamicCodeSupported` is `false`.
 - **Pagination.** The `Result<Page<T>>` overload always emits the `PagedResponse<TBody>` envelope; the RFC 8288 `Link` header is added only when `Page.Next` and/or `Page.Previous` cursors are present. Failure on the page result short-circuits through the standard error pipeline.
 - **Validation collection scope.** `ScalarValueValidationMiddleware` opens a `ValidationErrorsContext` scope per request. Both `ValidatingJsonConverter<,>` and `MaybeScalarValueJsonConverter<,>` collect errors into this scope; `ScalarValueValidationFilter` (MVC) and `ScalarValueValidationEndpointFilter` (Minimal API) short-circuit with a validation problem when the scope is non-empty at action/handler entry.
+- **Minimal API scalar binding failures are metadata-driven.** When ASP.NET Core throws a 400 while binding route/query parameters, `ScalarValueValidationMiddleware` no longer parses `BadHttpRequestException.Message` to discover a field name or invalid value. It inspects `IParameterBindingMetadata`, reads the matching route/query raw value, and re-runs Trellis scalar validation for `IScalarValue<,>` / `Maybe<TScalar>` parameters. Non-scalar endpoint binding failures are rethrown to ASP.NET Core.
 - **`AddTrellisAsp` is the one-call setup.** It registers `TrellisAspOptions` and chains `AddScalarValueValidation()`, configuring both the MVC and Minimal API JSON pipelines for scalar-value/`Maybe<T>` deserialization. You still need `UseScalarValueValidation()` middleware in the request pipeline and `WithScalarValueValidation()` on each Minimal API endpoint that should short-circuit on validation errors.
 - **Composite value objects in request/response DTOs.** `AddTrellisAsp`/`AddScalarValueValidation` only wires the **scalar** VO converters. Composite VOs (multi-field `[OwnedEntity]` types like `ShippingAddress`, `Money`) bind through `CompositeValueObjectJsonConverter<T>` (in `Trellis.Primitives`), which is **opt-in per type** via `[JsonConverter(typeof(CompositeValueObjectJsonConverter<MyVo>))]` on the value object class itself. Without that attribute, model binding falls back to default construction and **silently bypasses `TryCreate`** — the inner-field validation never runs and an invalid payload propagates into the domain layer. See [Cookbook Recipe 13](trellis-api-cookbook.md#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership) for the full Domain + API JSON + EF pattern.
 

--- a/docs/api_reference/trellis-api-asp.md
+++ b/docs/api_reference/trellis-api-asp.md
@@ -118,6 +118,16 @@ Configuration registered via `AddTrellisAsp(...)` that maps domain `Error` types
 
 Default mappings (closed-ADT): `Error.BadRequest=400`, `Error.Unauthorized=401`, `Error.Forbidden=403`, `Error.NotFound=404`, `Error.MethodNotAllowed=405`, `Error.NotAcceptable=406`, `Error.Conflict=409`, `Error.Gone=410`, `Error.PreconditionFailed=412`, `Error.ContentTooLarge=413`, `Error.UnsupportedMediaType=415`, `Error.RangeNotSatisfiable=416`, `Error.UnprocessableContent=422`, `Error.PreconditionRequired=428`, `Error.TooManyRequests=429`, `Error.InternalServerError=500`, `Error.Unexpected=500`, `Error.NotImplemented=501`, `Error.ServiceUnavailable=503`.
 
+### `RuleViolationProblemDetail`
+
+**Declaration**
+
+```csharp
+public sealed record RuleViolationProblemDetail(string Code, string? Detail, string[] Fields);
+```
+
+AOT-friendly JSON payload used inside Problem Details `extensions["rules"]` for `Error.UnprocessableContent` rule violations. Application code should treat this as response shape metadata, not as a domain model.
+
 ### `AggregateRepresentationValidator<T>`
 
 **Declaration**

--- a/docs/api_reference/trellis-api-cookbook.md
+++ b/docs/api_reference/trellis-api-cookbook.md
@@ -113,6 +113,8 @@ public interface IOrderRepository
 
 **What it shows.** `RequiredGuid<TSelf>` and `RequiredString<TSelf>` deliver a complete strongly-typed primitive (parsing, equality, JSON, EF) once you mark the partial class. `[StringLength]` and `[Range]` come from the **`Trellis` namespace** and are placed on the **class declaration** — using `System.ComponentModel.DataAnnotations` versions silently compiles but is ignored by the Trellis source generator (`TRLS017`).
 
+`Aggregate<TId>` already supplies inherited infrastructure members: `Id`, protected `DomainEvents`, persistence-managed `ETag`, and `IsChanged` based on pending domain events. Do not redeclare those members on every aggregate; use the inherited surface and add only domain-specific state.
+
 **Anti-pattern → fix (TRLS017).**
 
 ```csharp

--- a/docs/api_reference/trellis-api-cookbook.md
+++ b/docs/api_reference/trellis-api-cookbook.md
@@ -13,7 +13,7 @@
   - [trellis-api-authorization.md](trellis-api-authorization.md) — `IActorProvider`, `IAuthorize`, `IAuthorizeResource<>`
   - [trellis-api-statemachine.md](trellis-api-statemachine.md) — `FireResult`, `LazyStateMachine<,>`
   - [trellis-api-testing-reference.md](trellis-api-testing-reference.md) — `Should().Be(...)`, `UnwrapError()`
-  - [trellis-api-analyzers.md](trellis-api-analyzers.md) — `TRLS001`–`TRLS019`, `TrellisDiagnosticIds`
+  - [trellis-api-analyzers.md](trellis-api-analyzers.md) — `TRLS001`–`TRLS020`, `TrellisDiagnosticIds`
 
 ## How to read these recipes
 

--- a/docs/api_reference/trellis-api-cookbook.md
+++ b/docs/api_reference/trellis-api-cookbook.md
@@ -14,7 +14,7 @@
   - [trellis-api-servicedefaults.md](trellis-api-servicedefaults.md) — `AddTrellis`, `TrellisServiceBuilder`
   - [trellis-api-statemachine.md](trellis-api-statemachine.md) — `FireResult`, `LazyStateMachine<,>`
   - [trellis-api-testing-reference.md](trellis-api-testing-reference.md) — `Should().Be(...)`, `UnwrapError()`
-  - [trellis-api-analyzers.md](trellis-api-analyzers.md) — `TRLS001`–`TRLS020`, `TrellisDiagnosticIds`
+  - [trellis-api-analyzers.md](trellis-api-analyzers.md) — `TRLS001`–`TRLS021`, `TrellisDiagnosticIds`
 
 ## How to read these recipes
 

--- a/docs/api_reference/trellis-api-cookbook.md
+++ b/docs/api_reference/trellis-api-cookbook.md
@@ -11,6 +11,7 @@
   - [trellis-api-asp.md](trellis-api-asp.md) — `ToHttpResponse`, `HttpResponseOptionsBuilder<T>`, `AddTrellisAsp`, `AsActionResult`
   - [trellis-api-http.md](trellis-api-http.md) — `RangeOutcome`, range parser
   - [trellis-api-authorization.md](trellis-api-authorization.md) — `IActorProvider`, `IAuthorize`, `IAuthorizeResource<>`
+  - [trellis-api-servicedefaults.md](trellis-api-servicedefaults.md) — `AddTrellis`, `TrellisServiceBuilder`
   - [trellis-api-statemachine.md](trellis-api-statemachine.md) — `FireResult`, `LazyStateMachine<,>`
   - [trellis-api-testing-reference.md](trellis-api-testing-reference.md) — `Should().Be(...)`, `UnwrapError()`
   - [trellis-api-analyzers.md](trellis-api-analyzers.md) — `TRLS001`–`TRLS020`, `TrellisDiagnosticIds`
@@ -50,7 +51,7 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Write handler/domain tests | [Recipe 10](#recipe-10--test-handler-test-using-trellistesting-shouldbe--unwraperror) |
 | Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
-| Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-extension-methods-across-all-packages) |
+| Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-composition-builder) |
 
 ---
 
@@ -699,48 +700,36 @@ return Maybe<Email>.None;
 
 ---
 
-## Recipe 12 — DI wiring playbook: `AddTrellis*` extension methods across all packages
+## Recipe 12 — DI wiring playbook: `AddTrellis` composition builder
 
-**Problem.** Compose every `AddTrellis*` registration in the correct order so behaviors stack properly.
+**Problem.** Compose Trellis service modules in the correct order so behaviors stack properly without forcing simple apps to install every package.
+
+**Preferred: tiered builder.** Use `Trellis.ServiceDefaults` from the API/composition root. The builder records intent first, then applies modules in the canonical order. `UseEntityFrameworkUnitOfWork<TContext>()`, when selected, is always applied last so `TransactionalCommandBehavior<,>` lands innermost.
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Trellis;
-using Trellis.Asp;
-using Trellis.Asp.Authorization;
-using Trellis.Asp.Routing;
-using Trellis.EntityFrameworkCore;
+using Trellis.ServiceDefaults;
 
 public static class CompositionRoot
 {
     public static IServiceCollection AddApp(this IServiceCollection services, string connectionString)
     {
-        // 1. Mediator pipeline (outermost behaviors first).
-        services.AddTrellisBehaviors();
-
-        // 2. FluentValidation plug-in. Idempotent; safe to call after AddTrellisBehaviors.
-        services.AddTrellisFluentValidation(typeof(PlaceOrderValidator).Assembly);
-
-        // 3. ASP layer: Problem Details mapping + scalar-value validation pipeline.
-        services.AddTrellisAsp();
-
-        // 4. ASP authorization actor providers.
-        services.AddClaimsActorProvider();
-        services.AddResourceAuthorization(typeof(UpdateOrderCommand).Assembly);
-
-        // 5. EF Core context with Trellis interceptors + conventions.
+        // App-owned: provider, connection string, migrations, pooling, and Mediator registration.
         services.AddDbContext<AppDbContext>(opts => opts
             .UseSqlServer(connectionString)
             .AddTrellisInterceptors());
 
-        // 6. EF unit of work LAST so TransactionalCommandBehavior lands innermost.
-        services.AddTrellisUnitOfWork<AppDbContext>();
+        services.AddMediator(options => options.Assemblies = [typeof(PlaceOrderCommand).Assembly]);
 
-        // 7. Optional: route constraints for value-object IDs (reflection-based).
-        services.AddTrellisRouteConstraints(typeof(OrderId).Assembly);
+        services.AddTrellis(options => options
+            .UseAsp()
+            .UseMediator()
+            .UseFluentValidation(typeof(PlaceOrderValidator).Assembly)
+            .UseClaimsActorProvider()
+            .UseResourceAuthorization(typeof(UpdateOrderCommand).Assembly)
+            .UseEntityFrameworkUnitOfWork<AppDbContext>());
 
-        // 8. Application services.
         services.AddScoped<IOrderRepository, EfOrderRepository>();
 
         return services;
@@ -748,17 +737,18 @@ public static class CompositionRoot
 }
 ```
 
-**Composition order, summarized.**
+**Builder modules, summarized.**
 
-| Step | Call | Why this position |
+| Module | What it applies | Notes |
 | ---- | ---- | ----------------- |
-| 1 | `AddTrellisBehaviors()` | Registers tracing → telemetry → validation → exception → logging behaviors. Must come before any extension that piggybacks on the open-generic behavior list. |
-| 2 | `AddTrellisFluentValidation(...)` | Plugs `IValidator<T>` into the existing `ValidationBehavior<,>`. Idempotent; safe in any order after step 1. |
-| 3 | `AddTrellisAsp()` | Registers `TrellisAspOptions` (error → status mapping) and chains `AddScalarValueValidation()` for JSON pipeline integration. Add early so MVC/Minimal API JSON conventions are wired before endpoint registration. |
-| 4 | `AddClaimsActorProvider()` + `AddResourceAuthorization(...)` | `IActorProvider` + permission/resource-based behavior (not in `AddTrellisBehaviors()`). |
-| 5 | `AddDbContext(... .AddTrellisInterceptors())` | Wires `MaybeQueryInterceptor`, `ScalarValueQueryInterceptor`, ETag and timestamp interceptors. |
-| 6 | `AddTrellisUnitOfWork<TContext>()` | **Must be last** behavior registration so `TransactionalCommandBehavior<,>` lands innermost (closest to the handler) and commit failures stay visible to outer logging/tracing behaviors. |
-| 7 | `AddTrellisRouteConstraints(...)` / `AddTrellisRouteConstraint<T>(...)` | Optional; the reflection-based overload is **not** AOT-safe — the typed overload is. |
+| `UseAsp()` | `AddTrellisAsp()` | Error → status mapping plus scalar-value JSON/model-binding validation. |
+| `UseMediator()` | `AddTrellisBehaviors()` | Registers the canonical Result-aware pipeline behaviors. |
+| `UseFluentValidation(...)` | `AddTrellisFluentValidation(...)` | Implies `UseMediator()`. Pass assemblies to scan, or omit assemblies when validators are registered explicitly. |
+| `UseClaimsActorProvider()` / `UseEntraActorProvider()` / `UseDevelopmentActorProvider()` | One ASP actor provider | The builder rejects multiple actor providers. |
+| `UseResourceAuthorization(...)` | `AddResourceAuthorization(...)` | Implies `UseMediator()` and scans for resource auth/loaders. |
+| `UseEntityFrameworkUnitOfWork<TContext>()` | `AddTrellisUnitOfWork<TContext>()` | Implies `UseMediator()` and is always applied last. |
+
+**Still app-owned.** `AddTrellis(...)` does **not** call `AddDbContext`, `AddMediator`, or route-constraint registration. Those choices depend on provider, connection string, source-generator setup, migrations, route template names, and hosting style.
 
 ---
 

--- a/docs/api_reference/trellis-api-cookbook.md
+++ b/docs/api_reference/trellis-api-cookbook.md
@@ -32,6 +32,26 @@ Conventions used throughout:
 - Every async pipeline uses `*Async` extensions; mixing sync chain methods with `Task<Result<T>>` triggers `TRLS009`.
 - Examples reference an `OrderId : RequiredGuid<OrderId>` value object and an `Order` aggregate. Substitute your own types without changing the structure.
 
+## Task -> recipe lookup
+
+Use this table before writing code. If a task matches a row, read that recipe first.
+
+| Task | Start here |
+|---|---|
+| Create or load an aggregate with value objects | [Recipe 1](#recipe-1--crud-aggregate-ddd-value-objects--entity--repository-contract) |
+| Write a command handler that validates and persists | [Recipe 2](#recipe-2--command--handler--fluentvalidation--ef-persistence), then [Recipe 16](#recipe-16--unit-of-work-in-handlers-add-staging-vs-immediate-saveasync) |
+| Add a paginated list query | [Recipe 3](#recipe-3--query-handler-returning-paget-paginated-list-with-cursor) |
+| Add Minimal API or MVC endpoints | [Recipe 4](#recipe-4--minimal-api-endpoint-wiring-resultt--httpresponseoptionsbuilder--tohttpresponse), [Recipe 5](#recipe-5--mvc-controller-using-asactionresult) |
+| Map primitive DTO fields to value objects | [Recipe 18](#recipe-18--dto-primitives-to-value-object-command-no-test-only-unwrap) |
+| Add resource authorization | [Recipe 7](#recipe-7--authorization-iactorprovider--iauthorize--resource-based-auth) |
+| Map `Maybe<T>` or composite value objects with EF Core | [Recipe 8](#recipe-8--ef-core-maybepropertymapping-for-nullable-value-objects), [Recipe 13](#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership), [Recipe 15](#recipe-15--specifications-with-maybet-the-fakereal-divergence-trap) |
+| Add optional request/response fields | [Recipe 14](#recipe-14--optional-fields-in-request-dtos-maybetscalar-vs-nullable-transport) |
+| Add a state transition | [Recipe 9](#recipe-9--state-machine-canfire--fire-pattern-with-fireresult) |
+| Write handler/domain tests | [Recipe 10](#recipe-10--test-handler-test-using-trellistesting-shouldbe--unwraperror) |
+| Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
+| Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
+| Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-extension-methods-across-all-packages) |
+
 ---
 
 ## Recipe 1 — CRUD aggregate (DDD value objects + entity + repository contract)
@@ -200,7 +220,8 @@ public sealed class ListOrdersHandler(AppDbContext db)
 
         Guid afterId = Guid.Empty;
         if (q.Cursor is not null && !Guid.TryParseExact(q.Cursor, "N", out afterId))
-            return Error.UnprocessableContent.ForField("cursor", "cursor.malformed", "Cursor is not a valid opaque token.");
+            return Result.Fail<Page<OrderListItem>>(
+                Error.UnprocessableContent.ForField("cursor", "cursor.malformed", "Cursor is not a valid opaque token."));
 
         var query = db.Orders.AsNoTracking().OrderBy(o => o.Id);
         if (q.Cursor is not null)
@@ -224,7 +245,7 @@ public sealed class ListOrdersHandler(AppDbContext db)
 
 **What it shows.** `Page<T>` is a `readonly record struct`; instances always carry positive limits and a non-null `Items`. `WasCapped` becomes `true` automatically when the server clamped the limit. Use `Page.Empty<T>(req, app)` for the empty case rather than `default(Page<T>)`.
 
-> **Cursor parsing must be ROP, not throwing.** `Guid.Parse(q.Cursor)` would throw on malformed input and escape the handler as a 500. Use `Guid.TryParseExact(..., "N", out var)` and return `Error.UnprocessableContent.ForField("cursor", ...)` so a bad cursor surfaces as a clean 422, not a stack trace. Apply the same shape (TryParse → `Result` failure) for any opaque-token format you adopt.
+> **Cursor parsing must be ROP, not throwing.** `Guid.Parse(q.Cursor)` would throw on malformed input and escape the handler as a 500. Use `Guid.TryParseExact(..., "N", out var)` and return `Result.Fail<T>(Error.UnprocessableContent.ForField("cursor", ...))` so a bad cursor surfaces as a clean 422, not a stack trace. Apply the same shape (TryParse -> `Result` failure) for any opaque-token format you adopt.
 
 ---
 
@@ -531,6 +552,8 @@ public sealed class DocumentService
 ```
 
 **What it shows.** `StateMachineExtensions.FireResult(...)` honors `PermitIf`/`IgnoreIf` guards via `CanFire(...)` rather than parsing exception messages, so it survives Stateless library upgrades. For aggregates whose state lives in a backing field (e.g., loaded from EF), use `LazyStateMachine<TState, TTrigger>` to defer machine creation until the first `FireResult` call.
+
+**Side-effect placement.** Keep Stateless configuration declarative: states, triggers, permitted transitions, and pure/idempotent guards. Put business mutation, domain events, outbox writes, and other side effects after `FireResult` succeeds, usually in `.Tap(...)` as shown above. `FireResult` intentionally invokes `Fire(...)` even when `CanFire(...)` is false so any configured `OnUnhandledTrigger` callback can run. A custom unhandled-trigger callback may swallow the trigger, in which case `FireResult` returns success with the unchanged state. If side effects live in `OnEntry`, `OnExit`, transition callbacks, or `OnUnhandledTrigger`, they can run outside the visible ROP success/failure path and make handler behavior diverge from tests.
 
 > **HTTP semantics.** Invalid state-machine transitions surface as `Error.UnprocessableContent` (HTTP 422), not `Error.Conflict` (HTTP 409). The reasoning: `Error.Conflict` semantically means "your request is valid but collides with concurrent state — retry may succeed"; a state-machine rejection ("you asked for `Submit` on a `Cancelled` order") is not retriable and is not about concurrent modification — it's a semantic rule violation. Callers that need to distinguish state-machine rejections from other 422s can match on the `RuleViolation.ReasonCode` value `state.machine.invalid.transition`.
 
@@ -1275,6 +1298,75 @@ public Result<Order> Submit(TimeProvider clock)
 **Why a single timestamp.** Domain events flow into outbox tables, integration buses, audit projections, and event-sourced read models. Every consumer assumes `OccurredAt` is *the* occurrence time. Adding `SubmittedAt`/`ApprovedAt`/`ShippedAt` to individual events forces every consumer to know which field to project per event type — and the two fields can drift if the aggregate's setter and the event constructor are passed different `DateTime.UtcNow` calls.
 
 **See also.** The XML doc on `IDomainEvent.OccurredAt` (in `Trellis.Core`) calls this out explicitly. If your IDE shows the doc on hover, the rule is right there before you hit the compile error.
+
+---
+
+## Recipe 18 — DTO primitives to value-object command: no test-only `Unwrap()`
+
+**Problem.** Request DTOs often carry primitive transport fields (`string email`, `string customerName`), while commands and domain methods should receive Trellis value objects. Each `TryCreate` returns `Result<TVO>`. Do not use `Unwrap()` in production code — it is a `Trellis.Testing` helper for tests.
+
+```csharp
+using Mediator;
+using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
+using Trellis.Primitives;
+
+public sealed record CreateCustomerRequest(string Email, string CustomerName);
+
+public sealed partial class CustomerId : RequiredGuid<CustomerId>;
+
+public sealed record CustomerResponse(CustomerId Id, string Email, string CustomerName);
+
+[StringLength(200, MinimumLength = 1)]
+public sealed partial class CustomerName : RequiredString<CustomerName>;
+
+public sealed record CreateCustomerCommand(EmailAddress Email, CustomerName CustomerName)
+    : ICommand<Result<CustomerResponse>>
+{
+    public static Result<CreateCustomerCommand> TryCreate(CreateCustomerRequest request) =>
+        Result.Combine(
+                EmailAddress.TryCreate(request.Email, nameof(request.Email)),
+                CustomerName.TryCreate(request.CustomerName, nameof(request.CustomerName)))
+            .Map(values => new CreateCustomerCommand(values.Item1, values.Item2));
+}
+
+[ApiController]
+[Route("customers")]
+public sealed class CustomersController(ISender sender) : ControllerBase
+{
+    [HttpPost]
+    public ValueTask<ActionResult<CustomerResponse>> Create(
+        [FromBody] CreateCustomerRequest request,
+        CancellationToken ct) =>
+        CreateCustomerCommand.TryCreate(request)
+            .BindAsync(command => sender.Send(command, ct))
+            .ToHttpResponseAsync()
+            .AsActionResultAsync<CustomerResponse>();
+}
+```
+
+**What it shows.**
+
+- Keep DTOs transport-shaped and commands/domain methods value-object-shaped.
+- Pass field names into `TryCreate` so failures point at the request field (`/Email`, `/CustomerName` after pointer normalization at the ASP boundary).
+- Use `Result.Combine(...)` to aggregate per-field `Error.UnprocessableContent` failures into one validation response.
+- Stay on the ROP track: invalid input short-circuits before `sender.Send(...)`; valid input creates the command and continues.
+
+**Anti-pattern -> fix.**
+
+```csharp
+// WRONG — Unwrap() is test-only and turns validation failures into thrown exceptions.
+var command = new CreateCustomerCommand(
+    EmailAddress.TryCreate(request.Email).Unwrap(),
+    CustomerName.TryCreate(request.CustomerName).Unwrap());
+
+// FIX — aggregate value-object creation results and bind into the command.
+var command = Result.Combine(
+        EmailAddress.TryCreate(request.Email, nameof(request.Email)),
+        CustomerName.TryCreate(request.CustomerName, nameof(request.CustomerName)))
+    .Map(values => new CreateCustomerCommand(values.Item1, values.Item2));
+```
 
 ---
 

--- a/docs/api_reference/trellis-api-efcore.md
+++ b/docs/api_reference/trellis-api-efcore.md
@@ -38,19 +38,40 @@ public static class ModelConfigurationBuilderExtensions
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public static ModelConfigurationBuilder ApplyTrellisConventions(this ModelConfigurationBuilder configurationBuilder, params Assembly[] assemblies)` | `ModelConfigurationBuilder` | Scans the supplied assemblies plus `Trellis.Primitives`, registers scalar converters, collects composite value objects from those assemblies only, and adds internal conventions for `Maybe<T>`, composite value objects, `Money`, aggregate ETags, and transient aggregate properties. |
-| `public static ModelConfigurationBuilder ApplyTrellisConventionsCore(this ModelConfigurationBuilder configurationBuilder, IEnumerable<(Type ClrType, Type ProviderType)> scalars, IEnumerable<Type> composites)` | `ModelConfigurationBuilder` | Low-level helper used by the reflection-based `ApplyTrellisConventions` overload. Registers the supplied scalar converters via `Type.MakeGenericType` (not AOT/trim-friendly), then delegates to `AddTrellisCoreConventions`. |
-| `public static ModelConfigurationBuilder AddTrellisScalarConverter<TClr, TProvider>(this ModelConfigurationBuilder configurationBuilder) where TClr : class where TProvider : notnull` | `ModelConfigurationBuilder` | AOT/trim-friendly strongly-typed helper that registers `TrellisScalarConverter<TClr, TProvider>` for `TClr` properties. Emitted by the source generator; no `MakeGenericType` at runtime. |
-| `public static ModelConfigurationBuilder AddTrellisCoreConventions(this ModelConfigurationBuilder configurationBuilder, IEnumerable<Type> composites)` | `ModelConfigurationBuilder` | Adds the fixed Trellis conventions (`MaybeConvention`, `CompositeValueObjectConvention`, `MoneyConvention`, `AggregateETagConvention`, `AggregateTransientPropertyConvention`, `ValueObjectMappingGuardConvention`). AOT/trim-friendly: `composites` is an array of pre-closed `Type` tokens; no runtime reflection. |
+| `public static ModelConfigurationBuilder ApplyTrellisConventionsCore(this ModelConfigurationBuilder configurationBuilder, IEnumerable<(Type ClrType, Type ProviderType)> scalars, IEnumerable<Type> composites)` | `ModelConfigurationBuilder` | Low-level helper used by the reflection-based `ApplyTrellisConventions` overload. Registers the supplied scalar converters via `Type.MakeGenericType`, then delegates to `AddTrellisCoreConventions`. |
+| `public static ModelConfigurationBuilder AddTrellisScalarConverter<TClr, TProvider>(this ModelConfigurationBuilder configurationBuilder) where TClr : class where TProvider : notnull` | `ModelConfigurationBuilder` | Reflection-free strongly typed helper that registers `TrellisScalarConverter<TClr, TProvider>` for `TClr` properties. Emitted by the source generator; no `MakeGenericType` at runtime. |
+| `public static ModelConfigurationBuilder AddTrellisCoreConventions(this ModelConfigurationBuilder configurationBuilder, IEnumerable<Type> composites)` | `ModelConfigurationBuilder` | Adds the fixed Trellis conventions (`MaybeConvention`, `CompositeValueObjectConvention`, `MoneyConvention`, `AggregateETagConvention`, `AggregateTransientPropertyConvention`, `ValueObjectMappingGuardConvention`). `composites` is an array of pre-closed `Type` tokens supplied by the caller. |
 
-### `GeneratedTrellisConventions` (source-generator note)
+### `GeneratedTrellisConventions` (source-generated)
 
-The Trellis EF Core package itself does **not** ship a `GeneratedTrellisConventions` class or an `ApplyTrellisConventionsFor<TContext>` extension. The package source contains only:
+Installing `Trellis.EntityFrameworkCore` also attaches the bundled `Trellis.EntityFrameworkCore.Generator.dll` analyzer. In the consuming project, that generator emits:
 
-- `ApplyTrellisConventions(this ModelConfigurationBuilder, params Assembly[])` — reflection-based assembly scanner (above).
-- `ApplyTrellisConventionsCore(this ModelConfigurationBuilder, IEnumerable<(Type ClrType, Type ProviderType)>, IEnumerable<Type>)` — low-level helper used by `ApplyTrellisConventions` and intended as the integration target for a future source-generated entry point.
-- `AddTrellisScalarConverter<TClr, TProvider>` and `AddTrellisCoreConventions(IEnumerable<Type>)` — AOT/trim-friendly building blocks the planned generator will call.
+```csharp
+namespace Trellis.EntityFrameworkCore;
 
-Today, consumers should call `ApplyTrellisConventions(typeof(SomeRootType).Assembly)` from `ConfigureConventions`. A source-generated `ApplyTrellisConventionsFor<TContext>` extension (emitted into the consuming project) is referenced in XML doc comments inside `ModelConfigurationBuilderExtensions.cs` as a planned successor for AOT/trimming scenarios but is not currently emitted by the shipped generator assembly.
+public static class GeneratedTrellisConventions
+{
+    public static ModelConfigurationBuilder ApplyTrellisConventionsFor<TContext>(
+        this ModelConfigurationBuilder configurationBuilder)
+        where TContext : DbContext;
+}
+```
+
+Use it from `ConfigureConventions` when you want compile-time discovery instead of runtime assembly scanning:
+
+```csharp
+protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
+    configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
+```
+
+The generator walks every concrete `DbContext` in the current compilation, follows public `DbSet<T>` roots, recursively discovers reachable Trellis value objects through entity properties, unwraps `Maybe<T>`, nullable types, arrays, and common collection navigations, and emits explicit calls to `AddTrellisScalarConverter<TClr, TProvider>` plus `AddTrellisCoreConventions(...)`.
+
+Scope limits:
+
+- `TContext` must be a concrete, accessible `DbContext` defined in the current compilation.
+- The reachability walk starts at that context's accessible `DbSet<T>` properties.
+- Calling `ApplyTrellisConventionsFor<TContext>()` for a skipped context throws `InvalidOperationException`.
+- This removes Trellis' assembly scan and `MakeGenericType` path, but the EF Core package itself still opts out of NativeAOT/trimming support.
 
 ### `DbContextExtensions`
 
@@ -504,7 +525,7 @@ public static string ToMaybeMappingDebugString(this DbContext dbContext)
 - `CompositeValueObjectConvention` is internal. It only registers composite value objects discovered in the assemblies passed to `ApplyTrellisConventions` (plus built-in Trellis primitives scanning for scalar value objects). For `Maybe<T>` composite owned types, it uses nullable owned columns only when table-splitting is valid; it switches to a separate table named `{OwnerTypeName}_{PropertyName}` when nested owned navigations exist **or** when the owned type contains non-nullable value-type properties.
 - `MoneyConvention` is internal. It registers `Money` as an owned type, names the amount column `{PropertyName}`, names the currency column `{PropertyName}Currency`, sets `decimal(18,3)` precision/scale for `Amount`, and handles optional `Maybe<Money>` columns through the annotation written by `MaybeConvention`.
 - `ValueObjectMappingGuardConvention` is internal. Runs after `MaybeConvention` and `MoneyConvention` during model finalization and throws an actionable `InvalidOperationException` when an entity still has a scalar property whose CLR type is `Money` or `Maybe<T>` — the typical cause is an explicit `builder.Property(x => x.SomeMoneyOrMaybe)` call in `OnModelCreating` that bypasses the auto-mapping conventions. Replaces EF Core's cryptic "*property could not be mapped because the database provider does not support this type*" error with a message that names the offending entity + property and points to the correct pattern (do nothing for `Money`; declare `partial Maybe<T>` for Maybe).
-- `MaybePartialPropertyGenerator` and `OwnedEntityGenerator` are compiler-time helpers shipped in the `Trellis.EntityFrameworkCore.Generator.dll` assembly, which is bundled inside `Trellis.EntityFrameworkCore.nupkg` at `analyzers/dotnet/cs/` since Phase 2 of the v2 redesign — there is no separate `Trellis.EntityFrameworkCore.Generator` NuGet package. `TRLS035` is reported only for non-partial auto-properties of type `Maybe<T>` whose containing type is partial. `TRLS036`, `TRLS037`, and `TRLS038` come from `[OwnedEntity]` validation and generation. (These IDs were `TRLSGEN100`–`TRLSGEN103` in v1; the unified `TRLS###` namespace is canonical from v2 onward — see `TrellisDiagnosticIds`.)
+- `MaybePartialPropertyGenerator`, `OwnedEntityGenerator`, and `ApplyTrellisConventionsForGenerator` are compiler-time helpers shipped in the `Trellis.EntityFrameworkCore.Generator.dll` assembly, which is bundled inside `Trellis.EntityFrameworkCore.nupkg` at `analyzers/dotnet/cs/` since Phase 2 of the v2 redesign — there is no separate `Trellis.EntityFrameworkCore.Generator` NuGet package. `TRLS035` is reported only for non-partial auto-properties of type `Maybe<T>` whose containing type is partial. `TRLS036`, `TRLS037`, and `TRLS038` come from `[OwnedEntity]` validation and generation. (These IDs were `TRLSGEN100`–`TRLSGEN103` in v1; the unified `TRLS###` namespace is canonical from v2 onward — see `TrellisDiagnosticIds`.)
 
 ## Behavioral notes
 
@@ -514,8 +535,9 @@ public static string ToMaybeMappingDebugString(this DbContext dbContext)
 
 - `Maybe<T>` partial-property bodies with private `_camelCase` backing fields that EF Core can map through reflection-free conventions.
 - `[OwnedEntity]` validation/generation diagnostics (`TRLS035`–`TRLS038`).
+- `GeneratedTrellisConventions.ApplyTrellisConventionsFor<TContext>()`, which calls `AddTrellisScalarConverter<TClr, TProvider>` and `AddTrellisCoreConventions(...)` for value-object types reachable from the current compilation's accessible `DbSet<T>` roots.
 
-A generated `ApplyTrellisConventionsFor<TContext>` extension that would call `AddTrellisScalarConverter<TClr, TProvider>` and `AddTrellisCoreConventions(...)` directly (eliminating runtime `MakeGenericType`) is **planned** and is referenced in the package’s XML doc comments, but is not currently emitted. Today's recommended entry point remains the reflection-based `ModelConfigurationBuilder.ApplyTrellisConventions(typeof(SomeRootType).Assembly)`. AOT/trimming consumers can call `AddTrellisScalarConverter<TClr, TProvider>` and `AddTrellisCoreConventions` by hand to avoid `MakeGenericType`.
+`ApplyTrellisConventionsFor<TContext>()` is the reflection-free convention path. `ApplyTrellisConventions(typeof(SomeRootType).Assembly)` remains the broadest runtime scan and is still the right fallback when the context is private, generic, abstract, or otherwise skipped by source generation. The generated path removes Trellis' assembly scan and `MakeGenericType` converter construction; it does not make EF Core itself NativeAOT-supported.
 
 ### `Maybe<T>` storage, owned types, and migrations
 

--- a/docs/api_reference/trellis-api-http.md
+++ b/docs/api_reference/trellis-api-http.md
@@ -26,6 +26,8 @@ public static class HttpResponseExtensions
 | `ReadJsonAsync<T>(this Task<Result<HttpResponseMessage>> response, JsonTypeInfo<T> jsonTypeInfo, CancellationToken ct = default) where T : notnull` | `Task<Result<T>>` | Already-failed input short-circuits with the upstream error. Otherwise reads the body and deserializes; non-success status, `204`, `205`, empty body, null payload, or `JsonException` (caught) all map to `Fail<InternalServerError>`. **Always disposes** the response after reading. |
 | `ReadJsonMaybeAsync<T>(this Task<Result<HttpResponseMessage>> response, JsonTypeInfo<T> jsonTypeInfo, CancellationToken ct = default) where T : notnull` | `Task<Result<Maybe<T>>>` | Already-failed input short-circuits. Non-success status -> `Fail<InternalServerError>`. `204`, `205`, empty body, JSON `null` -> `Ok(Maybe.None)`. Invalid JSON throws `JsonException` (intentional). **Always disposes** the response. |
 
+> **Business API default.** Do not call bare `ToResultAsync()` for domain-facing HTTP clients unless every status code is intentionally handled later. With `statusMap: null`, `404`, `409`, and other non-success statuses remain on the success track until a later terminal operation maps them. Prefer `HandleNotFoundAsync`, `HandleConflictAsync`, `HandleUnauthorizedAsync`, or an explicit `statusMap` before calling `ReadJsonAsync`.
+
 ## Disposal contract
 
 The library owns the `HttpResponseMessage` lifecycle on terminal or transformative paths:

--- a/docs/api_reference/trellis-api-servicedefaults.md
+++ b/docs/api_reference/trellis-api-servicedefaults.md
@@ -1,0 +1,84 @@
+# Trellis.ServiceDefaults API Reference
+
+**Package:** `Trellis.ServiceDefaults`  
+**Namespace:** `Trellis.ServiceDefaults`  
+**Purpose:** Opinionated composition builder for API/composition-root projects that want Trellis integration modules applied in the canonical order.
+
+See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-12--di-wiring-playbook-addtrellis-composition-builder) — composition-root recipe.
+
+## Types
+
+### `TrellisServiceCollectionExtensions`
+
+```csharp
+public static class TrellisServiceCollectionExtensions
+```
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static IServiceCollection AddTrellis(this IServiceCollection services, Action<TrellisServiceBuilder> configure)` | `IServiceCollection` | Creates a `TrellisServiceBuilder`, lets the caller select modules, then applies the selected modules in canonical order. Does not register `DbContext` or Mediator handlers. |
+
+### `TrellisServiceBuilder`
+
+```csharp
+public sealed class TrellisServiceBuilder
+```
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `Trellis.Asp` integration via `AddTrellisAsp(...)`. |
+| `public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)` | `TrellisServiceBuilder` | Registers Trellis Mediator behaviors via `AddTrellisBehaviors(...)`. |
+| `public TrellisServiceBuilder UseFluentValidation(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers the FluentValidation adapter. When assemblies are supplied, also scans them for validators. Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseResourceAuthorization(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers resource authorization behaviors/loaders discovered in assemblies. Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseClaimsActorProvider(Action<ClaimsActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `ClaimsActorProvider` as `IActorProvider`. |
+| `public TrellisServiceBuilder UseEntraActorProvider(Action<EntraActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `EntraActorProvider` as `IActorProvider`. |
+| `public TrellisServiceBuilder UseDevelopmentActorProvider(Action<DevelopmentActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `DevelopmentActorProvider` as `IActorProvider`. Use only in development/testing hosts. |
+| `public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>() where TContext : DbContext` | `TrellisServiceBuilder` | Registers `EfUnitOfWork<TContext>` and `TransactionalCommandBehavior<,>` via `AddTrellisUnitOfWork<TContext>()`. Implies `UseMediator()` and is applied last. |
+
+## Behavior
+
+`AddTrellis(...)` records selected modules first and then applies them in this order:
+
+1. ASP integration.
+2. Actor provider.
+3. Mediator behaviors.
+4. Resource authorization.
+5. FluentValidation adapter/scanning when selected.
+6. EF Core Unit of Work.
+
+That order preserves the important pipeline invariant: `TransactionalCommandBehavior<,>` is the innermost behavior, closest to the handler, so commit failures remain visible to outer logging/tracing/exception behaviors.
+
+`AddTrellis(...)` deliberately does **not** register:
+
+- `AddDbContext<TContext>(...)` — provider, connection string, pooling, migrations, and interceptors are application-owned.
+- `AddMediator(...)` — handler discovery/source-generator configuration is application-owned.
+- route constraints — route parameter names are application-owned.
+
+## Examples
+
+```csharp
+services.AddTrellis(options => options.UseAsp());
+```
+
+```csharp
+services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator()
+    .UseFluentValidation(typeof(Program).Assembly));
+```
+
+```csharp
+// Adapter only; validators are registered explicitly elsewhere.
+services.AddTrellis(options => options
+    .UseMediator()
+    .UseFluentValidation());
+```
+
+```csharp
+services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator()
+    .UseClaimsActorProvider()
+    .UseResourceAuthorization(typeof(Program).Assembly)
+    .UseEntityFrameworkUnitOfWork<AppDbContext>());
+```


### PR DESCRIPTION
This PR closes the current TrellisFramework AI-first backlog slice by adding compile-time guardrails, syncing stale
API docs, introducing canonical service composition, and removing a NativeAOT-hostile ASP binding path.

What changed

 - Added TRLS020 to detect composite [OwnedEntity] value objects exposed through DTO surfaces without 
CompositeValueObjectJsonConverter<T>.
  - Covers MVC DTOs, Minimal API lambdas/method groups, and Mediator messages.
 - Synced EF Core convention docs with the shipped ApplyTrellisConventionsFor<TContext>() generator.
  - Removed stale “planned/not emitted” language and corrected diagnostic references.
 - Added Trellis.ServiceDefaults.
  - New services.AddTrellis(options => ...) builder for canonical 
ASP/Mediator/FluentValidation/resource-auth/actor/UoW registration.
  - Preserves low-level APIs while removing composition-order guesswork.
 - Added TRLS021 to flag redundant manual EF configuration for Maybe<T> and [OwnedEntity] properties when Trellis 
conventions are enabled.
  - Catches HasConversion, OwnsOne, and Ignore foot-guns at compile time.
 - Reworked ScalarValueValidationMiddleware to avoid parsing BadHttpRequestException.Message.
  - Uses endpoint binding metadata plus route/query raw values to re-run Trellis scalar validation.
  - Keeps JSON-body validation behavior intact.
  - Enables clean NativeAOT publish for the non-EF Showcase Minimal API path.

Why

These changes reduce AI choice points and make common wrong Trellis code fail earlier: missing composite VO
converters, duplicated EF convention mapping, incorrect composition-root ordering, and brittle scalar binding
recovery are now either analyzer-detected or hidden behind a canonical API.

Validation

 - Analyzer test suites updated and passing for TRLS020/TRLS021 scenarios.
 - Trellis.Asp test suite passed.
 - Showcase MinimalApi NativeAOT publish validated for win-x64.