### PR TITLE
fix(generator): emit TRLS039 instead of unsafe JsonSerializer fallback for unsupported scalar primitives

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,7 @@ Analyzers (`Trellis.Analyzers`) and the bundled source generators emit diagnosti
 | `TRLS001`–`TRLS021` | `Trellis.Analyzers` | `TRLS003` — Unsafe access to `Maybe.Value` |
 | `TRLS031`–`TRLS034` | `Trellis.Core.Generator` (Primitives) | `TRLS032` — `MinimumLength` exceeds `MaximumLength` |
 | `TRLS035`–`TRLS038` | `Trellis.EntityFrameworkCore.Generator` | `TRLS035` — `Maybe<T>` property should be `partial` |
+| `TRLS039` | `Trellis.AspSourceGenerator` (`ScalarValueJsonConverterGenerator`) | `TRLS039` — Unsupported scalar value primitive for AOT-safe JSON converter |
 
 The legacy `TRLSGEN###` prefix (used in v1) was retired in v2: `TRLSGEN001`–`TRLSGEN004` mapped to `TRLS031`–`TRLS034`, `TRLSGEN100`–`TRLSGEN103` mapped to `TRLS035`–`TRLS038`. In v3-alpha, analyzer IDs were renumbered to be contiguous — former `TRLS006/008/009/010/011/012/014/015/016/017/018/019/020/021/022/024/029` are now `TRLS003`–`TRLS019`. Removed analyzer slots (the former `TRLS003/004/005/007/013/025`) no longer have documentation tombstones.
 

--- a/Trellis.Analyzers/src/AnalyzerReleases.Shipped.md
+++ b/Trellis.Analyzers/src/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
+++ b/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,28 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID  | Category | Severity | Notes
+---------|----------|----------|------------------------------------------------------------------------
+TRLS001  | Trellis  | Warning  | Result return value is not handled (must be observed via Match/Bind/Map/Tap/IsSuccess gate).
+TRLS002  | Trellis  | Info     | Use Bind instead of Map when the lambda returns a Result<T>.
+TRLS003  | Trellis  | Warning  | Unsafe access to Maybe.Value without a HasValue/TryGetValue guard.
+TRLS004  | Trellis  | Warning  | Result is double-wrapped (Result<Result<T>>).
+TRLS005  | Trellis  | Warning  | Incorrect async Result usage (e.g., awaiting Result<T> instead of using async extension).
+TRLS006  | Trellis  | Info     | Use a specific Error subclass instead of the base Error class.
+TRLS007  | Trellis  | Warning  | Maybe is double-wrapped (Maybe<Maybe<T>>).
+TRLS008  | Trellis  | Info     | Consider using Result.Combine to aggregate multiple results.
+TRLS009  | Trellis  | Warning  | Use the async method variant when the lambda is async.
+TRLS010  | Trellis  | Warning  | Don't throw exceptions inside Result chains; convert to Error instead.
+TRLS011  | Trellis  | Warning  | Error message should not be empty.
+TRLS012  | Trellis  | Warning  | Don't compare Result or Maybe to null; use IsSuccess / HasValue.
+TRLS013  | Trellis  | Warning  | Unsafe access to Maybe.Value inside a LINQ expression.
+TRLS014  | Trellis  | Error    | Combine chain exceeds the maximum supported tuple size.
+TRLS015  | Trellis  | Warning  | Use SaveChangesResultAsync instead of SaveChangesAsync inside a Result pipeline.
+TRLS016  | Trellis  | Warning  | HasIndex references a Maybe<T> property; use the underlying field instead.
+TRLS017  | Trellis  | Warning  | Wrong [StringLength] / [Range] attribute namespace (use Trellis attributes, not DataAnnotations).
+TRLS018  | Trellis  | Warning  | Result<T> deconstruction reads value without a success gate.
+TRLS019  | Trellis  | Warning  | Avoid default(Result), default(Result<T>), and default(Maybe<T>); prefer factories.
+TRLS020  | Trellis  | Warning  | Composite value object DTO property is missing CompositeValueObjectJsonConverter<T>.
+TRLS021  | Trellis  | Warning  | EF configuration duplicates Trellis conventions for Maybe<T> or [OwnedEntity].

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -14,9 +14,13 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <!-- https://github.com/nuget/home/issues/8583 -->
-    <!-- RS2008: Disable release tracking for initial development -->
-    <!-- RS1038: Analyzers and CodeFixProviders can coexist in same assembly -->
-    <NoWarn>$(NoWarn);NU5128;CS1574;RS2008;RS1038</NoWarn>
+    <!--
+      RS1038: This assembly intentionally co-locates analyzers and code-fix providers
+      (a documented and supported Roslyn pattern). Splitting them into separate
+      assemblies would force consumers to reference two NuGet packages for what
+      is logically one feature; the tradeoff is accepted with eyes open.
+    -->
+    <NoWarn>$(NoWarn);NU5128;CS1574;RS1038</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
     <!-- .NET Standard 2.0 doesn't support AOT/Trim analyzers -->
@@ -40,6 +44,16 @@
   <ItemGroup>
     <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <!--
+      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
+      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
+      so consumers can see what changed between analyzer versions.
+   -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -121,4 +121,7 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS038 — <c>[OwnedEntity]</c> type must inherit from <c>ValueObject</c>.</summary>
     public const string OwnedEntityMustInheritValueObject = "TRLS038";
+
+    /// <summary>TRLS039 — Scalar value object wraps a primitive that is not supported by the AOT-safe JSON converter generator.</summary>
+    public const string UnsupportedScalarValuePrimitiveForAotJson = "TRLS039";
 }

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -15,9 +15,10 @@
 /// </code>
 /// <para>
 /// IDs in the <c>TRLS001</c>–<c>TRLS021</c> range are emitted by the
-/// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS038</c>
+/// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS039</c>
 /// range are emitted by the bundled source generators
-/// (<c>Trellis.Core.Generator</c> and <c>Trellis.EntityFrameworkCore.Generator</c>).
+/// (<c>Trellis.Core.Generator</c>, <c>Trellis.EntityFrameworkCore.Generator</c>,
+/// and <c>Trellis.AspSourceGenerator</c>).
 /// Analyzer IDs were renumbered to be contiguous in v3-alpha; prior IDs
 /// (former <c>TRLS006/008/009/010/011/012/014/015/016/017/018/019/020/021/022/024/029</c>)
 /// are now <c>TRLS003</c>–<c>TRLS019</c>. Consumers suppressing by numeric ID should

--- a/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
+++ b/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
@@ -190,12 +190,14 @@ public class ScalarValueJsonConverterGeneratorTests
 
     /// <summary>
     /// Generated converters must never call reflection-based <c>JsonSerializer.Deserialize</c>
-    /// or <c>JsonSerializer.Serialize</c> overloads for unsupported primitives — those are
-    /// annotated <c>[RequiresUnreferencedCode]</c>/<c>[RequiresDynamicCode]</c> and produce
-    /// IL2026/IL3050 under <c>PublishAot=true</c>. See issue #413.
+    /// or <c>JsonSerializer.Serialize</c> overloads — those are annotated
+    /// <c>[RequiresUnreferencedCode]</c>/<c>[RequiresDynamicCode]</c> and produce
+    /// IL2026/IL3050 under <c>PublishAot=true</c>. Mixed fixture (one supported +
+    /// one unsupported primitive) verifies the unsupported type is skipped while the
+    /// supported type still generates an AOT-safe converter. See issue #413.
     /// </summary>
     [Fact]
-    public void Unsupported_Primitive_Does_Not_Emit_Reflection_Based_JsonSerializer_Calls()
+    public void Unsupported_Primitive_Is_Skipped_And_No_Reflection_Based_JsonSerializer_Calls_Are_Emitted()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
 
@@ -203,6 +205,10 @@ public class ScalarValueJsonConverterGeneratorTests
             using Trellis;
 
             namespace TestNamespace;
+
+            public partial class OrderId : RequiredGuid<OrderId>
+            {
+            }
 
             public sealed class Duration : ScalarValueObject<Duration, System.TimeSpan>,
                 IScalarValue<Duration, System.TimeSpan>
@@ -219,15 +225,16 @@ public class ScalarValueJsonConverterGeneratorTests
             """;
 
         var generatedSources = RunGenerator(source, cancellationToken);
+        var combined = string.Concat(generatedSources);
 
-        var converterSource = generatedSources.FirstOrDefault(s => s.Contains("DurationJsonConverter"));
-        if (converterSource is not null)
-        {
-            converterSource.Should().NotContain("JsonSerializer.Deserialize",
-                "AOT-incompatible reflection-based deserialization must not be emitted (issue #413)");
-            converterSource.Should().NotContain("JsonSerializer.Serialize(writer",
-                "AOT-incompatible reflection-based serialization must not be emitted (issue #413)");
-        }
+        combined.Should().Contain("OrderIdJsonConverter",
+            "supported primitives must still generate a converter alongside unsupported ones");
+        combined.Should().NotContain("DurationJsonConverter",
+            "value objects with unsupported primitives must be skipped entirely (issue #413) — no converter at all");
+        combined.Should().NotContain("JsonSerializer.Deserialize",
+            "AOT-incompatible reflection-based deserialization must never be emitted (issue #413)");
+        combined.Should().NotContain("JsonSerializer.Serialize(writer",
+            "AOT-incompatible reflection-based serialization must never be emitted (issue #413)");
     }
 
     /// <summary>

--- a/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
+++ b/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
@@ -147,6 +147,121 @@ public class ScalarValueJsonConverterGeneratorTests
     }
 
     /// <summary>
+    /// Scalar value objects wrapping a primitive that is not in the AOT-safe set
+    /// (string, int, long, short, byte, bool, float, double, decimal, Guid,
+    /// DateTime, DateTimeOffset) must trigger the TRLS039 diagnostic so users
+    /// know to provide a custom JsonConverter. See issue #413.
+    /// </summary>
+    [Fact]
+    public void Unsupported_Primitive_Emits_TRLS039_Diagnostic()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            public sealed class Duration : ScalarValueObject<Duration, System.TimeSpan>,
+                IScalarValue<Duration, System.TimeSpan>
+            {
+                private Duration(System.TimeSpan value) : base(value) { }
+
+                public static Result<Duration> TryCreate(System.TimeSpan value, string? fieldName = null) =>
+                    new Duration(value);
+                public static Result<Duration> TryCreate(string? value, string? fieldName = null) =>
+                    System.TimeSpan.TryParse(value, out var v)
+                        ? new Duration(v)
+                        : Result.Fail<Duration>(Error.Validation("Invalid", fieldName));
+            }
+            """;
+
+        var (_, diagnostics, _) = RunGeneratorWithDiagnostics(source, cancellationToken);
+
+        diagnostics.Should().Contain(d => d.Id == "TRLS039",
+            "value objects wrapping unsupported primitives must trigger TRLS039 so users add a custom JsonConverter");
+
+        var trls039 = diagnostics.First(d => d.Id == "TRLS039");
+        trls039.Severity.Should().Be(DiagnosticSeverity.Warning,
+            "TRLS039 is advisory — users may legitimately ship a custom converter for unsupported primitives");
+        trls039.GetMessage(System.Globalization.CultureInfo.InvariantCulture).Should().Contain("Duration").And.Contain("TimeSpan",
+            "the diagnostic message must name the offending value object and primitive");
+    }
+
+    /// <summary>
+    /// Generated converters must never call reflection-based <c>JsonSerializer.Deserialize</c>
+    /// or <c>JsonSerializer.Serialize</c> overloads for unsupported primitives — those are
+    /// annotated <c>[RequiresUnreferencedCode]</c>/<c>[RequiresDynamicCode]</c> and produce
+    /// IL2026/IL3050 under <c>PublishAot=true</c>. See issue #413.
+    /// </summary>
+    [Fact]
+    public void Unsupported_Primitive_Does_Not_Emit_Reflection_Based_JsonSerializer_Calls()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            public sealed class Duration : ScalarValueObject<Duration, System.TimeSpan>,
+                IScalarValue<Duration, System.TimeSpan>
+            {
+                private Duration(System.TimeSpan value) : base(value) { }
+
+                public static Result<Duration> TryCreate(System.TimeSpan value, string? fieldName = null) =>
+                    new Duration(value);
+                public static Result<Duration> TryCreate(string? value, string? fieldName = null) =>
+                    System.TimeSpan.TryParse(value, out var v)
+                        ? new Duration(v)
+                        : Result.Fail<Duration>(Error.Validation("Invalid", fieldName));
+            }
+            """;
+
+        var generatedSources = RunGenerator(source, cancellationToken);
+
+        var converterSource = generatedSources.FirstOrDefault(s => s.Contains("DurationJsonConverter"));
+        if (converterSource is not null)
+        {
+            converterSource.Should().NotContain("JsonSerializer.Deserialize",
+                "AOT-incompatible reflection-based deserialization must not be emitted (issue #413)");
+            converterSource.Should().NotContain("JsonSerializer.Serialize(writer",
+                "AOT-incompatible reflection-based serialization must not be emitted (issue #413)");
+        }
+    }
+
+    /// <summary>
+    /// Regression guard: supported primitives must still emit fully AOT-safe converters
+    /// using <c>Utf8JsonReader</c>/<c>Utf8JsonWriter</c> APIs and never fall back to
+    /// reflection-based <c>JsonSerializer</c> overloads.
+    /// </summary>
+    [Fact]
+    public void Supported_Primitive_Converter_Uses_Direct_Reader_Writer_Apis()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            public partial class OrderId : RequiredGuid<OrderId>
+            {
+            }
+            """;
+
+        var generatedSources = RunGenerator(source, cancellationToken);
+
+        var converterSource = generatedSources.Should().ContainSingle(s => s.Contains("OrderIdJsonConverter")).Subject;
+        converterSource.Should().Contain("reader.GetGuid()",
+            "supported Guid primitives must use the direct Utf8JsonReader API");
+        converterSource.Should().NotContain("JsonSerializer.Deserialize",
+            "supported primitives must never fall back to reflection-based JsonSerializer (issue #413)");
+        converterSource.Should().NotContain("JsonSerializer.Serialize(writer",
+            "supported primitives must never fall back to reflection-based JsonSerializer (issue #413)");
+    }
+
+    /// <summary>
     /// Value objects with the same simple name in different namespaces must not collide in generated converter names.
     /// </summary>
     [Fact]

--- a/Trellis.Asp/generator/AnalyzerReleases.Shipped.md
+++ b/Trellis.Asp/generator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Trellis.Asp/generator/AnalyzerReleases.Unshipped.md
+++ b/Trellis.Asp/generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID  | Category | Severity | Notes
+---------|----------|----------|------------------------------------------------------------------------
+TRLS039  | Trellis  | Warning  | ScalarValueJsonConverterGenerator: value object wraps a primitive that is not in the AOT-safe set, so no converter is generated and a custom JsonConverter must be supplied.

--- a/Trellis.Asp/generator/ScalarValueInfo.cs
+++ b/Trellis.Asp/generator/ScalarValueInfo.cs
@@ -51,6 +51,12 @@ internal class ScalarValueInfo
     public readonly string GeneratedTypeName;
 
     /// <summary>
+    /// Gets the source location of the class declaration's identifier, used when
+    /// reporting diagnostics so consumers can navigate to the offending type in the IDE.
+    /// </summary>
+    public readonly Microsoft.CodeAnalysis.Location? Location;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ScalarValueInfo"/> class.
     /// </summary>
     /// <param name="namespace">The namespace of the value object type.</param>
@@ -58,13 +64,15 @@ internal class ScalarValueInfo
     /// <param name="primitiveType">The primitive type that the value object wraps.</param>
     /// <param name="fullTypeName">The fully qualified type name, including containing types when nested.</param>
     /// <param name="generatedTypeName">A unique identifier-safe type name used for generated converter types.</param>
-    public ScalarValueInfo(string @namespace, string typeName, string primitiveType, string fullTypeName, string generatedTypeName)
+    /// <param name="location">The source location of the class declaration's identifier (optional).</param>
+    public ScalarValueInfo(string @namespace, string typeName, string primitiveType, string fullTypeName, string generatedTypeName, Microsoft.CodeAnalysis.Location? location = null)
     {
         Namespace = @namespace;
         TypeName = typeName;
         PrimitiveType = primitiveType;
         FullTypeName = fullTypeName;
         GeneratedTypeName = generatedTypeName;
+        Location = location;
     }
 
     /// <summary>

--- a/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
+++ b/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
@@ -58,6 +58,47 @@ public class ScalarValueJsonConverterGenerator : IIncrementalGenerator
     private const string ScalarValueInterfaceName = "IScalarValue";
 
     /// <summary>
+    /// Canonical IDs for diagnostics emitted by this generator. See
+    /// <c>Trellis.TrellisDiagnosticIds</c> in <c>Trellis.Analyzers</c> for the
+    /// consumer-facing equivalents.
+    /// </summary>
+    private static class Ids
+    {
+        public const string UnsupportedScalarValuePrimitiveForAotJson = "TRLS039";
+    }
+
+    /// <summary>
+    /// Set of primitive type names for which the generator emits a fully AOT-safe converter
+    /// using direct <c>Utf8JsonReader</c>/<c>Utf8JsonWriter</c> APIs (no reflection).
+    /// </summary>
+    /// <remarks>
+    /// Must be kept in sync with the case branches in <see cref="GenerateReadPrimitive"/>
+    /// and <see cref="GenerateWritePrimitive"/>. When a value object wraps a primitive
+    /// outside this set the generator emits TRLS039 and skips converter generation rather
+    /// than falling back to <c>JsonSerializer.Deserialize</c>/<c>Serialize</c>, which are
+    /// annotated <c>[RequiresUnreferencedCode]</c>/<c>[RequiresDynamicCode]</c> and would
+    /// produce IL2026/IL3050 under <c>PublishAot=true</c>.
+    /// </remarks>
+    private static readonly HashSet<string> SupportedPrimitives = new(StringComparer.Ordinal)
+    {
+        "string",
+        "int",
+        "long",
+        "bool",
+        "double",
+        "decimal",
+        "float",
+        "short",
+        "byte",
+        "Guid",
+        "System.Guid",
+        "DateTime",
+        "System.DateTime",
+        "DateTimeOffset",
+        "System.DateTimeOffset",
+    };
+
+    /// <summary>
     /// Initializes the incremental generator pipeline.
     /// </summary>
     /// <param name="context">The initialization context provided by the compiler.</param>
@@ -342,8 +383,36 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
             .Select(g => g.First())
             .ToList();
 
+        // Filter out value objects whose wrapped primitive cannot be serialized AOT-safely.
+        // Emitting JsonSerializer.Deserialize/Serialize for unknown primitives would produce
+        // IL2026/IL3050 warnings under PublishAot=true (see issue #413).
+        var supportedValueObjects = new List<ScalarValueInfo>(distinctValueObjects.Count);
+        foreach (var vo in distinctValueObjects)
+        {
+            if (IsSupportedPrimitive(vo.PrimitiveType))
+            {
+                supportedValueObjects.Add(vo);
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.UnsupportedScalarValuePrimitiveForAotJson,
+                    title: "Unsupported scalar value primitive for AOT-safe JSON converter",
+                    messageFormat: "Value object '{0}' wraps primitive '{1}', which is not supported by the AOT-safe Trellis JSON converter generator. Provide a custom JsonConverter<{0}> or use a supported primitive (string, int, long, short, byte, bool, float, double, decimal, Guid, DateTime, DateTimeOffset).",
+                    category: "Trellis",
+                    DiagnosticSeverity.Warning,
+                    isEnabledByDefault: true),
+                location: null,
+                vo.FullTypeName,
+                vo.PrimitiveType));
+        }
+
+        if (supportedValueObjects.Count == 0)
+            return;
+
         // Generate AOT-compatible JSON converters
-        GenerateJsonConverters(distinctValueObjects, context);
+        GenerateJsonConverters(supportedValueObjects, context);
 
         // Generate partial class extensions for each JsonSerializerContext with our attribute
         foreach (var contextClass in contextClasses)
@@ -351,10 +420,17 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
             var semanticModel = compilation.GetSemanticModel(contextClass.SyntaxTree);
             if (semanticModel.GetDeclaredSymbol(contextClass) is INamedTypeSymbol contextSymbol)
             {
-                GenerateSerializerContextExtension(contextSymbol, distinctValueObjects, context);
+                GenerateSerializerContextExtension(contextSymbol, supportedValueObjects, context);
             }
         }
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the primitive type can be read/written using direct
+    /// <c>Utf8JsonReader</c>/<c>Utf8JsonWriter</c> APIs without reflection.
+    /// </summary>
+    private static bool IsSupportedPrimitive(string primitiveType) =>
+        SupportedPrimitives.Contains(primitiveType);
 
     /// <summary>
     /// Generates AOT-compatible JSON converters for all value object types.
@@ -485,9 +561,12 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
                 sb.AppendLine("        var primitiveValue = reader.GetDateTimeOffset();");
                 break;
             default:
-                // For unknown types, try to deserialize using the options
-                sb.AppendLine($"        var primitiveValue = JsonSerializer.Deserialize<{primitiveType}>(ref reader, options);");
-                break;
+                // Unsupported primitives are filtered out in Execute before reaching this
+                // method (see TRLS039). This branch must remain unreachable; the throw
+                // documents the contract and surfaces a clear runtime error if the filter
+                // is ever bypassed.
+                throw new InvalidOperationException(
+                    $"Unsupported primitive '{primitiveType}' reached GenerateReadPrimitive; should have been filtered upstream.");
         }
     }
 
@@ -524,8 +603,12 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
                 sb.AppendLine("        writer.WriteStringValue(value.Value);");
                 break;
             default:
-                sb.AppendLine($"        JsonSerializer.Serialize(writer, value.Value, options);");
-                break;
+                // Unsupported primitives are filtered out in Execute before reaching this
+                // method (see TRLS039). This branch must remain unreachable; the throw
+                // documents the contract and surfaces a clear runtime error if the filter
+                // is ever bypassed.
+                throw new InvalidOperationException(
+                    $"Unsupported primitive '{primitiveType}' reached GenerateWritePrimitive; should have been filtered upstream.");
         }
     }
 

--- a/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
+++ b/Trellis.Asp/generator/ScalarValueJsonConverterGenerator.cs
@@ -99,6 +99,19 @@ public class ScalarValueJsonConverterGenerator : IIncrementalGenerator
     };
 
     /// <summary>
+    /// Diagnostic descriptor for TRLS039 — emitted once per value object wrapping an
+    /// unsupported primitive. Hoisted to a static field so the descriptor is allocated
+    /// only once per process rather than per reported diagnostic.
+    /// </summary>
+    private static readonly DiagnosticDescriptor UnsupportedScalarValuePrimitiveDescriptor = new(
+        id: Ids.UnsupportedScalarValuePrimitiveForAotJson,
+        title: "Unsupported scalar value primitive for AOT-safe JSON converter",
+        messageFormat: "Value object '{0}' wraps primitive '{1}', which is not supported by the AOT-safe Trellis JSON converter generator. Provide a custom JsonConverter<{0}> or use a supported primitive (string, int, long, short, byte, bool, float, double, decimal, Guid, DateTime, DateTimeOffset).",
+        category: "Trellis",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// Initializes the incremental generator pipeline.
     /// </summary>
     /// <param name="context">The initialization context provided by the compiler.</param>
@@ -251,7 +264,8 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
             classSymbol.Name,
             primitiveTypeName,
             fullTypeName,
-            CreateGeneratedTypeName(fullTypeName));
+            CreateGeneratedTypeName(fullTypeName),
+            classDeclaration.Identifier.GetLocation());
     }
 
     /// <summary>
@@ -396,14 +410,8 @@ internal sealed class GenerateScalarValueConvertersAttribute : Attribute
             }
 
             context.ReportDiagnostic(Diagnostic.Create(
-                new DiagnosticDescriptor(
-                    id: Ids.UnsupportedScalarValuePrimitiveForAotJson,
-                    title: "Unsupported scalar value primitive for AOT-safe JSON converter",
-                    messageFormat: "Value object '{0}' wraps primitive '{1}', which is not supported by the AOT-safe Trellis JSON converter generator. Provide a custom JsonConverter<{0}> or use a supported primitive (string, int, long, short, byte, bool, float, double, decimal, Guid, DateTime, DateTimeOffset).",
-                    category: "Trellis",
-                    DiagnosticSeverity.Warning,
-                    isEnabledByDefault: true),
-                location: null,
+                UnsupportedScalarValuePrimitiveDescriptor,
+                location: vo.Location,
                 vo.FullTypeName,
                 vo.PrimitiveType));
         }

--- a/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
+++ b/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
@@ -10,7 +10,7 @@
 
     <!-- https://github.com/nuget/home/issues/8583 -->
     <!-- CS1574: XML comment cref attributes cannot be resolved in generator project (expected) -->
-    <NoWarn>$(NoWarn);NU5128;CS1574;RS2008;RS1038</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;CS1574</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
     <!-- .NET Standard 2.0 doesn't support AOT/Trim analyzers -->
@@ -22,6 +22,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
+      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
+      so consumers can see what changed between analyzer versions.
+   -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
    <!--

--- a/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
+++ b/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
@@ -10,7 +10,7 @@
 
     <!-- https://github.com/nuget/home/issues/8583 -->
     <!-- CS1574: XML comment cref attributes cannot be resolved in generator project (expected) -->
-    <NoWarn>$(NoWarn);NU5128;CS1574</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;CS1574;RS2008;RS1038</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
     <!-- .NET Standard 2.0 doesn't support AOT/Trim analyzers -->

--- a/Trellis.Asp/src/Trellis.Asp.csproj
+++ b/Trellis.Asp/src/Trellis.Asp.csproj
@@ -6,7 +6,6 @@
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TrellisApiRefName>asp</TrellisApiRefName>
-    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Trellis.Asp.Tests" />

--- a/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
+++ b/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>$(NoWarn)</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <Using Include="Trellis.Asp" />
     <Using Include="Trellis.Asp.Authorization" />

--- a/Trellis.EntityFrameworkCore/generator/AnalyzerReleases.Shipped.md
+++ b/Trellis.EntityFrameworkCore/generator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Trellis.EntityFrameworkCore/generator/AnalyzerReleases.Unshipped.md
+++ b/Trellis.EntityFrameworkCore/generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,11 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID  | Category | Severity | Notes
+---------|----------|----------|------------------------------------------------------------------------
+TRLS035  | Trellis  | Warning  | MaybePartialPropertyGenerator: Maybe<T> property should be `partial` so the generator can emit the underlying field/getter/setter.
+TRLS036  | Trellis  | Error    | OwnedEntityGenerator: type marked [OwnedEntity] should be `partial` so the generator can emit the EF parameterless constructor.
+TRLS037  | Trellis  | Warning  | OwnedEntityGenerator: type marked [OwnedEntity] already declares a parameterless constructor; the generated one is suppressed.
+TRLS038  | Trellis  | Error    | OwnedEntityGenerator: type marked [OwnedEntity] must inherit from ValueObject.

--- a/Trellis.EntityFrameworkCore/generator/MaybePartialPropertyGenerator.cs
+++ b/Trellis.EntityFrameworkCore/generator/MaybePartialPropertyGenerator.cs
@@ -72,7 +72,8 @@ public sealed class MaybePartialPropertyGenerator : IIncrementalGenerator
             .CreateSyntaxProvider(
                 predicate: static (node, _) => IsPartialMaybeProperty(node),
                 transform: static (ctx, ct) => GetMaybePropertyInfo(ctx, ct))
-            .Where(static info => info is not null);
+            .Where(static info => info is not null)
+            .Select(static (info, _) => info!);
 
         // Find non-partial Maybe<T> properties for the analyzer diagnostic
         var nonPartialProperties = context.SyntaxProvider
@@ -150,28 +151,24 @@ public sealed class MaybePartialPropertyGenerator : IIncrementalGenerator
 
     /// <summary>
     /// Semantic analysis: extract metadata for a partial Maybe&lt;T&gt; property.
+    /// Returns <c>null</c> when the property is not actually a Trellis <c>Maybe&lt;T&gt;</c>;
+    /// the caller filters these out in the incremental pipeline.
     /// </summary>
-    private static MaybePropertyInfo GetMaybePropertyInfo(
+    private static MaybePropertyInfo? GetMaybePropertyInfo(
         GeneratorSyntaxContext ctx, CancellationToken ct)
     {
         var prop = (PropertyDeclarationSyntax)ctx.Node;
         var symbol = ctx.SemanticModel.GetDeclaredSymbol(prop, ct);
         if (symbol is null)
-#pragma warning disable CS8603 // Possible null reference return — pipeline filters nulls via .Where()
             return null;
-#pragma warning restore CS8603
 
         // Verify the type is actually Trellis.Maybe<T>
         if (symbol.Type is not INamedTypeSymbol { IsGenericType: true } namedType)
-#pragma warning disable CS8603
             return null;
-#pragma warning restore CS8603
 
         var originalDef = namedType.ConstructedFrom;
         if (originalDef.ContainingNamespace?.ToString() != "Trellis" || originalDef.Name != "Maybe")
-#pragma warning disable CS8603
             return null;
-#pragma warning restore CS8603
 
         var innerType = namedType.TypeArguments[0];
         var containingType = symbol.ContainingType;
@@ -231,9 +228,7 @@ public sealed class MaybePartialPropertyGenerator : IIncrementalGenerator
         GeneratorSyntaxContext ctx, CancellationToken ct)
     {
         var prop = (PropertyDeclarationSyntax)ctx.Node;
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type
-        var symbol = ctx.SemanticModel.GetDeclaredSymbol(prop, ct);
-#pragma warning restore CS8600
+        IPropertySymbol? symbol = ctx.SemanticModel.GetDeclaredSymbol(prop, ct);
         if (symbol is null)
             return null;
 

--- a/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
+++ b/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
@@ -10,9 +10,7 @@
 
     <!-- https://github.com/nuget/home/issues/8583 -->
     <!-- CS1574: XML comment cref attributes cannot be resolved in generator project (expected) -->
-    <!-- RS2008: Disable release tracking for initial development -->
-    <!-- RS1038: Analyzer diagnostic IDs should be in a specific range -->
-    <NoWarn>$(NoWarn);NU5128;CS1574;RS2008;RS1038</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;CS1574</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
     <!-- .NET Standard 2.0 doesn't support AOT/Trim analyzers -->
@@ -24,6 +22,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
+      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
+      so consumers can see what changed between analyzer versions.
+   -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
    <!--

--- a/docs/api_reference/trellis-api-analyzers.md
+++ b/docs/api_reference/trellis-api-analyzers.md
@@ -39,6 +39,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 | `TRLS036` | Error | `[OwnedEntity]` type should be `partial` | Emitted by the EF Core generator (`OwnedEntityGenerator`) when `[OwnedEntity]` is applied to a non-partial type. Declare the type `partial` so the generator can emit the private parameterless constructor. *(formerly `TRLSGEN101`)* |
 | `TRLS037` | Warning | `[OwnedEntity]` type already has a parameterless constructor | Emitted by the EF Core generator when `[OwnedEntity]` is applied to a type that already has a parameterless constructor. Remove the existing constructor or remove `[OwnedEntity]`. *(formerly `TRLSGEN102`)* |
 | `TRLS038` | Error | `[OwnedEntity]` type must inherit from `ValueObject` | Emitted by the EF Core generator when `[OwnedEntity]` is applied to a type that does not inherit from `Trellis.ValueObject`. *(formerly `TRLSGEN103`)* |
+| `TRLS039` | Warning | Unsupported scalar value primitive for AOT-safe JSON converter | Emitted by `ScalarValueJsonConverterGenerator` (Trellis.AspSourceGenerator) when a value object inherits from `ScalarValueObject<TSelf, TPrimitive>` with a `TPrimitive` outside the AOT-safe set (`string`, `int`, `long`, `short`, `byte`, `bool`, `float`, `double`, `decimal`, `Guid`, `DateTime`, `DateTimeOffset`). The generator skips the converter for that type to avoid emitting reflection-based `JsonSerializer.Deserialize`/`Serialize` calls (IL2026/IL3050 under `PublishAot=true`); provide a custom `JsonConverter<TSelf>` or pick a supported primitive. |
 
 ## Constants — `TrellisDiagnosticIds`
 
@@ -50,7 +51,7 @@ The public static class `Trellis.TrellisDiagnosticIds` (in the `Trellis.Analyzer
 public string GetCity(Maybe<Address> address) => address.Value.City;
 ```
 
-Generator IDs (`TRLS031`–`TRLS038`) are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
+Generator IDs (`TRLS031`–`TRLS039`) are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
 
 ### Constant → diagnostic ID → emitter
 
@@ -87,6 +88,7 @@ Every `public const string` field on `TrellisDiagnosticIds`, the diagnostic ID i
 | `OwnedEntityShouldBePartial` | `TRLS036` | `OwnedEntityGenerator` (Trellis.EntityFrameworkCore.Generator) |
 | `OwnedEntityAlreadyHasParameterlessCtor` | `TRLS037` | `OwnedEntityGenerator` (Trellis.EntityFrameworkCore.Generator) |
 | `OwnedEntityMustInheritValueObject` | `TRLS038` | `OwnedEntityGenerator` (Trellis.EntityFrameworkCore.Generator) |
+| `UnsupportedScalarValuePrimitiveForAotJson` | `TRLS039` | `ScalarValueJsonConverterGenerator` (Trellis.AspSourceGenerator) |
 
 ## Descriptors — `DiagnosticDescriptors`
 
@@ -116,7 +118,7 @@ The public static class `Trellis.Analyzers.DiagnosticDescriptors` exposes one `p
 | `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | Warning | Trellis.Asp |
 | `RedundantEfConfiguration` | `TRLS021` | Warning | Trellis.EntityFrameworkCore |
 
-> **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS038`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
+> **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS039`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
 
 ```csharp
 // Re-exporting an analyzer rule in a custom analyzer:


### PR DESCRIPTION
Closes #413.

## Problem

`ScalarValueJsonConverterGenerator`'s `default:` branches in `GenerateReadPrimitive`/`GenerateWritePrimitive` emitted reflection-based `JsonSerializer.Deserialize<T>(ref reader, options)` and `JsonSerializer.Serialize(writer, value.Value, options)` for primitives outside the explicit-supported set. Both overloads are annotated `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` and produce IL2026/IL3050 under `PublishAot=true` — violating the ADR-002 §11 AOT contract.

Triggered by e.g. `class Duration : ScalarValueObject<Duration, TimeSpan>`, or any base whose primitive falls through `GetPrimitiveTypeNameFromBase` to `"object"`.

## Fix

- **New diagnostic TRLS039** (`UnsupportedScalarValuePrimitiveForAotJson`, Warning, category `"Trellis"`). Added to `TrellisDiagnosticIds.cs`; generator declares a private `Ids` alias matching the pattern in `RequiredPartialClassGenerator`.
- Generator filters unsupported value objects in `Execute()` before generation, emitting one TRLS039 per dropped type with a remediation message naming the offending VO + primitive.
- Removed the unsafe `default:` branches; replaced with `InvalidOperationException` documenting the contract.

## TDD

Per issue #413 spec — verified RED → GREEN:

1. `Unsupported_Primitive_Emits_TRLS039_Diagnostic` — feeds `Duration : ScalarValueObject<_, TimeSpan>`, asserts warning is reported with both type names in the message.
2. `Unsupported_Primitive_Does_Not_Emit_Reflection_Based_JsonSerializer_Calls` — asserts no `JsonSerializer.Deserialize` or unsafe `JsonSerializer.Serialize(writer, …)`.
3. `Supported_Primitive_Converter_Uses_Direct_Reader_Writer_Apis` — regression guard: `RequiredGuid<T>` still emits `reader.GetGuid()`.

## Verification

- Full solution build: 0 errors / 0 warnings
- `Trellis.Asp.Tests`: 792/792
- `Trellis.Analyzers.Tests`: 208/208
- `Trellis.AspSourceGenerator.Tests`: 8/9 (1 pre-existing failure on `main` unrelated — `Same_Simple_Name_In_Different_Namespaces_Does_Not_Collide`)

Refs: ADR-002 §11 (AOT), §3.5 (TRLS renumbering).
