### PR TITLE
docs: sweep stale Error.Validation examples in Trellis.Core doc-comments (Tier-3 B-2)

### DIFF
--- a/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
@@ -328,7 +328,7 @@ public abstract class Aggregate<TId> : Entity<TId>, IAggregate
     ///     catch (Exception ex)
     ///     {
     ///         await transaction.RollbackAsync(ct);
-    ///         return Error.Unexpected(ex.Message);
+    ///         return new Error.Unexpected("transaction_failed") { Detail = ex.Message };
     ///     }
     /// }
     /// ]]></code>

--- a/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
@@ -65,18 +65,18 @@ using System.Text.Json.Serialization;
 ///     }
 ///     
 ///     public static Result<Order> Create(CustomerId customerId) =>
-///         customerId.ToResult(Error.Validation("Customer ID required"))
+///         customerId.ToResult(Error.UnprocessableContent.ForField("customerId", "invalid", "Customer ID required"))
 ///             .Map(id => new Order(OrderId.NewUnique(), id));
 ///     
 ///     // All modifications go through methods that enforce invariants
 ///     public Result<Order> AddLine(ProductId productId, int quantity, Money unitPrice) =>
 ///         this.ToResult()
 ///             .Ensure(_ => Status == OrderStatus.Draft,
-///                    Error.Validation("Cannot modify submitted order"))
+///                    Error.UnprocessableContent.ForRule("invalid", "Cannot modify submitted order"))
 ///             .Ensure(_ => quantity > 0,
-///                    Error.Validation("Quantity must be positive"))
+///                    Error.UnprocessableContent.ForField("quantity", "invalid", "Quantity must be positive"))
 ///             .Ensure(_ => _lines.Count < 100,
-///                    Error.Validation("Order cannot have more than 100 lines"))
+///                    Error.UnprocessableContent.ForRule("invalid", "Order cannot have more than 100 lines"))
 ///             .Tap(_ =>
 ///             {
 ///                 var line = new OrderLine(productId, quantity, unitPrice);
@@ -90,9 +90,9 @@ using System.Text.Json.Serialization;
 ///     public Result<Order> Submit() =>
 ///         this.ToResult()
 ///             .Ensure(_ => Status == OrderStatus.Draft,
-///                    Error.Validation("Order already submitted"))
+///                    Error.UnprocessableContent.ForRule("invalid", "Order already submitted"))
 ///             .Ensure(_ => _lines.Count > 0,
-///                    Error.Validation("Cannot submit empty order"))
+///                    Error.UnprocessableContent.ForRule("invalid", "Cannot submit empty order"))
 ///             .Tap(_ =>
 ///             {
 ///                 Status = OrderStatus.Submitted;

--- a/Trellis.Core/src/DomainDrivenDesign/Entity.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/Entity.cs
@@ -61,7 +61,7 @@
 ///     
 ///     public static Result&lt;Customer&gt; TryCreate(string name, EmailAddress email) =>
 ///         name.ToResult()
-///             .Ensure(n => !string.IsNullOrWhiteSpace(n), Error.Validation("Name required"))
+///             .Ensure(n => !string.IsNullOrWhiteSpace(n), Error.UnprocessableContent.ForField("name", "invalid", "Name required"))
 ///             .Map(n => new Customer(CustomerId.NewUnique(), n, email));
 ///     
 ///     public Result&lt;Customer&gt; UpdateEmail(EmailAddress newEmail) =>

--- a/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
@@ -51,7 +51,7 @@
 ///     public Result&lt;Order&gt; Submit()
 ///     {
 ///         return this.ToResult()
-///             .Ensure(_ => Status == OrderStatus.Draft, Error.Validation("Wrong status"))
+///             .Ensure(_ => Status == OrderStatus.Draft, Error.UnprocessableContent.ForRule("invalid", "Wrong status"))
 ///             .Tap(_ =>
 ///             {
 ///                 Status = OrderStatus.Submitted;

--- a/Trellis.Core/src/DomainDrivenDesign/ScalarValueObject.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/ScalarValueObject.cs
@@ -44,14 +44,14 @@ namespace Trellis;
 ///     
 ///     public static Result<CustomerId> TryCreate(Guid value) =>
 ///         value.ToResult()
-///             .Ensure(v => v != Guid.Empty, Error.Validation("Customer ID cannot be empty"))
+///             .Ensure(v => v != Guid.Empty, Error.UnprocessableContent.ForField("customerId", "invalid", "Customer ID cannot be empty"))
 ///             .Map(v => new CustomerId(v));
 ///     
 ///     public static Result<CustomerId> TryCreate(string? stringOrNull) =>
-///         stringOrNull.ToResult(Error.Validation("Customer ID cannot be empty"))
+///         stringOrNull.ToResult(Error.UnprocessableContent.ForField("customerId", "invalid", "Customer ID cannot be empty"))
 ///             .Bind(s => Guid.TryParse(s, out var guid)
 ///                 ? Result.Ok(guid)
-///                 : Error.Validation("Invalid GUID format"))
+///                 : Error.UnprocessableContent.ForField("customerId", "invalid", "Invalid GUID format"))
 ///             .Bind(TryCreate);
 /// }
 /// 
@@ -70,9 +70,9 @@ namespace Trellis;
 ///     public static Result<Temperature> TryCreate(decimal value) =>
 ///         value.ToResult()
 ///             .Ensure(v => v >= -273.15m, 
-///                    Error.Validation("Temperature cannot be below absolute zero"))
+///                    Error.UnprocessableContent.ForField("temperature", "invalid", "Temperature cannot be below absolute zero"))
 ///             .Ensure(v => v <= 1_000_000m,
-///                    Error.Validation("Temperature exceeds physical limits"))
+///                    Error.UnprocessableContent.ForField("temperature", "invalid", "Temperature exceeds physical limits"))
 ///             .Map(v => new Temperature(v));
 ///     
 ///     // Custom equality - round to 2 decimal places
@@ -106,13 +106,13 @@ namespace Trellis;
 ///     private EmailAddress(string value) : base(value) { }
 ///     
 ///     public static Result<EmailAddress> TryCreate(string email) =>
-///         email.ToResult(Error.Validation("Email is required", "email"))
+///         email.ToResult(Error.UnprocessableContent.ForField("email", "invalid", "Email is required"))
 ///             .Ensure(e => !string.IsNullOrWhiteSpace(e),
-///                    Error.Validation("Email cannot be empty", "email"))
+///                    Error.UnprocessableContent.ForField("email", "invalid", "Email cannot be empty"))
 ///             .Ensure(e => e.Contains("@"),
-///                    Error.Validation("Email must contain @", "email"))
+///                    Error.UnprocessableContent.ForField("email", "invalid", "Email must contain @"))
 ///             .Ensure(e => e.Length <= 254,
-///                    Error.Validation("Email too long", "email"))
+///                    Error.UnprocessableContent.ForField("email", "invalid", "Email too long"))
 ///             .Map(e => new EmailAddress(e.Trim().ToLowerInvariant()));
 ///     
 ///     public string Domain => Value.Split('@')[1];

--- a/Trellis.Core/src/DomainDrivenDesign/ValueObject.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/ValueObject.cs
@@ -68,9 +68,9 @@
 ///         string street, string city, string state, string postalCode) =>
 ///         (street, city, state, postalCode).ToResult()
 ///             .Ensure(x => !string.IsNullOrWhiteSpace(x.street), 
-///                    Error.Validation("Street is required"))
+///                    Error.UnprocessableContent.ForField("street", "invalid", "Street is required"))
 ///             .Ensure(x => !string.IsNullOrWhiteSpace(x.city),
-///                    Error.Validation("City is required"))
+///                    Error.UnprocessableContent.ForField("city", "invalid", "City is required"))
 ///             .Map(x => new Address(x.street, x.city, x.state, x.postalCode));
 ///
 ///     // Define what makes two addresses equal
@@ -111,9 +111,9 @@
 ///     
 ///     public static Result&lt;Money&gt; TryCreate(decimal amount, string currency = "USD") =>
 ///         (amount, currency).ToResult()
-///             .Ensure(x => x.amount >= 0, Error.Validation("Amount cannot be negative"))
+///             .Ensure(x => x.amount >= 0, Error.UnprocessableContent.ForField("amount", "invalid", "Amount cannot be negative"))
 ///             .Ensure(x => x.currency.Length == 3, 
-///                    Error.Validation("Currency must be 3-letter ISO code"))
+///                    Error.UnprocessableContent.ForField("currency", "invalid", "Currency must be 3-letter ISO code"))
 ///             .Map(x => new Money(x.amount, x.currency.ToUpperInvariant()));
 ///     
 ///     protected override IEnumerable&lt;IComparable?&gt; GetEqualityComponents()
@@ -125,7 +125,7 @@
 ///     // Domain operations return new instances (immutability)
 ///     public Result&lt;Money&gt; Add(Money other) =>
 ///         Currency != other.Currency
-///             ? Error.Validation($"Cannot add {other.Currency} to {Currency}")
+///             ? Error.UnprocessableContent.ForRule("currency_mismatch", $"Cannot add {other.Currency} to {Currency}")
 ///             : new Money(Amount + other.Amount, Currency).ToResult();
 ///     
 ///     public Money Multiply(decimal factor) =>

--- a/Trellis.Core/src/IScalarValue.cs
+++ b/Trellis.Core/src/IScalarValue.cs
@@ -28,8 +28,8 @@
 ///     private EmailAddress(string value) : base(value) { }
 ///
 ///     public static Result<EmailAddress> TryCreate(string value, string? fieldName = null) =>
-///         value.ToResult(Error.Validation("Email is required", fieldName ?? "email"))
-///             .Ensure(e => e.Contains("@"), Error.Validation("Invalid email", fieldName ?? "email"))
+///         value.ToResult(Error.UnprocessableContent.ForField(fieldName ?? "email", "invalid", "Email is required"))
+///             .Ensure(e => e.Contains("@"), Error.UnprocessableContent.ForField(fieldName ?? "email", "invalid", "Invalid email"))
 ///             .Map(e => new EmailAddress(e));
 /// }
 /// ]]></code>

--- a/Trellis.Core/src/Result/Extensions/CombineTs.g.tt
+++ b/Trellis.Core/src/Result/Extensions/CombineTs.g.tt
@@ -85,7 +85,7 @@ public static partial class CombineExtensions
     /// <code>
     /// var result = FirstName.TryCreate("John")
     ///     .Combine(LastName.TryCreate("Doe"))
-    ///     .Combine(Result.Ensure(age >= 18, Error.Validation("Must be 18+")))
+    ///     .Combine(Result.Ensure(age >= 18, Error.UnprocessableContent.ForField("age", "invalid", "Must be 18+")))
     ///     .Bind((first, last) => CreateUser(first, last, age));
     /// // Age validation must pass, but age is not added to the tuple
     /// </code>

--- a/Trellis.Core/src/Result/Extensions/Debug.cs
+++ b/Trellis.Core/src/Result/Extensions/Debug.cs
@@ -39,7 +39,7 @@ public static class ResultDebugExtensions
     /// <code>
     /// var result = GetUser(id)
     ///     .Debug("After GetUser")
-    ///     .Ensure(u => u.IsActive, Error.Validation("Inactive"))
+    ///     .Ensure(u => u.IsActive, Error.UnprocessableContent.ForRule("inactive", "User is inactive"))
     ///     .Debug("After Ensure")
     ///     .Bind(ProcessUser)
     ///     .Debug("After ProcessUser");

--- a/Trellis.Core/src/Result/Extensions/Ensure.ValueTask.cs
+++ b/Trellis.Core/src/Result/Extensions/Ensure.ValueTask.cs
@@ -13,7 +13,7 @@ using System.Diagnostics;
 /// var ct = cancellationToken;
 /// await result.EnsureAsync(
 ///     value => ValidateAsync(value, ct),
-///     Error.Validation("Invalid")
+///     Error.UnprocessableContent.ForRule("invalid", "Validation failed")
 /// );
 /// </code>
 /// </example>

--- a/Trellis.Core/src/Result/Extensions/Linq.cs
+++ b/Trellis.Core/src/Result/Extensions/Linq.cs
@@ -94,7 +94,7 @@ public static class ResultLinqExtensions
     ///              
     /// // Better: Use Ensure for custom error
     /// var betterResult = GetUser(id)
-    ///     .Ensure(u => u.IsActive, Error.Domain("User is not active"));
+    ///     .Ensure(u => u.IsActive, Error.UnprocessableContent.ForRule("inactive", "User is not active"));
     /// </code>
     /// </example>
     public static Result<TSource> Where<TSource>(this Result<TSource> source, Func<TSource, bool> predicate)

--- a/Trellis.Core/src/Result/Extensions/Linq.cs
+++ b/Trellis.Core/src/Result/Extensions/Linq.cs
@@ -31,7 +31,7 @@ using System.Diagnostics;
 ///     .Bind(firstName => LastName.TryCreate(lastNameInput)
 ///         .Bind(lastName => EmailAddress.TryCreate(emailInput)
 ///             .Ensure(email => email.Value.EndsWith("@company.com"), 
-///                     Error.Validation("Must be company email"))
+///                     Error.UnprocessableContent.ForField("email", "invalid", "Must be company email"))
 ///             .Map(email => new User(firstName, lastName, email))));
 /// </code>
 /// </example>

--- a/Trellis.Core/src/Result/Extensions/MapOnFailure.cs
+++ b/Trellis.Core/src/Result/Extensions/MapOnFailure.cs
@@ -25,11 +25,11 @@ using System.Threading.Tasks;
 /// <code>
 /// // Convert a generic error to a more specific one
 /// var result = GetUser(id)
-///     .MapOnFailure(err => Error.NotFound($"User {id} not found", id));
+///     .MapOnFailure(err => new Error.NotFound(new ResourceRef("User", id.ToString())) { Detail = $"User {id} not found" });
 /// 
 /// // Add context to an error
 /// var result = ValidateEmail(email)
-///     .MapOnFailure(err => Error.UnprocessableContent.ForField("email", "invalid", $"Email validation failed: {(err as Error.UnprocessableContent)?.Fields[0].Detail}"));
+///     .MapOnFailure(err => Error.UnprocessableContent.ForField("email", "invalid", $"Email validation failed: {err.Detail}"));
 /// 
 /// // Async with CancellationToken using closure capture
 /// var ct = cancellationToken;

--- a/Trellis.Core/src/Result/Extensions/MapOnFailure.cs
+++ b/Trellis.Core/src/Result/Extensions/MapOnFailure.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 /// 
 /// // Add context to an error
 /// var result = ValidateEmail(email)
-///     .MapOnFailure(err => Error.Validation($"Email validation failed: {err.Detail}", "email"));
+///     .MapOnFailure(err => Error.UnprocessableContent.ForField("email", "invalid", $"Email validation failed: {(err as Error.UnprocessableContent)?.Fields[0].Detail}"));
 /// 
 /// // Async with CancellationToken using closure capture
 /// var ct = cancellationToken;

--- a/Trellis.Core/src/Result/Extensions/NullableExtensions.cs
+++ b/Trellis.Core/src/Result/Extensions/NullableExtensions.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 /// <code>
 /// // Convert nullable value type to Result
 /// int? maybeAge = GetAge();
-/// var result = maybeAge.ToResult(Error.Validation("Age is required"));
+/// var result = maybeAge.ToResult(Error.UnprocessableContent.ForField("age", "invalid", "Age is required"));
 /// 
 /// // Convert nullable reference type to Result
 /// User? maybeUser = FindUser(id);

--- a/Trellis.Core/src/Result/Extensions/NullableExtensions.cs
+++ b/Trellis.Core/src/Result/Extensions/NullableExtensions.cs
@@ -18,12 +18,12 @@ using System.Diagnostics;
 /// 
 /// // Convert nullable reference type to Result
 /// User? maybeUser = FindUser(id);
-/// var userResult = maybeUser.ToResult(Error.NotFound("User not found", id));
+/// var userResult = maybeUser.ToResult(new Error.NotFound(new ResourceRef("User", id.ToString())) { Detail = "User not found" });
 /// 
 /// // Chain with other Result operations
 /// var validatedResult = GetUser(id)
-///     .ToResult(Error.NotFound("User not found"))
-///     .Ensure(u => u.IsActive, Error.Domain("User is inactive"));
+///     .ToResult(new Error.NotFound(new ResourceRef("User", id.ToString())) { Detail = "User not found" })
+///     .Ensure(u => u.IsActive, Error.UnprocessableContent.ForRule("inactive", "User is inactive"));
 /// </code>
 /// </example>
 [DebuggerStepThrough]

--- a/Trellis.Core/src/Result/Result{TValue}.cs
+++ b/Trellis.Core/src/Result/Result{TValue}.cs
@@ -25,7 +25,7 @@ using System.Diagnostics;
 /// <code>
 /// // Creating results
 /// Result&lt;User&gt; success = Result.Ok(user);
-/// Result&lt;User&gt; failure = Error.NotFound("User not found");
+/// Result&lt;User&gt; failure = new Error.NotFound(new ResourceRef("User", "42")) { Detail = "User not found" };
 /// 
 /// // Pattern matching with Deconstruct
 /// var (isSuccess, value, error) = result;


### PR DESCRIPTION
## Summary

Phase **B-2** of the Tier-3 docs audit. Replaces stale v1 `Error.Validation(...)` references in C# XML doc-comments under `Trellis.Core/src` with the v2 closed-ADT equivalents.

## Mapping

| v1 (stale) | v2 (correct) |
|---|---|
| `Error.Validation(msg)` | `Error.UnprocessableContent.ForRule("invalid", msg)` |
| `Error.Validation(msg, field)` | `Error.UnprocessableContent.ForField(field, "invalid", msg)` |

The machine-readable `reasonCode` (`invalid`) is intentionally generic for these doc-comment examples — the human message is preserved verbatim in `detail`.

## Files touched (12)

- `DDD/Aggregate.cs` (6 hits)
- `DDD/ScalarValueObject.cs` (9 hits)
- `DDD/ValueObject.cs` (5 hits)
- `DDD/Entity.cs`, `DDD/IDomainEvent.cs`, `IScalarValue.cs` (4 hits)
- `Result/Extensions/CombineTs.g.tt` (1 hit, fans out to 7 `.g.cs` partials via T4.Build)
- `Result/Extensions/{Debug,Ensure.ValueTask,Linq,MapOnFailure,NullableExtensions}.cs` (5 hits)

## Verification

- `dotnet build Trellis.slnx -c Release` — 0 warnings, 0 errors
- `dotnet test` — 4916 passed, 15 skipped, 0 failed
- `grep 'Error\.Validation('' Trellis.Core/src/` — 0 matches

## Out of scope

- Markdown sweep (~99 hits) → **Phase B-3** (next sub-PR)
- Historical files (MIGRATION_v3.md, CHANGELOG.md, ADRs) — intentionally describe v1

Follows PR #424 (Phase B-1: deleted dead TRLS006 + TRLS011 analyzers).