### PR TITLE
test(asp-gen): fix Same_Simple_Name fixture using removed v1 APIs

### DIFF
--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -47,16 +47,11 @@
   </ItemGroup>
 
   <!--
-      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
-      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
-      so consumers can see what changed between analyzer versions.
+      Analyzer release tracking (RS2008). Diagnostics emitted from static DiagnosticDescriptor
+      fields must be listed in AnalyzerReleases.{Shipped,Unshipped}.md. The
+      Microsoft.CodeAnalysis.Analyzers package auto-registers these as AdditionalFiles;
+      we only need them on disk.
    -->
-  <ItemGroup>
-    <None Remove="AnalyzerReleases.Shipped.md" />
-    <None Remove="AnalyzerReleases.Unshipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />

--- a/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
+++ b/Trellis.Asp/generator-tests/ScalarValueJsonConverterGeneratorTests.cs
@@ -168,11 +168,11 @@ public class ScalarValueJsonConverterGeneratorTests
                 private Duration(System.TimeSpan value) : base(value) { }
 
                 public static Result<Duration> TryCreate(System.TimeSpan value, string? fieldName = null) =>
-                    new Duration(value);
+                    Result.Ok(new Duration(value));
                 public static Result<Duration> TryCreate(string? value, string? fieldName = null) =>
                     System.TimeSpan.TryParse(value, out var v)
-                        ? new Duration(v)
-                        : Result.Fail<Duration>(Error.Validation("Invalid", fieldName));
+                        ? Result.Ok(new Duration(v))
+                        : Result.Fail<Duration>(Error.UnprocessableContent.ForField(fieldName ?? "value", "Invalid"));
             }
             """;
 
@@ -216,11 +216,11 @@ public class ScalarValueJsonConverterGeneratorTests
                 private Duration(System.TimeSpan value) : base(value) { }
 
                 public static Result<Duration> TryCreate(System.TimeSpan value, string? fieldName = null) =>
-                    new Duration(value);
+                    Result.Ok(new Duration(value));
                 public static Result<Duration> TryCreate(string? value, string? fieldName = null) =>
                     System.TimeSpan.TryParse(value, out var v)
-                        ? new Duration(v)
-                        : Result.Fail<Duration>(Error.Validation("Invalid", fieldName));
+                        ? Result.Ok(new Duration(v))
+                        : Result.Fail<Duration>(Error.UnprocessableContent.ForField(fieldName ?? "value", "Invalid"));
             }
             """;
 
@@ -285,9 +285,9 @@ public class ScalarValueJsonConverterGeneratorTests
                 {
                     private Quantity(int value) : base(value) { }
 
-                    public static Result<Quantity> TryCreate(int value, string? fieldName = null) => new Quantity(value);
+                    public static Result<Quantity> TryCreate(int value, string? fieldName = null) => Result.Ok(new Quantity(value));
                     public static Result<Quantity> TryCreate(string? value, string? fieldName = null) =>
-                        int.TryParse(value, out var v) ? new Quantity(v) : Result.Fail<Quantity>(Error.Validation("Invalid", fieldName));
+                        int.TryParse(value, out var v) ? Result.Ok(new Quantity(v)) : Result.Fail<Quantity>(Error.UnprocessableContent.ForField(fieldName ?? "value", "Invalid"));
                 }
             }
 
@@ -297,9 +297,9 @@ public class ScalarValueJsonConverterGeneratorTests
                 {
                     private Quantity(int value) : base(value) { }
 
-                    public static Result<Quantity> TryCreate(int value, string? fieldName = null) => new Quantity(value);
+                    public static Result<Quantity> TryCreate(int value, string? fieldName = null) => Result.Ok(new Quantity(value));
                     public static Result<Quantity> TryCreate(string? value, string? fieldName = null) =>
-                        int.TryParse(value, out var v) ? new Quantity(v) : Result.Fail<Quantity>(Error.Validation("Invalid", fieldName));
+                        int.TryParse(value, out var v) ? Result.Ok(new Quantity(v)) : Result.Fail<Quantity>(Error.UnprocessableContent.ForField(fieldName ?? "value", "Invalid"));
                 }
             }
             """;

--- a/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
+++ b/Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj
@@ -25,16 +25,11 @@
   </ItemGroup>
 
   <!--
-      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
-      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
-      so consumers can see what changed between analyzer versions.
+      Analyzer release tracking (RS2008). Diagnostics emitted from static DiagnosticDescriptor
+      fields must be listed in AnalyzerReleases.{Shipped,Unshipped}.md. The
+      Microsoft.CodeAnalysis.Analyzers package auto-registers these as AdditionalFiles;
+      we only need them on disk.
    -->
-  <ItemGroup>
-    <None Remove="AnalyzerReleases.Shipped.md" />
-    <None Remove="AnalyzerReleases.Unshipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
-  </ItemGroup>
 
    <!--
       Force-disable PublishAot/PublishTrimmed inherited from a parent AOT-publishing project.

--- a/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
+++ b/Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj
@@ -25,16 +25,11 @@
   </ItemGroup>
 
   <!--
-      Analyzer release tracking (RS2008). Every diagnostic emitted from a static
-      DiagnosticDescriptor field must be listed in AnalyzerReleases.{Shipped,Unshipped}.md
-      so consumers can see what changed between analyzer versions.
+      Analyzer release tracking (RS2008). Diagnostics emitted from static DiagnosticDescriptor
+      fields must be listed in AnalyzerReleases.{Shipped,Unshipped}.md. The
+      Microsoft.CodeAnalysis.Analyzers package auto-registers these as AdditionalFiles;
+      we only need them on disk.
    -->
-  <ItemGroup>
-    <None Remove="AnalyzerReleases.Shipped.md" />
-    <None Remove="AnalyzerReleases.Unshipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
-  </ItemGroup>
 
    <!--
       Force-disable PublishAot/PublishTrimmed inherited from a parent AOT-publishing project.

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -70,6 +70,7 @@
   <Folder Name="/Trellis.Asp/">
     <File Path="Trellis.Asp/SAMPLES.md" />
     <Project Path="Trellis.Asp/generator/Trellis.AspSourceGenerator.csproj" />
+    <Project Path="Trellis.Asp/generator-tests/Trellis.AspSourceGenerator.Tests.csproj" />
     <Project Path="Trellis.Asp/src/Trellis.Asp.csproj" />
     <Project Path="Trellis.Asp/tests/Trellis.Asp.Tests.csproj" />
   </Folder>
@@ -82,6 +83,7 @@
   </Folder>
   <Folder Name="/Trellis.EntityFrameworkCore/">
     <Project Path="Trellis.EntityFrameworkCore/generator/Trellis.EntityFrameworkCore.Generator.csproj" />
+    <Project Path="Trellis.EntityFrameworkCore/generator-tests/Trellis.EntityFrameworkCore.Generator.Tests.csproj" />
     <Project Path="Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj" />
     <Project Path="Trellis.EntityFrameworkCore/tests/Trellis.EntityFrameworkCore.Tests.csproj" />
   </Folder>


### PR DESCRIPTION
Three fixtures in `ScalarValueJsonConverterGeneratorTests` used v1 APIs that no longer exist after the v2 redesign:

- Implicit `T -> Result<T>` (removed; only `Maybe<T>` has implicit ctor)
- `Error.Validation(reason, fieldName)` (removed; replaced by the closed `UnprocessableContent` case via `Error.UnprocessableContent.ForField(...)`)

`Same_Simple_Name_In_Different_Namespaces_Does_Not_Collide` surfaced both because it uses `RunGeneratorWithDiagnostics`, which inspects the full output compilation. The two TRLS039 fixtures added in #420 had the same bug but masked by `RunGenerator`, which only inspects generator-emitted diagnostics. Fixed all three for parity.

**Result:** generator-tests 9/9 (was 8/9). Solution build: 0 warn / 0 err.