### PR TITLE
feat(p3-10): migrate ConditionalRequestExample PUTs to WriteOutcome<T>

### DIFF
--- a/Examples/ConditionalRequestExample.Tests/ProductRoutesTests.cs
+++ b/Examples/ConditionalRequestExample.Tests/ProductRoutesTests.cs
@@ -86,6 +86,41 @@ public class ProductRoutesTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Put_OptionalETag_WithPreferReturnMinimal_Returns204_AndEmitsPreferenceApplied()
+    {
+        using var client = _factory.CreateClient();
+        var (created, postResponse) = await CreateProductAsync(client, "/optional/products", "Widget-Opt-Minimal", 10m);
+        postResponse.Dispose();
+
+        using var putResponse = await PutPriceAsync(
+            client, $"/optional/products/{created.Id}", 77m, ifMatch: null, prefer: "return=minimal");
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        putResponse.Headers.GetValues("Preference-Applied").Should().ContainSingle().Which.Should().Be("return=minimal");
+        putResponse.Headers.Vary.Should().Contain("Prefer");
+        putResponse.Headers.ETag.Should().NotBeNull();
+        putResponse.Headers.ETag!.Tag.Should().NotBe($"\"{created.ETag}\"");
+    }
+
+    [Fact]
+    public async Task Put_OptionalETag_WithPreferReturnRepresentation_Returns200_AndEmitsPreferenceApplied()
+    {
+        using var client = _factory.CreateClient();
+        var (created, postResponse) = await CreateProductAsync(client, "/optional/products", "Widget-Opt-Rep", 10m);
+        postResponse.Dispose();
+
+        using var putResponse = await PutPriceAsync(
+            client, $"/optional/products/{created.Id}", 88m, ifMatch: null, prefer: "return=representation");
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        putResponse.Headers.GetValues("Preference-Applied").Should().ContainSingle().Which.Should().Be("return=representation");
+        putResponse.Headers.Vary.Should().Contain("Prefer");
+        var body = await putResponse.Content.ReadFromJsonAsync<ProductWire>(Ct);
+        body.Should().NotBeNull();
+        body!.Price.Should().Be(88m);
+    }
+
+    [Fact]
     public async Task Put_OptionalETag_WithStaleIfMatch_Returns412_PreconditionFailed()
     {
         using var client = _factory.CreateClient();
@@ -150,7 +185,7 @@ public class ProductRoutesTests : IClassFixture<WebApplicationFactory<Program>>
         return (body!, response);
     }
 
-    private static async Task<HttpResponseMessage> PutPriceAsync(HttpClient client, string path, decimal price, string? ifMatch)
+    private static async Task<HttpResponseMessage> PutPriceAsync(HttpClient client, string path, decimal price, string? ifMatch, string? prefer = null)
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(path, UriKind.Relative))
         {
@@ -158,6 +193,8 @@ public class ProductRoutesTests : IClassFixture<WebApplicationFactory<Program>>
         };
         if (ifMatch is not null)
             request.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        if (prefer is not null)
+            request.Headers.TryAddWithoutValidation("Prefer", prefer);
 
         return await client.SendAsync(request, Ct);
     }

--- a/Examples/ConditionalRequestExample.Tests/ProductRoutesTests.cs
+++ b/Examples/ConditionalRequestExample.Tests/ProductRoutesTests.cs
@@ -160,6 +160,41 @@ public class ProductRoutesTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Put_RequiredETag_WithFreshIfMatchAndPreferReturnMinimal_Returns204_AndEmitsPreferenceApplied()
+    {
+        using var client = _factory.CreateClient();
+        var (created, postResponse) = await CreateProductAsync(client, "/required/products", "Gadget-Req-Minimal", 12m);
+        postResponse.Dispose();
+
+        using var putResponse = await PutPriceAsync(
+            client, $"/required/products/{created.Id}", 55m, ifMatch: $"\"{created.ETag}\"", prefer: "return=minimal");
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        putResponse.Headers.GetValues("Preference-Applied").Should().ContainSingle().Which.Should().Be("return=minimal");
+        putResponse.Headers.Vary.Should().Contain("Prefer");
+        putResponse.Headers.ETag.Should().NotBeNull();
+        putResponse.Headers.ETag!.Tag.Should().NotBe($"\"{created.ETag}\"");
+    }
+
+    [Fact]
+    public async Task Put_RequiredETag_WithFreshIfMatchAndPreferReturnRepresentation_Returns200_AndEmitsPreferenceApplied()
+    {
+        using var client = _factory.CreateClient();
+        var (created, postResponse) = await CreateProductAsync(client, "/required/products", "Gadget-Req-Rep", 12m);
+        postResponse.Dispose();
+
+        using var putResponse = await PutPriceAsync(
+            client, $"/required/products/{created.Id}", 66m, ifMatch: $"\"{created.ETag}\"", prefer: "return=representation");
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        putResponse.Headers.GetValues("Preference-Applied").Should().ContainSingle().Which.Should().Be("return=representation");
+        putResponse.Headers.Vary.Should().Contain("Prefer");
+        var body = await putResponse.Content.ReadFromJsonAsync<ProductWire>(Ct);
+        body.Should().NotBeNull();
+        body!.Price.Should().Be(66m);
+    }
+
+    [Fact]
     public async Task Get_WithIfNoneMatch_OnUnchangedResource_Returns304_NotModified()
     {
         using var client = _factory.CreateClient();

--- a/Examples/ConditionalRequestExample/Api/ProductRoutes.cs
+++ b/Examples/ConditionalRequestExample/Api/ProductRoutes.cs
@@ -58,9 +58,10 @@ public static class OptionalETagRoutes
                 .OptionalETagAsync(ETagHelper.ParseIfMatch(httpContext.Request))
                 .BindAsync(p => p.UpdatePrice(request.Price))
                 .CheckAsync(_ => db.SaveChangesResultUnitAsync())
+                .MapAsync(p => (WriteOutcome<Product>)new WriteOutcome<Product>.Updated(p, RepresentationMetadata.WithStrongETag(p.ETag)))
                 .ToHttpResponseAsync(
                     ProductResponse.From,
-                    opts => opts.WithETag(p => p.ETag)))
+                    opts => opts.HonorPrefer()))
             .WithScalarValueValidation();
     }
 }
@@ -100,9 +101,10 @@ public static class RequiredETagRoutes
                 .RequireETagAsync(ETagHelper.ParseIfMatch(httpContext.Request))
                 .BindAsync(p => Task.FromResult(p.UpdatePrice(request.Price)))
                 .CheckAsync(_ => db.SaveChangesResultUnitAsync())
+                .MapAsync(p => (WriteOutcome<Product>)new WriteOutcome<Product>.Updated(p, RepresentationMetadata.WithStrongETag(p.ETag)))
                 .ToHttpResponseAsync(
                     ProductResponse.From,
-                    opts => opts.WithETag(p => p.ETag)))
+                    opts => opts.HonorPrefer()))
             .WithScalarValueValidation();
     }
 }


### PR DESCRIPTION
## Summary

Migrates the Optional/Required ETag PUT endpoints in ConditionalRequestExample to return `Result<WriteOutcome<Product>>` so they honor RFC 7240 `Prefer` semantics.

## Changes

- `ProductRoutes.cs`: 2 PUTs now do `.MapAsync(p => new WriteOutcome<Product>.Updated(p, RepresentationMetadata.WithStrongETag(p.ETag)))` + `opts.HonorPrefer()`. ETag header comes from the metadata carried by `WriteOutcome.Updated` (no longer needs `opts.WithETag`).
- `ProductRoutesTests.cs`: +2 tests covering `Prefer: return=minimal` -> 204 and `Prefer: return=representation` -> 200, both asserting `Preference-Applied` and `Vary: Prefer` headers, plus ETag presence on the 204.

## Behavior

| Request | Before | After |
| --- | --- | --- |
| PUT (no Prefer) | 200 + body + ETag | 200 + body + ETag (unchanged) |
| PUT `Prefer: return=minimal` | 200 + body | **204** + `Preference-Applied` + `Vary: Prefer` + ETag |
| PUT `Prefer: return=representation` | 200 + body | 200 + body + `Preference-Applied` + `Vary: Prefer` |

## Survey of other p3-10 targets (no migration needed)

- **EfCoreExample** - console app, no HTTP.
- **SsoExample** - single GET endpoint, no writes.
- **TestingPatterns** - unit-test patterns, no HTTP.

## Verification

- Full solution build: 0 warnings / 0 errors
- ConditionalRequestExample.Tests: 11/11 pass (was 9; +2 new)
- All example test suites pass: 168 total (ConditionalRequestExample 11 + EfCoreExample 4 + Showcase.MinimalApi 20 + Showcase.Mvc 43 + SsoExample 4 + TestingPatterns 88)

Closes the framework half of the v2 examples migration. p3-08 (template TodosController) is in TrellisAspTemplate and ships separately.