### PR TITLE
Add TRLS022 OwnedEntity init-only property analyzer (B3)

### DIFF
--- a/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
+++ b/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
@@ -24,3 +24,4 @@ TRLS018  | Trellis  | Warning  | Result<T> deconstruction reads value without a 
 TRLS019  | Trellis  | Warning  | Avoid default(Result), default(Result<T>), and default(Maybe<T>); prefer factories.
 TRLS020  | Trellis  | Warning  | Composite value object DTO property is missing CompositeValueObjectJsonConverter<T>.
 TRLS021  | Trellis  | Warning  | EF configuration duplicates Trellis conventions for Maybe<T> or [OwnedEntity].
+TRLS022  | Trellis  | Warning  | [OwnedEntity] property uses init-only setter; use { get; private set; } instead.

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -299,4 +299,19 @@ public static class DiagnosticDescriptors
         description: "When ApplyTrellisConventions or ApplyTrellisConventionsFor<TContext>() is wired, manual HasConversion, OwnsOne, or Ignore configuration for Maybe<T> and [OwnedEntity] properties can override or conflict with Trellis EF conventions. " +
                      "Remove the redundant mapping so the convention-generated storage and ownership model stay authoritative.",
         helpLinkUri: HelpLinkBase + "TRLS021");
+
+    /// <summary>
+    /// TRLS022: [OwnedEntity] property uses init-only setter; use { get; private set; } instead.
+    /// </summary>
+    public static readonly DiagnosticDescriptor OwnedEntityInitOnlyProperty = new(
+        id: TrellisDiagnosticIds.OwnedEntityInitOnlyProperty,
+        title: "[OwnedEntity] property uses init-only setter",
+        messageFormat: "Property '{0}' on [OwnedEntity] type '{1}' uses an init-only setter. Use '{{ get; private set; }}' so EF Core can populate it during materialization through the generator-emitted parameterless constructor.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "[OwnedEntity] types are materialized by EF Core through a generator-emitted private parameterless constructor. " +
+                     "Init-only setters on [OwnedEntity] properties are not covered by Trellis tests today and round-trip behavior is not guaranteed. " +
+                     "Use '{ get; private set; }' as the supported, tested shape.",
+        helpLinkUri: HelpLinkBase + "TRLS022");
 }

--- a/Trellis.Analyzers/src/OwnedEntityInitOnlyPropertyAnalyzer.cs
+++ b/Trellis.Analyzers/src/OwnedEntityInitOnlyPropertyAnalyzer.cs
@@ -1,0 +1,117 @@
+﻿namespace Trellis.Analyzers;
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Analyzer that detects init-only properties (<c>{ get; init; }</c>) on classes or records
+/// decorated with <c>[Trellis.EntityFrameworkCore.OwnedEntityAttribute]</c>. The supported shape
+/// for <c>[OwnedEntity]</c> properties is <c>{ get; private set; }</c> so EF Core can populate
+/// them during materialization through the generator-emitted parameterless constructor.
+/// Only activates when the compilation references <c>Trellis.EntityFrameworkCore</c> (detected by
+/// the presence of the well-known <c>OwnedEntityAttribute</c> type). Inherited init-only
+/// properties from non-owned base types are also reported, mirroring the owned-entity generator's
+/// base-type walk.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class OwnedEntityInitOnlyPropertyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.OwnedEntityInitOnlyProperty];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var ownedEntityAttributeType = compilationContext.Compilation.GetTypeByMetadataName(
+                "Trellis.EntityFrameworkCore.OwnedEntityAttribute");
+            if (ownedEntityAttributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(
+                ctx => AnalyzeNamedType(ctx, ownedEntityAttributeType),
+                SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context, INamedTypeSymbol ownedEntityAttributeType)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+        if (typeSymbol.TypeKind != TypeKind.Class)
+            return;
+
+        if (!HasOwnedEntityAttribute(typeSymbol, ownedEntityAttributeType))
+            return;
+
+        var seen = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+        for (var current = typeSymbol; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is not IPropertySymbol property)
+                    continue;
+                if (property.IsStatic || property.IsIndexer)
+                    continue;
+                if (property.DeclaredAccessibility == Accessibility.Private)
+                    continue;
+                if (!property.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                    continue;
+
+                // Track all instance property names (regardless of init-only status) so a
+                // compliant derived property correctly hides a base init-only property under
+                // the C# `new` modifier.
+                if (!seen.Add(property.Name))
+                    continue;
+
+                if (property.SetMethod is null || !property.SetMethod.IsInitOnly)
+                    continue;
+
+                var location = GetInitKeywordLocation(property, context.CancellationToken)
+                    ?? property.Locations.FirstOrDefault()
+                    ?? typeSymbol.Locations.FirstOrDefault()
+                    ?? Location.None;
+
+                var diagnostic = Diagnostic.Create(
+                    DiagnosticDescriptors.OwnedEntityInitOnlyProperty,
+                    location,
+                    property.Name,
+                    typeSymbol.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+
+    private static Location? GetInitKeywordLocation(IPropertySymbol property, System.Threading.CancellationToken cancellationToken)
+    {
+        foreach (var declRef in property.DeclaringSyntaxReferences)
+        {
+            var node = declRef.GetSyntax(cancellationToken);
+            if (node is PropertyDeclarationSyntax propertyDecl && propertyDecl.AccessorList is { } accessors)
+            {
+                var initAccessor = accessors.Accessors.FirstOrDefault(a => a.IsKind(SyntaxKind.InitAccessorDeclaration));
+                if (initAccessor is not null)
+                    return initAccessor.Keyword.GetLocation();
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasOwnedEntityAttribute(INamedTypeSymbol classSymbol, INamedTypeSymbol ownedEntityAttributeType)
+    {
+        foreach (var attr in classSymbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, ownedEntityAttributeType))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -14,7 +14,7 @@
 ///     Justification = "guarded by HasValue check earlier in the pipeline")]
 /// </code>
 /// <para>
-/// IDs in the <c>TRLS001</c>–<c>TRLS021</c> range are emitted by the
+/// IDs in the <c>TRLS001</c>–<c>TRLS022</c> range are emitted by the
 /// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS039</c>
 /// range are emitted by the bundled source generators
 /// (<c>Trellis.Core.Generator</c>, <c>Trellis.EntityFrameworkCore.Generator</c>,
@@ -97,6 +97,9 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS021 — EF configuration duplicates Trellis conventions for <c>Maybe&lt;T&gt;</c> or <c>[OwnedEntity]</c>.</summary>
     public const string RedundantEfConfiguration = "TRLS021";
+
+    /// <summary>TRLS022 — <c>[OwnedEntity]</c> property uses init-only setter; use <c>{ get; private set; }</c> instead.</summary>
+    public const string OwnedEntityInitOnlyProperty = "TRLS022";
 
     // ---- Generator IDs (Trellis.Core.Generator / Trellis.EntityFrameworkCore.Generator) ----
     // Renumbered from TRLSGEN### to TRLS###. Mapping:

--- a/Trellis.Analyzers/tests/OwnedEntityInitOnlyPropertyAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/OwnedEntityInitOnlyPropertyAnalyzerTests.cs
@@ -1,0 +1,256 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="OwnedEntityInitOnlyPropertyAnalyzer"/> (TRLS022 — init-only properties on
+/// <c>[OwnedEntity]</c> types).
+/// </summary>
+public class OwnedEntityInitOnlyPropertyAnalyzerTests
+{
+    [Fact]
+    public async Task OwnedEntity_PropertyWithInitSetter_ReportsDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                public string Street { get; init; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.OwnedEntityInitOnlyProperty)
+                .WithArguments("Street", "Address")
+                .WithLocation(12, 33));
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_PropertyWithPrivateSet_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                public string Street { get; private set; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_PropertyWithPublicSet_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                public string Street { get; set; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_GetOnlyProperty_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                public string Street { get; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task NonOwnedEntity_PropertyWithInitSetter_NoDiagnostic()
+    {
+        const string source = """
+            public class RegularClass
+            {
+                public string Name { get; init; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task UnrelatedAttributeNamedOwnedEntity_InitProperty_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            namespace OtherLibrary
+            {
+                [AttributeUsage(AttributeTargets.Class)]
+                public sealed class OwnedEntityAttribute : Attribute;
+            }
+
+            namespace Test
+            {
+                [OtherLibrary.OwnedEntity]
+                public class Address
+                {
+                    public string Street { get; init; } = "";
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_MultipleInitProperties_ReportsAllDiagnostics()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                public string Street { get; init; } = "";
+                public string City { get; init; } = "";
+                public string State { get; private set; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.OwnedEntityInitOnlyProperty)
+                .WithArguments("Street", "Address")
+                .WithLocation(12, 33),
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.OwnedEntityInitOnlyProperty)
+                .WithArguments("City", "Address")
+                .WithLocation(13, 31));
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_RecordWithInitProperty_ReportsDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial record class Address
+            {
+                public string Street { get; init; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.OwnedEntityInitOnlyProperty)
+                .WithArguments("Street", "Address")
+                .WithLocation(12, 33));
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_InheritedInitPropertyFromNonOwnedBase_ReportsDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            public class BaseAddress
+            {
+                public string Country { get; init; } = "";
+            }
+
+            [OwnedEntity]
+            public partial class Address : BaseAddress
+            {
+                public string Street { get; private set; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.OwnedEntityInitOnlyProperty)
+                .WithArguments("Country", "Address")
+                .WithLocation(11, 34));
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_DerivedHidesBaseInitProperty_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            public class BaseAddress
+            {
+                public string Country { get; init; } = "";
+            }
+
+            [OwnedEntity]
+            public partial class Address : BaseAddress
+            {
+                public new string Country { get; private set; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task OwnedEntity_PrivateInitProperty_NoDiagnostic()
+    {
+        const string source = """
+            using Trellis.EntityFrameworkCore;
+
+            [OwnedEntity]
+            public partial class Address
+            {
+                private string Secret { get; init; } = "";
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<OwnedEntityInitOnlyPropertyAnalyzer>(source);
+        test.TestState.Sources.Add(("OwnedEntityStubs.cs", OwnedEntityTestStubs.Source));
+
+        await test.RunAsync();
+    }
+}

--- a/Trellis.Analyzers/tests/OwnedEntityTestStubs.cs
+++ b/Trellis.Analyzers/tests/OwnedEntityTestStubs.cs
@@ -1,0 +1,21 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+/// <summary>
+/// Shared stub source for <c>Trellis.EntityFrameworkCore.OwnedEntityAttribute</c> used in
+/// TRLS022 (<see cref="OwnedEntityInitOnlyPropertyAnalyzer"/>) tests.
+/// </summary>
+public static class OwnedEntityTestStubs
+{
+    /// <summary>
+    /// Stub source providing <c>Trellis.EntityFrameworkCore.OwnedEntityAttribute</c>.
+    /// </summary>
+    public const string Source = """
+        namespace Trellis.EntityFrameworkCore
+        {
+            using System;
+
+            [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+            public sealed class OwnedEntityAttribute : Attribute;
+        }
+        """;
+}

--- a/Trellis.EntityFrameworkCore/src/OwnedEntityAttribute.cs
+++ b/Trellis.EntityFrameworkCore/src/OwnedEntityAttribute.cs
@@ -16,7 +16,7 @@
 /// <strong>Note — init-only properties.</strong> <c>{ get; init; }</c> on properties of
 /// <c>[OwnedEntity]</c> types is not covered by Trellis tests today and is therefore not
 /// guaranteed to round-trip. Use <c>{ get; private set; }</c>, which is the supported shape.
-/// A future analyzer is planned to enforce this at compile time.
+/// The <c>TRLS022</c> analyzer flags <c>{ get; init; }</c> properties on <c>[OwnedEntity]</c> types.
 /// </para>
 /// </remarks>
 /// <example>

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -29,6 +29,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 | `TRLS019` | Warning | Avoid `default(Result)`, `default(Result<T>)`, and `default(Maybe<T>)` | `default(Result)` and `default(Result<T>)` are typed failures carrying the `new Error.Unexpected("default_initialized")` sentinel — never silent successes. `default(Maybe<T>)` equals `Maybe<T>.None` but the explicit literal obscures intent. Construct via `Result.Ok(...)` / `Result.Fail(...)` or `Maybe<T>.None` / `Maybe.From(...)`. Suppress with `[SuppressMessage("Trellis", TrellisDiagnosticIds.DefaultResultOrMaybe)]` or `#pragma warning disable TRLS019` for sanctioned sentinel/test-helper sites. |
 | `TRLS020` | Warning | Composite value object DTO property is missing JSON converter | Composite `[OwnedEntity]` value objects exposed through request/response DTO surfaces must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` so JSON binding round-trips through `TryCreate`. |
 | `TRLS021` | Warning | EF configuration duplicates Trellis conventions | Flags `HasConversion`, `OwnsOne`, and `Ignore` calls on `Maybe<T>` or `[OwnedEntity]` properties when `ApplyTrellisConventions(...)` / `ApplyTrellisConventionsFor<TContext>()` is wired. Remove the manual mapping and let Trellis conventions own the property. |
+| `TRLS022` | Warning | `[OwnedEntity]` property uses init-only setter | Flags `{ get; init; }` properties on classes annotated with `[OwnedEntity]`. EF Core materializes owned entities through a generator-emitted private parameterless constructor; init-only setters are not covered by Trellis tests today and round-trip behavior is not guaranteed. Use `{ get; private set; }`. |
 | `TRLS031` | Warning | Unsupported base type for `RequiredPartialClassGenerator` | Emitted by the Primitives source generator when a `Required*`-derived value object inherits from an unsupported base. Supported bases: `RequiredGuid`, `RequiredString`, `RequiredInt`, `RequiredDecimal`, `RequiredLong`, `RequiredBool`, `RequiredDateTime`, `RequiredEnum`. *(formerly `TRLSGEN001`)* |
 | `TRLS032` | Error | `MinimumLength` exceeds `MaximumLength` | Emitted by the Primitives source generator when a `[StringLength]` attribute has `MinimumLength > MaximumLength`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN002`)* |
 | `TRLS033` | Error | `Range` minimum exceeds maximum | Emitted by the Primitives source generator when a `[Range]` attribute on `int`/`long`/`decimal` has `Min > Max`. Adjust the attribute values so the range is non-empty. *(formerly `TRLSGEN003`)* |
@@ -76,6 +77,7 @@ Every `public const string` field on `TrellisDiagnosticIds`, the diagnostic ID i
 | `DefaultResultOrMaybe` | `TRLS019` | `DefaultResultOrMaybeAnalyzer` |
 | `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | `CompositeValueObjectDtoConverterAnalyzer` |
 | `RedundantEfConfiguration` | `TRLS021` | `RedundantEfConfigurationAnalyzer` |
+| `OwnedEntityInitOnlyProperty` | `TRLS022` | `OwnedEntityInitOnlyPropertyAnalyzer` |
 | `UnsupportedRequiredBaseType` | `TRLS031` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `InvalidStringLengthRange` | `TRLS032` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `InvalidRangeMinExceedsMax` | `TRLS033` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
@@ -111,6 +113,7 @@ The public static class `Trellis.Analyzers.DiagnosticDescriptors` exposes one `p
 | `DefaultResultOrMaybe` | `TRLS019` | Warning | Trellis.Result |
 | `CompositeValueObjectDtoMissingJsonConverter` | `TRLS020` | Warning | Trellis.Asp |
 | `RedundantEfConfiguration` | `TRLS021` | Warning | Trellis.EntityFrameworkCore |
+| `OwnedEntityInitOnlyProperty` | `TRLS022` | Warning | Trellis.EntityFrameworkCore |
 
 > **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS039`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
 
@@ -324,6 +327,13 @@ This analyzer was deleted from the current API. The `result.IsSuccess ? result.V
   - `builder.OwnsOne(e => e.OwnedEntityValueObject)`
   - `builder.Ignore(e => e.MaybeOrOwnedEntityProperty)`
 - Targets `Maybe<T>` and types annotated with `Trellis.EntityFrameworkCore.OwnedEntityAttribute`.
+- No code fix.
+
+#### `OwnedEntityInitOnlyPropertyAnalyzer` — `TRLS022`
+- Activates only when the compilation references `Trellis.EntityFrameworkCore.OwnedEntityAttribute`.
+- Flags property declarations with an `init` accessor whose containing class is annotated with `[OwnedEntity]`.
+- Diagnostic anchors at the `init` keyword and includes the property name and class name.
+- Recommends `{ get; private set; }`, the supported and tested shape for owned-entity properties materialized through the generator-emitted parameterless constructor.
 - No code fix.
 
 ## Code fix providers


### PR DESCRIPTION
## Summary

Adds **TRLS022 `OwnedEntityInitOnlyPropertyAnalyzer`** (backlog item B3) — flags `{ get; init; }` properties on classes/records annotated with `[Trellis.EntityFrameworkCore.OwnedEntityAttribute]` and recommends `{ get; private set; }`, the supported and tested shape for owned-entity properties materialized through the generator-emitted parameterless constructor.

## Implementation

- Symbol-action over `NamedType` (not syntax-action) so it covers **records** and **inherited init-only properties** from non-owned base classes, mirroring the owned-entity generator's base-type walk.
- Tracks all instance property names before the init-only check so a derived `new` property with a compliant setter correctly **suppresses** the inherited base diagnostic.
- Skips `private` properties and explicit interface implementations to match the generator's accessibility filter.
- Anchors the diagnostic at the `init` keyword location.
- Bails entirely when `Trellis.EntityFrameworkCore.OwnedEntityAttribute` is not referenced.

## Tests (11 new)

| Scenario | Expected |
|---|---|
| `[OwnedEntity]` class with `init` property | 1 diagnostic |
| `[OwnedEntity]` class with `{ get; private set; }` | none |
| `[OwnedEntity]` class with public `set` | none |
| `[OwnedEntity]` class with get-only | none |
| Non-`[OwnedEntity]` class with `init` | none |
| Unrelated namespace `OwnedEntityAttribute` | none |
| Multiple `init` properties | multi-diag |
| `[OwnedEntity]` record with `init` | 1 diagnostic |
| Inherited `init` from non-owned base | 1 diagnostic |
| Derived `new` private-set hides base `init` | none |
| `[OwnedEntity]` private `init` | none |

## Documentation

- Updated `[OwnedEntity]` XML doc to reference TRLS022 (was `A future analyzer is planned`).
- Added TRLS022 to `AnalyzerReleases.Unshipped.md`.
- Updated `TrellisDiagnosticIds` header comment range `TRLS001–TRLS021` → `TRLS001–TRLS022`.
- Added entries to `trellis-api-analyzers.md` summary table, ID-to-analyzer mapping table, ID-by-package table, and detail section.

## Validation (local)

- `dotnet build -c Release`: 0 errors, 0 warnings
- `dotnet test --filter-not-trait Category=Integration`: 4972 passed, 15 skipped, 0 failed
- AOT publish gate (Showcase.MinimalApi, win-x64): no IL warnings
- v1-stale `Error.X(...)` factory gate: clean
- `audit-stale-docs.ps1`: clean
- `docfx` build (warnings-as-errors filter): clean
- Two rounds of gpt-5.5 code-review applied (caught record + inheritance false negatives, then property-hiding + private/explicit-interface false positives)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
