### PR TITLE
Clean up suppression usage

### DIFF
--- a/Examples/ConditionalRequestExample.Tests/ConditionalRequestExample.Tests.csproj
+++ b/Examples/ConditionalRequestExample.Tests/ConditionalRequestExample.Tests.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>$(NoWarn)</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ConditionalRequestExample\ConditionalRequestExample.csproj" />
     <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />

--- a/Examples/ConditionalRequestExample/ConditionalRequestExample.csproj
+++ b/Examples/ConditionalRequestExample/ConditionalRequestExample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <RootNamespace>ConditionalRequestExample</RootNamespace>
-    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/CookbookSnippets/CookbookSnippets.csproj
+++ b/Examples/CookbookSnippets/CookbookSnippets.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>CookbookSnippets</RootNamespace>
     <!-- Cookbook snippets intentionally exercise reflection-based overloads (e.g.
          AddTrellisFluentValidation(Assembly), AddResourceAuthorization(Assembly)). They
-         are not AOT consumers, so suppress the related advisory warnings. -->
-    <NoWarn>$(NoWarn);IL2026;IL3050;CA1707;CA1725;CA1822;CA1812;CA2007;IDE0022;IDE0021;IDE0058;IDE0059;IDE0060;IDE0001;IDE1006</NoWarn>
+         are not AOT consumers, so suppress only those advisory warnings globally. -->
+    <NoWarn>$(NoWarn);IL2026;IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
+++ b/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
@@ -29,9 +29,9 @@ public sealed class PlaceOrderValidator : AbstractValidator<PlaceOrderCommand>
 public sealed class PlaceOrderHandler(IOrderRepository repo)
     : ICommandHandler<PlaceOrderCommand, Result<OrderId>>
 {
-    public ValueTask<Result<OrderId>> Handle(PlaceOrderCommand cmd, CancellationToken ct) =>
-        new(OrderId.TryCreate(cmd.OrderId)
-            .BindZip(id => CurrencyCode.TryCreate(cmd.Currency).Map(c => new Money(cmd.Amount, c)))
+    public ValueTask<Result<OrderId>> Handle(PlaceOrderCommand command, CancellationToken cancellationToken) =>
+        new(OrderId.TryCreate(command.OrderId)
+            .BindZip(id => CurrencyCode.TryCreate(command.Currency).Map(c => new Money(command.Amount, c)))
             .Bind(t => Order.Create(t.Item1, t.Item2))
             .Tap(repo.Add)
             .Map(o => o.Id));

--- a/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
+++ b/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
@@ -18,22 +18,22 @@ public sealed class ListOrdersHandler(AppDbContext db)
 {
     private const int MaxLimit = 100;
 
-    public async ValueTask<Result<Page<OrderListItem>>> Handle(ListOrdersQuery q, CancellationToken ct)
+    public async ValueTask<Result<Page<OrderListItem>>> Handle(ListOrdersQuery query, CancellationToken cancellationToken)
     {
-        var requested = q.Limit;
+        var requested = query.Limit;
         var applied   = System.Math.Clamp(requested, 1, MaxLimit);
 
-        var query = db.Orders.AsNoTracking().OrderBy(o => o.Id);
-        if (q.Cursor is not null)
+        var orders = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+        if (query.Cursor is not null)
         {
-            if (!System.Guid.TryParseExact(q.Cursor, "N", out var cursorId))
+            if (!System.Guid.TryParseExact(query.Cursor, "N", out var cursorId))
                 return Result.Fail<Page<OrderListItem>>(
-                    Error.UnprocessableContent.ForField(nameof(q.Cursor), "Cursor is not a valid pagination token."));
+                    Error.UnprocessableContent.ForField(nameof(query.Cursor), "Cursor is not a valid pagination token."));
 
-            query = query.Where(o => o.Id.Value > cursorId).OrderBy(o => o.Id);
+            orders = orders.Where(o => o.Id.Value > cursorId).OrderBy(o => o.Id);
         }
 
-        var rows = await query.Take(applied + 1).ToListAsync(ct);
+        var rows = await orders.Take(applied + 1).ToListAsync(cancellationToken);
         var hasNext = rows.Count > applied;
         var items   = rows.Take(applied)
                           .Select(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value))
@@ -42,7 +42,7 @@ public sealed class ListOrdersHandler(AppDbContext db)
         return Result.Ok(new Page<OrderListItem>(
             Items: items,
             Next: hasNext ? new Cursor(items[^1].Id.ToString("N")) : null,
-            Previous: q.Cursor is null ? null : new Cursor(q.Cursor),
+            Previous: query.Cursor is null ? null : new Cursor(query.Cursor),
             RequestedLimit: requested,
             AppliedLimit: applied));
     }

--- a/Examples/CookbookSnippets/Recipe06_ConditionalGet.cs
+++ b/Examples/CookbookSnippets/Recipe06_ConditionalGet.cs
@@ -11,8 +11,7 @@ using CookbookSnippets.Stubs;
 
 public static class ConditionalGetSample
 {
-    public static void Map(IEndpointRouteBuilder app)
-    {
+    public static void Map(IEndpointRouteBuilder app) =>
         app.MapGet("/blobs/{id:guid}", async (System.Guid id, HttpRequest req, IBlobRepository repo, CancellationToken ct) =>
         {
             Result<BlobContent> result = await repo.FindAsync(new BlobId(id), ct);
@@ -33,5 +32,4 @@ public static class ConditionalGetSample
                 })
                 .EvaluatePreconditions());
         });
-    }
 }

--- a/Examples/CookbookSnippets/Recipe09_StateMachine.cs
+++ b/Examples/CookbookSnippets/Recipe09_StateMachine.cs
@@ -26,7 +26,7 @@ public sealed class Document
 
 public sealed class DocumentService
 {
-    public Result<DocumentState> Submit(Document doc)
+    public static Result<DocumentState> Submit(Document doc)
     {
         var machine = new StateMachine<DocumentState, DocumentTrigger>(doc.State);
         machine.Configure(DocumentState.Draft).Permit(DocumentTrigger.Submit, DocumentState.Submitted);

--- a/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
+++ b/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 public class PlaceOrderHandlerTests
 {
+#pragma warning disable CA1707 // Cookbook test recipe intentionally shows readable xUnit-style test names.
     [Fact]
     public async Task PlaceOrder_returns_id_on_success()
     {
@@ -41,4 +42,5 @@ public class PlaceOrderHandlerTests
         unwrapped.Should().BeOfType<Error.UnprocessableContent>();
         error.Should().HaveFieldError("currency");
     }
+#pragma warning restore CA1707
 }

--- a/Examples/CookbookSnippets/Recipe11_AntiPatternFixes.cs
+++ b/Examples/CookbookSnippets/Recipe11_AntiPatternFixes.cs
@@ -12,6 +12,7 @@ using CookbookSnippets.Recipe08;
 
 public static class AntiPatternFixes
 {
+#pragma warning disable CA1707 // Diagnostic IDs are deliberately embedded in recipe method names for searchability.
     // ─── TRLS001 — Result return value not handled ─────────────────────────
 #if FALSE
     // WRONG — Result<T> dropped on the floor.
@@ -61,6 +62,7 @@ public static class AntiPatternFixes
     // ─── TRLS019 — default(Result) / default(Maybe<T>) ─────────────────────
     public static Result TRLS019_FixResult() => Result.Ok();
     public static Maybe<EmailAddress> TRLS019_FixMaybe() => Maybe<EmailAddress>.None;
+#pragma warning restore CA1707
 
     // Helpers used above — minimal stubs.
     private static Result<OrderId> PlaceOrder(object cmd) => Result.Fail<OrderId>(new Error.NotFound(new ResourceRef("Order")));

--- a/Examples/Showcase/tests/Showcase.MinimalApi.Tests/Showcase.MinimalApi.Tests.csproj
+++ b/Examples/Showcase/tests/Showcase.MinimalApi.Tests/Showcase.MinimalApi.Tests.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>$(NoWarn)</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>

--- a/Examples/Showcase/tests/Showcase.Tests/Showcase.Tests.csproj
+++ b/Examples/Showcase/tests/Showcase.Tests/Showcase.Tests.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>$(NoWarn)</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -52,6 +52,8 @@
       so consumers can see what changed between analyzer versions.
    -->
   <ItemGroup>
+    <None Remove="AnalyzerReleases.Shipped.md" />
+    <None Remove="AnalyzerReleases.Unshipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>

--- a/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
+++ b/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
@@ -30,6 +30,8 @@
       so consumers can see what changed between analyzer versions.
    -->
   <ItemGroup>
+    <None Remove="AnalyzerReleases.Shipped.md" />
+    <None Remove="AnalyzerReleases.Unshipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Trellis.Asp;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -168,7 +169,9 @@ public static class ServiceCollectionExtensions
             if (innerScalarConverter is null)
                 continue;
 
-            // Wrap it with property name awareness
+            // Wrap it with property name awareness. In Native AOT this returns null because
+            // runtime closed-generic converter construction is disabled; source-generated
+            // converters are expected to own scalar JSON conversion there.
             var wrappedScalarConverter = CreatePropertyNameAwareConverter(innerScalarConverter, property.Name, propertyType);
             if (wrappedScalarConverter is not null)
                 property.CustomConverter = wrappedScalarConverter;
@@ -247,11 +250,14 @@ public static class ServiceCollectionExtensions
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050",
-        Justification = "MakeGenericType is required to wrap a per-property converter. The wrapper type PropertyNameAwareConverter<T> is constructed for property types that are reachable through the JsonTypeInfo.Properties metadata, so the runtime instantiation is bounded by reachable JSON-serialized types. AOT consumers should source-generate their JsonSerializerContext to keep these types reachable.")]
+        Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported; Native AOT returns null before constructing a closed generic wrapper.")]
     [UnconditionalSuppressMessage("Trimming", "IL2055",
-        Justification = "PropertyNameAwareConverter<T> is constructed only for property types that JSON serialization metadata already preserves; the metadata system keeps T reachable.")]
+        Justification = "Reflection-enabled fallback only. PropertyNameAwareConverter<T> is constructed only for property types already present in JSON serialization metadata.")]
     private static JsonConverter? CreatePropertyNameAwareConverter(JsonConverter innerConverter, string propertyName, Type type)
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
+
         var wrapperType = typeof(PropertyNameAwareConverter<>).MakeGenericType(type);
         return Activator.CreateInstance(wrapperType, innerConverter, propertyName) as JsonConverter;
     }

--- a/Trellis.Asp/src/Validation/MaybeScalarValueJsonConverter.cs
+++ b/Trellis.Asp/src/Validation/MaybeScalarValueJsonConverter.cs
@@ -2,7 +2,6 @@
 
 namespace Trellis.Asp.Validation;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -49,8 +48,6 @@ public sealed class MaybeScalarValueJsonConverter<TValue, TPrimitive> : ScalarVa
     protected override Maybe<TValue> OnValidationFailure() => default;
 
     /// <inheritdoc />
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TPrimitive type parameter is preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON serialization of primitive types is compatible with AOT")]
     public override void Write(Utf8JsonWriter writer, Maybe<TValue> value, JsonSerializerOptions options)
     {
         if (value.HasNoValue)

--- a/Trellis.Asp/src/Validation/MaybeScalarValueJsonConverterFactory.cs
+++ b/Trellis.Asp/src/Validation/MaybeScalarValueJsonConverterFactory.cs
@@ -25,7 +25,7 @@ public sealed class MaybeScalarValueJsonConverterFactory : JsonConverterFactory
     /// </summary>
     /// <param name="typeToConvert">The type to check.</param>
     /// <returns><c>true</c> if the type is <see cref="Maybe{T}"/> where T implements <see cref="IScalarValue{TSelf, TPrimitive}"/>.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Value object types are preserved by JSON serialization infrastructure")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection-enabled fallback factory. Trellis registers this factory only when JsonSerializer.IsReflectionEnabledByDefault is true.")]
     public override bool CanConvert(Type typeToConvert) =>
         ScalarValueTypeHelper.IsMaybeScalarValue(typeToConvert);
 
@@ -35,10 +35,10 @@ public sealed class MaybeScalarValueJsonConverterFactory : JsonConverterFactory
     /// <param name="typeToConvert">The <see cref="Maybe{T}"/> type.</param>
     /// <param name="options">The serializer options.</param>
     /// <returns>A <see cref="MaybeScalarValueJsonConverter{TValue, TPrimitive}"/> for the type.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Value object types are preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Value object types are preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Inner type of Maybe<T> is preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JsonConverterFactory is not compatible with Native AOT")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection-enabled fallback factory. Trellis registers this factory only when JsonSerializer.IsReflectionEnabledByDefault is true.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Reflection-enabled fallback factory. Source-generated contexts should use generated converters instead.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection-enabled fallback factory. Maybe<T> metadata comes from the serializer-provided type.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JsonConverterFactory dynamic converter creation is not Native AOT compatible; Trellis does not auto-register this factory when reflection is disabled.")]
     public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         var innerType = ScalarValueTypeHelper.GetMaybeInnerType(typeToConvert);

--- a/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
+++ b/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Validation;
+﻿namespace Trellis.Asp.Validation;
 
 using System.Globalization;
 using System.Text.Json;
@@ -112,15 +112,15 @@ internal static class PrimitiveJsonReader
         }
         else if (primitiveType == typeof(DateOnly))
         {
-            boxed = TryReadDateOnly(ref reader, out var date) ? date : null;
+            boxed = ReadDateOnly(ref reader);
         }
         else if (primitiveType == typeof(TimeOnly))
         {
-            boxed = TryReadTimeOnly(ref reader, out var time) ? time : null;
+            boxed = ReadTimeOnly(ref reader);
         }
         else if (primitiveType == typeof(TimeSpan))
         {
-            boxed = TryReadTimeSpan(ref reader, out var duration) ? duration : null;
+            boxed = ReadTimeSpan(ref reader);
         }
         else
         {
@@ -132,21 +132,27 @@ internal static class PrimitiveJsonReader
         return boxed is not null || primitiveType == typeof(string);
     }
 
-    private static bool TryReadDateOnly(ref Utf8JsonReader reader, out DateOnly date)
+    private static DateOnly ReadDateOnly(ref Utf8JsonReader reader)
     {
         var raw = reader.GetString();
-        return DateOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
+        return DateOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)
+            ? date
+            : throw new FormatException();
     }
 
-    private static bool TryReadTimeOnly(ref Utf8JsonReader reader, out TimeOnly time)
+    private static TimeOnly ReadTimeOnly(ref Utf8JsonReader reader)
     {
         var raw = reader.GetString();
-        return TimeOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out time);
+        return TimeOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var time)
+            ? time
+            : throw new FormatException();
     }
 
-    private static bool TryReadTimeSpan(ref Utf8JsonReader reader, out TimeSpan duration)
+    private static TimeSpan ReadTimeSpan(ref Utf8JsonReader reader)
     {
         var raw = reader.GetString();
-        return TimeSpan.TryParse(raw, CultureInfo.InvariantCulture, out duration);
+        return TimeSpan.TryParse(raw, CultureInfo.InvariantCulture, out var duration)
+            ? duration
+            : throw new FormatException();
     }
 }

--- a/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
+++ b/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
@@ -1,0 +1,152 @@
+namespace Trellis.Asp.Validation;
+
+using System.Globalization;
+using System.Text.Json;
+
+/// <summary>
+/// Reads primitive values from a <see cref="Utf8JsonReader"/> without using reflection-based
+/// <see cref="JsonSerializer"/> fallback APIs.
+/// </summary>
+internal static class PrimitiveJsonReader
+{
+    /// <summary>
+    /// Reads a primitive value directly from the JSON reader using the typed reader API for
+    /// supported primitive types.
+    /// </summary>
+    public static bool TryRead<TPrimitive>(
+        ref Utf8JsonReader reader,
+        string fieldName,
+        out TPrimitive? value)
+        where TPrimitive : IComparable
+    {
+        value = default;
+
+        try
+        {
+            if (TryReadKnownPrimitive(ref reader, out value))
+                return true;
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidOperationException)
+        {
+            ValidationErrorsContext.AddError(fieldName, $"'{fieldName}' is not a valid {typeof(TPrimitive).Name}.");
+            return false;
+        }
+
+        ValidationErrorsContext.AddError(
+            fieldName,
+            $"Primitive type '{typeof(TPrimitive).Name}' is not supported by the Trellis validation JSON converter. Provide a custom JsonConverter.");
+        return false;
+    }
+
+    private static bool TryReadKnownPrimitive<TPrimitive>(
+        ref Utf8JsonReader reader,
+        out TPrimitive? value)
+        where TPrimitive : IComparable
+    {
+        object? boxed;
+        var primitiveType = typeof(TPrimitive);
+
+        if (primitiveType == typeof(string))
+        {
+            boxed = reader.GetString();
+        }
+        else if (primitiveType == typeof(Guid))
+        {
+            boxed = reader.GetGuid();
+        }
+        else if (primitiveType == typeof(int))
+        {
+            boxed = reader.GetInt32();
+        }
+        else if (primitiveType == typeof(long))
+        {
+            boxed = reader.GetInt64();
+        }
+        else if (primitiveType == typeof(short))
+        {
+            boxed = reader.GetInt16();
+        }
+        else if (primitiveType == typeof(byte))
+        {
+            boxed = reader.GetByte();
+        }
+        else if (primitiveType == typeof(sbyte))
+        {
+            boxed = reader.GetSByte();
+        }
+        else if (primitiveType == typeof(ushort))
+        {
+            boxed = reader.GetUInt16();
+        }
+        else if (primitiveType == typeof(uint))
+        {
+            boxed = reader.GetUInt32();
+        }
+        else if (primitiveType == typeof(ulong))
+        {
+            boxed = reader.GetUInt64();
+        }
+        else if (primitiveType == typeof(double))
+        {
+            boxed = reader.GetDouble();
+        }
+        else if (primitiveType == typeof(float))
+        {
+            boxed = reader.GetSingle();
+        }
+        else if (primitiveType == typeof(decimal))
+        {
+            boxed = reader.GetDecimal();
+        }
+        else if (primitiveType == typeof(bool))
+        {
+            boxed = reader.GetBoolean();
+        }
+        else if (primitiveType == typeof(DateTime))
+        {
+            boxed = reader.GetDateTime();
+        }
+        else if (primitiveType == typeof(DateTimeOffset))
+        {
+            boxed = reader.GetDateTimeOffset();
+        }
+        else if (primitiveType == typeof(DateOnly))
+        {
+            boxed = TryReadDateOnly(ref reader, out var date) ? date : null;
+        }
+        else if (primitiveType == typeof(TimeOnly))
+        {
+            boxed = TryReadTimeOnly(ref reader, out var time) ? time : null;
+        }
+        else if (primitiveType == typeof(TimeSpan))
+        {
+            boxed = TryReadTimeSpan(ref reader, out var duration) ? duration : null;
+        }
+        else
+        {
+            value = default;
+            return false;
+        }
+
+        value = boxed is null ? default : (TPrimitive)boxed;
+        return boxed is not null || primitiveType == typeof(string);
+    }
+
+    private static bool TryReadDateOnly(ref Utf8JsonReader reader, out DateOnly date)
+    {
+        var raw = reader.GetString();
+        return DateOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
+    }
+
+    private static bool TryReadTimeOnly(ref Utf8JsonReader reader, out TimeOnly time)
+    {
+        var raw = reader.GetString();
+        return TimeOnly.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out time);
+    }
+
+    private static bool TryReadTimeSpan(ref Utf8JsonReader reader, out TimeSpan duration)
+    {
+        var raw = reader.GetString();
+        return TimeSpan.TryParse(raw, CultureInfo.InvariantCulture, out duration);
+    }
+}

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace Trellis.Asp.Validation;
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -84,13 +85,6 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
         if (!PrimitiveJsonReader.TryRead(ref reader, fieldName, out primitiveValue))
             return false;
 
-        if (typeof(TPrimitive).IsEnum && primitiveValue is not null && !IsValidEnumValue(primitiveValue))
-        {
-            ValidationErrorsContext.AddError(fieldName, $"'{primitiveValue}' is not a valid {typeof(TPrimitive).Name}.");
-            primitiveValue = default;
-            return false;
-        }
-
         return true;
     }
 
@@ -139,17 +133,9 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
     private static object ReadNumericEnumValue(ref Utf8JsonReader reader)
     {
         var underlyingType = Enum.GetUnderlyingType(typeof(TPrimitive));
-        var rawValue = Type.GetTypeCode(underlyingType) switch
-        {
-            TypeCode.Byte => (object)reader.GetByte(),
-            TypeCode.SByte => reader.GetSByte(),
-            TypeCode.Int16 => reader.GetInt16(),
-            TypeCode.UInt16 => reader.GetUInt16(),
-            TypeCode.Int32 => reader.GetInt32(),
-            TypeCode.UInt32 => reader.GetUInt32(),
-            TypeCode.Int64 => reader.GetInt64(),
-            _ => reader.GetUInt64(),
-        };
+        var rawValue = underlyingType == typeof(ulong)
+            ? reader.GetUInt64()
+            : Convert.ChangeType(reader.GetInt64(), underlyingType, CultureInfo.InvariantCulture);
 
         return Enum.ToObject(typeof(TPrimitive), rawValue);
     }

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -1,6 +1,5 @@
 ﻿namespace Trellis.Asp.Validation;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -39,8 +38,6 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
     protected abstract TResult OnValidationFailure();
 
     /// <inheritdoc />
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TPrimitive type parameter is preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON deserialization of primitive types is compatible with AOT")]
     public override TResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -50,7 +47,7 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
         }
 
         var fieldName = ValidationErrorsContext.CurrentPropertyName ?? GetDefaultFieldName();
-        if (!TryReadPrimitiveValue(ref reader, options, fieldName, out var primitiveValue))
+        if (!TryReadPrimitiveValue(ref reader, fieldName, out var primitiveValue))
             return OnValidationFailure();
 
         if (primitiveValue is null)
@@ -76,11 +73,8 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
             });
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TPrimitive type parameter is preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON deserialization of primitive types is compatible with AOT")]
     private static bool TryReadPrimitiveValue(
         ref Utf8JsonReader reader,
-        JsonSerializerOptions options,
         string fieldName,
         out TPrimitive? primitiveValue)
     {
@@ -94,16 +88,8 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
             return false;
         }
 
-        try
-        {
-            primitiveValue = JsonSerializer.Deserialize<TPrimitive>(ref reader, options);
-        }
-        catch (JsonException)
-        {
-            primitiveValue = default;
-            ValidationErrorsContext.AddError(fieldName, $"{typeof(TValue).Name} is invalid.");
+        if (!PrimitiveJsonReader.TryRead(ref reader, fieldName, out primitiveValue))
             return false;
-        }
 
         if (typeof(TPrimitive).IsEnum && primitiveValue is not null && !IsValidEnumValue(primitiveValue))
         {

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -78,15 +78,8 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
         string fieldName,
         out TPrimitive? primitiveValue)
     {
-        if (typeof(TPrimitive).IsEnum && reader.TokenType == JsonTokenType.String)
-        {
-            var rawValue = reader.GetString();
-            if (TryParseEnumValue(rawValue, out primitiveValue))
-                return true;
-
-            ValidationErrorsContext.AddError(fieldName, $"'{rawValue}' is not a valid {typeof(TPrimitive).Name}.");
-            return false;
-        }
+        if (typeof(TPrimitive).IsEnum)
+            return TryReadEnumValue(ref reader, fieldName, out primitiveValue);
 
         if (!PrimitiveJsonReader.TryRead(ref reader, fieldName, out primitiveValue))
             return false;
@@ -99,6 +92,66 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
         }
 
         return true;
+    }
+
+    private static bool TryReadEnumValue(
+        ref Utf8JsonReader reader,
+        string fieldName,
+        out TPrimitive? primitiveValue)
+    {
+        primitiveValue = default;
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var rawValue = reader.GetString();
+            if (TryParseEnumValue(rawValue, out primitiveValue))
+                return true;
+
+            ValidationErrorsContext.AddError(fieldName, $"'{rawValue}' is not a valid {typeof(TPrimitive).Name}.");
+            return false;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            try
+            {
+                var enumValue = ReadNumericEnumValue(ref reader);
+                if (!IsValidEnumValue(enumValue))
+                {
+                    ValidationErrorsContext.AddError(fieldName, $"'{enumValue}' is not a valid {typeof(TPrimitive).Name}.");
+                    return false;
+                }
+
+                primitiveValue = (TPrimitive)enumValue;
+                return true;
+            }
+            catch (Exception ex) when (ex is FormatException or InvalidOperationException)
+            {
+                ValidationErrorsContext.AddError(fieldName, $"JSON number is not a valid {typeof(TPrimitive).Name}.");
+                return false;
+            }
+        }
+
+        ValidationErrorsContext.AddError(fieldName, $"JSON token '{reader.TokenType}' is not a valid {typeof(TPrimitive).Name}.");
+        return false;
+    }
+
+    private static object ReadNumericEnumValue(ref Utf8JsonReader reader)
+    {
+        var underlyingType = Enum.GetUnderlyingType(typeof(TPrimitive));
+        var rawValue = Type.GetTypeCode(underlyingType) switch
+        {
+            TypeCode.Byte => (object)reader.GetByte(),
+            TypeCode.SByte => reader.GetSByte(),
+            TypeCode.Int16 => reader.GetInt16(),
+            TypeCode.UInt16 => reader.GetUInt16(),
+            TypeCode.Int32 => reader.GetInt32(),
+            TypeCode.UInt32 => reader.GetUInt32(),
+            TypeCode.Int64 => reader.GetInt64(),
+            _ => reader.GetUInt64(),
+        };
+
+        return Enum.ToObject(typeof(TPrimitive), rawValue);
     }
 
     private static bool TryParseEnumValue(string? rawValue, out TPrimitive? primitiveValue)

--- a/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueTypeHelper.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Trellis.Asp.ModelBinding;
 
 /// <summary>
@@ -61,9 +62,9 @@ internal static class ScalarValueTypeHelper
     /// <param name="valueObjectType">The value object type (first type argument).</param>
     /// <param name="primitiveType">The primitive type (second type argument).</param>
     /// <returns>An instance of the constructed generic type, or null if creation fails.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2055", Justification = "MakeGenericType is used with known converter/binder types")]
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Types are preserved by ASP.NET Core serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Not compatible with Native AOT")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055", Justification = "Reflection-enabled fallback only. Native AOT returns null before MakeGenericType; callers then rely on source-generated converters/binders.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection-enabled fallback only. Types come from ASP.NET Core metadata or explicit model-binding inputs.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported; Native AOT returns null before constructing a closed generic type.")]
     public static TResult? CreateGenericInstance<TResult>(
         Type genericTypeDefinition,
         Type valueObjectType,
@@ -73,6 +74,9 @@ internal static class ScalarValueTypeHelper
         ArgumentNullException.ThrowIfNull(genericTypeDefinition);
         ArgumentNullException.ThrowIfNull(valueObjectType);
         ArgumentNullException.ThrowIfNull(primitiveType);
+
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
 
         try
         {

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -94,7 +94,7 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         return new BadRequestObjectResult(problemDetails);
     }
 
-    [UnconditionalSuppressMessage("AOT", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
+    [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
         Justification = "The type check for IScalarValue interfaces is safe - we only check interface implementation, not instantiate or invoke members.")]
     private static void ValidateScalarValueParameters(ActionExecutingContext context)
     {

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -97,9 +97,9 @@ public sealed class ScalarValueValidationMiddleware
         await result.ExecuteAsync(context).ConfigureAwait(false);
     }
 
-    [UnconditionalSuppressMessage("AOT", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
+    [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
         Justification = "The type check for IScalarValue interfaces is safe - we only check interface implementation, not instantiate or invoke members.")]
-    [UnconditionalSuppressMessage("AOT", "IL2073:Return type does not satisfy 'DynamicallyAccessedMembersAttribute' requirements.",
+    [UnconditionalSuppressMessage("Trimming", "IL2073:Return type does not satisfy 'DynamicallyAccessedMembersAttribute' requirements.",
         Justification = "The returned type comes from ParameterInfo.ParameterType which preserves type metadata at runtime.")]
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)]
     private static Type? GetScalarValueParameterType(IParameterBindingMetadata parameterMetadata)

--- a/Trellis.Asp/src/Validation/ValidatingJsonConverter.cs
+++ b/Trellis.Asp/src/Validation/ValidatingJsonConverter.cs
@@ -2,7 +2,6 @@
 
 namespace Trellis.Asp.Validation;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -50,8 +49,6 @@ public sealed class ValidatingJsonConverter<TValue, TPrimitive> : ScalarValueJso
     protected override TValue? OnValidationFailure() => null;
 
     /// <inheritdoc />
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TPrimitive type parameter is preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON serialization of primitive types is compatible with AOT")]
     public override void Write(Utf8JsonWriter writer, TValue? value, JsonSerializerOptions options)
     {
         if (value is null)

--- a/Trellis.Asp/src/Validation/ValidatingJsonConverterFactory.cs
+++ b/Trellis.Asp/src/Validation/ValidatingJsonConverterFactory.cs
@@ -27,7 +27,7 @@ public sealed class ValidatingJsonConverterFactory : JsonConverterFactory
     /// </summary>
     /// <param name="typeToConvert">The type to check.</param>
     /// <returns><c>true</c> if the type implements <see cref="IScalarValue{TSelf, TPrimitive}"/>.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Value object types are preserved by JSON serialization infrastructure")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection-enabled fallback factory. Trellis registers this factory only when JsonSerializer.IsReflectionEnabledByDefault is true.")]
     public override bool CanConvert(Type typeToConvert) =>
         ScalarValueTypeHelper.IsScalarValue(typeToConvert);
 
@@ -37,9 +37,9 @@ public sealed class ValidatingJsonConverterFactory : JsonConverterFactory
     /// <param name="typeToConvert">The value object type.</param>
     /// <param name="options">The serializer options.</param>
     /// <returns>A validating JSON converter for the value object type.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Value object types are preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Value object types are preserved by JSON serialization infrastructure")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JsonConverterFactory is not compatible with Native AOT")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection-enabled fallback factory. Trellis registers this factory only when JsonSerializer.IsReflectionEnabledByDefault is true.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Reflection-enabled fallback factory. Source-generated contexts should use generated converters instead.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JsonConverterFactory dynamic converter creation is not Native AOT compatible; Trellis does not auto-register this factory when reflection is disabled.")]
     public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         var primitiveType = ScalarValueTypeHelper.GetPrimitiveType(typeToConvert);

--- a/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
@@ -269,6 +269,29 @@ public class ValidatingJsonConverterEdgeCasesTests
     }
 
     [Fact]
+    public void Read_EnumNumericValue_BindsSuccessfully()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var json = "2";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Value.Should().Be(ProcessingMode.Safe);
+            ValidationErrorsContext.HasErrors.Should().BeFalse();
+        }
+    }
+
+    [Fact]
     public void Read_NonValidationError_CollectsAsSimpleError()
     {
         // Arrange - Create a value object that returns non-Error.UnprocessableContent

--- a/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
@@ -62,6 +62,11 @@ public class ValidatingJsonConverterEdgeCasesTests
         Safe = 2,
     }
 
+    public enum LargeProcessingMode : ulong
+    {
+        Bulk = 18446744073709551615ul,
+    }
+
     public sealed class ProcessingModeVO : ScalarValueObject<ProcessingModeVO, ProcessingMode>, IScalarValue<ProcessingModeVO, ProcessingMode>
     {
         private ProcessingModeVO(ProcessingMode value) : base(value) { }
@@ -71,6 +76,16 @@ public class ValidatingJsonConverterEdgeCasesTests
                 ? Result.Fail<ProcessingModeVO>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "processingMode"), "validation.error") { Detail = "Processing mode is required." })))
                 : Result.Ok(new ProcessingModeVO(value));
         public static Result<ProcessingModeVO> TryCreate(string? value, string? fieldName = null) =>
+            throw new NotImplementedException();
+    }
+
+    public sealed class LargeProcessingModeVO : ScalarValueObject<LargeProcessingModeVO, LargeProcessingMode>, IScalarValue<LargeProcessingModeVO, LargeProcessingMode>
+    {
+        private LargeProcessingModeVO(LargeProcessingMode value) : base(value) { }
+
+        public static Result<LargeProcessingModeVO> TryCreate(LargeProcessingMode value, string? fieldName = null) =>
+            Result.Ok(new LargeProcessingModeVO(value));
+        public static Result<LargeProcessingModeVO> TryCreate(string? value, string? fieldName = null) =>
             throw new NotImplementedException();
     }
 
@@ -288,6 +303,137 @@ public class ValidatingJsonConverterEdgeCasesTests
             result.Should().NotBeNull();
             result!.Value.Should().Be(ProcessingMode.Safe);
             ValidationErrorsContext.HasErrors.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Read_EnumNumericUlongValue_BindsSuccessfully()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<LargeProcessingModeVO, LargeProcessingMode>();
+        var json = "18446744073709551615";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(LargeProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Value.Should().Be(LargeProcessingMode.Bulk);
+            ValidationErrorsContext.HasErrors.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Read_EnumInvalidString_CollectsValidationError()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var json = "\"Slow\"";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/mode"
+                    && v.Detail == "'Slow' is not a valid ProcessingMode.");
+        }
+    }
+
+    [Fact]
+    public void Read_EnumUndefinedNumericValue_CollectsValidationError()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var json = "10";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/mode"
+                    && v.Detail == "'10' is not a valid ProcessingMode.");
+        }
+    }
+
+    [Fact]
+    public void Read_EnumNumericOverflow_CollectsValidationError()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var json = "999999999999999999999999";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/mode"
+                    && v.Detail == "JSON number is not a valid ProcessingMode.");
+        }
+    }
+
+    [Fact]
+    public void Read_EnumUnsupportedToken_CollectsValidationError()
+    {
+        // Arrange
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var json = "true";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            // Act
+            var result = converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            // Assert
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/mode"
+                    && v.Detail == "JSON token 'True' is not a valid ProcessingMode.");
         }
     }
 

--- a/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
@@ -198,6 +198,37 @@ public class ValidatingJsonConverterPrimitiveTypesTests
             throw new NotImplementedException();
     }
 
+    public readonly record struct CustomPrimitive(string Value) : IComparable
+    {
+        public static bool operator <(CustomPrimitive left, CustomPrimitive right) =>
+            string.Compare(left.Value, right.Value, StringComparison.Ordinal) < 0;
+
+        public static bool operator <=(CustomPrimitive left, CustomPrimitive right) =>
+            string.Compare(left.Value, right.Value, StringComparison.Ordinal) <= 0;
+
+        public static bool operator >(CustomPrimitive left, CustomPrimitive right) =>
+            string.Compare(left.Value, right.Value, StringComparison.Ordinal) > 0;
+
+        public static bool operator >=(CustomPrimitive left, CustomPrimitive right) =>
+            string.Compare(left.Value, right.Value, StringComparison.Ordinal) >= 0;
+
+        public int CompareTo(object? obj) =>
+            obj is CustomPrimitive other
+                ? string.Compare(Value, other.Value, StringComparison.Ordinal)
+                : 1;
+
+        public override string ToString() => Value;
+    }
+
+    public class CustomPrimitiveVO : ScalarValueObject<CustomPrimitiveVO, CustomPrimitive>, IScalarValue<CustomPrimitiveVO, CustomPrimitive>
+    {
+        private CustomPrimitiveVO(CustomPrimitive value) : base(value) { }
+        public static Result<CustomPrimitiveVO> TryCreate(CustomPrimitive value, string? fieldName = null) =>
+            Result.Ok(new CustomPrimitiveVO(value));
+        public static Result<CustomPrimitiveVO> TryCreate(string? value, string? fieldName = null) =>
+            throw new NotImplementedException();
+    }
+
     #endregion
 
     #region String Tests
@@ -742,6 +773,32 @@ public class ValidatingJsonConverterPrimitiveTypesTests
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<ULongVO, ulong>());
 
         roundTripped!.Value.Should().Be(18446744073709551615ul);
+    }
+
+    #endregion
+
+    #region Unsupported Primitive Tests
+
+    [Fact]
+    public void Read_UnsupportedPrimitive_CollectsValidationError()
+    {
+        var converter = new ValidatingJsonConverter<CustomPrimitiveVO, CustomPrimitive>();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"abc\""));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            var result = converter.Read(ref reader, typeof(CustomPrimitiveVO), new JsonSerializerOptions());
+
+            result.Should().BeNull();
+            ValidationErrorsContext.HasErrors.Should().BeTrue();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/customPrimitiveVO"
+                    && v.Detail == "Primitive type 'CustomPrimitive' is not supported by the Trellis validation JSON converter. Provide a custom JsonConverter.");
+        }
     }
 
     #endregion

--- a/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterPrimitiveTypesTests.cs
@@ -576,6 +576,27 @@ public class ValidatingJsonConverterPrimitiveTypesTests
         roundTripped!.Value.Should().Be(date);
     }
 
+    [Fact]
+    public void Read_InvalidDateOnly_CollectsInvalidValueError()
+    {
+        var converter = new ValidatingJsonConverter<DateOnlyVO, DateOnly>();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"not-a-date\""));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            var result = converter.Read(ref reader, typeof(DateOnlyVO), new JsonSerializerOptions());
+
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/dateOnlyVO"
+                    && v.Detail == "'dateOnlyVO' is not a valid DateOnly.");
+        }
+    }
+
     #endregion
 
     #region TimeOnly Tests
@@ -605,6 +626,27 @@ public class ValidatingJsonConverterPrimitiveTypesTests
         roundTripped!.Value.Should().Be(time);
     }
 
+    [Fact]
+    public void Read_InvalidTimeOnly_CollectsInvalidValueError()
+    {
+        var converter = new ValidatingJsonConverter<TimeOnlyVO, TimeOnly>();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"not-a-time\""));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            var result = converter.Read(ref reader, typeof(TimeOnlyVO), new JsonSerializerOptions());
+
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/timeOnlyVO"
+                    && v.Detail == "'timeOnlyVO' is not a valid TimeOnly.");
+        }
+    }
+
     #endregion
 
     #region TimeSpan Tests
@@ -629,6 +671,27 @@ public class ValidatingJsonConverterPrimitiveTypesTests
         var roundTripped = RoundTrip(vo, new ValidatingJsonConverter<TimeSpanVO, TimeSpan>());
 
         roundTripped!.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Read_InvalidTimeSpan_CollectsInvalidValueError()
+    {
+        var converter = new ValidatingJsonConverter<TimeSpanVO, TimeSpan>();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"not-a-duration\""));
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            var result = converter.Read(ref reader, typeof(TimeSpanVO), new JsonSerializerOptions());
+
+            result.Should().BeNull();
+            ValidationErrorsContext.GetUnprocessableContent()!
+                .Fields
+                .Items
+                .Should().ContainSingle(v =>
+                    v.Field.Path == "/timeSpanVO"
+                    && v.Detail == "'timeSpanVO' is not a valid TimeSpan.");
+        }
     }
 
     #endregion

--- a/Trellis.Benchmark/BenchmarkROP.cs
+++ b/Trellis.Benchmark/BenchmarkROP.cs
@@ -46,8 +46,6 @@ public partial class FirstName : RequiredString<FirstName>
 {
 }
 
-#pragma warning disable CA1822 // Mark members as static
-
 [MemoryDiagnoser]
 public class BenchmarkROP
 {

--- a/Trellis.Core/src/Primitives/RequiredString.cs
+++ b/Trellis.Core/src/Primitives/RequiredString.cs
@@ -294,7 +294,7 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
     /// </summary>
     // Single-parameter overloads match what EF Core's ScalarValueExpressionRewriter
     // targets on string — the rewriter maps Name.StartsWith(x) to ((string)Name).StartsWith(x).
-    // Using StringComparison.Ordinal would produce a two-parameter call that EF Core cannot translate.
+    // Adding StringComparison.Ordinal would produce a two-parameter call that EF Core cannot translate.
 #pragma warning disable CA1310 // Specify StringComparison for correctness
     public bool StartsWith(string value) => Value.StartsWith(value);
 

--- a/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
+++ b/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
@@ -30,6 +30,8 @@
       so consumers can see what changed between analyzer versions.
    -->
   <ItemGroup>
+    <None Remove="AnalyzerReleases.Shipped.md" />
+    <None Remove="AnalyzerReleases.Unshipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- remove empty/no-op NoWarn entries and narrow CookbookSnippets suppressions to AOT/reflection warnings
- replace scalar validation JSON reflection deserialization fallback with direct primitive reads
- make remaining trim/AOT suppressions explicit and guarded where runtime generic construction is reflection-only
- fix cookbook warnings that were previously hidden, with targeted suppressions only where recipe names intentionally include diagnostic IDs

## Validation
- dotnet build Trellis.slnx --no-restore
- dotnet test --solution Trellis.slnx --no-build