### PR TITLE
harden Trellis API reference sync target

### DIFF
--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -21,9 +21,13 @@
     already-imported file paths.
   -->
   <PropertyGroup>
-    <_TrellisApiRefImportKey>;$(MSBuildThisFileFullPath);</_TrellisApiRefImportKey>
+    <!-- Reset on each import; MSBuild properties persist across evaluations,
+         so stale 'true' from a prior duplicate-import would otherwise cause
+         a later first-time import of a different package to be skipped. -->
+    <_TrellisApiRefAlreadyImported></_TrellisApiRefAlreadyImported>
+    <_TrellisApiRefImportKey>;$(MSBuildThisFileFullPath.ToLowerInvariant());</_TrellisApiRefImportKey>
     <_TrellisApiRefAlreadyImported Condition="'$(_TrellisApiReferenceTargetsImported)' != '' AND $([System.String]::Copy(';$(_TrellisApiReferenceTargetsImported);').Contains('$(_TrellisApiRefImportKey)'))">true</_TrellisApiRefAlreadyImported>
-    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">$(_TrellisApiReferenceTargetsImported);$(MSBuildThisFileFullPath)</_TrellisApiReferenceTargetsImported>
+    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">$(_TrellisApiReferenceTargetsImported);$(MSBuildThisFileFullPath.ToLowerInvariant())</_TrellisApiReferenceTargetsImported>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">
@@ -47,18 +51,33 @@
     <_Tp3>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp2)', '..'))))</_Tp3>
     <_Tp4>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp3)', '..'))))</_Tp4>
     <_Tp5>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp4)', '..'))))</_Tp5>
+    <_Tp6>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp5)', '..'))))</_Tp6>
+    <_Tp7>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp6)', '..'))))</_Tp7>
+    <_Tp8>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp7)', '..'))))</_Tp8>
+    <_Tp9>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp8)', '..'))))</_Tp9>
+    <_Tp10>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(_Tp9)', '..'))))</_Tp10>
     <_Tp0Git>$([System.IO.Path]::Combine('$(_Tp0)', '.git'))</_Tp0Git>
     <_Tp1Git>$([System.IO.Path]::Combine('$(_Tp1)', '.git'))</_Tp1Git>
     <_Tp2Git>$([System.IO.Path]::Combine('$(_Tp2)', '.git'))</_Tp2Git>
     <_Tp3Git>$([System.IO.Path]::Combine('$(_Tp3)', '.git'))</_Tp3Git>
     <_Tp4Git>$([System.IO.Path]::Combine('$(_Tp4)', '.git'))</_Tp4Git>
     <_Tp5Git>$([System.IO.Path]::Combine('$(_Tp5)', '.git'))</_Tp5Git>
+    <_Tp6Git>$([System.IO.Path]::Combine('$(_Tp6)', '.git'))</_Tp6Git>
+    <_Tp7Git>$([System.IO.Path]::Combine('$(_Tp7)', '.git'))</_Tp7Git>
+    <_Tp8Git>$([System.IO.Path]::Combine('$(_Tp8)', '.git'))</_Tp8Git>
+    <_Tp9Git>$([System.IO.Path]::Combine('$(_Tp9)', '.git'))</_Tp9Git>
+    <_Tp10Git>$([System.IO.Path]::Combine('$(_Tp10)', '.git'))</_Tp10Git>
     <_TrellisRepoRoot Condition="Exists('$(_Tp0Git)')">$(_Tp0)</_TrellisRepoRoot>
     <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp1Git)')">$(_Tp1)</_TrellisRepoRoot>
     <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp2Git)')">$(_Tp2)</_TrellisRepoRoot>
     <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp3Git)')">$(_Tp3)</_TrellisRepoRoot>
     <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp4Git)')">$(_Tp4)</_TrellisRepoRoot>
     <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp5Git)')">$(_Tp5)</_TrellisRepoRoot>
+    <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp6Git)')">$(_Tp6)</_TrellisRepoRoot>
+    <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp7Git)')">$(_Tp7)</_TrellisRepoRoot>
+    <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp8Git)')">$(_Tp8)</_TrellisRepoRoot>
+    <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp9Git)')">$(_Tp9)</_TrellisRepoRoot>
+    <_TrellisRepoRoot Condition="'$(_TrellisRepoRoot)' == '' AND Exists('$(_Tp10Git)')">$(_Tp10)</_TrellisRepoRoot>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -76,7 +95,7 @@
   <Target Name="_CopyTrellisApiReference"
           BeforeTargets="Build"
           Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
-    <Message Text="Trellis API references not copied: .git not found within 6 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
+    <Message Text="Trellis API references not copied: .git not found within 11 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
              Importance="Low"
              Condition="'$(_TrellisApiOutputDir)' == ''" />
     <MakeDir Directories="$(_TrellisApiOutputDir)"

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Shared targets file packed into each Trellis NuGet package.
     Declares TrellisApiReference items pointing to the API reference markdown
@@ -9,7 +9,19 @@
     Set TrellisDisableApiReferenceSync=true to disable automatic sync.
     Manual sync: dotnet build /t:TrellisSyncApiReference
   -->
-  <ItemGroup>
+
+  <!--
+    Idempotency guard. NuGet imports build/<id>.targets for direct refs and
+    buildTransitive/<id>.targets for transitive refs; we ship both so direct
+    consumers always get the sync. If the same package is imported through
+    both paths (or imported twice for any other reason), this guard prevents
+    duplicate TrellisApiReference items and target re-registration.
+  -->
+  <PropertyGroup>
+    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiReferenceTargetsImported)' == ''">$(MSBuildThisFileFullPath)</_TrellisApiReferenceTargetsImported>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_TrellisApiReferenceTargetsImported)' == '$(MSBuildThisFileFullPath)'">
     <TrellisApiReference Include="$(MSBuildThisFileDirectory)..\trellis\*.md" />
   </ItemGroup>
 
@@ -46,26 +58,47 @@
 
   <PropertyGroup>
     <_TrellisApiOutputDir Condition="'$(_TrellisRepoRoot)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::Combine('$(_TrellisRepoRoot)', '.github'))))</_TrellisApiOutputDir>
+    <!-- Stamp file used as Outputs to make this target incremental and reduce
+         contention when multiple projects build in parallel. -->
+    <_TrellisApiSyncStamp Condition="'$(_TrellisApiOutputDir)' != ''">$(IntermediateOutputPath)trellis-api-sync.stamp</_TrellisApiSyncStamp>
   </PropertyGroup>
 
   <Target Name="_CopyTrellisApiReference"
           BeforeTargets="Build"
+          Inputs="@(TrellisApiReference)"
+          Outputs="$(_TrellisApiSyncStamp)"
           Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
     <Message Text="Trellis API references not copied: .git not found within 6 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
              Importance="Low"
              Condition="'$(_TrellisApiOutputDir)' == ''" />
     <MakeDir Directories="$(_TrellisApiOutputDir)"
+             ContinueOnError="WarnAndContinue"
              Condition="'$(_TrellisApiOutputDir)' != '' AND !Exists('$(_TrellisApiOutputDir)')" />
     <Copy SourceFiles="@(TrellisApiReference)"
           DestinationFolder="$(_TrellisApiOutputDir)"
           SkipUnchangedFiles="true"
+          Retries="3"
+          RetryDelayMilliseconds="200"
+          ContinueOnError="WarnAndContinue"
           Condition="'$(_TrellisApiOutputDir)' != ''" />
+    <!-- Touch the stamp so subsequent builds skip when inputs are unchanged. -->
+    <MakeDir Directories="$(IntermediateOutputPath)"
+             Condition="'$(_TrellisApiSyncStamp)' != '' AND !Exists('$(IntermediateOutputPath)')" />
+    <Touch Files="$(_TrellisApiSyncStamp)"
+           AlwaysCreate="true"
+           ContinueOnError="WarnAndContinue"
+           Condition="'$(_TrellisApiSyncStamp)' != ''" />
   </Target>
 
   <!--
     Manual invocation: dotnet build /t:TrellisSyncApiReference
-    Copies API reference files without running a full build.
+    Copies API reference files without running a full build. Forces re-sync
+    by deleting the stamp file first so Inputs/Outputs incremental skip
+    doesn't short-circuit a deliberate sync request.
   -->
-  <Target Name="TrellisSyncApiReference"
-          DependsOnTargets="_CopyTrellisApiReference" />
+  <Target Name="TrellisSyncApiReference">
+    <Delete Files="$(_TrellisApiSyncStamp)"
+            Condition="'$(_TrellisApiSyncStamp)' != '' AND Exists('$(_TrellisApiSyncStamp)')" />
+    <CallTarget Targets="_CopyTrellisApiReference" />
+  </Target>
 </Project>

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -50,9 +50,12 @@
 
   <Target Name="_CopyTrellisApiReference"
           BeforeTargets="Build"
-          Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true'">
-    <Warning Text="Trellis API references not copied: .git not found within 6 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
+          Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
+    <Message Text="Trellis API references not copied: .git not found within 6 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
+             Importance="Low"
              Condition="'$(_TrellisApiOutputDir)' == ''" />
+    <MakeDir Directories="$(_TrellisApiOutputDir)"
+             Condition="'$(_TrellisApiOutputDir)' != '' AND !Exists('$(_TrellisApiOutputDir)')" />
     <Copy SourceFiles="@(TrellisApiReference)"
           DestinationFolder="$(_TrellisApiOutputDir)"
           SkipUnchangedFiles="true"

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -11,26 +11,20 @@
   -->
 
   <!--
-    Idempotency guard, keyed on this targets file's full path. Each Trellis
-    package ships its own renamed copy (build/<PackageId>.targets and
-    buildTransitive/<PackageId>.targets), so we must allow every distinct
-    package to register its own TrellisApiReference items, but block the
-    case where the same package's targets file is imported twice (e.g. via
-    both build/ and buildTransitive/ assets, or a re-evaluation pass).
-    _TrellisApiReferenceTargetsImported is a semicolon-separated list of
-    already-imported file paths.
-  -->
-  <PropertyGroup>
-    <!-- Reset on each import; MSBuild properties persist across evaluations,
-         so stale 'true' from a prior duplicate-import would otherwise cause
-         a later first-time import of a different package to be skipped. -->
-    <_TrellisApiRefAlreadyImported></_TrellisApiRefAlreadyImported>
-    <_TrellisApiRefImportKey>;$(MSBuildThisFileFullPath.ToLowerInvariant());</_TrellisApiRefImportKey>
-    <_TrellisApiRefAlreadyImported Condition="'$(_TrellisApiReferenceTargetsImported)' != '' AND $([System.String]::Copy(';$(_TrellisApiReferenceTargetsImported);').Contains('$(_TrellisApiRefImportKey)'))">true</_TrellisApiRefAlreadyImported>
-    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">$(_TrellisApiReferenceTargetsImported);$(MSBuildThisFileFullPath.ToLowerInvariant())</_TrellisApiReferenceTargetsImported>
-  </PropertyGroup>
+    Each Trellis package ships this targets file at both build/<PackageId>.targets
+    and buildTransitive/<PackageId>.targets. NuGet may import either or both
+    depending on whether the package is referenced directly, transitively, or
+    both, so this file can run multiple times per package and once per package
+    in a multi-package solution.
 
-  <ItemGroup Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">
+    We declare TrellisApiReference items unconditionally and dedupe at copy
+    time by canonical %(FullPath). PropertyGroup-based "already imported"
+    guards do NOT work for ItemGroup conditions: MSBuild evaluates all
+    PropertyGroups across all imports first, then all ItemGroups, so any
+    ItemGroup condition would see the final property value, not the per-import
+    value.
+  -->
+  <ItemGroup>
     <TrellisApiReference Include="$(MSBuildThisFileDirectory)..\trellis\*.md" />
   </ItemGroup>
 
@@ -91,17 +85,25 @@
     obj/, and would not actually reduce contention across projects.)
     Retries on Copy handle the residual race when two projects in a parallel
     solution build write the same file at the same instant.
+
+    %(FullPath) canonicalizes paths like "build\..\trellis\x.md" and
+    "buildTransitive\..\trellis\x.md" to the same absolute path, so
+    KeepDuplicates="false" collapses the build/ vs buildTransitive/ pickups
+    of the same package to a single Copy.
   -->
   <Target Name="_CopyTrellisApiReference"
           BeforeTargets="Build"
           Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
+    <ItemGroup>
+      <_TrellisApiReferenceUnique Include="@(TrellisApiReference->'%(FullPath)')" KeepDuplicates="false" />
+    </ItemGroup>
     <Message Text="Trellis API references not copied: .git not found within 11 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
              Importance="Low"
              Condition="'$(_TrellisApiOutputDir)' == ''" />
     <MakeDir Directories="$(_TrellisApiOutputDir)"
              ContinueOnError="WarnAndContinue"
              Condition="'$(_TrellisApiOutputDir)' != '' AND !Exists('$(_TrellisApiOutputDir)')" />
-    <Copy SourceFiles="@(TrellisApiReference)"
+    <Copy SourceFiles="@(_TrellisApiReferenceUnique)"
           DestinationFolder="$(_TrellisApiOutputDir)"
           SkipUnchangedFiles="true"
           Retries="3"

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -11,17 +11,22 @@
   -->
 
   <!--
-    Idempotency guard. NuGet imports build/<id>.targets for direct refs and
-    buildTransitive/<id>.targets for transitive refs; we ship both so direct
-    consumers always get the sync. If the same package is imported through
-    both paths (or imported twice for any other reason), this guard prevents
-    duplicate TrellisApiReference items and target re-registration.
+    Idempotency guard, keyed on this targets file's full path. Each Trellis
+    package ships its own renamed copy (build/<PackageId>.targets and
+    buildTransitive/<PackageId>.targets), so we must allow every distinct
+    package to register its own TrellisApiReference items, but block the
+    case where the same package's targets file is imported twice (e.g. via
+    both build/ and buildTransitive/ assets, or a re-evaluation pass).
+    _TrellisApiReferenceTargetsImported is a semicolon-separated list of
+    already-imported file paths.
   -->
   <PropertyGroup>
-    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiReferenceTargetsImported)' == ''">$(MSBuildThisFileFullPath)</_TrellisApiReferenceTargetsImported>
+    <_TrellisApiRefImportKey>;$(MSBuildThisFileFullPath);</_TrellisApiRefImportKey>
+    <_TrellisApiRefAlreadyImported Condition="'$(_TrellisApiReferenceTargetsImported)' != '' AND $([System.String]::Copy(';$(_TrellisApiReferenceTargetsImported);').Contains('$(_TrellisApiRefImportKey)'))">true</_TrellisApiRefAlreadyImported>
+    <_TrellisApiReferenceTargetsImported Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">$(_TrellisApiReferenceTargetsImported);$(MSBuildThisFileFullPath)</_TrellisApiReferenceTargetsImported>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(_TrellisApiReferenceTargetsImported)' == '$(MSBuildThisFileFullPath)'">
+  <ItemGroup Condition="'$(_TrellisApiRefAlreadyImported)' != 'true'">
     <TrellisApiReference Include="$(MSBuildThisFileDirectory)..\trellis\*.md" />
   </ItemGroup>
 
@@ -58,15 +63,18 @@
 
   <PropertyGroup>
     <_TrellisApiOutputDir Condition="'$(_TrellisRepoRoot)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::Combine('$(_TrellisRepoRoot)', '.github'))))</_TrellisApiOutputDir>
-    <!-- Stamp file used as Outputs to make this target incremental and reduce
-         contention when multiple projects build in parallel. -->
-    <_TrellisApiSyncStamp Condition="'$(_TrellisApiOutputDir)' != ''">$(IntermediateOutputPath)trellis-api-sync.stamp</_TrellisApiSyncStamp>
   </PropertyGroup>
 
+  <!--
+    SkipUnchangedFiles="true" makes the Copy a no-op when destinations are
+    up-to-date, so we don't need an Inputs/Outputs stamp file. (A per-project
+    obj/ stamp would also go stale if .github/ is cleaned independently of
+    obj/, and would not actually reduce contention across projects.)
+    Retries on Copy handle the residual race when two projects in a parallel
+    solution build write the same file at the same instant.
+  -->
   <Target Name="_CopyTrellisApiReference"
           BeforeTargets="Build"
-          Inputs="@(TrellisApiReference)"
-          Outputs="$(_TrellisApiSyncStamp)"
           Condition="'@(TrellisApiReference)' != '' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
     <Message Text="Trellis API references not copied: .git not found within 6 levels of $(MSBuildProjectDirectory). Set TrellisApiReferenceRoot to override."
              Importance="Low"
@@ -81,24 +89,12 @@
           RetryDelayMilliseconds="200"
           ContinueOnError="WarnAndContinue"
           Condition="'$(_TrellisApiOutputDir)' != ''" />
-    <!-- Touch the stamp so subsequent builds skip when inputs are unchanged. -->
-    <MakeDir Directories="$(IntermediateOutputPath)"
-             Condition="'$(_TrellisApiSyncStamp)' != '' AND !Exists('$(IntermediateOutputPath)')" />
-    <Touch Files="$(_TrellisApiSyncStamp)"
-           AlwaysCreate="true"
-           ContinueOnError="WarnAndContinue"
-           Condition="'$(_TrellisApiSyncStamp)' != ''" />
   </Target>
 
   <!--
     Manual invocation: dotnet build /t:TrellisSyncApiReference
-    Copies API reference files without running a full build. Forces re-sync
-    by deleting the stamp file first so Inputs/Outputs incremental skip
-    doesn't short-circuit a deliberate sync request.
+    Copies API reference files without running a full build.
   -->
-  <Target Name="TrellisSyncApiReference">
-    <Delete Files="$(_TrellisApiSyncStamp)"
-            Condition="'$(_TrellisApiSyncStamp)' != '' AND Exists('$(_TrellisApiSyncStamp)')" />
-    <CallTarget Targets="_CopyTrellisApiReference" />
-  </Target>
+  <Target Name="TrellisSyncApiReference"
+          DependsOnTargets="_CopyTrellisApiReference" />
 </Project>


### PR DESCRIPTION
Mirror of ServiceLevelIndicators#59. Same bugs apply to this targets
file because it's the original that was copied into the SLI repo.

- Downgrade <Warning> to <Message Importance="Low"> so consumers with
  TreatWarningsAsErrors don't fail when .git can't be located.
- Add MakeDir before Copy so the destination .github folder is created
  on first run instead of failing the build.
- Skip the sync during DesignTimeBuild and BuildingForLiveUnitTesting
  to avoid surprise file writes from IDE/test-explorer background builds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
