### PR TITLE
docs(api-reference): make canonical examples value-object-first

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -1,4 +1,4 @@
-# Trellis.Authorization — API Reference
+﻿# Trellis.Authorization — API Reference
 
 **Package:** `Trellis.Authorization`
 **Namespace:** `Trellis.Authorization`
@@ -188,7 +188,9 @@ A single loader shared across every command that authorizes against the same `TR
 using Trellis;
 using Trellis.Authorization;
 
-public sealed record DeleteOrderCommand(string OrderId) : ICommand<Result>, IAuthorize
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+
+public sealed record DeleteOrderCommand(OrderId OrderId) : ICommand<Result>, IAuthorize
 {
     public IReadOnlyList<string> RequiredPermissions { get; } = ["orders:delete"];
 }
@@ -196,29 +198,39 @@ public sealed record DeleteOrderCommand(string OrderId) : ICommand<Result>, IAut
 
 ### Resource-based authorization with a shared loader
 
+> **Preferred in generated services.** Use `IIdentifyResource<TResource, TId>` + `SharedResourceLoaderById<TResource, TId>` for resource authorization. A per-command `IResourceLoader<TMessage, TResource>` is an escape hatch for request-scoped state or command-specific load logic.
+
 ```csharp
 using Trellis;
 using Trellis.Authorization;
 
-public sealed record Order(string Id, string OwnerId);
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+public sealed partial class ActorId : RequiredString<ActorId>;
 
-public sealed record CancelOrderCommand(string OrderId)
-    : ICommand<Result>, IAuthorizeResource<Order>, IIdentifyResource<Order, string>
+public sealed record Order(OrderId Id, ActorId OwnerId);
+
+public sealed record CancelOrderCommand(OrderId OrderId)
+    : ICommand<Result>, IAuthorizeResource<Order>, IIdentifyResource<Order, OrderId>
 {
-    public string GetResourceId() => OrderId;
+    public OrderId GetResourceId() => OrderId;
 
     public IResult Authorize(Actor actor, Order order) =>
-        actor.IsOwner(order.OwnerId) || actor.HasPermission("orders:cancel-any")
+        order.OwnerId.Value == actor.Id || actor.HasPermission("orders:cancel-any")
             ? Result.Ok()
             : Result.Fail(new Error.Forbidden("orders.cancel")
                 { Detail = "Only the owner can cancel this order." });
 }
 
-public sealed class OrderResourceLoader(IOrderRepository repo)
-    : SharedResourceLoaderById<Order, string>
+public interface IOrderRepository
 {
-    public override Task<Result<Order>> GetByIdAsync(string id, CancellationToken ct) =>
-        repo.GetByIdAsync(id, ct);
+    Task<Maybe<Order>> GetByIdAsync(OrderId id, CancellationToken ct);
+}
+
+public sealed class OrderResourceLoader(IOrderRepository repo)
+    : SharedResourceLoaderById<Order, OrderId>
+{
+    public override async Task<Result<Order>> GetByIdAsync(OrderId id, CancellationToken ct) =>
+        (await repo.GetByIdAsync(id, ct)).ToResult(new Error.NotFound(ResourceRef.For<Order>(id)));
 }
 ```
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -153,22 +153,36 @@ public sealed partial class CurrencyCode : RequiredString<CurrencyCode>;
 ```csharp
 using FluentValidation;
 using Mediator;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis;
+using Trellis.Asp;
 using Trellis.EntityFrameworkCore;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
+using Trellis.Primitives;
 
-public sealed record PlaceOrderCommand(Guid OrderId, decimal Amount, string Currency)
-    : ICommand<Result<OrderId>>;
+public sealed record PlaceOrderRequest(Guid OrderId, decimal Amount, string Currency);
+
+public sealed record PlaceOrderCommand(OrderId OrderId, Money Total)
+    : ICommand<Result<OrderId>>
+{
+    public static Result<PlaceOrderCommand> TryCreate(PlaceOrderRequest request) =>
+        Result.Combine(
+                OrderId.TryCreate(request.OrderId, nameof(request.OrderId)),
+                MonetaryAmount.TryCreate(request.Amount, nameof(request.Amount)),
+                CurrencyCode.TryCreate(request.Currency, nameof(request.Currency)))
+            .Map((orderId, amount, currency) =>
+                new PlaceOrderCommand(orderId, Money.Create(amount.Value, currency.Value)));
+}
 
 public sealed class PlaceOrderValidator : AbstractValidator<PlaceOrderCommand>
 {
     public PlaceOrderValidator()
     {
-        RuleFor(x => x.OrderId).NotEmpty();
-        RuleFor(x => x.Amount).GreaterThan(0);
-        RuleFor(x => x.Currency).Length(3);
+        RuleFor(x => x.Total.Amount)
+            .LessThanOrEqualTo(10_000m)
+            .WithMessage("Orders over 10,000 require manual approval.");
     }
 }
 
@@ -176,12 +190,22 @@ public sealed class PlaceOrderHandler(IOrderRepository repo)
     : ICommandHandler<PlaceOrderCommand, Result<OrderId>>
 {
     public ValueTask<Result<OrderId>> Handle(PlaceOrderCommand cmd, CancellationToken cancellationToken) =>
-        OrderId.TryCreate(cmd.OrderId)
-            .BindZip(_ => CurrencyCode.TryCreate(cmd.Currency).Map(c => new Money(cmd.Amount, c)))
-            .Bind((orderId, money) => Order.Create(orderId, money))
+        Order.Create(cmd.OrderId, cmd.Total)
             .Tap(repo.Add)
             .Map(o => o.Id)
             .AsValueTask();
+}
+
+[ApiController]
+[Route("orders")]
+public sealed class OrdersController(ISender sender) : ControllerBase
+{
+    [HttpPost]
+    public ValueTask<ActionResult<OrderId>> Place([FromBody] PlaceOrderRequest request, CancellationToken ct) =>
+        PlaceOrderCommand.TryCreate(request)
+            .BindAsync(command => sender.Send(command, ct))
+            .ToHttpResponseAsync()
+            .AsActionResultAsync<OrderId>();
 }
 
 // Composition root
@@ -196,7 +220,9 @@ public static class OrdersDi
 }
 ```
 
-**What it shows.** The mediator pipeline already runs `ValidationBehavior<TMessage, TResponse>` before the handler — `AddTrellisFluentValidation` plugs every `IValidator<T>` into it via the open-generic `IMessageValidator<T>` adapter. `AddTrellisUnitOfWork<TContext>` registers `TransactionalCommandBehavior<,>` *after* the others, so it lands innermost and commits only when the handler returns success. The handler itself is pure: no `try`/`catch`, no `await db.SaveChangesAsync()` — that's the unit of work's job.
+**What it shows.** The mediator pipeline already runs `ValidationBehavior<TMessage, TResponse>` before the handler — `AddTrellisFluentValidation` plugs every `IValidator<T>` into it via the open-generic `IMessageValidator<T>` adapter. `AddTrellisUnitOfWork<TContext>` registers `TransactionalCommandBehavior<,>` *after* the others, so it lands innermost and commits only when the handler returns success. The handler itself is pure: no `try`/`catch`, no primitive parsing, no `await db.SaveChangesAsync()` — that's the unit of work's job.
+
+> **Validation ownership.** Primitive→VO conversion happens at the transport seam. FluentValidation validates VO-shaped commands for cross-field rules and business invariants. Handlers receive value-object-shaped commands and must not parse primitives. See [Recipe 18](#recipe-18--dto-primitives-to-value-object-command-no-test-only-unwrap) for the canonical controller-seam adapter.
 
 **Anti-pattern → fix (TRLS010).**
 
@@ -222,6 +248,7 @@ public static class OrdersDi
 ```csharp
 using Trellis;
 
+// Paging cursor and limit are protocol/query-string controls validated at the transport seam.
 public sealed record ListOrdersQuery(string? Cursor, int Limit) : IQuery<Result<Page<OrderListItem>>>;
 
 public sealed record OrderListItem(Guid Id, decimal Amount, string Currency);
@@ -284,7 +311,10 @@ var app = builder.Build();
 
 app.MapGet("/orders/{id:guid}", async (Guid id, IMediator mediator, CancellationToken ct) =>
 {
-    Result<Order> result = await mediator.Send(new GetOrderQuery(id), ct);
+    Result<OrderId> orderId = OrderId.TryCreate(id, nameof(id));
+    if (!orderId.IsSuccess) return orderId.Error.ToHttpResponse();
+
+    Result<Order> result = await mediator.Send(new GetOrderQuery(orderId.Value), ct);
 
     return result.ToHttpResponse(opts => opts
         .WithETag(o => o.ETag)                         // strong ETag from aggregate
@@ -316,7 +346,10 @@ public sealed class OrdersController(IMediator mediator) : ControllerBase
     [HttpGet("{id:guid}")]
     public async Task<ActionResult<OrderDto>> Get(Guid id, CancellationToken ct)
     {
-        Result<Order> result = await mediator.Send(new GetOrderQuery(id), ct);
+        Result<OrderId> orderId = OrderId.TryCreate(id, nameof(id));
+        if (!orderId.IsSuccess) return orderId.Error.ToHttpResponse().AsActionResult<OrderDto>();
+
+        Result<Order> result = await mediator.Send(new GetOrderQuery(orderId.Value), ct);
 
         return result
             .ToHttpResponse(
@@ -382,7 +415,7 @@ public sealed record DeleteOrderCommand(OrderId OrderId) : ICommand<Result>, IAu
     public IReadOnlyList<string> RequiredPermissions => ["orders:delete"];
 }
 
-public sealed record UpdateOrderCommand(OrderId OrderId, decimal NewAmount)
+public sealed record UpdateOrderCommand(OrderId OrderId, Money NewTotal)
     : ICommand<Result>, IAuthorizeResource<Order>, IIdentifyResource<Order, OrderId>
 {
     // Typed VO carried straight through — no parse, no throw.
@@ -591,6 +624,7 @@ unproc.Rules.Should().ContainSingle().Which.ReasonCode.Should().Be("state.machin
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis;
+using Trellis.Primitives;
 using Trellis.Testing;
 using Xunit;
 
@@ -602,22 +636,22 @@ public class PlaceOrderHandlerTests
         var repo = new InMemoryOrderRepository();
         var sut  = new PlaceOrderHandler(repo);
 
-        var result = await sut.Handle(
-            new PlaceOrderCommand(Guid.NewGuid(), 100m, "USD"),
-            CancellationToken.None);
+        var command = new PlaceOrderCommand(
+            OrderId.TryCreate(Guid.NewGuid()).Unwrap(),
+            Money.TryCreate(100m, "USD").Unwrap());
+
+        var result = await sut.Handle(command, CancellationToken.None);
 
         result.Should().BeSuccess();
         result.Should().HaveValue(repo.Last().Id);                  // structural equality on Result<T>
     }
 
     [Fact]
-    public async Task PlaceOrder_fails_with_validation_when_currency_invalid()
+    public void PlaceOrder_request_adapter_fails_when_currency_invalid()
     {
-        var sut = new PlaceOrderHandler(new InMemoryOrderRepository());
+        var request = new PlaceOrderRequest(Guid.NewGuid(), 100m, "US"); // 2 chars, not 3
 
-        var result = await sut.Handle(
-            new PlaceOrderCommand(Guid.NewGuid(), 100m, "US"),       // 2 chars, not 3
-            CancellationToken.None);
+        var result = PlaceOrderCommand.TryCreate(request);
 
         result.Should().BeFailureOfType<Error.UnprocessableContent>()
             .Which.Should().HaveFieldError("currency");

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -311,10 +311,10 @@ var app = builder.Build();
 
 app.MapGet("/orders/{id:guid}", async (Guid id, IMediator mediator, CancellationToken ct) =>
 {
-    Result<OrderId> orderId = OrderId.TryCreate(id, nameof(id));
-    if (!orderId.IsSuccess) return orderId.Error.ToHttpResponse();
+    if (!OrderId.TryCreate(id, nameof(id)).TryGetValue(out var orderId, out var idError))
+        return idError.ToHttpResponse();
 
-    Result<Order> result = await mediator.Send(new GetOrderQuery(orderId.Value), ct);
+    Result<Order> result = await mediator.Send(new GetOrderQuery(orderId), ct);
 
     return result.ToHttpResponse(opts => opts
         .WithETag(o => o.ETag)                         // strong ETag from aggregate
@@ -346,10 +346,10 @@ public sealed class OrdersController(IMediator mediator) : ControllerBase
     [HttpGet("{id:guid}")]
     public async Task<ActionResult<OrderDto>> Get(Guid id, CancellationToken ct)
     {
-        Result<OrderId> orderId = OrderId.TryCreate(id, nameof(id));
-        if (!orderId.IsSuccess) return orderId.Error.ToHttpResponse().AsActionResult<OrderDto>();
+        if (!OrderId.TryCreate(id, nameof(id)).TryGetValue(out var orderId, out var idError))
+            return idError.ToHttpResponse().AsActionResult<OrderDto>();
 
-        Result<Order> result = await mediator.Send(new GetOrderQuery(orderId.Value), ct);
+        Result<Order> result = await mediator.Send(new GetOrderQuery(orderId), ct);
 
         return result
             .ToHttpResponse(
@@ -409,6 +409,7 @@ app.MapGet("/blobs/{id:guid}", async (Guid id, HttpRequest req, IBlobRepository 
 using Trellis;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
+using Trellis.Primitives;
 
 public sealed record DeleteOrderCommand(OrderId OrderId) : ICommand<Result>, IAuthorize
 {

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -307,6 +307,7 @@ services.AddScoped<IActorProvider, StaticActorProvider>();
 services.AddScoped<SharedResourceLoaderById<Order, OrderId>, OrderResourceLoader>();
 services.AddTrellisBehaviors();
 services.AddResourceAuthorization<GetOrderQuery, Order, Result<Order>>();
+services.AddSharedResourceLoader<GetOrderQuery, Order, OrderId>();
 
 var behaviorOrder = Trellis.Mediator.ServiceCollectionExtensions.PipelineBehaviors;
 Console.WriteLine(string.Join(", ", behaviorOrder.Select(type => type.Name)));

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -287,7 +287,7 @@ The Trellis pipeline executes outermost → innermost in this order. The first f
 
 ## Code examples
 
-### Registering behaviors and explicit resource authorization
+### Registering behaviors and shared resource authorization
 
 ```csharp
 using System;
@@ -304,36 +304,41 @@ using Trellis.Mediator;
 var services = new ServiceCollection();
 
 services.AddScoped<IActorProvider, StaticActorProvider>();
-services.AddScoped<IResourceLoader<GetOrderQuery, Order>, GetOrderResourceLoader>();
+services.AddScoped<SharedResourceLoaderById<Order, OrderId>, OrderResourceLoader>();
 services.AddTrellisBehaviors();
 services.AddResourceAuthorization<GetOrderQuery, Order, Result<Order>>();
 
 var behaviorOrder = Trellis.Mediator.ServiceCollectionExtensions.PipelineBehaviors;
 Console.WriteLine(string.Join(", ", behaviorOrder.Select(type => type.Name)));
 
-public sealed record Order(string Id, string OwnerId);
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+public sealed partial class ActorId : RequiredString<ActorId>;
 
-public sealed record GetOrderQuery(string Id)
-    : IQuery<Result<Order>>, IAuthorize, IAuthorizeResource<Order>, IValidate
+public sealed record Order(OrderId Id, ActorId OwnerId);
+
+public sealed record GetOrderQuery(OrderId Id)
+    : IQuery<Result<Order>>, IAuthorize, IAuthorizeResource<Order>, IIdentifyResource<Order, OrderId>, IValidate
 {
     public IReadOnlyList<string> RequiredPermissions => ["orders:read"];
 
-    public IResult Validate() =>
-        string.IsNullOrWhiteSpace(Id)
-            ? Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(Id)), "required") { Detail = "Order ID is required." })))
-            : Result.Ok();
+    public OrderId GetResourceId() => Id;
+
+    public IResult Validate() => Result.Ok();
 
     public IResult Authorize(Actor actor, Order resource) =>
-        actor.IsOwner(resource.OwnerId)
+        resource.OwnerId.Value == actor.Id
             ? Result.Ok()
             : Result.Fail(new Error.Forbidden("orders.read") { Detail = "Only the owner can view the order." });
 }
 
-public sealed class GetOrderResourceLoader : IResourceLoader<GetOrderQuery, Order>
+public sealed class OrderResourceLoader : SharedResourceLoaderById<Order, OrderId>
 {
-    public Task<Result<Order>> LoadAsync(GetOrderQuery message, CancellationToken cancellationToken) =>
-        Task.FromResult(Result.Ok(new Order(message.Id, "user-1")));
+    public override Task<Result<Order>> GetByIdAsync(OrderId id, CancellationToken cancellationToken) =>
+        Task.FromResult(ActorId.TryCreate("user-1").Map(ownerId => new Order(id, ownerId)));
 }
+
+// Escape hatch: prefer IIdentifyResource<TResource, TId> + SharedResourceLoaderById<TResource, TId> in generated services.
+// services.AddScoped<IResourceLoader<GetOrderQuery, Order>, GetOrderResourceLoader>();
 
 public sealed class StaticActorProvider : IActorProvider
 {


### PR DESCRIPTION
Closes two BACKLOG items: AI reference examples uniformly follow strict template VO-first conventions, and decision points have 'Preferred in generated services' callouts.

## Changes

- **authorization.md**: Resource-auth example uses OrderId/ActorId VOs and SharedResourceLoaderById<Order, OrderId>; added 'Preferred in generated services' callout for shared loader.
- **cookbook.md Recipe 2**: Rewritten to PlaceOrderCommand(OrderId, Money) with controller-seam adapter (per-field TryCreate + Combine); validator validates VO shape; handler is pure; tests use Unwrap(); added validation-ownership callout. Recipes 4/5 endpoints now lift Guid id -> OrderId.TryCreate before send. Recipe 3 ListOrdersQuery labeled as wire-only paging controls. UpdateOrderCommand.NewAmount -> Money NewTotal.
- **mediator.md**: GetOrderQuery example uses OrderId VO + IIdentifyResource + SharedResourceLoaderById; per-command IResourceLoader registration kept as commented escape hatch.

## Verification (grep on api_reference/)
- Zero primitive-shaped commands/queries (only labeled ListOrdersQuery paging case)
- Only IResourceLoader<…> reference is the labeled escape-hatch comment in mediator.md
- Zero BindZip(_ => …TryCreate(cmd.…)) anti-patterns
- Authored by GPT-5.5 sub-agent; reviewed by Claude Opus 4.7.