### PR TITLE
docs(llm-restructure): api_reference frontmatter + audit fixes + 31 LLM-optimized articles

### DIFF
--- a/docs/docfx_project/api_reference/audit-stale-docs.ps1
+++ b/docs/docfx_project/api_reference/audit-stale-docs.ps1
@@ -20,6 +20,7 @@ try {
     $allowlistedPathPatterns = @(
         '^CHANGELOG\.md$',
         '^MIGRATION_v3\.md$',
+        '^docs/docfx_project/articles/migration\.md$',
         '^docs/docfx_project/api_reference/audit-stale-docs\.ps1$',
         '^docs/docfx_project/adr/',
         '^Trellis\.Asp/SAMPLES\.md$',

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Analyzers — API Reference
+﻿---
+package: Trellis.Analyzers
+namespaces: [Trellis.Analyzers]
+types: [TRLS001..TRLS022 diagnostic rules, TrellisDiagnosticIds]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Analyzers — API Reference
 
 - **Package:** `Trellis.Analyzers`
 - **Namespace:** `Trellis.Analyzers`

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Analyzers]
 types: [TRLS001..TRLS022 diagnostic rules, TrellisDiagnosticIds]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Analyzers — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Asp, Trellis.Asp.Authorization, Trellis.Asp.ModelBinding, T
 types: [TrellisHttpResult, ToHttpResponse, AsActionResult, HttpResponseOptionsBuilder<T>, ClaimsActorProvider, EntraActorProvider, DevelopmentActorProvider, CachingActorProvider]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Asp — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Asp — API Reference
+﻿---
+package: Trellis.Asp
+namespaces: [Trellis.Asp, Trellis.Asp.Authorization, Trellis.Asp.ModelBinding, Trellis.Asp.Routing, Trellis.Asp.Validation]
+types: [TrellisHttpResult, ToHttpResponse, AsActionResult, HttpResponseOptionsBuilder<T>, ClaimsActorProvider, EntraActorProvider, DevelopmentActorProvider, CachingActorProvider]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Asp — API Reference
 
 **Package:** `Trellis.Asp` (bundles the AOT-friendly `Trellis.AspSourceGenerator.dll` at `analyzers/dotnet/cs/` — installing `Trellis.Asp` attaches the generator automatically — and contains the ASP.NET actor providers formerly published as `Trellis.Asp.Authorization`).
 **Namespaces:** `Trellis.Asp`, `Trellis.Asp.Authorization`, `Trellis.Asp.ModelBinding`, `Trellis.Asp.Routing`, `Trellis.Asp.Validation`

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Authorization — API Reference
+﻿---
+package: Trellis.Authorization
+namespaces: [Trellis.Authorization]
+types: [IActorProvider, ActorContext, Actor, Permission, AuthorizeAttribute, IAuthorizationRequirement, IResourceAuthorizationHandler]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Authorization — API Reference
 
 **Package:** `Trellis.Authorization`
 **Namespace:** `Trellis.Authorization`

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Authorization]
 types: [IActorProvider, ActorContext, Actor, Permission, AuthorizeAttribute, IAuthorizationRequirement, IResourceAuthorizationHandler]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Authorization — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1,4 +1,13 @@
-﻿# Trellis Cross-Package Cookbook
+﻿---
+package: Trellis (cross-package recipes)
+namespaces: [Trellis, Trellis.Asp, Trellis.EntityFrameworkCore, Trellis.Mediator]
+types: [recipes]
+related_docs: [trellis-api-core.md, trellis-api-asp.md, trellis-api-efcore.md, trellis-api-mediator.md]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis Cross-Package Cookbook
 
 - **Audience:** AI coding agents (and humans) writing Trellis code from documentation alone.
 - **Purpose:** End-to-end recipes that cross package boundaries — DDD, Mediator, FluentValidation, EF Core, ASP.NET Core, Authorization, State Machine, Testing, Analyzers — using the *exact* public surface listed in the per-package API references.

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -5,7 +5,7 @@ types: [recipes]
 related_docs: [trellis-api-core.md, trellis-api-asp.md, trellis-api-efcore.md, trellis-api-mediator.md]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis Cross-Package Cookbook
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, Result<T>, Maybe<T>, Error, Unit, Page<T>, Cursor, EquatableArray<T>, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, Aggregate<TId>, Entity<TId>, IDomainEvent, ScalarValueObject<TSelf,T>, Specification<T>, RepresentationMetadata]
+types: [Result, Result<T>, Maybe<T>, Error, Unit, Page<T>, Cursor, EquatableArray<T>, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, Aggregate<TId>, Entity<TId>, IDomainEvent, "ScalarValueObject<TSelf,T>", Specification<T>, RepresentationMetadata]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Core API Reference
+﻿---
+package: Trellis.Core
+namespaces: [Trellis]
+types: [Result, Result<T>, Maybe<T>, Error, Unit, Page<T>, Cursor, EquatableArray<T>, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, Aggregate<TId>, Entity<TId>, IDomainEvent, ScalarValueObject<TSelf,T>, Specification<T>, RepresentationMetadata]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Core API Reference
 
 **Package:** `Trellis.Core`  
 **Namespace:** `Trellis`  
@@ -21,7 +29,7 @@ Use this table before searching the long type catalog.
 | Goal | Canonical API | See |
 |---|---|---|
 | Return success/failure without payload | `Result.Ok()` / `Result.Fail(error)` (returns `Result<Unit>`) | [`Result`](#public-static-partial-class-result) |
-| Return success/failure with payload | `Result.Ok(value)` / `Result.Fail<T>(error)` | [`Result<TValue>`](#public-readonly-partial-struct-resulttvalue--iresulttvalue-iequatableresulttvalue-ifailurefactoryresulttvalue) |
+| Return success/failure with payload | `Result.Ok(value)` / `Result.Fail<T>(error)` | [`Result<TValue>`](#public-readonly-struct-resulttvalue--iresulttvalue-iequatableresulttvalue-ifailurefactoryresulttvalue) |
 | Turn a boolean guard into a result | `Result.Ensure(condition, error)` or `.Ensure(...)` in a chain | [`Result`](#public-static-partial-class-result), [`Ensure family`](#ensure-family--ensureextensions-ensureextensionsasync-ensureallextensions-ensureallextensionsasync) |
 | Start independent async result-producing operations concurrently | `Result.ParallelAsync(...)`, then combine the returned tasks | [`Result`](#public-static-partial-class-result) |
 | Combine multiple validated *typed* fields into a tuple | static `Result.Combine<T1,T2>(Result<T1>, Result<T2>)` or instance `r1.Combine(r2)`, then `.Map(...)` | [`Combine family`](#combine-family--combineextensions-combineextensionsasync-combineerrorextensions) |
@@ -30,7 +38,7 @@ Use this table before searching the long type catalog.
 | Model expected absence | `Maybe<T>`, `Maybe.Some(value)`, `Maybe<T>.None` | [`Maybe<T>`](#public-readonly-struct-maybet-where-t--notnull) |
 | Convert absence to a domain failure | `maybe.ToResult(error)` / `maybe.ToResult(errorFactory)` | [`MaybeExtensions`](#maybeextensions) |
 | Create HTTP-oriented domain errors | Closed `Error` cases plus `ResourceRef.For<TResource>(id)` | [`Error`](#public-abstract-record-error), [`Error Cases`](#error-cases-closed-adt) |
-| Page list responses | `Page.Create(...)`, `Cursor` | [`Pagination`](#pagination) |
+| Page list responses | `new Page<T>(items, next, previous, requestedLimit, appliedLimit)` (or `Page.Empty<T>(...)` when there are no items), `Cursor` | [`Pagination`](#pagination) |
 | Model aggregates/entities/events | `Aggregate<TId>`, `Entity<TId>`, `IDomainEvent` | [`Domain-Driven Design`](#domain-driven-design) |
 | Move reusable query predicates out of repositories | `Specification<T>` | [`Specification<T>`](#specificationt) |
 | Define custom required value objects | `partial class X : RequiredString<X>` / `RequiredGuid<X>` / other `Required*` bases | [`Primitive value object base classes`](#primitive-value-object-base-classes) |
@@ -106,11 +114,11 @@ Migration notes for users moving from the previous `Trellis.Core` API surface.
 | Deferred failure factory | `Result.Failure<T>(Func<Error> errorFactory)` | *(removed)* | Inline the factory: `Result.Fail<T>(errorFactory())` | <!-- stale-doc-ok: migration-comparison row intentionally cites removed v1 factory -->
 | Conditional factory | `Result.SuccessIf(cond, value, error)` / `Result.SuccessIf(cond, t1, t2, error)` | *(removed)* | Use a ternary: `cond ? Result.Ok(value) : Result.Fail<T>(error)` | <!-- stale-doc-ok: migration-comparison row intentionally cites removed v1 factory -->
 | Inverse-conditional factory | `Result.FailureIf(cond, value, error)` / `Result.FailureIf(predicate, value, error)` | *(removed)* | Use a ternary: `cond ? Result.Fail<T>(error) : Result.Ok(value)` | <!-- stale-doc-ok: migration-comparison row intentionally cites removed v1 factory -->
-| Async-conditional factories | `Result.SuccessIfAsync(predicate, value, error)` / `Result.FailureIfAsync(predicate, value, error)` | *(removed)* | `await predicate() ? Result.Ok(value) : Result.Fail<T>(error)` (invert as needed) | <!-- stale-doc-ok: migration-comparison row intentionally cites removed v1 factory -->
+| Async-conditional factories | `Result.SuccessIfAsync(predicate, value, error)` / `Result.FailureIfAsync(predicate, value, error)` | *(removed)* | `(await predicate()) ? Result.Ok(value) : Result.Fail<T>(error)` (invert as needed; parens required because `await` binds tighter than `?:`) | <!-- stale-doc-ok: migration-comparison row intentionally cites removed v1 factory -->
 | Exception → result helpers | `Result.FromException(ex)` / `Result.FromException<T>(ex)` | *(removed)* | Use `Result.Fail(new Error.InternalServerError(faultId) { Detail = ex.Message, Cause = ... })` or rely on `Result.Try` / `Result.TryAsync` for inline exception capture. |
 | Implicit operators on `Result<T>` | `Result<T> r = value;` and `Result<T> r = error;` | *(removed)* | Use the explicit factory: `Result.Ok(value)` / `Result.Fail<T>(error)`. The compiler flags every site with CS0029. |
 | Non-generic `Result` for void flows | `Result` was a separate `readonly struct` for success/failure with no payload, distinct from `Result<T>`. | The non-generic `Result` instance type was removed. `Result` is now a `public static partial class` factory only; for no-payload success/failure use `Result<Unit>` (returned by parameterless `Result.Ok()` / `Result.Fail(error)` / `Result.Ensure(...)` / `Result.Try(...)` factories). The `Trellis.Unit` type is a public `readonly record struct` with a single value (`Unit.Default`). | Replace `Result` parameter/return types with `Result<Unit>`; replace `Task<Result>` with `Task<Result<Unit>>`; in lambdas after `.Bind(...)` / `BindAsync(...)` accept the `Unit` argument explicitly (`_ =>` or `(Unit _) =>`). |
-| `Error` as open class hierarchy | `Error` was a `class` with 18 hand-written subclasses (`ValidationError`, `NotFoundError`, …) and static factory helpers (`Error.Validation(...)`, `Error.NotFound(...)`, …). | `Error` is an `abstract record` with **18 nested `sealed record` cases** (`Error.NotFound`, `Error.UnprocessableContent`, …). Closed via `private` constructor; no static factories. | Replace `Error.X("msg")` factories with `new Error.X(payload) { Detail = "msg" }`. Replace concrete subclass type names (`ValidationError`, `NotFoundError`) with `Error.UnprocessableContent`, `Error.NotFound`. See "Error Cases (closed ADT)" below. | <!-- v1-stale-ok: migration-comparison row intentionally cites removed v1 factories -->
+| `Error` as open class hierarchy | `Error` was a `class` with 18 hand-written subclasses (`ValidationError`, `NotFoundError`, …) and static factory helpers (`Error.Validation(...)`, `Error.NotFound(...)`, …). | `Error` is an `abstract record` with **20 nested `sealed record` cases** (`Error.NotFound`, `Error.UnprocessableContent`, …). Closed via `private` constructor; no static factories. | Replace `Error.X("msg")` factories with `new Error.X(payload) { Detail = "msg" }`. Replace concrete subclass type names (`ValidationError`, `NotFoundError`) with `Error.UnprocessableContent`, `Error.NotFound`. See "Error Cases (closed ADT)" below. | <!-- v1-stale-ok: migration-comparison row intentionally cites removed v1 factories -->
 | `MatchErrorExtensions` | `result.MatchError(onValidation: ..., onNotFound: ..., onUnexpected: ...)` | *(removed)* | Use a `switch` expression on the closed ADT: `result.Match(_ => ..., e => e switch { Error.NotFound nf => ..., Error.UnprocessableContent uc => ..., _ => ... })`. C# verifies exhaustiveness against the closed catalog. |
 | `FlattenValidationErrorsExtensions` | `result.FlattenValidationErrors()` | *(removed)* | `Combine` over multiple `Result<T>` automatically merges `Error.UnprocessableContent.Fields` and `.Rules`. |
 | `Error.Instance` field | `error.Instance` (string-shaped HTTP vocabulary) | *(removed)* | The ASP wire layer synthesizes `ProblemDetails.Instance` from the request URL plus any `ResourceRef` carried by the typed payload. |
@@ -235,7 +243,7 @@ The default exception mapper produces `new Error.InternalServerError(FaultId: Gu
 
 ---
 
-### `public readonly partial struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>, IFailureFactory<Result<TValue>>`
+### `public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>, IFailureFactory<Result<TValue>>`
 
 Represents either a successful `TValue` or a failure `Error`.
 
@@ -470,7 +478,7 @@ Construct cases directly: `new Error.NotFound(payload) { Detail = "..." }`. The 
 
 ### Concrete error cases
 
-Eighteen nested `sealed record` cases under `Error`. Each case constructor is `internal` from external code's perspective only insofar as the base ctor is `private`; cases themselves are `public sealed record`s and instantiable with `new`.
+Twenty nested `sealed record` cases under `Error`. Each case constructor is `internal` from external code's perspective only insofar as the base ctor is `private`; cases themselves are `public sealed record`s and instantiable with `new`.
 
 | Case | Constructor | Wire status | Notes |
 | --- | --- | --- | --- |
@@ -482,7 +490,7 @@ Eighteen nested `sealed record` cases under `Error`. Each case constructor is `i
 | `Error.NotAcceptable` | `(EquatableArray<string> Available)` | 406 | Available media types. |
 | `Error.Conflict` | `(ResourceRef? Resource, string ReasonCode)` | 409 | `Code` returns `ReasonCode`. |
 | `Error.Gone` | `(ResourceRef Resource)` | 410 | Soft-deleted resource. |
-| `Error.PreconditionFailed` | `(ResourceRef Resource, PreconditionKind Condition)` | 412 | Optimistic concurrency mismatch. `Condition` is the typed precondition kind (`IfMatch`, `IfNoneMatch`, `IfUnmodifiedSince`, `IfModifiedSince`). |
+| `Error.PreconditionFailed` | `(ResourceRef Resource, PreconditionKind Condition)` | 412 | Optimistic concurrency mismatch. `Condition` is the typed precondition kind (`IfMatch`, `IfNoneMatch`, `IfModifiedSince`, `IfUnmodifiedSince`). |
 | `Error.ContentTooLarge` | `(long? MaxBytes = null)` | 413 | |
 | `Error.UnsupportedMediaType` | `(EquatableArray<string> Supported)` | 415 | |
 | `Error.RangeNotSatisfiable` | `(long CompleteLength, string Unit = "bytes")` | 416 | Drives `Content-Range` synthesis. |
@@ -500,12 +508,12 @@ Eighteen nested `sealed record` cases under `Error`. Each case constructor is `i
 | Type | Shape | Purpose |
 | --- | --- | --- |
 | `ResourceRef` | `readonly record struct (string Type, string? Id = null)` plus `ResourceRef.For(string type, object? id = null)` and `ResourceRef.For<TResource>(object? id = null)` | Aggregate identity. The `For(...)` helpers convert IDs with invariant formatting when possible and `For<TResource>` uses `typeof(TResource).Name` exactly. |
-| `InputPointer` | `readonly record struct (string Path)` | RFC 6901 JSON Pointer (e.g. `/email`). Construct via `InputPointer.ForProperty("email")`, append with `Append(...)`, or use the document-root sentinel `InputPointer.Root` (path `""`). `InputPointer.Root` is the canonical pointer for whole-body / object-level violations. |
+| `InputPointer` | `readonly record struct (string Path)` | RFC 6901 JSON Pointer (e.g. `/email`). Construct via `InputPointer.ForProperty("email")`, or use the document-root sentinel `InputPointer.Root` (path `""`). `InputPointer.Root` is the canonical pointer for whole-body / object-level violations. |
 | `FieldViolation` | `sealed record (InputPointer Field, string ReasonCode, ImmutableDictionary<string,string>? Args = null, string? Detail = null)` | Single per-field violation inside `UnprocessableContent.Fields`. `Detail` is the 4th positional parameter; supplies the boundary renderer's user-facing message when non-null. `Equals`/`GetHashCode` compare `Args` by content. |
 | `RuleViolation` | `sealed record (string ReasonCode, EquatableArray<InputPointer> Fields = default, ImmutableDictionary<string,string>? Args = null, string? Detail = null)` | Multi-field invariant or object-level rule inside `UnprocessableContent.Rules`. `Detail` is the 4th positional parameter. `Equals`/`GetHashCode` compare `Args` by content. |
 | `AuthChallenge` | `sealed record (string Scheme, ImmutableDictionary<string,string>? Params = null)` | Carried by `Unauthorized` to round-trip `WWW-Authenticate`. `Equals`/`GetHashCode` compare `Params` by content; parameter order is not significant. |
 | `RetryAfterValue` | sealed class, see below | `Retry-After` as delay seconds or absolute date. |
-| `PreconditionKind` | `enum { IfMatch, IfNoneMatch, IfUnmodifiedSince, IfModifiedSince }` | Typed precondition vocabulary. |
+| `PreconditionKind` | `enum { IfMatch, IfNoneMatch, IfModifiedSince, IfUnmodifiedSince }` | Typed precondition vocabulary. |
 | `EquatableArray<T>` | `readonly struct (ImmutableArray<T> Items)` | Wraps `ImmutableArray<T>` so records get sequence equality (built-in records compare arrays by reference). See dedicated section below. Construct with `EquatableArray.Create(...)`, `EquatableArray.From(items)`, `EquatableArray<T>.Empty`, or implicitly from an `ImmutableArray<T>`. |
 
 ---
@@ -840,7 +848,7 @@ The result API contains a large generated extension surface. Exact public famili
 | `DiscardExtensions`, `DiscardTaskExtensions`, `DiscardValueTaskExtensions` | Drops the `Result<T>` value entirely (returns `void`/`Task`/`ValueTask`) for intentional fire-and-forget pipelines |
 | `EnsureExtensions`, `EnsureExtensionsAsync`, `EnsureAllExtensions`, `EnsureAllExtensionsAsync` | Predicate-based validation on successful values; includes collection-wide validation |
 | `GetValueOrDefaultExtensions` | Non-throwing value fallback helpers |
-| `ResultLinqExtensions` | LINQ query syntax support via `Select`/`SelectMany` |
+| `ResultLinqExtensions` | LINQ query syntax support via `Select`/`SelectMany`/`Where` |
 | `MapExtensions`, `MapExtensionsAsync`, `MapIfExtensions`, `MapOnFailureExtensions` | Success-path mapping, conditional mapping, and failure remapping; tuple overloads generated for arities 2-9 |
 | `MatchExtensions`, `MatchExtensionsAsync`, `MatchTupleExtensions`, `MatchTupleExtensionsAsync` | Terminal branching for normal and tuple results. (The previous `MatchErrorExtensions` API was removed — use `result.Match(_ => ..., e => e switch { Error.NotFound nf => ..., ... })` against the closed catalog.) |
 | `NullableExtensions`, `NullableExtensionsAsync` | Converts nullable reference/value types to `Result<T>` |
@@ -942,7 +950,7 @@ Side effects without altering the result. `Tap` runs on success; `TapOnFailure` 
 | `public static Result<TValue> Tap<TValue>(this Result<TValue> result, Action<TValue> action)` | `Result<TValue>` | Sync side effect on success. |
 | `public static Task<Result<TValue>> TapAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task> func)` | `Task<Result<TValue>>` | `TapExtensionsAsync` covers all sync/Task/ValueTask × value-/no-value-lambda combinations (12 overloads). |
 | `public static Result<TValue> TapOnFailure<TValue>(this Result<TValue> result, Action<Error> action)` | `Result<TValue>` | Sync side effect on failure. |
-| `public static Task<Result<TValue>> TapOnFailureAsync<TValue>(this Task<Result<TValue>> resultTask, Func<Error, Task> func)` | `Task<Result<TValue>>` | `TapOnFailureExtensionsAsync` covers all sync/Task/ValueTask × error-/no-arg-lambda combinations (12 overloads). |
+| `public static Task<Result<TValue>> TapOnFailureAsync<TValue>(this Task<Result<TValue>> resultTask, Func<Error, Task> func)` | `Task<Result<TValue>>` | `TapOnFailureExtensionsAsync` covers all sync/Task/ValueTask × error-/no-arg-lambda combinations (12 non-tuple overloads; tuple arities 2–9 generate the same set per arity). |
 
 ```csharp
 Task<Result<Order>> Save(Order o) =>
@@ -1005,7 +1013,7 @@ Predicate-based validation. `Ensure` short-circuits on the first failed predicat
 | `public static Result<string> EnsureNotNullOrWhiteSpace(this string? str, Error error)` | `Result<string>` | Lifts a possibly-blank string to `Result<string>`. |
 | `public static Result<T> EnsureNotNull<T>(this Result<T?> result, Error error) where T : class` | `Result<T>` | Reference-type `EnsureNotNull` overload that strips the nullable annotation. |
 | `public static Result<T> EnsureNotNull<T>(this Result<T?> result, Error error) where T : struct` | `Result<T>` | Value-type `EnsureNotNull` overload that unwraps the nullable. |
-| `public static Task<Result<TValue>> EnsureAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task<bool>> predicate, Error error)` | `Task<Result<TValue>>` | `EnsureExtensionsAsync` covers all Task/ValueTask × constant-/factory-/embedded-result combinations (10 overloads). |
+| `public static Task<Result<TValue>> EnsureAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task<bool>> predicate, Error error)` | `Task<Result<TValue>>` | `EnsureExtensionsAsync` covers all `Result<T>`/`Task<Result<T>>`/`ValueTask<Result<T>>` receivers × `Func<TValue, bool>`/`Task<bool>`/`ValueTask<bool>` predicates × constant-, factory-, async-factory- and embedded-`Result<TValue>` error producers (~34 overloads across the six `Ensure.*` partial files). |
 | `public static Result<TValue> EnsureAll<TValue>(this Result<TValue> result, params (Func<TValue, bool> predicate, Error error)[] checks)` | `Result<TValue>` | Applicative validation: runs every check and folds failures via `error.Combine(...)` into one `Error.Aggregate`. |
 | `public static Task<Result<TValue>> EnsureAllAsync<TValue>(this Task<Result<TValue>> resultTask, params (Func<TValue, bool> predicate, Error error)[] checks)` | `Task<Result<TValue>>` | Task overload of `EnsureAllAsync`. |
 | `public static ValueTask<Result<TValue>> EnsureAllAsync<TValue>(this ValueTask<Result<TValue>> resultTask, params (Func<TValue, bool> predicate, Error error)[] checks)` | `ValueTask<Result<TValue>>` | ValueTask overload of `EnsureAllAsync`. |
@@ -1110,7 +1118,10 @@ Folds a sequence of inputs through a `Result`-producing selector into a single `
 | `public static Task<Result<IReadOnlyList<TOut>>> TraverseAsync<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, Task<Result<TOut>>> selector)` | `Task<Result<IReadOnlyList<TOut>>>` | Async traversal; sequential evaluation. |
 | `public static Task<Result<IReadOnlyList<TOut>>> TraverseAsync<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, CancellationToken, Task<Result<TOut>>> selector, CancellationToken cancellationToken = default)` | `Task<Result<IReadOnlyList<TOut>>>` | Cancellation-token overload. |
 | `public static ValueTask<Result<IReadOnlyList<TOut>>> TraverseAsync<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, ValueTask<Result<TOut>>> selector)` | `ValueTask<Result<IReadOnlyList<TOut>>>` | ValueTask variant. |
+| `public static ValueTask<Result<IReadOnlyList<TOut>>> TraverseAsync<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, CancellationToken, ValueTask<Result<TOut>>> selector, CancellationToken cancellationToken = default)` | `ValueTask<Result<IReadOnlyList<TOut>>>` | ValueTask + cancellation-token variant. |
+| `public static Task<Result<Unit>> TraverseAsync<TIn>(this IEnumerable<TIn> source, Func<TIn, CancellationToken, Task<Result<Unit>>> selector, CancellationToken cancellationToken = default)` | `Task<Result<Unit>>` | No-payload selector overload — short-circuits on the first failure and returns `Result<Unit>` for void-flavoured fan-out. |
 | `public static Result<IReadOnlyList<T>> Sequence<T>(this IEnumerable<Result<T>> source)` | `Result<IReadOnlyList<T>>` | Identity-selector form of `Traverse`. Lifts an `IEnumerable<Result<T>>` to `Result<IReadOnlyList<T>>`; short-circuits on the first failure. |
+| `public static Result<Unit> Sequence(this IEnumerable<Result<Unit>> source)` | `Result<Unit>` | No-payload `Sequence` overload for void-flavoured pipelines; short-circuits on the first failure. |
 
 ```csharp
 Task<Result<IReadOnlyList<Order>>> orders =
@@ -1181,11 +1192,11 @@ Absence of a cursor is represented by `null` (`Cursor?`). There is no "empty cur
 public readonly record struct Page<T>
 {
     public Page(
-        IReadOnlyList<T> Items,
-        Cursor? Next,
-        Cursor? Previous,
-        int RequestedLimit,
-        int AppliedLimit);
+        IReadOnlyList<T> items,
+        Cursor? next,
+        Cursor? previous,
+        int requestedLimit,
+        int appliedLimit);
 
     public IReadOnlyList<T> Items { get; }
     public Cursor?          Next { get; }

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -4,7 +4,7 @@ namespaces: [Trellis]
 types: [Result, Result<T>, Maybe<T>, Error, Unit, Page<T>, Cursor, EquatableArray<T>, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, Aggregate<TId>, Entity<TId>, IDomainEvent, ScalarValueObject<TSelf,T>, Specification<T>, RepresentationMetadata]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Core API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -1,4 +1,12 @@
-﻿# Trellis.EntityFrameworkCore
+﻿---
+package: Trellis.EntityFrameworkCore
+namespaces: [Trellis.EntityFrameworkCore]
+types: [RepositoryBase<TAggregate,TId>, IUnitOfWork, DbContextExtensions, SaveChangesResultAsync, OwnedEntityHelpers]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.EntityFrameworkCore
 
 **Package:** `Trellis.EntityFrameworkCore` (bundles the `Trellis.EntityFrameworkCore.Generator.dll` source generator at `analyzers/dotnet/cs/` — installing `Trellis.EntityFrameworkCore` attaches the `Maybe<T>` / `[OwnedEntity]` generator automatically; there is no separate `Trellis.EntityFrameworkCore.Generator` NuGet package).
 **Namespace:** `Trellis.EntityFrameworkCore`  

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.EntityFrameworkCore]
 types: [RepositoryBase<TAggregate,TId>, IUnitOfWork, DbContextExtensions, SaveChangesResultAsync, OwnedEntityHelpers]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.EntityFrameworkCore
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.EntityFrameworkCore
 namespaces: [Trellis.EntityFrameworkCore]
-types: [RepositoryBase<TAggregate,TId>, IUnitOfWork, DbContextExtensions, SaveChangesResultAsync, OwnedEntityHelpers]
+types: ["RepositoryBase<TAggregate,TId>", IUnitOfWork, DbContextExtensions, SaveChangesResultAsync, OwnedEntityHelpers]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.FluentValidation]
 types: [TrellisValidator<T>, ValidationResultExtensions]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.FluentValidation — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -1,4 +1,12 @@
-﻿# Trellis.FluentValidation — API Reference
+﻿---
+package: Trellis.FluentValidation
+namespaces: [Trellis.FluentValidation]
+types: [TrellisValidator<T>, ValidationResultExtensions]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.FluentValidation — API Reference
 
 ## Header
 

--- a/docs/docfx_project/api_reference/trellis-api-http.md
+++ b/docs/docfx_project/api_reference/trellis-api-http.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Http]
 types: [HttpResponseMessageExtensions, HttpClientResultExtensions]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Http &mdash; API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-http.md
+++ b/docs/docfx_project/api_reference/trellis-api-http.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Http &mdash; API Reference
+﻿---
+package: Trellis.Http
+namespaces: [Trellis.Http]
+types: [HttpResponseMessageExtensions, HttpClientResultExtensions]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Http &mdash; API Reference
 
 **Package:** `Trellis.Http`
 **Namespace:** `Trellis.Http`

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Mediator
 namespaces: [Trellis.Mediator]
-types: [ICommand<T>, IQuery<T>, IRequestHandler<,>, IPipelineBehavior<,>, ServiceCollectionExtensions]
+types: [ICommand<T>, IQuery<T>, "IRequestHandler<,>", "IPipelineBehavior<,>", ServiceCollectionExtensions]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Mediator]
 types: [ICommand<T>, IQuery<T>, IRequestHandler<,>, IPipelineBehavior<,>, ServiceCollectionExtensions]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Mediator — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Mediator — API Reference
+﻿---
+package: Trellis.Mediator
+namespaces: [Trellis.Mediator]
+types: [ICommand<T>, IQuery<T>, IRequestHandler<,>, IPipelineBehavior<,>, ServiceCollectionExtensions]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Mediator — API Reference
 
 **Package:** `Trellis.Mediator`
 **Namespace:** `Trellis.Mediator`

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -4,7 +4,7 @@ namespaces: [Trellis, Trellis.Primitives]
 types: [Age, CountryCode, CurrencyCode, EmailAddress, Hostname, IpAddress, LanguageCode, MonetaryAmount, Money, Percentage, PhoneNumber, Slug, Url, ParsableJsonConverter<T>, CompositeValueObjectJsonConverter<T>]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis API Primitives
 

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -1,4 +1,12 @@
-﻿# Trellis API Primitives
+﻿---
+package: Trellis.Primitives
+namespaces: [Trellis, Trellis.Primitives]
+types: [Age, CountryCode, CurrencyCode, EmailAddress, Hostname, IpAddress, LanguageCode, MonetaryAmount, Money, Percentage, PhoneNumber, Slug, Url, ParsableJsonConverter<T>, CompositeValueObjectJsonConverter<T>]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis API Primitives
 
 **Package:** `Trellis.Primitives`  
 **Namespaces:** `Trellis`, `Trellis.Primitives`  

--- a/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
+++ b/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.ServiceDefaults]
 types: [AddTrellisServiceDefaults, WebApplicationBuilderExtensions]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.ServiceDefaults API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
+++ b/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
@@ -1,4 +1,12 @@
-﻿# Trellis.ServiceDefaults API Reference
+﻿---
+package: Trellis.ServiceDefaults
+namespaces: [Trellis.ServiceDefaults]
+types: [AddTrellisServiceDefaults, WebApplicationBuilderExtensions]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.ServiceDefaults API Reference
 
 **Package:** `Trellis.ServiceDefaults`  
 **Namespace:** `Trellis.ServiceDefaults`  

--- a/docs/docfx_project/api_reference/trellis-api-statemachine.md
+++ b/docs/docfx_project/api_reference/trellis-api-statemachine.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.StateMachine]
 types: [IStateMachine<,>, StateBuilder<,>, Transition<,>]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.StateMachine — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-statemachine.md
+++ b/docs/docfx_project/api_reference/trellis-api-statemachine.md
@@ -1,4 +1,12 @@
-﻿# Trellis.StateMachine — API Reference
+﻿---
+package: Trellis.StateMachine
+namespaces: [Trellis.StateMachine]
+types: [IStateMachine<,>, StateBuilder<,>, Transition<,>]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.StateMachine — API Reference
 
 ## Header
 

--- a/docs/docfx_project/api_reference/trellis-api-statemachine.md
+++ b/docs/docfx_project/api_reference/trellis-api-statemachine.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.StateMachine
 namespaces: [Trellis.StateMachine]
-types: [IStateMachine<,>, StateBuilder<,>, Transition<,>]
+types: ["IStateMachine<,>", "StateBuilder<,>", "Transition<,>"]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Testing.AspNetCore, Trellis.Testing.AspNetCore.Http]
 types: [WebApplicationFactory<TEntryPoint>, TestClient, FakeTimeProvider, EntraTokenAcquirer, HttpFileReplayer]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Testing.AspNetCore &mdash; API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Testing.AspNetCore &mdash; API Reference
+﻿---
+package: Trellis.Testing.AspNetCore
+namespaces: [Trellis.Testing.AspNetCore, Trellis.Testing.AspNetCore.Http]
+types: [WebApplicationFactory<TEntryPoint>, TestClient, FakeTimeProvider, EntraTokenAcquirer, HttpFileReplayer]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Testing.AspNetCore &mdash; API Reference
 
 **Package:** `Trellis.Testing.AspNetCore`  
 **Namespaces:** `Trellis.Testing.AspNetCore`, `Trellis.Testing.AspNetCore.Http`  

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -4,7 +4,7 @@ namespaces: [Trellis.Testing]
 types: [FakeRepository<,>, InMemoryUnitOfWork, ResultAssertions]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis.Testing — API Reference
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -1,4 +1,12 @@
-﻿# Trellis.Testing — API Reference
+﻿---
+package: Trellis.Testing
+namespaces: [Trellis.Testing]
+types: [FakeRepository<,>, InMemoryUnitOfWork, ResultAssertions]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis.Testing — API Reference
 
 - **Package:** `Trellis.Testing`
 - **Namespace:** `Trellis.Testing`

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Testing
 namespaces: [Trellis.Testing]
-types: [FakeRepository<,>, InMemoryUnitOfWork, ResultAssertions]
+types: ["FakeRepository<,>", InMemoryUnitOfWork, ResultAssertions]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
+++ b/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
@@ -1,6 +1,29 @@
-﻿# Trellis Value Object Taxonomy
+﻿---
+package: Trellis.Core, Trellis.Primitives
+namespaces: [Trellis, Trellis.Primitives]
+types: [ValueObject, ScalarValueObject<TSelf,T>, RequiredString<TSelf>, RequiredGuid<TSelf>, RequiredInt<TSelf>, RequiredDecimal<TSelf>, RequiredEnum<TSelf>, Maybe<T>]
+version: v3
+last_verified: 2026-05-01
+audience: [llm, developer]
+---
+# Trellis Value Object Taxonomy
 
 **Packages:** `Trellis.Core` (DDD primitives `Aggregate<T>`, `Entity<T>`, `ValueObject`, `Specification<T>`, `IDomainEvent`, plus VO base classes `RequiredString<TSelf>`, `RequiredGuid<TSelf>`, `RequiredInt<TSelf>`, `RequiredDecimal<TSelf>`, `RequiredEnum<TSelf>`); `Trellis.Primitives` (concrete VOs only — `EmailAddress`, `Money`, etc.) | **Namespaces:** `Trellis`, `Trellis.Primitives` | **Purpose:** canonical category map for Trellis value-like types: scalar, symbolic, structured, and optionality wrappers.
+
+## Patterns Index
+
+Use this table to pick the right base class before reading the per-type signatures below.
+
+| Goal | Canonical base / type | See |
+|---|---|---|
+| Wrap a single primitive (string, Guid, int, decimal, enum) into a typed value object | `RequiredString<TSelf>`, `RequiredGuid<TSelf>`, `RequiredInt<TSelf>`, `RequiredDecimal<TSelf>`, `RequiredEnum<TSelf>` (one base per primitive) | [`RequiredString<TSelf>`](#requiredstringtself), [`RequiredGuid<TSelf>`](#requiredguidtself), [`RequiredInt<TSelf>`](#requiredinttself), [`RequiredDecimal<TSelf>`](#requireddecimaltself), [`RequiredEnum<TSelf>`](#requiredenumtself) |
+| Define a custom-validated scalar with no source-generated infrastructure | `ScalarValueObject<TSelf, T>` + `IScalarValue<TSelf, T>` | [`ScalarValueObject<TSelf, T>`](#scalarvalueobjecttself-t) |
+| Compose multiple value-typed fields into a structural value object | `ValueObject` (override `GetEqualityComponents`) | [`ValueObject`](#valueobject) |
+| Wrap an entity with identity (mutable through methods) | `Entity<TId>` | See [trellis-api-core.md → Domain-Driven Design](trellis-api-core.md#domain-driven-design) |
+| Wrap a consistency boundary with domain events | `Aggregate<TId>` | See [trellis-api-core.md → Domain-Driven Design](trellis-api-core.md#domain-driven-design) |
+| Express expected absence of a value | `Maybe<T>` | See [trellis-api-core.md → Maybe](trellis-api-core.md#public-readonly-struct-maybet-where-t--notnull) |
+| Move a query predicate out of a repository | `Specification<T>` | See [trellis-api-core.md → Domain-Driven Design](trellis-api-core.md#domain-driven-design) |
+| Pick a built-in concrete value object instead of writing your own | `EmailAddress`, `Money`, `CountryCode`, `Url`, etc. | See [trellis-api-primitives.md](trellis-api-primitives.md) |
 
 ## Types
 

--- a/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
+++ b/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
@@ -4,7 +4,7 @@ namespaces: [Trellis, Trellis.Primitives]
 types: [ValueObject, ScalarValueObject<TSelf,T>, RequiredString<TSelf>, RequiredGuid<TSelf>, RequiredInt<TSelf>, RequiredDecimal<TSelf>, RequiredEnum<TSelf>, Maybe<T>]
 version: v3
 last_verified: 2026-05-01
-audience: [llm, developer]
+audience: [llm]
 ---
 # Trellis Value Object Taxonomy
 

--- a/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
+++ b/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core, Trellis.Primitives
 namespaces: [Trellis, Trellis.Primitives]
-types: [ValueObject, ScalarValueObject<TSelf,T>, RequiredString<TSelf>, RequiredGuid<TSelf>, RequiredInt<TSelf>, RequiredDecimal<TSelf>, RequiredEnum<TSelf>, Maybe<T>]
+types: [ValueObject, "ScalarValueObject<TSelf,T>", RequiredString<TSelf>, RequiredGuid<TSelf>, RequiredInt<TSelf>, RequiredDecimal<TSelf>, RequiredEnum<TSelf>, Maybe<T>]
 version: v3
 last_verified: 2026-05-01
 audience: [llm]

--- a/docs/docfx_project/articles/BENCHMARKS.md
+++ b/docs/docfx_project/articles/BENCHMARKS.md
@@ -1,3 +1,11 @@
+﻿---
+title: Benchmarks
+package: Trellis (multiple)
+topics: [benchmarks, performance, allocations, rop, microbenchmarks]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Benchmarks
 
 This article is the "show me the numbers" companion to [Performance](performance.md).

--- a/docs/docfx_project/articles/advanced-features.md
+++ b/docs/docfx_project/articles/advanced-features.md
@@ -1,3 +1,11 @@
+﻿---
+title: Advanced Features
+package: Trellis.Core
+topics: [pattern-matching, combine, try, parallel, linq, maybe]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Advanced Features
 
 Once you know `Map`, `Bind`, and `Ensure`, the next question is usually: **how do I keep the same style when the workflow gets more complex?**
@@ -9,6 +17,17 @@ This article covers the Trellis features that help when you need to:
 - capture exceptions from throw-happy APIs
 - run independent async work in parallel
 - write more declarative pipelines with LINQ
+
+## Patterns Index
+
+| Goal | Use | See |
+|---|---|---|
+| Decide success vs failure at the end of a pipeline | `Match(onSuccess, onFailure)` / `MatchAsync(...)` | [Pattern matching](#pattern-matching-make-the-end-of-the-pipeline-obvious) |
+| Combine several `Result<T>` values without tuple plumbing | `Combine(...)` then `Bind` / `Map` / `Match` with destructured tuple | [Tuple destructuring](#tuple-destructuring-combine-values-without-manual-unpacking) |
+| Bridge a throwing API into a `Result<T>` | `Result.Try(...)` / `Result.TryAsync(...)` (optionally with exception mapper) | [Exception capture](#exception-capture-keep-throwing-apis-at-the-edge) |
+| Run independent async result-producing work concurrently | `Result.ParallelAsync(...).WhenAllAsync()` | [Parallel operations](#parallel-operations-run-independent-async-work-together) |
+| Express sequential composition with query syntax | `from x in result1 from y in result2 select ...` | [LINQ query syntax](#linq-query-syntax-write-sequential-intent-clearly) |
+| Drop the error and keep only “did it succeed?” | `result.ToMaybe()` / `ToMaybeAsync()` | [Result-to-Maybe conversion](#result-to-maybe-conversion) |
 
 ## Start Here: a Compact Example
 
@@ -293,3 +312,7 @@ Maybe<string> value = await Task.FromResult(Result.Ok("Ada")).ToMaybeAsync();
 
 - Read [Error Handling](error-handling.md) for type-specific matching and aggregation
 - Read [Why Maybe?](maybe-type.md) for domain optionality and `ToResult(...)`
+
+## Cross-references
+
+- `Match` / `MatchAsync`, `Combine`, tuple-aware verbs, `Result.Try` / `TryAsync`, `ParallelAsync`, `WhenAllAsync`, LINQ extensions, `ToMaybe` / `ToMaybeAsync`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)

--- a/docs/docfx_project/articles/aggregate-factory-pattern.md
+++ b/docs/docfx_project/articles/aggregate-factory-pattern.md
@@ -1,39 +1,66 @@
-﻿# Aggregate Factory Pattern
+﻿---
+title: Aggregate Factory Pattern
+package: Trellis.Core
+topics: [ddd, aggregate, factory, invariants, result, value-objects, reconstitution]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Aggregate Factory Pattern
 
-When an aggregate can be both **created from scratch** and **reconstituted from existing data**, one factory method is not enough.
+A convention for giving `Aggregate<TId>` two safe creation paths — `TryCreate` for new instances and `TryCreateExisting` for reconstitution — so identity, invariants, and creation events live in one place.
 
-That is the problem this pattern solves.
+## Patterns Index
 
-- new aggregates need a **new ID**
-- reconstituted aggregates must keep an **existing ID**
-- both paths should enforce the same domain invariants
+| Goal | Use | See |
+|---|---|---|
+| Create a brand-new aggregate (generate ID, raise creation event) | `static Result<TAgg> TryCreate(...)` | [Defining the factory](#defining-the-factory) |
+| Reconstitute an aggregate with a known ID (importer, fixture, manual hydration) | `static Result<TAgg> TryCreateExisting(TId id, ...)` | [Reconstitution path](#reconstitution-path) |
+| Throw on invalid input (seeders, known-good test data) | `static TAgg Create(...)` / `CreateExisting(id, ...)` | [Throwing helpers](#throwing-helpers) |
+| Run the same invariants on both paths | private `static Result<Unit> Validate(...)` | [Centralizing validation](#centralizing-validation) |
+| Type the constructor parameters | derive each input from `Required*<TSelf>` | [Composing primitives](#composing-primitives) |
+| Raise creation events exactly once | `DomainEvents.Add(...)` inside `TryCreate` only | [Domain events and reconstitution](#domain-events-and-reconstitution) |
 
-> [!TIP]
-> `Aggregate<TId>` does not impose factory methods for you. The pattern below is a Trellis-friendly convention for keeping creation explicit and safe.
+## Use this guide when
 
-## The recommended shape
+- Your aggregate must support both new construction *and* reconstitution from existing data (importers, manual rehydration, fixtures, migrations).
+- You want one place that enforces invariants, regardless of which path the caller took.
+- Tests need deterministic IDs while production generates them.
+- Creation events must fire exactly once per aggregate lifetime.
 
-Use two factory paths:
+## Surface at a glance
 
-| Method | Use it for | ID behavior |
-| --- | --- | --- |
-| `TryCreate(...)` | New aggregate | Generates a new ID |
-| `TryCreateExisting(id, ...)` | Reconstitution, migrations, tests with known IDs | Preserves the supplied ID |
-| `Create(...)` | Same as `TryCreate`, but for known-good data | Throws on failure |
-| `CreateExisting(id, ...)` | Same as `TryCreateExisting`, but for known-good data | Throws on failure |
+This is a **convention**, not API. `Aggregate<TId>` itself only requires `protected Aggregate(TId id)` and exposes `DomainEvents`, `UncommittedEvents()`, `AcceptChanges()`, and `ETag` — see [`Aggregate<TId>` reference](../api_reference/trellis-api-core.md#aggregatetid). The pattern adds the four static methods below.
 
-## A working example
+| Method | Signature shape | ID source | Validation | Raises creation event? |
+|---|---|---|---|---|
+| `TryCreate` | `static Result<T> TryCreate(...primitives)` | Generated (e.g. `TId.NewUniqueV7()`) | Yes | Yes |
+| `TryCreateExisting` | `static Result<T> TryCreateExisting(TId id, ...primitives)` | Caller-supplied | Yes | No |
+| `Create` | `static T Create(...primitives)` | Generated | Yes (throws on failure) | Yes |
+| `CreateExisting` | `static T CreateExisting(TId id, ...primitives)` | Caller-supplied | Yes (throws on failure) | No |
+
+Underlying types: [`Aggregate<TId>`, `IAggregate`, `IDomainEvent`](../api_reference/trellis-api-core.md#domain-driven-design); [`Required*<TSelf>` primitive bases](../api_reference/trellis-api-core.md#primitive-value-object-base-classes).
+
+## Installation
+
+```bash
+dotnet add package Trellis.Core
+```
+
+## Quick start
+
+A minimal `Product` aggregate exposing all four factory paths.
 
 ```csharp
+using System;
 using Trellis;
-using Trellis.Primitives;
 
-namespace AggregateFactories;
+namespace Catalog;
 
-[Trellis.StringLength(200)]
+[StringLength(200)]
 public partial class ProductName : RequiredString<ProductName> { }
 
-[Trellis.StringLength(64)]
+[StringLength(64)]
 public partial class Sku : RequiredString<Sku> { }
 
 public partial class ProductId : RequiredGuid<ProductId> { }
@@ -42,8 +69,11 @@ public sealed record ProductCreated(ProductId ProductId, DateTime OccurredAt) : 
 
 public sealed class Product : Aggregate<ProductId>
 {
-    private Product(ProductId id, ProductName name, Sku sku)
-        : base(id)
+    public ProductName Name { get; private set; }
+    public Sku Sku { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private Product(ProductId id, ProductName name, Sku sku) : base(id)
     {
         Name = name;
         Sku = sku;
@@ -56,10 +86,6 @@ public sealed class Product : Aggregate<ProductId>
         Sku = null!;
     }
 
-    public ProductName Name { get; private set; }
-    public Sku Sku { get; private set; }
-    public bool IsActive { get; private set; }
-
     public static Result<Product> TryCreate(ProductName name, Sku sku)
     {
         var product = new Product(ProductId.NewUniqueV7(), name, sku);
@@ -67,18 +93,14 @@ public sealed class Product : Aggregate<ProductId>
         return Result.Ok(product);
     }
 
-    public static Result<Product> TryCreateExisting(ProductId id, ProductName name, Sku sku)
-    {
-        var product = new Product(id, name, sku);
-        return Result.Ok(product);
-    }
+    public static Result<Product> TryCreateExisting(ProductId id, ProductName name, Sku sku) =>
+        Result.Ok(new Product(id, name, sku));
 
     public static Product Create(ProductName name, Sku sku)
     {
         var result = TryCreate(name, sku);
         if (!result.TryGetValue(out var product))
             throw new InvalidOperationException(result.Error!.Detail);
-
         return product;
     }
 
@@ -87,56 +109,72 @@ public sealed class Product : Aggregate<ProductId>
         var result = TryCreateExisting(id, name, sku);
         if (!result.TryGetValue(out var product))
             throw new InvalidOperationException(result.Error!.Detail);
-
         return product;
     }
 }
 ```
 
-## Why two methods are better than one
+## Defining the factory
 
-If `TryCreate(...)` always generates an ID, you cannot safely rebuild an existing aggregate:
+Two pillars:
+
+1. **Identity is generated** inside `TryCreate` — the caller never supplies an ID.
+2. **Validation runs first**; the constructor stays trivial (assignment-only).
+
+Use `Result.Ok(aggregate)` on success and `Result.Fail<TAgg>(error)` on failure. There is no implicit `Error → Result<T>` conversion in the current API — always go through the static factory.
+
+| Element | Convention | Why |
+|---|---|---|
+| Constructor visibility | `private` | Forces all callers through the factory. |
+| ID parameter | First positional | Matches `Aggregate<TId>`'s base constructor. |
+| Field assignment | Inside the constructor only | Keeps factories side-effect-free until the `Result.Ok` line. |
+| Domain events | Added on the *new* path only | Reconstitution must not republish creation events. |
+| Strong-typed inputs | `RequiredString<TSelf>`, `RequiredGuid<TSelf>`, ... | Each primitive validates itself at construction time — see [`Required*` bases](../api_reference/trellis-api-core.md#primitive-value-object-base-classes). |
+
+### Reconstitution path
+
+`TryCreateExisting(TId id, ...)` exists for any caller that already knows the ID:
+
+- importing data from an external system,
+- manual rehydration (no EF Core),
+- tests that need a deterministic ID,
+- migrations that must preserve the existing primary key.
+
+It runs the *same* validation as `TryCreate`, but it never raises a creation event — the aggregate already exists.
 
 ```csharp
 var knownId = ProductId.Create(Guid.Parse("8e945d6d-e4f4-4dd6-bb50-3ab19f9d9fd1"));
 var name = ProductName.Create("Trellis Mug");
 var sku = Sku.Create("MUG-001");
 
-var newProduct = Product.Create(name, sku);                     // new ID
-var existingProduct = Product.CreateExisting(knownId, name, sku); // preserved ID
+var fresh = Product.TryCreate(name, sku);                    // new ID, ProductCreated raised
+var rebuilt = Product.TryCreateExisting(knownId, name, sku); // ID preserved, no event
 ```
 
-That distinction matters for:
+### Throwing helpers
 
-- **manual rehydration**
-- **tests that need fixed IDs**
-- **data import or migration code**
-- **reconstitution outside EF Core**
+`Create` / `CreateExisting` are thin wrappers around the `Try*` variants. Use them only for known-good data — fixtures, seeders, inline test setup. Production code paths should consume `Result<TAgg>` directly so the failure stays observable.
 
-## Where EF Core fits
+```csharp
+public static Product Create(ProductName name, Sku sku)
+{
+    var result = TryCreate(name, sku);
+    if (!result.TryGetValue(out var product))
+        throw new InvalidOperationException(result.Error!.Detail);
+    return product;
+}
+```
 
-When EF Core materializes an aggregate, it typically uses the parameterless constructor and sets properties during rehydration.
+## Centralizing validation
 
-That is why many Trellis aggregates use this shape:
-
-- parameterless constructor for EF Core
-- private constructor with all required state
-- `TryCreate(...)` for new instances
-- `TryCreateExisting(...)` for explicit reconstitution outside EF Core
-
-> [!NOTE]
-> The parameterless constructor is for infrastructure. Your domain code should still prefer explicit factory methods.
-
-## Keep validation in one place
-
-Both creation paths should enforce the same rules. A simple way to do that is to validate the arguments before either constructor call.
+Both creation paths must enforce the same rules. Extract them into a private static method that returns `Result<Unit>` (returned by the parameterless `Result.Ok()` / `Result.Fail(error)` overloads), and call it before constructing the aggregate.
 
 ```csharp
 public static Result<Product> TryCreate(ProductName name, Sku sku)
 {
     var validation = Validate(name, sku);
     if (validation.IsFailure)
-        return validation.Error;
+        return Result.Fail<Product>(validation.Error!);
 
     var product = new Product(ProductId.NewUniqueV7(), name, sku);
     product.DomainEvents.Add(new ProductCreated(product.Id, DateTime.UtcNow));
@@ -147,59 +185,114 @@ public static Result<Product> TryCreateExisting(ProductId id, ProductName name, 
 {
     var validation = Validate(name, sku);
     if (validation.IsFailure)
-        return validation.Error;
+        return Result.Fail<Product>(validation.Error!);
 
     return Result.Ok(new Product(id, name, sku));
 }
 
-private static Result Validate(ProductName name, Sku sku)
+private static Result<Unit> Validate(ProductName name, Sku sku)
 {
     if (sku.Value.StartsWith("LEGACY-", StringComparison.OrdinalIgnoreCase))
-        return new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(sku)), "validation.error") { Detail = "SKU cannot start with LEGACY." }));
+        return Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(
+            new FieldViolation(InputPointer.ForProperty(nameof(sku)), "validation.error")
+            {
+                Detail = "SKU cannot start with LEGACY.",
+            })));
 
     return Result.Ok();
 }
 ```
 
+> [!TIP]
+> Per-field invariants (length, range, non-empty) belong on the value-object primitive itself via `[StringLength]`, `[Range]`, etc. The aggregate `Validate` method is for *cross-field* rules that no single primitive can enforce.
+
+## Composing primitives
+
+Strong-typed inputs eliminate most aggregate-level validation. By the time `TryCreate` runs, every primitive has already passed its own invariants.
+
+```csharp
+[StringLength(200)]
+public partial class ProductName : RequiredString<ProductName> { }   // empty/whitespace + length
+
+[StringLength(64)]
+public partial class Sku : RequiredString<Sku> { }                   // empty/whitespace + length
+
+public partial class ProductId : RequiredGuid<ProductId> { }         // Guid.Empty rejection
+```
+
+The source generator emits `TryCreate` / `Create` / `Parse` / `JsonConverter` for each primitive — full surface in the [`Required*` source-generated members table](../api_reference/trellis-api-core.md#source-generated-members). Callers convert raw input once at the boundary:
+
+```csharp
+var nameResult = ProductName.TryCreate(input.Name, fieldName: nameof(input.Name));
+var skuResult  = Sku.TryCreate(input.Sku, fieldName: nameof(input.Sku));
+```
+
 ## Domain events and reconstitution
 
-A common mistake is raising “created” events while reconstituting existing data.
+A common mistake is raising "created" events while reconstituting existing data. The rule:
 
-Use this rule:
+| Path | `DomainEvents.Add(new XxxCreated(...))`? |
+|---|---|
+| `TryCreate` | Yes — the aggregate is new |
+| `TryCreateExisting` | No — the aggregate already exists |
+| `Create` / `CreateExisting` | Inherits from the underlying `Try*` it wraps |
 
-- `TryCreate(...)` may raise creation events
-- `TryCreateExisting(...)` usually should **not**
+That keeps `UncommittedEvents()` (see [`Aggregate<TId>`](../api_reference/trellis-api-core.md#aggregatetid)) meaningful: the only events present are the ones that actually happened in this unit of work.
 
-That keeps `UncommittedEvents()` meaningful.
+## Where EF Core fits
 
-## What this pattern does **not** do
+When EF Core materializes an aggregate, it uses the parameterless constructor and sets properties during rehydration — the same constructor that lets `private Product() : base(null!) { ... }` exist for infrastructure use only.
 
-These concerns belong elsewhere:
+| Constructor | Purpose | Visibility |
+|---|---|---|
+| `private Product(ProductId id, ProductName name, Sku sku)` | Real construction; called by `TryCreate` and `TryCreateExisting` | `private` |
+| `private Product()` | EF Core materialization stub | `private` |
 
-- **`ETag`** is infrastructure-managed
-- **`AcceptChanges()`** belongs after persistence/event publication
-- **repository lookups** belong in repositories or handlers, not in the aggregate constructor
+Domain code stays on the factory methods; only the EF Core proxy ever touches the parameterless overload. `TryCreateExisting` is for *non-EF-Core* reconstitution (importers, JSON hydration, migrations).
 
-> [!WARNING]
-> Do not assign `ETag` in your factory methods. `ETag` exists for optimistic concurrency and is owned by persistence infrastructure.
+## Composition
 
-## A practical checklist
+Aggregate factories return `Result<TAgg>`, which composes with the rest of Trellis (`Bind`, `Map`, `Ensure`, etc.). A typical write-side flow validates input primitives, calls `TryCreate`, then hands the aggregate to the persistence layer — application command handlers stay on `Result<Unit>`.
 
-Use this pattern when your aggregate:
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
 
-- has a strong identity type like `ProductId`
-- needs a constructor for EF Core
-- must support both new and existing instances
-- raises domain events for true state changes
+public sealed record CreateProductCommand(string Name, string Sku);
 
-## Summary
+public sealed class CreateProductHandler(IProductRepository repo)
+{
+    public Task<Result<Unit>> HandleAsync(CreateProductCommand cmd, CancellationToken ct) =>
+        Result.Combine(
+                ProductName.TryCreate(cmd.Name, fieldName: nameof(cmd.Name)),
+                Sku.TryCreate(cmd.Sku, fieldName: nameof(cmd.Sku)))
+            .Bind(parts => Product.TryCreate(parts.Item1, parts.Item2))
+            .BindAsync((product, token) => repo.AddAsync(product, token), ct)
+            .AsUnitAsync();
+}
 
-The aggregate factory pattern gives you:
+public interface IProductRepository
+{
+    Task<Result<Product>> AddAsync(Product product, CancellationToken ct);
+}
+```
 
-- clear intent
-- correct identity handling
-- safer tests
-- cleaner reconstitution paths
-- fewer accidental domain events
+`Result.Combine` aggregates per-field failures; `BindAsync` runs the persistence step only on success; `AsUnitAsync` projects the success payload to `Unit` for the command contract.
 
-If the aggregate is new, generate a new ID. If it already exists, preserve the ID you were given.
+## Practical guidance
+
+- **Don't touch `ETag` from a factory.** It is owned by persistence infrastructure (see [`Aggregate<TId>` reference](../api_reference/trellis-api-core.md#aggregatetid)).
+- **Don't call `AcceptChanges()` from a factory.** That belongs after persistence and event publication, in the repository or unit-of-work boundary.
+- **Don't fetch from repositories in a factory.** Lookups belong in handlers; the factory takes already-resolved primitives and returns a fresh aggregate.
+- **Pick `TryCreate` vs `Create` by audience.** Public API surfaces, command handlers, and parsers want `Result<TAgg>`. Test fixtures and inline seed data want `Create`.
+- **One `Validate` method, two callers.** If you need a third creation path, add another wrapper around the same `Validate` — never duplicate the rules.
+- **Use `RequireETagAsync` / `OptionalETagAsync` at the read-modify-write boundary**, not in the factory — see [`AggregateETagExtensions`](../api_reference/trellis-api-core.md#aggregateetagextensions).
+
+## Cross-references
+
+- API surface: [`trellis-api-core.md` → Domain-Driven Design](../api_reference/trellis-api-core.md#domain-driven-design)
+- Primitive value-object bases (`Required*<TSelf>`): [`trellis-api-core.md` → Primitive value object base classes](../api_reference/trellis-api-core.md#primitive-value-object-base-classes)
+- Built-in primitives (`EmailAddress`, `Money`, ...): [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- ETag-based optimistic concurrency on aggregates: [`trellis-api-core.md` → AggregateETagExtensions](../api_reference/trellis-api-core.md#aggregateetagextensions)
+- EF Core conventions for aggregates and entities: [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)

--- a/docs/docfx_project/articles/ai-code-generation.md
+++ b/docs/docfx_project/articles/ai-code-generation.md
@@ -1,3 +1,11 @@
+﻿---
+title: Trellis for AI Code Generation
+package: Trellis (multiple)
+topics: [ai, llm, code-generation, value-objects, result, prompting]
+related_api_reference: [trellis-api-core.md, trellis-api-primitives.md, trellis-api-asp.md, trellis-api-statemachine.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Trellis for AI Code Generation
 
 AI is good at producing code quickly.

--- a/docs/docfx_project/articles/asp-tohttpresponse.md
+++ b/docs/docfx_project/articles/asp-tohttpresponse.md
@@ -1,145 +1,312 @@
-﻿# ToHttpResponse — the unified ASP.NET response verb
+﻿---
+title: ToHttpResponse — Unified Response Verb
+package: Trellis.Asp
+topics: [asp, http-response, builder, etag, prefer, problem-details, write-outcome]
+related_api_reference: [trellis-api-asp.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# ToHttpResponse — Unified Response Verb
 
-`Result<T>.ToHttpResponse(...)` is the single, recommended verb for translating a
-Trellis `Result` (or `Result<WriteOutcome<T>>`, or `Result<Page<T>>`) into an
-HTTP response in **both MVC and Minimal API** apps. It returns
-`Microsoft.AspNetCore.Http.IResult`, so it works directly in Minimal API
-endpoints and converts to an MVC `ActionResult<T>` via `.AsActionResult<T>()`.
+`ToHttpResponse(...)` is the single Trellis verb for translating `Result`, `Result<T>`, `Result<WriteOutcome<T>>`, and `Result<Page<T>>` into ASP.NET Core responses, returning `Microsoft.AspNetCore.Http.IResult` for both Minimal API and MVC hosts.
 
-`ToHttpResponse` collapses the previous family of 16+ verbs
-(`ToActionResult`, `ToHttpResult`, `ToActionResultAsync`, <!-- stale-doc-ok: legacy verb list in migration guidance -->
-`ToHttpResultAsync`, `ToPagedHttpResult`, …) into one fluent surface that <!-- stale-doc-ok: legacy verb list in migration guidance -->
-honors the same RFC 9110 conditional-request, `Prefer`, `Vary`, `Range` and
-companion-header semantics they did.
+## Patterns Index
 
-## Read endpoint (success → 200, failure → mapped status)
+| Goal | Use | See |
+|---|---|---|
+| Map `Result<T>` to `200 OK` (or mapped Problem Details on failure) | `result.ToHttpResponse()` / `await ...ToHttpResponseAsync()` | [Quick start](#quick-start) |
+| Send no body on success | Return `Result<Unit>` (`Result.Ok()`) — emits `204 No Content` | [Basic mapping](#basic-mapping) |
+| Project the response body separately from the domain value | `result.ToHttpResponse(body: domain => dto, configure: opts => ...)` | [Body projection](#body-projection) |
+| Map `Result<WriteOutcome<T>>` to RFC 9110 write semantics | `result.ToHttpResponse(opts => opts.CreatedAtRoute(...))` | [Created responses](#created-responses), [WriteOutcome variants](#writeoutcomet-variants) |
+| Wrap as MVC `ActionResult<T>` | Chain `.AsActionResult<T>()` / `.AsActionResultAsync<T>()` | [MVC adapter](#mvc-adapter) |
+| Add ETag / `Last-Modified` and honor conditional `GET`/`HEAD` | `opts.WithETag(...).WithLastModified(...).EvaluatePreconditions()` | [ETag and conditional requests](#etag-and-conditional-requests) |
+| Honor `Prefer: return=minimal` / `return=representation` | `opts.HonorPrefer()` | [Prefer header](#prefer-header) |
+| Return `206 Partial Content` for byte ranges | `opts.WithRange(from, to, total)` / `opts.WithRange(selector)` | [Range responses](#range-responses) |
+| Return paginated JSON with RFC 8288 `Link` header | `result.ToHttpResponse(nextUrlBuilder, body)` on `Result<Page<T>>` | [Pagination](#pagination) |
+| Override error → status mapping for one endpoint | `opts.WithErrorMapping<TError>(status)` / `opts.WithErrorMapping(err => ...)` | [Per-call error mapping](#per-call-error-mapping) |
+| Render a standalone `Error` (no `Result` pipeline) | `error.ToHttpResponse(...)` | [Standalone error](#standalone-error) |
 
-```csharp
-[HttpGet("{id:guid}")]
-public Task<ActionResult<TodoItem>> Get(Guid id, CancellationToken ct) =>
-    _mediator.SendAsync(new GetTodo(id), ct)
-             .ToHttpResponseAsync()       // returns IResult
-             .AsActionResultAsync<TodoItem>();
+## Use this guide when
+
+- You are writing endpoint code and need the exact overload, parameter order, or builder method for `ToHttpResponse`.
+- You want to confirm what each `HttpResponseOptionsBuilder<T>` method does without scanning the API reference.
+- You need to know which HTTP status / headers a given `Result` shape produces.
+- You are migrating from a v1 ASP integration that used the legacy result-mapping helpers — see [migration.md](migration.md#aspnet-core-trellisasp).
+
+For broader ASP.NET integration topics (Problem Details rendering, scalar validation, route constraints, actor providers, controller examples), see [`integration-aspnet.md`](integration-aspnet.md).
+
+## Surface at a glance
+
+| Receiver | Overload (simplified) | Success status | Failure |
+|---|---|---|---|
+| `Error` | `error.ToHttpResponse(configure?)` | n/a | Problem Details |
+| `Result<T>` | `result.ToHttpResponse(configure?)` | `200` (or `201` if `Created*` configured); `204` for `Result<Unit>` | Problem Details |
+| `Result<T>` | `result.ToHttpResponse(body, configure?)` | Same as above; body is `body(domain)` | Problem Details |
+| `Result<WriteOutcome<T>>` | `result.ToHttpResponse(configure?)` | Variant-driven (`Created → 201`, `Updated → 200/204`, `UpdatedNoContent → 204`, `Accepted → 202`, `AcceptedNoContent → 202`) | Problem Details |
+| `Result<WriteOutcome<T>>` | `result.ToHttpResponse(body, configure?)` | Same; projected body | Problem Details |
+| `Result<Page<T>>` | `result.ToHttpResponse(nextUrlBuilder, body, configure?)` | `200` with `PagedResponse<TBody>` envelope + RFC 8288 `Link` | Problem Details |
+
+Each overload also exposes `Task<...>` and `ValueTask<...>` async variants named `ToHttpResponseAsync` with identical signatures. The `configure` delegate runs against `HttpResponseOptionsBuilder<TDomain>` (or the non-generic `HttpResponseOptionsBuilder` for the `Error` overload).
+
+Full signatures: [trellis-api-asp.md](../api_reference/trellis-api-asp.md).
+
+### `HttpResponseOptionsBuilder<TDomain>` — chainable surface
+
+| Method | Effect |
+|---|---|
+| `WithETag(Func<T, string>)` / `WithETag(Func<T, EntityTagValue>)` | Emits `ETag`; the string overload wraps as `EntityTagValue.Strong`. |
+| `WithLastModified(Func<T, DateTimeOffset>)` | Emits `Last-Modified` in RFC 1123 format. |
+| `Vary(params string[])` | Appends to `Vary` (preserves existing values; case-insensitive dedupe). |
+| `WithContentLanguage(params string[])` / `WithContentLocation(Func<T, string>)` / `WithAcceptRanges(string)` | Sets the matching response header. |
+| `Created(string literal)` / `Created(Func<T, string>)` | `201 Created` with literal or value-derived `Location`. |
+| `CreatedAtRoute(name, Func<T, RouteValueDictionary>)` | `201 Created` via `LinkGenerator.GetUriByName`. AOT-safe. |
+| `CreatedAtAction(action, Func<T, RouteValueDictionary>, controller?)` | MVC `CreatedAtAction` equivalent. **Not trim/AOT-safe** — `RequiresUnreferencedCode` / `RequiresDynamicCode`. |
+| `EvaluatePreconditions()` | On `GET`/`HEAD`, evaluates `If-Match`, `If-Unmodified-Since`, `If-None-Match`, `If-Modified-Since` against the configured ETag/`Last-Modified`. **Not on by default.** |
+| `HonorPrefer()` | Honors RFC 7240 `Prefer: return=minimal` / `return=representation`. Always emits `Vary: Prefer`; emits `Preference-Applied` only when honored. **Not on by default.** |
+| `WithRange(Func<T, ContentRangeHeaderValue>)` | `206 Partial Content` with selector-driven `Content-Range` (or `200` if range covers the whole resource). |
+| `WithRange(long from, long to, long totalLength)` | Static range variant; clamps `to` to `totalLength - 1`. |
+| `WithErrorMapping(Func<Error, int>)` | Per-call error → status mapper. Highest precedence. |
+| `WithErrorMapping<TError>(int status)` | Per-call override for a single error type. |
+
+The non-generic `HttpResponseOptionsBuilder` (for `error.ToHttpResponse(...)`) only exposes `Vary`, `HonorPrefer`, and the two `WithErrorMapping` methods.
+
+> [!NOTE]
+> The options builder has no `body` method. To project the response body, use the `body` **parameter** of the `ToHttpResponse<TDomain, TBody>` overload. Selectors in the options builder always run against the `TDomain` value, not the projected body.
+
+## Installation
+
+```bash
+dotnet add package Trellis.Asp
 ```
 
-In Minimal API:
+Register defaults in `Program.cs`:
 
 ```csharp
-app.MapGet("/todos/{id:guid}", (Guid id, IMediator m, CancellationToken ct) =>
-    m.SendAsync(new GetTodo(id), ct).ToHttpResponseAsync());
+builder.Services.AddTrellisAsp();
 ```
 
-## Write endpoint (`Result<WriteOutcome<T>>`)
+## Quick start
 
-`ToHttpResponse` understands every `WriteOutcome` variant
-(`Created`, `Updated`, `UpdatedNoContent`, `Accepted`, `AcceptedNoContent`)
-and emits the right status, `Location`, `ETag` and `Last-Modified` headers.
+A read endpoint, in both API styles. Same `Result` pipeline, same verb.
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
+
+public sealed record TodoDto(Guid Id, string Title);
+
+// Minimal API
+app.MapGet("/todos/{id:guid}", async (Guid id, ITodoService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct).ToHttpResponseAsync());
+
+// MVC controller
+[ApiController]
+[Route("todos")]
+public sealed class TodosController(ITodoService svc) : ControllerBase
+{
+    [HttpGet("{id:guid}")]
+    public Task<ActionResult<TodoDto>> Get(Guid id, CancellationToken ct) =>
+        svc.GetAsync(id, ct)
+           .ToHttpResponseAsync()
+           .AsActionResultAsync<TodoDto>();
+}
+```
+
+`ToHttpResponseAsync` returns `Task<IResult>`; `AsActionResultAsync<T>` adapts it to `ActionResult<T>` for MVC signatures.
+
+## Basic mapping
+
+| Receiver shape | Success status | Body |
+|---|---|---|
+| `Result<T>` (no `Created*`) | `200 OK` | `T` (or `body(domain)` if projecting) |
+| `Result<T>` (with `Created*`) | `201 Created` + `Location` | `T` |
+| `Result<Unit>` | `204 No Content` | none |
+| `Result<WriteOutcome<T>>` | Variant-driven (see [WriteOutcome variants](#writeoutcomet-variants)) | Variant-driven |
+| `Result<Page<T>>` (paginated overload) | `200 OK` + `Link` | `PagedResponse<TBody>` |
+| Any `Fail(error)` | Mapped via `TrellisAspOptions` (or per-call override) | `application/problem+json` |
+
+Use `Result<Unit>` for no-payload commands:
+
+```csharp
+app.MapDelete("/todos/{id:guid}", async (Guid id, ITodoService svc, CancellationToken ct) =>
+    await svc.DeleteAsync(id, ct).ToHttpResponseAsync()); // 204 on Ok, Problem Details on Fail
+```
+
+## Body projection
+
+Pass `body` as the **second positional argument** to project a DTO without losing access to the domain value for header selectors.
+
+```csharp
+public sealed record TodoView(Guid Id, string Title, string ETag);
+
+app.MapGet("/todos/{id:guid}", async (Guid id, ITodoService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct).ToHttpResponseAsync(
+        body: t => new TodoView(t.Id, t.Title, $""{t.Version}""),
+        configure: opts => opts.WithETag(t => $""{t.Version}"")));
+```
+
+Selectors (`WithETag`, `WithLastModified`, `Created(Func<T, string>)`, `WithRange(selector)`, etc.) always receive the **domain** value, not the projected body.
+
+## ETag and conditional requests
+
+`EvaluatePreconditions()` opts in to RFC 9110 evaluation on safe methods (`GET`, `HEAD`). Pair it with `WithETag` and/or `WithLastModified`:
+
+```csharp
+app.MapGet("/todos/{id:guid}", async (Guid id, ITodoService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct).ToHttpResponseAsync(opts => opts
+        .WithETag(t => $""{t.Version}"")
+        .WithLastModified(t => t.UpdatedAt)
+        .EvaluatePreconditions()));
+```
+
+Evaluation order (per `ConditionalRequestEvaluator`): `If-Match` → `If-Unmodified-Since` → `If-None-Match` → `If-Modified-Since`. Failed `If-Match` / `If-Unmodified-Since` → `412 Precondition Failed`; failed `If-None-Match` / `If-Modified-Since` on `GET`/`HEAD` → `304 Not Modified`. On unsafe methods, evaluate the precondition **before** the mutation (see [`integration-aspnet.md`](integration-aspnet.md#conditional-requests)).
+
+## Prefer header
+
+`HonorPrefer()` is meaningful on `Result<WriteOutcome<T>>` updates: `Prefer: return=minimal` short-circuits `Updated → 204 No Content`; `return=representation` returns `200 OK` with the body. `Vary: Prefer` is always emitted when honored; `Preference-Applied` is emitted only when the preference was honored.
+
+```csharp
+app.MapPut("/todos/{id:guid}", async (Guid id, UpdateTodo cmd, ITodoService svc, CancellationToken ct) =>
+    await svc.UpdateAsync(id, cmd, ct).ToHttpResponseAsync(opts => opts
+        .WithETag(t => $""{t.Version}"")
+        .HonorPrefer()));
+```
+
+## Created responses
+
+| Configuration | Result |
+|---|---|
+| `opts.Created("/orders/123")` | `201 Created`, literal `Location`. |
+| `opts.Created(o => $"/orders/{o.Id}")` | `201 Created`, value-derived `Location`. |
+| `opts.CreatedAtRoute("Orders_GetById", o => new RouteValueDictionary { ["id"] = o.Id })` | `201 Created`, link via `LinkGenerator.GetUriByName`. AOT-safe. |
+| `opts.CreatedAtAction("GetById", o => new RouteValueDictionary { ["id"] = o.Id })` | `201 Created`, MVC link. **Not trim/AOT-safe.** |
+
+```csharp
+app.MapPost("/orders", async (CreateOrder cmd, IOrderService svc, CancellationToken ct) =>
+    await svc.CreateAsync(cmd, ct).ToHttpResponseAsync(opts => opts
+        .CreatedAtRoute("Orders_GetById", o => new RouteValueDictionary { ["id"] = o.Id })))
+   .WithName("Orders_Create");
+```
+
+> [!IMPORTANT]
+> Under query-string API versioning, the `RouteValueDictionary` MUST include `["api-version"] = ApiVersion`; otherwise the emitted `Location` omits the version segment and `404`s on dereference.
+
+### `WriteOutcome<T>` variants
+
+When the receiver is `Result<WriteOutcome<T>>`, the outcome variant drives status and headers — `Created*` builder methods are **not** required (they are required for `Result<T>` create endpoints). See [`integration-aspnet.md → WriteOutcome<T>`](integration-aspnet.md#writeoutcomet) for the full mapping table and command examples.
+
+## Range responses
+
+| Overload | Behavior |
+|---|---|
+| `WithRange(Func<T, ContentRangeHeaderValue>)` | Returns `206` with selector-derived `Content-Range`. Returns `200` if the range covers the whole representation. |
+| `WithRange(long from, long to, long totalLength)` | Static variant. Clamps `to` to `totalLength - 1`. |
+
+```csharp
+app.MapGet("/blobs/{id:guid}", async (Guid id, IBlobService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct).ToHttpResponseAsync(opts => opts
+        .WithAcceptRanges("bytes")
+        .WithRange(b => new System.Net.Http.Headers.ContentRangeHeaderValue(0, b.Length - 1, b.Length))));
+```
+
+## Pagination
+
+`Result<Page<T>>` has a dedicated overload requiring `nextUrlBuilder` and a per-item `body` projector. The pagination signature is **not** the same as the `Result<T>` overload:
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `nextUrlBuilder` | `Func<Cursor, int, string>` | Receives the cursor and the applied page limit; returns an absolute URL. Used for both `next` and `prev` links in the RFC 8288 `Link` header. |
+| `body` | `Func<T, TBody>` | Per-**item** projector (not per-page). Each `Page<T>` item is mapped to `TBody` for the envelope. |
+
+```csharp
+app.MapGet("/todos", async (string? cursor, int? limit, ITodoService svc, HttpRequest req, CancellationToken ct) =>
+    await svc.ListAsync(cursor, limit, ct).ToHttpResponseAsync(
+        nextUrlBuilder: (c, n) => $"{req.Scheme}://{req.Host}{req.Path}?cursor={c}&limit={n}",
+        body: t => new TodoDto(t.Id, t.Title)));
+```
+
+## Per-call error mapping
+
+Override the global `TrellisAspOptions` defaults for a single endpoint. Per-call overrides have **higher precedence** than the global registration.
+
+```csharp
+// Global default at composition root:
+builder.Services.AddTrellisAsp(opts => opts.MapError<Error.Conflict>(StatusCodes.Status409Conflict));
+
+// Per-call override for one endpoint:
+app.MapGet("/legacy/{id:guid}", async (Guid id, ITodoService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct).ToHttpResponseAsync(opts => opts
+        .WithErrorMapping<Error.NotFound>(StatusCodes.Status410Gone)));
+```
+
+For Problem Details payload rules and the full default mapping table, see [`integration-aspnet.md → Error mapping`](integration-aspnet.md#error-mapping) and [`integration-aspnet.md → Problem Details output`](integration-aspnet.md#problem-details-output).
+
+## Standalone error
+
+For diagnostic / fault-demo endpoints that produce an `Error` without a `Result` pipeline:
+
+```csharp
+app.MapGet("/diagnostics/throttle",
+    () => new Error.TooManyRequests("rate-limit-policy") { Detail = "10 req/min" }
+        .ToHttpResponse(opts => opts.WithErrorMapping<Error.TooManyRequests>(StatusCodes.Status429TooManyRequests)));
+```
+
+The non-generic `HttpResponseOptionsBuilder` exposes `Vary`, `HonorPrefer`, and the two `WithErrorMapping` overloads only.
+
+## MVC adapter
+
+`AsActionResult<T>()` / `AsActionResultAsync<T>()` (in `ActionResultAdapterExtensions`) wrap the `IResult` so it satisfies `ActionResult<T>` signatures. The MVC pipeline still executes the same `IResult` via `IConvertToActionResult`.
 
 ```csharp
 [HttpPost]
-public Task<ActionResult<TodoItem>> Create(CreateTodo cmd, CancellationToken ct) =>
-    _mediator.SendAsync(cmd, ct)
-             .ToHttpResponseAsync(opts => opts.CreatedAtRoute(
-                 routeName: "GetTodo",
-                 routeValues: t => new RouteValueDictionary { ["id"] = t.Id }))
-             .AsActionResultAsync<TodoItem>();
+public Task<ActionResult<TodoDto>> Create(CreateTodo cmd, CancellationToken ct) =>
+    _svc.CreateAsync(cmd, ct)
+        .ToHttpResponseAsync(opts => opts.CreatedAtRoute(
+            "Todos_GetById",
+            t => new RouteValueDictionary { ["id"] = t.Id }))
+        .AsActionResultAsync<TodoDto>();
 ```
 
-## Conditional requests & `Prefer`
+> [!NOTE]
+> `ToHttpResponse` writes via the Minimal API `Results.*` infrastructure, **bypassing MVC output formatters**. If an endpoint depends on a custom MVC formatter (e.g. XML), return an MVC `ObjectResult` directly for that endpoint and use `ToHttpResponse(...).AsActionResult<T>()` for the rest.
 
-`HonorPreconditions` and `HonorPrefer` are on by default. Pair with
-`WithETag` / `WithLastModified` to opt in:
+## Composition
+
+`ToHttpResponseAsync` accepts both `Task<Result<T>>` and `ValueTask<Result<T>>` receivers, so it composes naturally at the end of a `Bind`/`Map`/`Ensure` chain.
 
 ```csharp
-result.ToHttpResponse(opts => opts
-    .WithETag(t => EntityTagHeaderValue.Parse($"\"{t.Version}\""))
-    .WithLastModified(t => t.UpdatedAt));
+app.MapPut("/todos/{id:guid}/title", async (Guid id, RenameTodo cmd, ITodoService svc, CancellationToken ct) =>
+    await svc.GetAsync(id, ct)
+             .EnsureAsync(t => t.OwnerId == cmd.OwnerId,
+                          new Error.Forbidden("todos.rename"))
+             .BindAsync((t, token) => svc.RenameAsync(t.Id, cmd.NewTitle, token), ct)
+             .ToHttpResponseAsync(opts => opts
+                 .WithETag(t => $""{t.Version}"")
+                 .HonorPrefer()));
 ```
 
-This emits `ETag` / `Last-Modified` on success, evaluates
-`If-Match` / `If-None-Match` / `If-Modified-Since` / `If-Unmodified-Since`,
-and respects `Prefer: return=minimal|representation`.
-
-## Vary, Range, paginated and projected bodies
+Test the produced `IResult` directly without spinning up the host:
 
 ```csharp
-opts.Vary("Accept-Language", "Accept-Encoding");
-opts.WithRange(maxRangeBytes: 4 * 1024 * 1024);
+var http = (await result).ToHttpResponse(opts => opts.WithETag(t => $""{t.Version}""));
+await http.ExecuteAsync(httpContext);
+// Assert on httpContext.Response.StatusCode and headers.
 ```
 
-Paginated:
+## Practical guidance
 
-```csharp
-result.ToHttpResponse(
-    nextUrlBuilder: page => $"/todos?cursor={page.NextCursor}",
-    body: page => page.Items);
-```
+- **Pick the right receiver shape.** Reads → `Result<T>`. Commands with a no-body success → `Result<Unit>` (auto `204`). Writes that need RFC 9110 status semantics (`201`/`202`/`204` with `Location`/`Retry-After`) → `Result<WriteOutcome<T>>`. Lists → `Result<Page<T>>` with the paginated overload.
+- **Use `CreatedAtRoute` for AOT.** `CreatedAtAction` carries `RequiresUnreferencedCode` / `RequiresDynamicCode`. Pass `RouteValueDictionary` (not anonymous types) to stay AOT-safe.
+- **Opt in to preconditions and `Prefer`.** Both `EvaluatePreconditions()` and `HonorPrefer()` are off by default — call them where you need the behavior.
+- **Selectors run on the domain value.** When projecting via `body`, all `With*` selectors still receive the domain `T`. Use this to compute strong ETags from version fields the DTO does not expose.
+- **Per-call mappings beat globals.** `opts.WithErrorMapping<TError>(status)` overrides the `TrellisAspOptions` registration for that one call.
+- **Don't pre-compute the `IResult`.** Build it inside the endpoint handler so the configured `LinkGenerator` resolves at execute time with the live `HttpContext.RequestServices`.
 
-Body projection:
+## Cross-references
 
-```csharp
-result.ToHttpResponse<TodoItem, TodoDto>(opts => opts.WithBody(t => TodoDto.From(t)));
-```
-
-## Error mapping
-
-Default mapping is configured at startup with `AddTrellisAsp`. Override per call:
-
-```csharp
-// Startup — configure global defaults:
-builder.Services.AddTrellisAsp(options =>
-{
-    options.MapError<Error.Conflict>(StatusCodes.Status400BadRequest);
-});
-
-// Per call — override for a single endpoint:
-opts.WithErrorMapping<Error.NotFound>(StatusCodes.Status410Gone);
-```
-
-Companion headers (`Allow`, `Retry-After`, `Content-Range`, …) are emitted
-automatically based on the concrete `Error` subtype.
-
-## MVC ↔ Minimal API
-
-Same code, two presentation styles:
-
-| API style       | Wrap with                       |
-|-----------------|---------------------------------|
-| Minimal API     | `await result.ToHttpResponse()` |
-| MVC controller  | `result.ToHttpResponse().AsActionResult<T>()` |
-
-`.AsActionResult<T>()` implements `IConvertToActionResult` and forwards
-`ExecuteResultAsync` to `IResult.ExecuteAsync`, so the MVC pipeline executes
-the same `IResult` you would use in Minimal API.
-
-## Migration from the legacy verbs
-
-The previous extension classes
-(`HttpResultExtensions`, `HttpResultExtensionsAsync`, `ActionResultExtensions`,
-`ActionResultExtensionsAsync`, `WriteOutcomeExtensions`,
-`PageHttpResultExtensions`, `PageActionResultExtensions`) have been **deleted**
-in v3. Migrate as follows:
-
-| Old                                                | New                                                              |
-|----------------------------------------------------|------------------------------------------------------------------|
-| `result.ToActionResult()`                          | `result.ToHttpResponse().AsActionResult<T>()`                    | <!-- stale-doc-ok: legacy verb in migration table -->
-| `result.ToActionResultAsync()`                     | `result.ToHttpResponseAsync().AsActionResultAsync<T>()`          | <!-- stale-doc-ok: legacy verb in migration table -->
-| `result.ToHttpResult(httpContext)`                 | `result.ToHttpResponse()` (returns `IResult`)                    | <!-- stale-doc-ok: legacy verb in migration table -->
-| `outcome.ToActionResult(routeName, routeValues)`   | `result.ToHttpResponse(o => o.CreatedAtRoute(routeName, rv))`    | <!-- stale-doc-ok: legacy verb in migration table -->
-| `outcome.ToHttpResult(httpContext, map)`           | `result.ToHttpResponse(o => o.CreatedAtRoute(...))`              | <!-- stale-doc-ok: legacy verb in migration table -->
-| `pageResult.ToPagedHttpResult(nextUrlBuilder, ...)` | `result.ToHttpResponse(nextUrlBuilder, body: p => p.Items)`     | <!-- stale-doc-ok: legacy verb in migration table -->
-
-### Other migration notes
-
-- **VO binding auto-registration.** `services.AddTrellisAsp()` now
-  automatically calls `AddScalarValueValidation()`. The standalone
-  `UseScalarValueValidation()` / `WithScalarValueValidation()` calls remain
-  functional but are redundant when `AddTrellisAsp` is used.
-- **Controller-test pattern.** Tests that previously asserted on
-  `ActionResult` shapes can now exercise the `IResult` directly:
-  `var http = (await result).ToHttpResponse(); await http.ExecuteAsync(httpContext);`
-- **MVC formatter bypass.** `ToHttpResponse` writes responses through the
-  Minimal API `Results.*` infrastructure, bypassing MVC output formatters.
-  If an endpoint depends on a custom MVC formatter (e.g. XML), return an MVC
-  `ActionResult` / `ObjectResult` directly from the controller for that
-  endpoint and use `ToHttpResponse().AsActionResult<T>()` for the rest.
+- API surface: [trellis-api-asp.md](../api_reference/trellis-api-asp.md)
+- `Result<T>`, `WriteOutcome<T>`, `Page<T>`, `Cursor`, `Error` semantics: [trellis-api-core.md](../api_reference/trellis-api-core.md)
+- Broader ASP.NET integration (Problem Details rendering, scalar validation, route constraints, actor providers, MVC patterns): [integration-aspnet.md](integration-aspnet.md)
+- HTTP client side (`HttpResponseMessage` → `Result<T>`): [integration-http.md](integration-http.md)

--- a/docs/docfx_project/articles/basics.md
+++ b/docs/docfx_project/articles/basics.md
@@ -1,6 +1,32 @@
-﻿# Basics
+﻿---
+title: Basics
+package: Trellis (multiple)
+topics: [result, railway-oriented-programming, value-objects, ddd, error-handling, async, beginner]
+related_api_reference: [trellis-api-core.md, trellis-api-primitives.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Basics
 
 This article teaches the handful of Trellis concepts you will use most often: **value objects**, **`Result<T>`**, and the core operators that turn a multi-step workflow into readable code.
+
+## Patterns Index
+
+| Goal | Use | See |
+|---|---|---|
+| Replace primitive parameters with typed value objects | `RequiredString<T>` / `RequiredGuid<T>` partial classes | [Why avoid primitive obsession?](#why-avoid-primitive-obsession) |
+| Validate several independent fields and keep all failures | `Combine` | [`Combine`](#combine-validate-independent-inputs-together) |
+| Call the next result-producing step | `Bind` | [`Bind`](#bind-call-the-next-result-producing-step) |
+| Transform a success value with a non-failing function | `Map` | [`Map`](#map-transform-a-successful-value) |
+| Add a single business rule | `Ensure` | [`Ensure`](#ensure-add-a-business-rule) |
+| Collect several rule violations together | `EnsureAll` | [`EnsureAll`](#ensureall-collect-several-business-rule-failures-at-once) |
+| Run a side effect on the success path | `Tap` | [`Tap`](#tap-run-a-side-effect-without-changing-the-result) |
+| Provide a fallback when an error matches a predicate | `RecoverOnFailure` | [`RecoverOnFailure`](#recoveronfailure-provide-a-fallback-path) |
+| Finish the pipeline and produce a plain value | `Match` | [`Match`](#match-finish-the-pipeline) |
+| Chain over async I/O without losing readability | `BindAsync` / `TapAsync` / `MatchAsync` | [Working with async operations](#working-with-async-operations) |
+| Run independent async work in parallel and combine | `Result.ParallelAsync(...).WhenAllAsync()` | [Parallel async work](#parallel-async-work) |
+
+Full operator signatures and overloads: [`trellis-api-core.md`](../api_reference/trellis-api-core.md). Built-in value-object base classes: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md).
 
 ## Table of Contents
 

--- a/docs/docfx_project/articles/clean-architecture.md
+++ b/docs/docfx_project/articles/clean-architecture.md
@@ -1,6 +1,12 @@
-﻿# Clean Architecture with Trellis
-
-**Level:** Intermediate | **Packages:** `Trellis.Core`, `Trellis.Primitives`
+﻿---
+title: Clean Architecture with Trellis
+package: Trellis (multiple)
+topics: [clean-architecture, ddd, aggregates, application-layer, value-objects, result]
+related_api_reference: [trellis-api-core.md, trellis-api-primitives.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Clean Architecture with Trellis
 
 If your API starts as “just a few endpoints,” it is easy for validation, orchestration, persistence, and business rules to end up tangled together.
 
@@ -437,3 +443,5 @@ You do **not** need one pattern for the whole system. A codebase can keep simple
 - [Primitive Value Objects](primitives.md)
 - [Specifications](specifications.md)
 - [RequiredEnum](required-enum.md)
+- API surface for `Result<T>`, `Aggregate<TId>`, `IDomainEvent`, `Error.UnprocessableContent`, `Error.Conflict`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Value-object base classes (`RequiredString<TSelf>`, `RequiredGuid<TSelf>`, `EmailAddress`): [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)

--- a/docs/docfx_project/articles/debugging.md
+++ b/docs/docfx_project/articles/debugging.md
@@ -1,4 +1,12 @@
-﻿# Debugging Trellis Pipelines
+﻿---
+title: Debugging Trellis Pipelines
+package: Trellis (multiple)
+topics: [debugging, tap, tryget, opentelemetry, logging, result]
+related_api_reference: [trellis-api-core.md, trellis-api-primitives.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Debugging Trellis Pipelines
 
 Trellis pipelines are easy to read when they work — and sometimes harder to inspect when they do not.
 
@@ -300,3 +308,8 @@ Debugging Trellis is different from debugging exception-heavy code, but it is us
 - let error values tell you what happened
 
 When you do that, most pipeline bugs become straightforward to locate.
+
+## Cross-references
+
+- `Result<T>` accessors (`TryGetValue`, `TryGetError`, `Match`), `Tap` / `TapOnFailure`, `ResultDebugSettings`, `AddResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- `AddPrimitiveValueObjectInstrumentation`: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)

--- a/docs/docfx_project/articles/error-handling.md
+++ b/docs/docfx_project/articles/error-handling.md
@@ -107,7 +107,7 @@ new Error.NotFound(ResourceRef.For<Order>("42")) { Detail = "Order 42 not found"
 | Internal invariant violated | `new Error.Unexpected("default_initialized")` |
 
 > [!TIP]
-> Reach for `Error.Conflict(resource, "domain.violation")` when the input is structurally valid but a business rule blocks it. `Error.UnprocessableContent` is for input the caller can fix.
+> Reach for `new Error.Conflict(resource) { ReasonCode = "domain.violation" }` when the input is structurally valid but a business rule blocks it. `Error.UnprocessableContent` is for input the caller can fix.
 
 ### Validation failures
 

--- a/docs/docfx_project/articles/error-handling.md
+++ b/docs/docfx_project/articles/error-handling.md
@@ -1,169 +1,151 @@
-﻿# Error Handling
+﻿---
+title: Error Handling
+package: Trellis.Core
+topics: [error-handling, error-adt, fail, problem-details, hierarchy, validation, aggregate]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Error Handling
 
-Errors are where Trellis becomes practical. They let you keep business rules, validation, and HTTP concerns explicit **without** falling back to exceptions for normal control flow.
+`Error` is a closed discriminated union of typed records that lets you return failures as values and pattern-match them at the boundary, without falling back to exceptions for normal control flow.
 
-> [!TIP]
-> In Trellis, an error is a **closed discriminated union of typed records**. You can log it, transform it, combine it, test it, and `switch` over it with compile-time exhaustiveness checking.
+## Patterns Index
 
-## Start Here: the Everyday Flow
+| Goal | Use | See |
+|---|---|---|
+| Return a typed failure from a function | `Result.Fail<T>(new Error.X(payload) { Detail = "..." })` | [Creating errors](#creating-errors) |
+| Build a single-violation 422 from a property name | `Error.UnprocessableContent.ForField("email", "required", "...")` | [Validation failures](#validation-failures) |
+| Build a single-violation 422 from an object-level rule | `Error.UnprocessableContent.ForRule("passwords_must_match", "...")` | [Validation failures](#validation-failures) |
+| Aggregate per-field and cross-field violations | `new Error.UnprocessableContent(Fields: ..., Rules: ...)` | [Validation failures](#validation-failures) |
+| Branch on the closed catalog at a boundary | `result.Match(value => ..., error => error switch { Error.NotFound nf => ..., ... })` | [Pattern matching](#pattern-matching) |
+| Log without changing the result | `result.TapOnFailure(error => logger.LogWarning(...))` | [Propagating errors](#propagating-errors) |
+| Translate one failure case into another | `result.MapOnFailure(error => error switch { ... })` | [Propagating errors](#propagating-errors) |
+| Capture a thrown exception as a typed error | `Result.Try(() => ..., ex => new Error.X(...))` | [Capturing exceptions](#capturing-exceptions) |
+| Merge multiple failures into one | `Result.Combine(r1, r2, r3)` or `left.Combine(right)` on `Error` | [Composition](#composition) |
+| Map an `Error` to an HTTP / Problem Details response | `result.ToHttpResponse(...)` (in `Trellis.Asp`) | [Boundary mapping](#boundary-mapping) |
 
-Most applications need the same shape:
+## Use this guide when
 
-1. Do work in a `Result<T>` pipeline.
-2. Return a specific `Error` case when something goes wrong.
-3. `switch` on the case at the boundary to convert it.
+- You want expected failures (validation, not found, conflict, forbidden) to be values your callers can branch on, not exceptions.
+- You need compile-time exhaustiveness across every failure case at a boundary.
+- You are aggregating multiple validation failures and want to keep them all instead of throwing the first one away.
+- You need a stable wire vocabulary (`Kind`, `Code`, payload) that survives refactors and renders consistently as Problem Details.
+
+## Surface at a glance
+
+`Error` is an `abstract record` with **20 nested `sealed record` cases**. The base type has a `private` constructor, so the catalog is closed and `switch` over an `Error` reference is exhaustive at the language level.
+
+| Category | Cases | Wire status |
+|---|---|---|
+| 4xx client | `BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `MethodNotAllowed`, `NotAcceptable`, `Conflict`, `Gone`, `PreconditionFailed`, `ContentTooLarge`, `UnsupportedMediaType`, `RangeNotSatisfiable`, `UnprocessableContent`, `PreconditionRequired`, `TooManyRequests` | `400` – `429` |
+| 5xx server | `InternalServerError`, `Unexpected`, `NotImplemented`, `ServiceUnavailable` | `500` – `503` |
+| Composition | `Aggregate` | `207` / `extensions.errors` |
+
+Every case carries a strongly-typed payload, an init-only `Detail` property, and a structured (never `Exception`) `Cause` chain. Full per-case constructor signatures, payload notes, and the supporting types (`ResourceRef`, `InputPointer`, `FieldViolation`, `RuleViolation`, `AuthChallenge`, `RetryAfterValue`, `PreconditionKind`, `EquatableArray<T>`) live in [`trellis-api-core.md` → `Error`](../api_reference/trellis-api-core.md#public-abstract-record-error).
+
+> [!NOTE]
+> `Error.Unexpected` and `Error.InternalServerError` both map to HTTP 500 but are distinct cases. `InternalServerError(faultId)` carries an opaque per-incident id correlating with telemetry; `Unexpected(reasonCode)` identifies the *kind* of "shouldn't happen" condition (default-initialized `Result`, exhausted match arms, internal invariant violations) and does not attach a `faultId` extension at the ASP boundary.
+
+## Installation
+
+```bash
+dotnet add package Trellis.Core
+```
+
+## Quick start
+
+Return a typed failure, then pattern-match at the boundary.
 
 ```csharp
 using Trellis;
 
-public record User(string Id, string Email);
+public sealed record User(string Id, string Email);
 
-static Result<User> GetUser(string id) =>
-    id == "42"
-        ? Result.Ok(new User("42", "ada@example.com"))
-        : Result.Fail<User>(new Error.NotFound(new ResourceRef("User", id)) { Detail = $"User {id} not found" });
+public static class UserService
+{
+    public static Result<User> GetUser(string id) =>
+        id == "42"
+            ? Result.Ok(new User("42", "ada@example.com"))
+            : Result.Fail<User>(new Error.NotFound(ResourceRef.For<User>(id)) { Detail = $"User {id} not found" });
+}
 
-var response = GetUser("42").Match(
-    onSuccess: user => $"200 OK: {user.Email}",
+var message = UserService.GetUser("42").Match(
+    onSuccess: user  => $"200 OK: {user.Email}",
     onFailure: error => error switch
     {
-        Error.NotFound nf      => $"404 Not Found: {nf.Detail}",
-        Error.Forbidden f      => $"403 Forbidden: {f.PolicyId}",
-        _                      => $"500 Internal: {error.Kind}"
+        Error.NotFound nf  => $"404 Not Found: {nf.Detail}",
+        Error.Forbidden f  => $"403 Forbidden: {f.PolicyId}",
+        _                  => $"500 Internal: {error.Kind}",
     });
 ```
 
-That is the core mental model.
+## Creating errors
 
-## Why Trellis Uses Explicit Errors
+There are no static factory methods on the base `Error` type. Every call site names the case it produces:
 
-The problem with raw exceptions is that they mix two very different things:
+```csharp
+new Error.NotFound(ResourceRef.For<Order>("42")) { Detail = "Order 42 not found" }
+```
 
-- **expected failures** — validation, not found, conflict, forbidden
-- **unexpected failures** — I/O faults, programmer bugs
+`Detail` is an init-only property on the base record; set it via object-initializer when you want to override the boundary renderer's default human-readable text. `Kind` (the stable IANA-aligned slug) and `Code` (the per-instance machine code, defaulting to `Kind`) are read-only.
 
-Trellis separates them:
-
-- expected failures are `Error.X` cases inside `Result<T>` failures
-- unexpected exceptions become `new Error.InternalServerError(faultId)` via `Result.Try` / `Result.TryAsync`
-
-## The Error ADT
-
-`Error` is an `abstract record` with **18 nested `sealed record` cases**. The catalog is closed (the base type has a `private` constructor) so every `switch` is exhaustive at compile time.
-
-| Case | Payload | HTTP | Use when... |
-| --- | --- | --- | --- |
-| `Error.BadRequest` | `(string ReasonCode, InputPointer? At = null)` | 400 | Request shape itself is malformed |
-| `Error.Unauthorized` | `(EquatableArray<AuthChallenge> Challenges = default)` | 401 | Authentication missing or invalid |
-| `Error.Forbidden` | `(string PolicyId, ResourceRef? Resource = null)` | 403 | Authenticated but not allowed |
-| `Error.NotFound` | `(ResourceRef Resource)` | 404 | A resource does not exist |
-| `Error.MethodNotAllowed` | `(EquatableArray<string> Allow)` | 405 | HTTP method not supported here |
-| `Error.NotAcceptable` | `(EquatableArray<string> Available)` | 406 | No acceptable representation |
-| `Error.Conflict` | `(ResourceRef? Resource, string ReasonCode)` | 409 | State or business rule conflict |
-| `Error.Gone` | `(ResourceRef Resource)` | 410 | Resource intentionally removed |
-| `Error.PreconditionFailed` | `(ResourceRef, PreconditionKind)` | 412 | `If-Match`/etc. failed |
-| `Error.ContentTooLarge` | `(long? MaxBytes = null)` | 413 | Request body too large |
-| `Error.UnsupportedMediaType` | `(EquatableArray<string> Supported)` | 415 | Content-Type not supported |
-| `Error.RangeNotSatisfiable` | `(long CompleteLength, string Unit = "bytes")` | 416 | Requested range invalid |
-| `Error.UnprocessableContent` | `(EquatableArray<FieldViolation> Fields, EquatableArray<RuleViolation> Rules = default)` | 422 | Domain-validation failures |
-| `Error.PreconditionRequired` | `(PreconditionKind Condition)` | 428 | Required precondition header missing |
-| `Error.TooManyRequests` | `(RetryAfter? RetryAfter = null)` | 429 | Rate-limited |
-| `Error.InternalServerError` | `(string FaultId)` | 500 | Unhandled failure; rich diagnostics live in your log indexed by `FaultId` |
-| `Error.NotImplemented` | `(string Feature)` | 501 | Feature not implemented |
-| `Error.ServiceUnavailable` | `(RetryAfter? RetryAfter = null)` | 503 | Dependency unavailable |
-| `Error.Aggregate` | `(EquatableArray<Error> Errors)` | varies | Multiple failures collected; auto-flattens nested aggregates |
+| Pattern | Example |
+|---|---|
+| Resource not found | `new Error.NotFound(ResourceRef.For<Order>(id)) { Detail = $"Order {id} not found" }` |
+| State conflict | `new Error.Conflict(ResourceRef.For<User>(userId), "duplicate.key") { Detail = "Email is already in use" }` |
+| Domain rule conflict (no resource) | `new Error.Conflict(null, "cancel_after_ship") { Detail = "Cannot cancel after shipment" }` |
+| Authentication missing | `new Error.Unauthorized() { Detail = "Authentication token is missing" }` |
+| Authenticated but not allowed | `new Error.Forbidden("orders.write") { Detail = "Administrator role required" }` |
+| Soft-deleted resource | `new Error.Gone(ResourceRef.For<Document>(id))` |
+| Wrong content type | `new Error.UnsupportedMediaType(EquatableArray.Create("application/json"))` |
+| Body too large | `new Error.ContentTooLarge(MaxBytes: 10 * 1024 * 1024)` |
+| Method not supported | `new Error.MethodNotAllowed(EquatableArray.Create("GET", "POST"))` |
+| Rate limited | `new Error.TooManyRequests(RetryAfterValue.FromSeconds(30))` |
+| Dependency unavailable | `new Error.ServiceUnavailable(RetryAfterValue.FromSeconds(120)) { Detail = "Payment gateway offline" }` |
+| Unhandled fault (correlates to logs) | `new Error.InternalServerError(faultId) { Detail = ex.Message }` |
+| Internal invariant violated | `new Error.Unexpected("default_initialized")` |
 
 > [!TIP]
-> `new Error.Conflict(resource, "domain.violation")` is usually a better fit than `Error.UnprocessableContent` when the input is structurally valid but violates a business rule.
+> Reach for `Error.Conflict(resource, "domain.violation")` when the input is structurally valid but a business rule blocks it. `Error.UnprocessableContent` is for input the caller can fix.
 
-## Construction syntax
+### Validation failures
 
-There are **no static factory methods**. Every call site names the case it produces:
+`Error.UnprocessableContent` carries `EquatableArray<FieldViolation> Fields` and `EquatableArray<RuleViolation> Rules`. For single-violation cases prefer the static factories on the case itself; the boundary renderer surfaces a single field-violation's `Detail` as the response detail directly.
 
-```csharp
-new Error.NotFound(new ResourceRef("Order", "42")) { Detail = "Order 42 not found" }
-```
-
-The free-form `Detail` is an init-only property on the base type — set it via object initializer when you want to override the renderer's default human-readable text.
-
-### Common patterns
-
-**Single-field validation**
+| Factory | Use when |
+|---|---|
+| `Error.UnprocessableContent.ForField(propertyName, reasonCode, detail?)` | Single property failure named by simple property (escaped via `InputPointer.ForProperty`). |
+| `Error.UnprocessableContent.ForField(InputPointer field, reasonCode, detail?)` | Single field failure where you already have a pointer (nested / array / `InputPointer.Root`). |
+| `Error.UnprocessableContent.ForRule(reasonCode, detail?)` | Single object-level invariant with no field pointer. |
+| `new Error.UnprocessableContent(EquatableArray<FieldViolation> Fields, EquatableArray<RuleViolation> Rules = default)` | Aggregate multiple per-field and/or cross-field violations. |
 
 ```csharp
-var error = new Error.UnprocessableContent(EquatableArray.Create(
-    new FieldViolation(InputPointer.ForProperty("email"), "required") { Detail = "Email is required" }));
-```
+using System.Collections.Immutable;
+using Trellis;
 
-**Multi-field validation**
+var single = Error.UnprocessableContent.ForField("email", "required", "Email is required");
 
-```csharp
-var error = new Error.UnprocessableContent(EquatableArray.Create(
+var multiField = new Error.UnprocessableContent(EquatableArray.Create(
     new FieldViolation(InputPointer.ForProperty("email"),    "required") { Detail = "Email is required" },
-    new FieldViolation(InputPointer.ForProperty("password"), "min_length", ImmutableDictionary<string, string>.Empty.Add("min", "8")) { Detail = "Password must be at least 8 characters" },
-    new FieldViolation(InputPointer.ForProperty("age"),      "min", ImmutableDictionary<string, string>.Empty.Add("min", "18")) { Detail = "Must be 18 or older" }));
-```
+    new FieldViolation(InputPointer.ForProperty("password"), "min_length",
+        ImmutableDictionary<string, string>.Empty.Add("min", "8")) { Detail = "Password must be at least 8 characters" },
+    new FieldViolation(InputPointer.ForProperty("age"),      "min",
+        ImmutableDictionary<string, string>.Empty.Add("min", "18")) { Detail = "Must be 18 or older" }));
 
-**Cross-field business rule**
-
-```csharp
-var error = new Error.UnprocessableContent(
+var crossField = new Error.UnprocessableContent(
     Fields: EquatableArray<FieldViolation>.Empty,
     Rules:  EquatableArray.Create(new RuleViolation(
         "passwords_must_match",
-        Fields: EquatableArray.Create(InputPointer.ForProperty("password"), InputPointer.ForProperty("passwordConfirmation")))
+        Fields: EquatableArray.Create(
+            InputPointer.ForProperty("password"),
+            InputPointer.ForProperty("passwordConfirmation")))
         { Detail = "Passwords must match" }));
 ```
 
-**Not found**
+## Pattern matching
 
-```csharp
-var error = new Error.NotFound(new ResourceRef("Order", "123")) { Detail = "Order 123 was not found" };
-```
-
-**Conflict (state vs domain)**
-
-```csharp
-var stateConflict  = new Error.Conflict(new ResourceRef("User", "ada"), "duplicate.key")     { Detail = "Email address is already in use" };
-var domainConflict = new Error.Conflict(null,                            "cancel_after_ship")  { Detail = "Cannot cancel an order after shipment has started" };
-```
-
-**Authorization (authenticated vs not)**
-
-```csharp
-var unauth     = new Error.Unauthorized()              { Detail = "Authentication token is missing" };
-var forbidden  = new Error.Forbidden("orders.write")   { Detail = "Administrator role is required" };
-```
-
-**Operational HTTP cases**
-
-```csharp
-var gone        = new Error.Gone(new ResourceRef("Document", "42"))                          { Detail = "Document 42 was permanently removed" };
-var media       = new Error.UnsupportedMediaType(EquatableArray.Create("application/json"))  { Detail = "Only application/json is supported" };
-var tooLarge    = new Error.ContentTooLarge(MaxBytes: 10 * 1024 * 1024)                      { Detail = "Upload exceeds the 10 MB limit" };
-var notAccept   = new Error.NotAcceptable(EquatableArray.Create("application/json"))         { Detail = "The requested response format is not available" };
-var notAllowed  = new Error.MethodNotAllowed(EquatableArray.Create("GET", "POST"))           { Detail = "PATCH is not supported for this endpoint" };
-var rangeBad    = new Error.RangeNotSatisfiable(CompleteLength: 4096)                        { Detail = "Requested range exceeds file length" };
-```
-
-**Rate limit and availability**
-
-```csharp
-var rate = new Error.TooManyRequests(new RetryAfter(Delta: TimeSpan.FromSeconds(30)));
-var down = new Error.ServiceUnavailable(new RetryAfter(Delta: TimeSpan.FromMinutes(2))) { Detail = "Payment gateway is temporarily unavailable" };
-```
-
-**Unexpected**
-
-```csharp
-var error = new Error.InternalServerError(faultId: "f-7c2") { Detail = "Database connection failed" };
-```
-
-## Matching at the Boundary
-
-Use `Match` to fold a `Result<T>` into a value, or check `result.Error` directly to perform side effects.
-
-### `Match` with a `switch` expression
+Use `Match` to fold a `Result<T>` into a value, or read `result.Error` (which is `Error?` and never throws) to perform side effects. The C# compiler verifies exhaustiveness against the closed catalog — adding a new case to `Error` lights up every `switch` that does not handle it.
 
 ```csharp
 var message = LoadUser("42").Match(
@@ -173,124 +155,133 @@ var message = LoadUser("42").Match(
         Error.UnprocessableContent uc => $"Bad input: {uc.GetDisplayMessage()}",
         Error.NotFound nf             => $"Missing {nf.Resource.Type} {nf.Resource.Id}",
         Error.Forbidden f             => $"Not allowed by {f.PolicyId}",
-        _                              => $"Fallback: {error.Kind}"
+        _                             => $"Fallback: {error.Kind}",
     });
 ```
 
-The C# compiler verifies exhaustiveness against the closed catalog. Add a new case to `Error` and every `switch` that doesn't handle it lights up.
+`Match` has async overloads for `Task<Result<T>>` and `ValueTask<Result<T>>` (`MatchAsync`) and tuple overloads for arities 2–9. Full signatures: [`trellis-api-core.md` → Match family](../api_reference/trellis-api-core.md#match-family--matchextensions-matchextensionsasync-matchtupleextensions-matchtupleextensionsasync).
 
-> [!NOTE]
-> The previous `MatchError` / `SwitchError` extensions and `FlattenValidationErrors` were removed. Use `switch` patterns and `Combine` instead.
+### `Kind` vs `Code`
 
-## Side Effects Without Breaking the Pipeline
+- `Kind` is the **stable, low-cardinality slug** used for the OTel `error.type` attribute (e.g. `"not-found"`, `"unprocessable-content"`, `"conflict"`). Cases override this; payload is irrelevant.
+- `Code` defaults to `Kind` and is overridden when the payload carries a per-instance reason — `Conflict`/`Forbidden`/`BadRequest` return their `ReasonCode`/`PolicyId`/`ReasonCode`, `InternalServerError` returns its `FaultId`, `Unexpected` returns its `ReasonCode`, `NotImplemented` returns its `Feature`, and `PreconditionRequired` returns its `Condition`.
+
+Boundary renderers read `Kind` for the Problem Details `type` URI and `Code` for the per-instance machine identifier.
+
+## Propagating errors
+
+| Operator | Effect |
+|---|---|
+| `TapOnFailure(action)` | Side effect (log/metric) on failure; result passes through unchanged. |
+| `MapOnFailure(error => newError)` | Translate one failure case into another (e.g. when crossing layers). |
+| `RecoverOnFailure(error => Result<T>)` | Replace a failure with a fallback `Result` (success or different failure). |
 
 ```csharp
-var result = Result.Fail<string>(new Error.ServiceUnavailable() { Detail = "Search is temporarily offline" })
-    .TapOnFailure(error => Console.WriteLine($"Log: {error.Kind} - {error.Detail}"));
-```
-
-`TapOnFailureAsync` works the same way for `Task<Result<T>>` / `ValueTask<Result<T>>`.
-
-## Transforming Errors
-
-```csharp
-var result = Result.Fail<string>(new Error.InternalServerError("f-1") { Detail = "Timeout while calling CRM" })
+var result = LoadFromCrm(id)
+    .TapOnFailure(error => logger.LogWarning("CRM call failed: {Kind} {Code}", error.Kind, error.Code))
     .MapOnFailure(error => error switch
     {
-        Error.InternalServerError => new Error.ServiceUnavailable() { Detail = "Customer service is temporarily unavailable" },
-        _                          => error
+        Error.InternalServerError => new Error.ServiceUnavailable(RetryAfterValue.FromSeconds(60))
+            { Detail = "Customer service is temporarily unavailable" },
+        _ => error,
     });
-```
 
-`RecoverOnFailure` lets you fall back to an alternate path when failure is legitimate (not when you are hiding a bug):
-
-```csharp
-static Result<string> GetFromCache()    => Result.Fail<string>(new Error.NotFound(new ResourceRef("CacheEntry", "user:42")));
+static Result<string> GetFromCache()    => Result.Fail<string>(new Error.NotFound(ResourceRef.For<string>("user:42")));
 static Result<string> GetFromDatabase() => Result.Ok("Ada Lovelace");
 
-var result = GetFromCache().RecoverOnFailure(_ => GetFromDatabase());
+var withFallback = GetFromCache().RecoverOnFailure(_ => GetFromDatabase());
 ```
 
-## Combining Errors
+All three operators have `Async` variants on `Task<Result<T>>` and `ValueTask<Result<T>>`. See [`trellis-api-core.md` → Tap, Map, Recover families](../api_reference/trellis-api-core.md#result-pipeline-extension-families).
 
-`Combine` merges multiple `Result<T>` failures into one:
+## Capturing exceptions
 
-- All failures are `Error.UnprocessableContent` → merged into a single `UnprocessableContent` with concatenated `Fields` and `Rules`.
-- Heterogeneous failures → wrapped in an `Error.Aggregate` (which auto-flattens nested aggregates at construction).
+Expected failures should be regular `Error` values. For code that genuinely throws, `Result.Try` and `Result.TryAsync` bridge the gap. Without a custom map, the default mapping wraps the exception as `Error.InternalServerError` with a generated `FaultId`.
 
 ```csharp
-var emailErr    = Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("email"),    "required"))));
-var passwordErr = Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("password"), "required"))));
-var ageErr      = Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("age"),      "required"))));
+using System.IO;
+using Trellis;
+
+static Result<string> LoadText(string path) =>
+    Result.Try(() => File.ReadAllText(path));
+
+static Task<Result<string>> LoadTextAsync(string path) =>
+    Result.TryAsync(() => File.ReadAllTextAsync(path));
+
+static Result<string> LoadConfig(string path) =>
+    Result.Try(
+        () => File.ReadAllText(path),
+        exception => exception switch
+        {
+            FileNotFoundException       => new Error.NotFound(ResourceRef.For<FileInfo>(path)) { Detail = $"{path} was not found" },
+            UnauthorizedAccessException => new Error.Forbidden("file.read") { Detail = "Access denied" },
+            _                           => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = exception.Message },
+        });
+```
+
+`Result.Try` and `Result.TryAsync` also have parameterless-work overloads that return `Result<Unit>` for void/`Task` work — useful for command handlers, which return `Result<Unit>`.
+
+## Composition
+
+`Combine` merges multiple `Result<T>` failures into one. Two distinct shapes:
+
+| Input failures | Result |
+|---|---|
+| All `Error.UnprocessableContent` | One merged `Error.UnprocessableContent` with concatenated `Fields` and `Rules`. |
+| Heterogeneous (mixed cases) | One `Error.Aggregate` wrapping the children. Nested aggregates are flattened at construction. |
+
+```csharp
+var emailErr    = Result.Fail(Error.UnprocessableContent.ForField("email",    "required"));
+var passwordErr = Result.Fail(Error.UnprocessableContent.ForField("password", "required"));
+var ageErr      = Result.Fail(Error.UnprocessableContent.ForField("age",      "required"));
 
 var combined = Result.Combine(emailErr, passwordErr, ageErr);
 // combined.Error is one Error.UnprocessableContent with three Fields entries.
 ```
 
-## Async Error Handling
-
-`Match`, `TapOnFailure`, `MapOnFailure`, and `Combine` all have async overloads on `Task<Result<T>>` and `ValueTask<Result<T>>`. The patterns are identical; just `await` the chain.
-
-## Exception Capture with `Try` and `TryAsync`
-
-Expected failures should be regular `Error` values. For code that genuinely throws, Trellis bridges the gap:
+`Error.Combine(left, right)` (extension on `Error?`) does the same merging at the error level; passing a `null` left returns `right`.
 
 ```csharp
-static Result<string> LoadText(string path) => Result.Try(() => File.ReadAllText(path));
-
-static Task<Result<string>> LoadTextAsync(string path) => Result.TryAsync(() => File.ReadAllTextAsync(path));
+Error? acc = null;
+acc = acc.Combine(new Error.NotFound(ResourceRef.For<Order>("1")));
+acc = acc.Combine(new Error.Forbidden("orders.write"));
+// acc is Error.Aggregate { Errors = [NotFound, Forbidden] }
 ```
 
-With custom mapping:
+`Error.Aggregate` exposes three constructor overloads (`EquatableArray<Error>`, `IEnumerable<Error>`, `params Error[]`); all three throw `ArgumentException` if no errors are supplied, and all flatten nested aggregates.
+
+## Boundary mapping
+
+Map an `Error` to an HTTP / Problem Details response with `result.ToHttpResponse(...)` from `Trellis.Asp`. The boundary uses `Kind` for the Problem Details `type` URI, `Code` for the per-instance code, and renders the typed payload (e.g. `Allow`, `Retry-After`, `WWW-Authenticate`, `Content-Range`) as the appropriate header or `extensions` field. For `Result<Unit>` the success branch emits `204 No Content`.
 
 ```csharp
-var result = Result.Try(
-    () => File.ReadAllText("settings.json"),
-    exception => exception switch
-    {
-        FileNotFoundException        => new Error.NotFound(new ResourceRef("File", "settings.json")) { Detail = "settings.json was not found" },
-        UnauthorizedAccessException  => new Error.Forbidden("file.read") { Detail = "Access denied" },
-        _                             => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = exception.Message }
-    });
+using Trellis;
+using Trellis.Asp;
+
+public static IResult Get(string id, IUserService users) =>
+    users.GetUser(id).ToHttpResponse();
 ```
 
-## Equality
+Full mapping rules and per-case behaviour live in:
 
-Errors are records — two errors compare equal when their **`Kind` and payload are equal**. The `Cause` chain is excluded from equality (so two semantically identical errors raised from different code paths compare equal).
+- API reference: [`trellis-api-asp.md` → `HttpResponseExtensions`](../api_reference/trellis-api-asp.md#httpresponseextensions)
+- Article: [`asp-tohttpresponse.md` → Per-call error mapping](asp-tohttpresponse.md#per-call-error-mapping)
 
-```csharp
-var a = new Error.NotFound(new ResourceRef("User", "42")) { Detail = "x" };
-var b = new Error.NotFound(new ResourceRef("User", "42")) { Detail = "x" };
-var c = new Error.NotFound(new ResourceRef("User", "99")) { Detail = "x" };
+## Practical guidance
 
-Console.WriteLine(a.Equals(b)); // True  — same case, same payload
-Console.WriteLine(a.Equals(c)); // False — payload differs
-```
+- **Pick the case the caller can act on.** `UnprocessableContent` when the request data can be fixed; `Conflict` when state or a business rule blocks an otherwise-valid request; `NotFound` when the resource does not exist; `PreconditionFailed` for optimistic-concurrency mismatches; `Gone` for soft-deleted resources.
+- **`InternalServerError(faultId)` is for true surprises.** Never use it for business logic — use `Unexpected(reasonCode)` for "shouldn't happen" invariant violations and a typed 4xx case for everything else.
+- **Set `Detail` only when it adds information.** Boundary renderers compute a usable default from `Kind`/`Code` and the typed payload; override `Detail` only when you have something more specific to say.
+- **Prefer `Match` (or a property pattern on `result.Error`) at boundaries.** Inside pipelines, prefer `Bind`/`Map`/`Ensure` over inspecting `Error` directly.
+- **Use `TapOnFailure` for logging and metrics.** It does not mutate the result.
+- **Use `MapOnFailure` when crossing layers.** Translating a low-level `InternalServerError` from a dependency into a domain-meaningful `ServiceUnavailable` is a typical use.
+- **Use `Combine` to preserve every failure.** This is the difference between "first error wins" and "tell the caller everything that's wrong."
+- **Equality.** Two errors compare equal when `Kind`, payload, and `Detail` match. `Cause` is excluded from equality so the same surface failure raised from different code paths still compares equal.
 
-`Detail` participates in equality because it's an init-only property on the base record. If you want to compare semantically regardless of human-readable text, compare the typed payload directly (e.g. `nf.Resource.Equals(other.Resource)`).
+## Cross-references
 
-## `Kind` vs `Code`
-
-- `Kind` is the **stable, low-cardinality slug** the OTel `error.type` attribute is set from (e.g. `"not-found"`, `"unprocessable-content"`, `"conflict"`).
-- `Code` defaults to `Kind` and is overridden when the payload carries a per-instance `ReasonCode` (`Conflict`, `Forbidden`, `BadRequest`) or a `FaultId` (`InternalServerError`).
-
-Boundary renderers (ProblemDetails / gRPC / GraphQL) read `Kind` for `type` and `Code` for the per-instance identifier.
-
-## Practical Rules of Thumb
-
-- `Error.UnprocessableContent` when the caller can fix the request data
-- `Error.Conflict` with reason code `"domain.violation"` when the input is valid but a business rule blocks it
-- `Error.Conflict` with reason code `"duplicate.key"` (or similar) when current state blocks the operation
-- `Error.NotFound` when the resource does not exist
-- `Error.PreconditionFailed` for optimistic-concurrency mismatches
-- `Error.Gone` for soft-deleted resources
-- `new Error.InternalServerError(faultId)` only for true surprises — never for business logic
-- `Match` (or a property pattern on `result.Error`) at system boundaries
-- `TapOnFailure` for logging and metrics
-- `MapOnFailure` when crossing layers
-- `Combine` to preserve multiple failures instead of throwing the first one away
-
-## Next Steps
-
-- Read [Advanced Features](advanced-features.md) for `Try`, `ParallelAsync`, tuple destructuring, and LINQ flows
-- Read [Why Maybe?](maybe-type.md) for optional values that compose with `Result<T>`
+- API surface (full per-case table, supporting types, `Result.Try`/`TryAsync`, Combine family, Match/Tap/Map/Recover families): [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- HTTP response mapping for `Result<T>` and standalone `Error`: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md), [`asp-tohttpresponse.md`](asp-tohttpresponse.md)
+- FluentValidation → `Error.UnprocessableContent` adapter: [`integration-fluentvalidation.md`](integration-fluentvalidation.md)
+- HTTP client failure mapping (turning upstream statuses into typed `Error` cases): [`integration-http.md`](integration-http.md)
+- Mediator pipeline behaviours that operate on `Result`/`Error`: [`integration-mediator.md`](integration-mediator.md)

--- a/docs/docfx_project/articles/examples.md
+++ b/docs/docfx_project/articles/examples.md
@@ -1,8 +1,31 @@
-﻿# Examples
+﻿---
+title: Examples
+package: Trellis (multiple)
+topics: [examples, patterns, validation, async, http, fluentvalidation, recovery, parallel]
+related_api_reference: [trellis-api-core.md, trellis-api-asp.md, trellis-api-primitives.md, trellis-api-fluentvalidation.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Examples
 
 This article is a pattern library for real application code. Each section starts with the problem, then shows a working Trellis approach you can adapt.
 
 If you want the big-picture tutorial first, read [Introduction](intro.md) and [Basics](basics.md) before coming back here.
+
+## Patterns Index
+
+| Goal | Use | See |
+|---|---|---|
+| Validate a request, enforce a duplicate-check, and run side effects on success | `Combine` + `Bind` + `Ensure` + `Tap` | [Example 1](#example-1-validate-a-registration-request-without-losing-readability) |
+| Map a `Result<T>` to an MVC `ActionResult<T>` without a switch | `ToHttpResponse().AsActionResult<T>()` | [Example 2](#example-2-return-the-right-http-response-from-mvc-without-a-giant-switch-statement) |
+| Map a `Result<T>` to a Minimal API response | `ToHttpResponse()` | [Example 3](#example-3-do-the-same-thing-in-minimal-apis) |
+| Run several independent async queries and combine into one result | `Result.ParallelAsync(...).WhenAllAsync().MapAsync(...)` | [Example 4](#example-4-fetch-independent-dashboard-data-in-parallel) |
+| Reuse a FluentValidation validator as a `Result<T>` | `validator.ValidateToResult(input)` | [Example 5](#example-5-reuse-fluentvalidation-instead-of-duplicating-rules) |
+| Fall back to another source on a recoverable failure | `RecoverOnFailure(predicate, func)` | [Example 6](#example-6-recover-from-a-failure-when-a-fallback-is-acceptable) |
+| Chain async I/O, business rules, mutation, and notification | `ToResultAsync` + `EnsureAsync` + `TapAsync` + `BindAsync` + `MatchAsync` | [Example 7](#example-7-handle-async-side-effects-and-notifications-cleanly) |
+| Branch HTTP behavior on the concrete `Error` case | `result.Match(_, e => e switch { Error.X => ..., ... })` | [Example 8](#example-8-branch-on-specific-error-types-when-the-caller-cares) |
+
+Full signatures and overloads: [`trellis-api-core.md`](../api_reference/trellis-api-core.md), [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md), [`trellis-api-fluentvalidation.md`](../api_reference/trellis-api-fluentvalidation.md).
 
 ## Real-world sample projects
 

--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -1,45 +1,78 @@
+﻿---
+title: ASP.NET Core Authorization
+package: Trellis.Asp
+topics: [authorization, actor, entra, claims, abac, mediator, asp]
+related_api_reference: [trellis-api-authorization.md, trellis-api-asp.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # ASP.NET Core Authorization
 
-**Level:** Intermediate | **Time:** 15-20 min | **Prerequisites:** [Basics](basics.md), [ASP.NET Core Integration](integration-aspnet.md)
+`Trellis.Asp.Authorization` translates an authenticated `ClaimsPrincipal` into a frozen `Actor` (id + permissions + forbidden permissions + ABAC attributes) so handlers, mediator behaviors, and endpoints stop parsing JWT claims directly.
 
-Authentication tells you **who** called the API. Trellis authorization needs one more step: turn that authenticated principal into an `Actor` with permissions, forbidden permissions, and attributes that the rest of your application can trust. `Trellis.Asp.Authorization` handles that translation.
+## Patterns Index
 
-This article focuses on Azure Entra ID because `AddEntraActorProvider()` is the most opinionated setup, but the same package also includes generic claims-based and development-only providers.
+| Goal | Use | See |
+|---|---|---|
+| Resolve actors from Azure Entra ID v2.0 tokens | `AddEntraActorProvider(options?)` | [Entra ID provider](#entra-id-provider) |
+| Resolve actors from any flat-claim OIDC/JWT provider | `AddClaimsActorProvider(options?)` | [Generic claims provider](#generic-claims-provider) |
+| Inject a fake actor in Development / integration tests | `AddDevelopmentActorProvider(options?)` | [Development provider](#development-provider) |
+| Cache an async actor resolution per request | `AddCachingActorProvider<T>()` | [Caching wrapper](#caching-wrapper) |
+| Flatten roles into permissions / add ABAC attributes | `EntraActorOptions.MapPermissions` / `MapAttributes` | [Customizing claim mapping](#customizing-claim-mapping) |
+| Read well-known attributes safely | `Actor.GetAttribute(ActorAttributes.*)` | [ABAC attributes](#abac-attributes) |
+| Enforce static permissions on a command | `IAuthorize.RequiredPermissions` | [Mediator integration](#mediator-integration) |
+| Authorize against a loaded entity | `IAuthorizeResource<TResource>` | [Mediator integration](#mediator-integration) |
 
-## The mental model
+## Use this guide when
 
-```mermaid
-flowchart LR
-    Jwt[JWT claims]
-    Provider[EntraActorProvider]
-    Actor[Actor]
-    Behavior[AuthorizationBehavior]
-    Handler[Handler / Endpoint]
+- You host a Trellis service in ASP.NET Core and need to convert an authenticated principal into an `Actor` exactly once per request.
+- You want one DI registration that gives every handler, behavior, and endpoint a consistent view of the caller.
+- You want to customize how JWT claims map to permissions, deny lists, or ABAC attributes without forking the provider.
+- You want development/integration-test seams that fail closed outside `IsDevelopment()`.
 
-    Jwt --> Provider
-    Provider --> Actor
-    Actor --> Behavior
-    Behavior --> Handler
+## Surface at a glance
+
+`Trellis.Asp.Authorization` (namespace inside the `Trellis.Asp` package) exposes one set of DI extensions plus four `IActorProvider` implementations and matching options classes.
+
+| API | Kind | Returns / Lifetime | Purpose |
+|---|---|---|---|
+| `AddEntraActorProvider(this IServiceCollection, Action<EntraActorOptions>?)` | DI extension | Scoped `IActorProvider` → `EntraActorProvider` | Entra v2.0 (`oid`/`roles`/`tid`/`amr` ...) → `Actor`. |
+| `AddClaimsActorProvider(this IServiceCollection, Action<ClaimsActorOptions>?)` | DI extension | Scoped `IActorProvider` → `ClaimsActorProvider` | Generic flat-claim mapping (configurable `ActorIdClaim`, `PermissionsClaim`). |
+| `AddDevelopmentActorProvider(this IServiceCollection, Action<DevelopmentActorOptions>?)` | DI extension | Scoped `IActorProvider` → `DevelopmentActorProvider` | Reads `X-Test-Actor` JSON header; throws outside `IsDevelopment()`. |
+| `AddCachingActorProvider<T>(this IServiceCollection)` | DI extension | Scoped `IActorProvider` → `CachingActorProvider` wrapping `T` | Caches one resolution task per request scope. |
+| `ClaimsActorProvider` | Class | Scoped, virtual `GetCurrentActorAsync` | Subclass for custom flat-claim providers. Permissions collected via `FindAll(PermissionsClaim)`. |
+| `EntraActorProvider` | Class | Scoped, sealed | Falls back to short `oid` when `IdClaimType` is the default; rewraps mapper exceptions in `InvalidOperationException`. |
+| `DevelopmentActorProvider` | Class | Scoped, sealed partial | Logs a warning and falls back when the header is malformed (unless `ThrowOnMalformedHeader = true`). |
+| `CachingActorProvider` | Class | Scoped, sealed | Uses `LazyInitializer.EnsureInitialized` + `HttpContext.RequestAborted`; honors per-call `CancellationToken` via `Task.WaitAsync`. |
+| `EntraActorOptions` / `ClaimsActorOptions` / `DevelopmentActorOptions` | Options | — | Mapping delegates / claim-type strings / dev defaults. |
+
+Full signatures: [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md).
+
+## Installation
+
+```bash
+dotnet add package Trellis.Asp
 ```
 
-Why this matters:
+The actor providers ship in `Trellis.Asp` under namespace `Trellis.Asp.Authorization`. Domain primitives (`Actor`, `IActorProvider`, `IAuthorize`, `IAuthorizeResource<T>`) come from `Trellis.Authorization`.
 
-- your handlers stop parsing claims directly
-- permission checks become uniform
-- ABAC data such as tenant ID or MFA state is available from one object
+## Quick start
 
-## Quick start with Entra ID
+Authenticate with `JwtBearer`, register `EntraActorProvider`, then read the current `Actor` from any endpoint or handler.
 
 ```csharp
 using System.Linq;
-using Microsoft.AspNetCore.Authorization;
+using System.Threading;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddAuthentication().AddJwtBearer();
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
 builder.Services.AddAuthorization();
 builder.Services.AddEntraActorProvider();
 
@@ -51,233 +84,45 @@ app.UseAuthorization();
 app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationToken ct) =>
 {
     var actor = await actorProvider.GetCurrentActorAsync(ct);
-
     return Results.Ok(new
     {
         actor.Id,
         Permissions = actor.Permissions.OrderBy(p => p).ToArray(),
         TenantId = actor.GetAttribute(ActorAttributes.TenantId),
-        Mfa = actor.GetAttribute(ActorAttributes.MfaAuthenticated)
+        Mfa = actor.GetAttribute(ActorAttributes.MfaAuthenticated),
     });
 });
 
 app.Run();
 ```
 
-That one registration makes `IActorProvider` available in DI, and `EntraActorProvider` builds the `Actor` from the current authenticated user.
-
 > [!NOTE]
-> `AddEntraActorProvider()` maps claims to an `Actor`. It does **not** authenticate tokens by itself. You still need your normal authentication middleware.
+> The provider extracts an `Actor` from `HttpContext.User`. It does **not** validate tokens — keep your normal authentication middleware in place.
 
-## Default Entra mapping
+## Entra ID provider
 
-Out of the box, `EntraActorProvider` does a useful amount of work for you.
+| Member | Default | Override to... |
+|---|---|---|
+| `EntraActorOptions.IdClaimType` | `"http://schemas.microsoft.com/identity/claims/objectidentifier"` (falls back to short `"oid"`) | Use `sub`, employee ID, etc. |
+| `EntraActorOptions.MapPermissions` | union of `roles` and `ClaimTypes.Role` claim values (case-insensitive type match) | Flatten roles into fine-grained permissions; merge DB-sourced grants. |
+| `EntraActorOptions.MapForbiddenPermissions` | empty `HashSet<string>` | Project a deny-list claim or DB lookup. |
+| `EntraActorOptions.MapAttributes` | extracts `tid`, `preferred_username`, `azp`, `azpacr`, `acrs`; adds `ip_address` from `Connection.RemoteIpAddress` and `mfa = "true"\|"false"` from any `amr` claim equal to `"mfa"` | Add tenant-scoped or request-scoped attributes. |
 
-| `Actor` member | Default source | Notes |
-| --- | --- | --- |
-| `Id` | `IdClaimType`, defaulting to the long object identifier claim | Falls back to short `oid` when `IdClaimType` is left at its default |
-| `Permissions` | `roles` and `ClaimTypes.Role` | Stored as a set for fast lookups |
-| `ForbiddenPermissions` | empty set | Override with `MapForbiddenPermissions` |
-| `Attributes["tid"]` | `tid` | Tenant ID |
-| `Attributes["preferred_username"]` | `preferred_username` | Good for display and audit, not authorization |
-| `Attributes["azp"]` | `azp` | Authorized party / client app |
-| `Attributes["azpacr"]` | `azpacr` | Client authentication method |
-| `Attributes["acrs"]` | `acrs` | Authentication context class reference |
-| `Attributes["ip_address"]` | `HttpContext.Connection.RemoteIpAddress` | Request IP |
-| `Attributes["mfa"]` | derived from `amr` | `"true"` if any `amr` claim equals `"mfa"` ignoring case; otherwise `"false"` |
+`EntraActorProvider` throws `InvalidOperationException` when no `HttpContext` is available, no authenticated `ClaimsIdentity` exists, or the configured `IdClaimType` is missing (and the short `oid` fallback also misses). Any exception thrown by `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped in `InvalidOperationException` naming the failing delegate.
 
-## Customizing claim mapping
+## Generic claims provider
 
-Most teams customize permissions before they customize anything else.
+For any flat-claim OIDC token where you can name the id and permissions claim types directly.
 
-### Flatten Entra roles into app permissions
+| Member | Default | Notes |
+|---|---|---|
+| `ClaimsActorOptions.ActorIdClaim` | `"sub"` | Verbatim claim-type match — no JSON-path traversal. |
+| `ClaimsActorOptions.PermissionsClaim` | `"permissions"` | Multi-valued JWT claims arrive as repeated `Claim` instances and are aggregated via `FindAll`. |
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
 
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddEntraActorProvider(options =>
-{
-    options.MapPermissions = claims =>
-    {
-        var rolePermissionMap = new Dictionary<string, string[]>
-        {
-            ["Catalog.Admin"] = ["Products.Read", "Products.Write", "Products.Delete"],
-            ["Catalog.Reader"] = ["Products.Read"]
-        };
-
-        return claims
-            .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
-            .SelectMany(c => rolePermissionMap.TryGetValue(c.Value, out var permissions)
-                ? permissions
-                : Array.Empty<string>())
-            .ToHashSet(StringComparer.Ordinal);
-    };
-});
-```
-
-### Use delegated scopes instead of roles
-
-```csharp
-builder.Services.AddEntraActorProvider(options =>
-{
-    options.MapPermissions = claims => claims
-        .Where(c => string.Equals(c.Type, "scp", StringComparison.OrdinalIgnoreCase))
-        .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-        .ToHashSet(StringComparer.Ordinal);
-});
-```
-
-### Change the actor ID claim
-
-```csharp
-builder.Services.AddEntraActorProvider(options =>
-{
-    options.IdClaimType = "sub";
-});
-```
-
-### Add forbidden permissions or custom attributes
-
-```csharp
-builder.Services.AddEntraActorProvider(options =>
-{
-    options.MapForbiddenPermissions = claims => claims
-        .Where(c => string.Equals(c.Type, "denied_permissions", StringComparison.OrdinalIgnoreCase))
-        .Select(c => c.Value)
-        .ToHashSet(StringComparer.Ordinal);
-
-    options.MapAttributes = (claims, httpContext) =>
-    {
-        var attributes = new Dictionary<string, string>();
-
-        var region = claims.FirstOrDefault(c => c.Type == "region")?.Value;
-        if (!string.IsNullOrWhiteSpace(region))
-            attributes["region"] = region;
-
-        var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
-        if (!string.IsNullOrWhiteSpace(ipAddress))
-            attributes[ActorAttributes.IpAddress] = ipAddress;
-
-        return attributes;
-    };
-});
-```
-
-> [!WARNING]
-> If `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` throws, `EntraActorProvider` wraps that exception in an `InvalidOperationException` that points back to the failing option delegate.
-
-## Working with `Actor`
-
-Once you have an `Actor`, authorization logic becomes plain application code.
-
-### Permission checks
-
-```csharp
-if (!actor.HasPermission("Products.Delete"))
-    return Result.Fail(new Error.Forbidden("policy.id") { Detail = "Products.Delete is required." });
-```
-
-### Scoped permissions
-
-`Actor.HasPermission(permission, scope)` uses `Actor.PermissionScopeSeparator`, which is `':'`.
-
-```csharp
-var tenantId = actor.GetAttribute(ActorAttributes.TenantId);
-
-if (tenantId is null || !actor.HasPermission("Documents.Read", tenantId))
-    return Result.Fail(new Error.Forbidden("policy.id") { Detail = "You cannot read documents in this tenant." });
-```
-
-That call checks for a permission string shaped like:
-
-```text
-Documents.Read:tenant-123
-```
-
-## Using authorization with Trellis.Mediator
-
-This is where the actor-provider abstraction becomes especially useful: authorization runs in the pipeline instead of being repeated in every handler.
-
-### Static permission checks with `IAuthorize`
-
-```csharp
-using Mediator;
-using Trellis;
-using Trellis.Authorization;
-
-public sealed record DeleteDocumentCommand(string DocumentId)
-    : ICommand<Result<Unit>>, IAuthorize
-{
-    public IReadOnlyList<string> RequiredPermissions => ["Documents.Delete"];
-}
-```
-
-Register the provider and the Trellis mediator behaviors together:
-
-```csharp
-using Mediator;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Trellis.Asp.Authorization;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddAuthentication().AddJwtBearer();
-builder.Services.AddAuthorization();
-builder.Services.AddEntraActorProvider();
-
-builder.Services.AddMediator(options =>
-{
-    options.ServiceLifetime = ServiceLifetime.Scoped;
-    options.PipelineBehaviors = [.. Trellis.Mediator.ServiceCollectionExtensions.PipelineBehaviors];
-});
-```
-
-### Resource-based checks with `IAuthorizeResource<TResource>`
-
-Use resource-based authorization when the rule depends on the loaded entity, not just the caller’s static permissions.
-
-```csharp
-using Mediator;
-using Trellis;
-using Trellis.Authorization;
-
-public sealed record Document(string Id, string OwnerId);
-
-public sealed record EditDocumentCommand(string DocumentId)
-    : ICommand<Result<Document>>, IAuthorizeResource<Document>
-{
-    public IResult Authorize(Actor actor, Document resource) =>
-        actor.IsOwner(resource.OwnerId) || actor.HasPermission("Documents.EditAny")
-            ? Result.Ok()
-            : Result.Fail(new Error.Forbidden("policy.id") { Detail = "Only the owner can edit this document." });
-}
-```
-
-`IAuthorizeResource<TResource>` is contravariant (`in TResource`), which makes it easy to express rules against broader resource types when that fits your design.
-
-## `ActorAttributes` constants
-
-Use the built-in constants instead of hand-typed strings:
-
-```csharp
-using Trellis.Authorization;
-
-var tenantId = actor.GetAttribute(ActorAttributes.TenantId);
-var clientApp = actor.GetAttribute(ActorAttributes.AuthorizedParty);
-var mfa = actor.GetAttribute(ActorAttributes.MfaAuthenticated);
-```
-
-This helps avoid subtle bugs from casing or spelling mismatches.
-
-## Other actor providers in the same package
-
-### `AddClaimsActorProvider()`
-
-Use this when your identity provider is not Entra or when your tokens already have the exact claims you want.
-
-```csharp
 builder.Services.AddClaimsActorProvider(options =>
 {
     options.ActorIdClaim = "sub";
@@ -285,35 +130,58 @@ builder.Services.AddClaimsActorProvider(options =>
 });
 ```
 
-### `AddDevelopmentActorProvider()`
+`ClaimsActorProvider.GetCurrentActorAsync` is `virtual` — subclass it to compute permissions from nested claims, look them up in a store, etc., then register your subclass via `AddCachingActorProvider<TYourProvider>()` to amortize the cost across the request.
 
-Use this only for local development and tests.
+## Development provider
+
+For local development and integration tests only. The provider reads an `X-Test-Actor` JSON header shaped like `{ "Id": "...", "Permissions": [...], "ForbiddenPermissions": [...], "Attributes": {...} }` (case-insensitive property matching).
+
+| Member | Default | Notes |
+|---|---|---|
+| `DevelopmentActorOptions.DefaultActorId` | `"development"` | Used when the header is missing or empty. |
+| `DevelopmentActorOptions.DefaultPermissions` | empty `HashSet<string>` | Used when the header is missing or empty. |
+| `DevelopmentActorOptions.ThrowOnMalformedHeader` | `false` | When `true`, malformed JSON throws instead of logging a warning and falling back. |
 
 ```csharp
-builder.Services.AddDevelopmentActorProvider(options =>
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Trellis.Asp.Authorization;
+
+if (builder.Environment.IsDevelopment())
 {
-    options.DefaultActorId = "development";
-    options.DefaultPermissions = new HashSet<string> { "Products.Read", "Products.Write" };
-});
+    builder.Services.AddDevelopmentActorProvider(options =>
+    {
+        options.DefaultActorId = "developer@local";
+        options.DefaultPermissions = new HashSet<string> { "Products.Read", "Products.Write" };
+    });
+}
+else
+{
+    builder.Services.AddEntraActorProvider();
+}
 ```
 
 > [!WARNING]
-> `DevelopmentActorProvider` throws whenever the host environment is **not** Development. That is true even if the `X-Test-Actor` header is absent.
+> `DevelopmentActorProvider.GetCurrentActorAsync` throws `InvalidOperationException` whenever `IHostEnvironment.IsDevelopment()` is `false` — even when the header is absent. Registering it in Production is a fail-fast safety net.
 
-### `AddCachingActorProvider<T>()`
+For test clients, the `WebApplicationFactoryExtensions.CreateClientWithActor(...)` helper in `Trellis.Testing.AspNetCore` writes the same header for you; see [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md).
 
-Use this when resolving the current actor requires extra async work, such as database lookups.
+## Caching wrapper
+
+When resolving an actor requires extra async work (database lookups, remote calls), wrap the inner provider so a single resolution task is shared across the request scope.
 
 ```csharp
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Trellis.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
-
-builder.Services.AddCachingActorProvider<DatabaseActorProvider>();
+using Trellis.Authorization;
 
 public interface IPermissionStore
 {
-    Task<IReadOnlySet<string>> GetPermissionsAsync(string userId, CancellationToken cancellationToken);
+    Task<IReadOnlySet<string>> GetPermissionsAsync(string userId, CancellationToken ct);
 }
 
 public sealed class DatabaseActorProvider(
@@ -329,20 +197,233 @@ public sealed class DatabaseActorProvider(
         return Actor.Create(userId, permissions);
     }
 }
+
+builder.Services.AddSingleton<IPermissionStore, MyPermissionStore>();
+builder.Services.AddCachingActorProvider<DatabaseActorProvider>();
 ```
 
-`CachingActorProvider` caches the first resolution task per request scope, so repeated authorization checks do not repeat the expensive work.
+`CachingActorProvider` issues the inner call with `HttpContext.RequestAborted` so the shared work is cancelled with the request, then forwards each caller's own `CancellationToken` via `Task.WaitAsync`.
 
-## Best practices
+## Customizing claim mapping
 
-1. **Map coarse claims to fine-grained permissions once.** Keep runtime checks simple and fast.
-2. **Use `ActorAttributes` constants.** They are safer than raw strings.
-3. **Do not authorize on `preferred_username`.** It is for display and audit, not identity stability.
-4. **Use scoped permissions when tenant or resource scope matters.**
-5. **Keep development-only actor injection out of non-development environments.**
+`EntraActorOptions` exposes three independent delegates — override only what you need.
 
-## Next steps
+### Flatten Entra roles into application permissions
 
-- Pair this with [ASP.NET Core Integration](integration-aspnet.md) to map failures cleanly to HTTP
-- Use [FluentValidation Integration](integration-fluentvalidation.md) if commands also need structured validation
-- Use [integration-mediator.md](integration-mediator.md) for deeper pipeline-behavior patterns
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+builder.Services.AddEntraActorProvider(options =>
+{
+    var rolePermissionMap = new Dictionary<string, string[]>(StringComparer.Ordinal)
+    {
+        ["Catalog.Admin"]  = ["Products.Read", "Products.Write", "Products.Delete"],
+        ["Catalog.Reader"] = ["Products.Read"],
+    };
+
+    options.MapPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(c => rolePermissionMap.TryGetValue(c.Value, out var perms) ? perms : Array.Empty<string>())
+        .ToHashSet(StringComparer.Ordinal);
+});
+```
+
+### Use delegated scopes (`scp`) instead of roles
+
+```csharp
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+builder.Services.AddEntraActorProvider(options =>
+{
+    options.MapPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "scp", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        .ToHashSet(StringComparer.Ordinal);
+});
+```
+
+### Add forbidden permissions and custom attributes
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+using Trellis.Authorization;
+
+builder.Services.AddEntraActorProvider(options =>
+{
+    options.MapForbiddenPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "denied_permissions", StringComparison.OrdinalIgnoreCase))
+        .Select(c => c.Value)
+        .ToHashSet(StringComparer.Ordinal);
+
+    options.MapAttributes = (claims, httpContext) =>
+    {
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var region = claims.FirstOrDefault(c => c.Type == "region")?.Value;
+        if (!string.IsNullOrWhiteSpace(region))
+            attributes["region"] = region;
+
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString();
+        if (!string.IsNullOrWhiteSpace(ip))
+            attributes[ActorAttributes.IpAddress] = ip;
+
+        return attributes;
+    };
+});
+```
+
+> [!WARNING]
+> Throwing inside any `Map*` delegate produces an `InvalidOperationException` with the message `EntraActorOptions.<delegate> threw an exception while mapping the authenticated user's claims.` — it does not silently default.
+
+## ABAC attributes
+
+`Actor.Attributes` is an immutable `FrozenDictionary<string, string>`. Read it via `GetAttribute` (returns `string?`) or `HasAttribute`, and key it with `ActorAttributes.*` constants instead of magic strings.
+
+```csharp
+using Trellis;
+using Trellis.Authorization;
+
+var tenantId = actor.GetAttribute(ActorAttributes.TenantId);
+
+if (tenantId is null || !actor.HasPermission("Documents.Read", tenantId))
+    return Result.Fail(new Error.Forbidden("documents.read") { Detail = "Wrong tenant." });
+
+var clientApp = actor.GetAttribute(ActorAttributes.AuthorizedParty);
+var mfaPassed = actor.GetAttribute(ActorAttributes.MfaAuthenticated) == "true";
+```
+
+`Actor.HasPermission(permission, scope)` checks for the joined string `permission:scope`, where `:` is `Actor.PermissionScopeSeparator`. See [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md#actor) for the full deny-overrides-allow rules.
+
+## Mediator integration
+
+When a request flows through `Trellis.Mediator`, prefer pipeline behaviors over per-handler permission checks — `AuthorizationBehavior<TMessage, TResponse>` (see [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)) calls `IActorProvider.GetCurrentActorAsync` once and short-circuits the pipeline with a typed `Error.Forbidden`.
+
+### Static permission checks via `IAuthorize`
+
+```csharp
+using System.Collections.Generic;
+using Mediator;
+using Trellis;
+using Trellis.Authorization;
+
+public sealed record DeleteDocumentCommand(string DocumentId)
+    : ICommand<Result<Unit>>, IAuthorize
+{
+    public IReadOnlyList<string> RequiredPermissions { get; } = ["Documents.Delete"];
+}
+```
+
+The behavior requires the actor to hold **every** listed permission (AND semantics). Returning `Result<Unit>` from the command is the canonical command shape.
+
+### Resource-based checks via `IAuthorizeResource<TResource>`
+
+Use this when the rule depends on a loaded entity, not just static permissions. Pair it with `IIdentifyResource<TResource, TId>` + a `SharedResourceLoaderById<TResource, TId>` so every command authorizing against the same resource type loads it the same way.
+
+```csharp
+using Mediator;
+using Trellis;
+using Trellis.Authorization;
+
+public sealed record Document(string Id, string OwnerId);
+
+public sealed record EditDocumentCommand(string DocumentId)
+    : ICommand<Result<Unit>>, IAuthorizeResource<Document>, IIdentifyResource<Document, string>
+{
+    public string GetResourceId() => DocumentId;
+
+    public IResult Authorize(Actor actor, Document resource) =>
+        Result.Ensure(
+            actor.IsOwner(resource.OwnerId) || actor.HasPermission("Documents.EditAny"),
+            new Error.Forbidden("documents.edit") { Detail = "Only the owner can edit this document." });
+}
+```
+
+Wire the loader and pipeline behaviors in `Program.cs`:
+
+```csharp
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+using Trellis.Mediator;
+
+builder.Services.AddEntraActorProvider();
+
+builder.Services.AddResourceAuthorization<Document, string, DocumentResourceLoader>();
+
+builder.Services.AddMediator(options =>
+{
+    options.ServiceLifetime = ServiceLifetime.Scoped;
+    options.PipelineBehaviors = [.. Trellis.Mediator.ServiceCollectionExtensions.PipelineBehaviors];
+});
+```
+
+> [!NOTE]
+> `AddResourceAuthorization` lives in `Trellis.Mediator`. Forgetting `using Trellis.Mediator;` produces `CS1061: 'IServiceCollection' does not contain a definition for 'AddResourceAuthorization'`. The full registration shape is documented in [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md#servicecollectionextensions).
+
+## Composition
+
+These providers compose three ways:
+
+- **Provider stack.** `AddCachingActorProvider<TInner>()` decorates *any* `IActorProvider` — including a `ClaimsActorProvider` subclass you authored — without changing handler code.
+- **Mediator pipeline.** Once an `IActorProvider` is registered, both `IAuthorize` (static) and `IAuthorizeResource<T>` (resource) checks run inside `AuthorizationBehavior` and fail with typed `Error.Forbidden`. ASP integration ([`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)) maps that to RFC 7807 `403`.
+- **Result pipelines.** Inside handlers, `Actor` predicates return `bool`, so `Result.Ensure(actor.HasPermission(...), new Error.Forbidden(...))` plugs straight into `Bind` / `Map` chains.
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Authorization;
+
+public sealed record Document(string Id, string OwnerId);
+
+public interface IDocumentRepository
+{
+    Task<Result<Document>> GetByIdAsync(string id, CancellationToken ct);
+}
+
+public static class DocumentService
+{
+    public static async Task<Result<Document>> LoadForEditAsync(
+        IActorProvider actors,
+        IDocumentRepository repo,
+        string id,
+        CancellationToken ct)
+    {
+        var actor = await actors.GetCurrentActorAsync(ct);
+
+        return await repo.GetByIdAsync(id, ct)
+            .EnsureAsync(
+                doc => actor.IsOwner(doc.OwnerId) || actor.HasPermission("Documents.EditAny"),
+                new Error.Forbidden("documents.edit") { Detail = "Only the owner can edit this document." });
+    }
+}
+```
+
+## Practical guidance
+
+- **Never authorize on `preferred_username`.** It is for display and audit only and may change.
+- **Use `ActorAttributes` constants.** Guarantees consistent casing and survives renames.
+- **Map roles to permissions once, in `MapPermissions`.** Keeps runtime checks `O(1)` against a `FrozenSet<string>`.
+- **Prefer scoped permissions** (`Documents.Read:tenant-123`) and `Actor.HasPermission(name, scope)` over a separate ABAC dictionary lookup.
+- **Wrap expensive providers** with `AddCachingActorProvider<T>()` so re-checks during the same request stay cheap.
+- **Keep `AddDevelopmentActorProvider` behind `IsDevelopment()`.** The provider also fails closed, but registration discipline avoids accidental dependency on `X-Test-Actor` from staging tests.
+- **Let mapper exceptions bubble.** A buggy `MapPermissions` becomes `InvalidOperationException("EntraActorOptions.MapPermissions threw ...")`; surfacing it during development reveals bad role tables faster than any silent fallback.
+
+## Cross-references
+
+- Domain primitives (`Actor`, `IAuthorize`, `IAuthorizeResource<T>`, `ActorAttributes`): [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- ASP DI surface and other ASP integration helpers: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- `Result`, `Error.Forbidden`, `Error.NotFound`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- `AuthorizationBehavior<TMessage, TResponse>` and `AddResourceAuthorization`: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- Test client header helper (`CreateClientWithActor`): [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)

--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -359,7 +359,14 @@ using Trellis.Mediator;
 
 builder.Services.AddEntraActorProvider();
 
-builder.Services.AddResourceAuthorization<Document, string, DocumentResourceLoader>();
+// 1. Register the resource loader for this command.
+//    DocumentResourceLoader implements IResourceLoader<EditDocumentCommand, Document>.
+builder.Services.AddScoped<IResourceLoader<EditDocumentCommand, Document>, DocumentResourceLoader>();
+
+// 2. Register the resource-authorization pipeline behavior.
+//    Type arguments are <TMessage, TResource, TResponse> — the *command* type comes first,
+//    then the resource type loaded for it, then the command's response type.
+builder.Services.AddResourceAuthorization<EditDocumentCommand, Document, Result<Unit>>();
 
 builder.Services.AddMediator(options =>
 {

--- a/docs/docfx_project/articles/integration-aspnet.md
+++ b/docs/docfx_project/articles/integration-aspnet.md
@@ -1,31 +1,129 @@
-﻿# ASP.NET Core Integration
+﻿---
+title: ASP.NET Core Integration
+package: Trellis.Asp
+topics: [asp, minimal-api, controllers, http-result, problem-details, etag, prefer, pagination]
+related_api_reference: [trellis-api-asp.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# ASP.NET Core Integration
 
-**Level:** Intermediate | **Time:** 25-35 min | **Prerequisites:** [Basics](basics.md)
+`Trellis.Asp` maps `Result`, `Result<T>`, `Result<WriteOutcome<T>>`, and `Result<Page<T>>` to ASP.NET Core HTTP responses (status codes, Problem Details, ETags, `Prefer`, ranges, paginated envelopes) using the single verb `ToHttpResponse(...)`.
 
-When your application already returns `Result<T>`, the next problem is predictable HTTP behavior: correct status codes, useful Problem Details responses, clean controller code, and support for web concerns like ETags, `Prefer`, and pagination. `Trellis.Asp` solves that boundary.
+## Patterns Index
 
-> [!TIP]
-> Register `AddTrellisAsp()` even though Trellis has fallback defaults. It makes your HTTP mappings explicit and gives you one obvious place to customize them later.
+| Goal | Use | See |
+|---|---|---|
+| Map `Result<T>` to a Minimal API response | `result.ToHttpResponse(...)` / `ToHttpResponseAsync(...)` | [Quick start](#quick-start) |
+| Project the response body separately from the domain value | `result.ToHttpResponse(body: domain => dto, configure: opts => ...)` | [Body projection](#body-projection) |
+| Return `ActionResult<T>` from an MVC controller | `.AsActionResult<T>()` / `.AsActionResultAsync<T>()` | [MVC controllers](#mvc-controllers) |
+| Map `Result<Unit>` (no payload) | Return `Result.Ok()` — `ToHttpResponse` emits `204 No Content` | [Result&lt;Unit&gt; → 204](#resultunit--204-no-content) |
+| Override an error → status mapping for one endpoint | `opts.WithErrorMapping<TError>(status)` / `opts.WithErrorMapping(err => ...)` | [Error mapping](#error-mapping) |
+| Override mappings globally | `AddTrellisAsp(opts => opts.MapError<TError>(status))` | [Error mapping](#error-mapping) |
+| Conditional `GET`/`HEAD` (`If-None-Match`, `If-Modified-Since`) | `opts.WithETag(...).EvaluatePreconditions()` | [Conditional requests](#conditional-requests) |
+| Honor `Prefer: return=minimal` / `return=representation` | `opts.HonorPrefer()` on a `WriteOutcome` response | [Prefer header](#prefer-header) |
+| Emit `201 Created` with a `Location` header | `opts.CreatedAtRoute(name, values)` (AOT-safe) / `Created(...)` / `CreatedAtAction(...)` | [Created responses](#created-responses) |
+| Return paginated JSON + RFC 8288 `Link` header | `Result<Page<T>>.ToHttpResponse(nextUrlBuilder, body)` | [Pagination](#pagination) |
+| Return `206 Partial Content` for byte / item ranges | `opts.WithRange(from, to, total)` / `opts.WithRange(selector)` | [Range responses](#range-responses) |
+| Validate scalar value objects (route, query, JSON body) | `AddScalarValueValidation` + `UseScalarValueValidation` + `WithScalarValueValidation` | [Scalar value validation](#scalar-value-validation) |
+| Bind value objects in route segments | `AddTrellisRouteConstraint<T>("Name")` then `"/x/{id:Name}"` | [Route constraints](#route-constraints) |
+| Hydrate the current `Actor` from JWT claims | `AddClaimsActorProvider` / `AddEntraActorProvider` / `AddDevelopmentActorProvider` | [Actor providers](#actor-providers) |
 
-## What this package gives you
+## Use this guide when
 
-`Trellis.Asp` is the ASP.NET Core adapter layer for Trellis.
+- Your application returns `Result<T>` and you need predictable HTTP status, Problem Details, and conditional-request behavior at the boundary.
+- You are wiring Minimal API endpoints or MVC controllers and want one verb (`ToHttpResponse`) instead of a `switch`-per-endpoint.
+- You need ETag, `If-Match` / `If-None-Match`, `Prefer`, or `Range` semantics that match RFC 9110 / 7240 / 8288 without hand-rolling header parsing.
+- You bind scalar value objects (`IScalarValue<TSelf, TPrimitive>`) from routes, queries, or JSON bodies and want validation collected as `Error.UnprocessableContent`.
+- You hydrate the current `Actor` from JWT/OIDC claims for downstream authorization checks.
 
-It gives you:
+## Surface at a glance
 
-- `ToHttpResponse(...)` for mapping `Result<T>` to HTTP responses in Minimal APIs and MVC
-- `AsActionResult<T>()` for typed MVC `ActionResult<T>` signatures
-- default error-type-to-status-code mappings
-- Problem Details responses for failures
-- automatic `204 No Content` for successful `Result<Unit>` (returned from `Result.Ok()`)
-- scalar value validation for MVC and Minimal APIs
-- representation metadata support for headers like `ETag` and `Last-Modified`
-- `Prefer`-aware update helpers
-- partial-content helpers for paginated responses
+| Type | Purpose |
+|---|---|
+| `HttpResponseExtensions` | `ToHttpResponse` / `ToHttpResponseAsync` for `Error`, `Result<T>`, `Result<WriteOutcome<T>>`, `Result<Page<T>>` (with optional body projector). |
+| `HttpResponseOptionsBuilder<TDomain>` | Fluent options for the generic overloads (`WithETag`, `WithLastModified`, `Vary`, `Created`/`CreatedAtRoute`/`CreatedAtAction`, `EvaluatePreconditions`, `HonorPrefer`, `WithRange`, `WithErrorMapping`, …). |
+| `HttpResponseOptionsBuilder` | Non-generic builder for the `Error` overload (`Vary`, `HonorPrefer`, `WithErrorMapping`). |
+| `ActionResultAdapterExtensions` | `AsActionResult<T>` / `AsActionResultAsync<T>` to wrap an `IResult` for MVC. |
+| `TrellisAspOptions` | DI-registered error-type → status-code map; configure via `AddTrellisAsp(opts => opts.MapError<TError>(status))`. |
+| `ETagHelper` | `ParseIfMatch` / `ParseIfNoneMatch` returning `EntityTagValue[]?`; `IfMatchSatisfied` / `IfNoneMatchMatches` comparison helpers. |
+| `IfNoneMatchExtensions` | `EnforceIfNoneMatchPrecondition(EntityTagValue[]?)` — converts a successful result into `Error.PreconditionFailed` when `If-None-Match: *` is sent and the resource exists. |
+| `PreferHeader` | `Parse(HttpRequest)` → `ReturnRepresentation`, `ReturnMinimal`, `RespondAsync`, `Wait`, `HandlingStrict`, `HandlingLenient`, `HasPreferences`. |
+| `RangeRequestEvaluator` / `RangeOutcome` | RFC 9110 §14 `Range` evaluation (`bytes` only) returning `FullRepresentation` / `PartialContent` / `NotSatisfiable`. |
+| `PartialContentHttpResult` / `PartialContentResult` | `IResult` and MVC `ObjectResult` companions that emit `206 Partial Content`. |
+| `PagedResponse<TResponse>` / `PageLink` | JSON envelope and `Link` header entries returned by the `Result<Page<T>>` overload. |
+| `Trellis.Asp.Authorization.*` | `AddClaimsActorProvider` / `AddEntraActorProvider` / `AddDevelopmentActorProvider` / `AddCachingActorProvider<T>`. |
+| `Trellis.Asp.ModelBinding.*` | `ScalarValueModelBinder<,>` / `MaybeModelBinder<,>` / `ScalarValueModelBinderProvider`. |
+| `Trellis.Asp.Routing.*` | `TrellisValueObjectRouteConstraint<T>` + `AddTrellisRouteConstraint<T>` / `AddTrellisRouteConstraints`. |
+| `Trellis.Asp.Validation.*` | `ValidatingJsonConverter<,>`, `MaybeScalarValueJsonConverter<,>`, `ScalarValueValidationFilter` (MVC), `ScalarValueValidationEndpointFilter` (Minimal API), `ScalarValueValidationMiddleware`, `ValidationErrorsContext`. |
 
-## Quick start: MVC controllers
+Full signatures: [trellis-api-asp.md](../api_reference/trellis-api-asp.md).
 
-If you are using controllers, this is the smallest complete setup:
+## Installation
+
+```bash
+dotnet add package Trellis.Asp
+```
+
+`Trellis.Asp` bundles the AOT-friendly `Trellis.AspSourceGenerator.dll` (attached automatically) and contains the actor providers formerly published as `Trellis.Asp.Authorization`.
+
+## Quick start
+
+A composition root that wires Trellis.Asp once, then a Minimal API endpoint that returns `Result<T>`:
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Asp;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddTrellisAsp();
+
+var app = builder.Build();
+app.UseScalarValueValidation();
+
+app.MapGet("/users/{id}", async (string id, IUserService users, CancellationToken ct) =>
+        (await users.GetByIdAsync(id, ct))
+            .ToHttpResponse(user => new UserResponse(user.Id, user.Email)))
+    .WithName("Users_GetById")
+    .WithScalarValueValidation();
+
+app.Run();
+
+public sealed record User(string Id, string Email);
+public sealed record UserResponse(string Id, string Email);
+
+public interface IUserService
+{
+    Task<Result<User>> GetByIdAsync(string id, CancellationToken ct);
+}
+```
+
+Behavior:
+
+- Success → `200 OK` with the projected `UserResponse` body.
+- `Error.NotFound` → `404 Not Found` Problem Details.
+- `Error.UnprocessableContent` → `422 Unprocessable Content` validation Problem Details.
+- Any other failure → status from `TrellisAspOptions` (default `500`).
+
+## `Result<Unit>` → 204 No Content
+
+Side-effecting commands return `Result<Unit>` from `Result.Ok()` / `Result.Fail(error)`. `Trellis.Asp` maps a successful `Result<Unit>` to `204 No Content` automatically — no body, no projector required.
+
+```csharp
+app.MapDelete("/users/{id}", async (string id, IUserService users, CancellationToken ct) =>
+    (await users.DeleteAsync(id, ct)).ToHttpResponse());
+
+public interface IUserService
+{
+    Task<Result<Unit>> DeleteAsync(string id, CancellationToken ct);
+}
+```
+
+## MVC controllers
+
+For MVC, convert with `ToHttpResponse` / `ToHttpResponseAsync`, then adapt with `AsActionResult<T>` / `AsActionResultAsync<T>` so the action signature stays `Task<ActionResult<T>>` for OpenAPI / `[ProducesResponseType<T>]`.
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;
@@ -34,11 +132,9 @@ using Trellis;
 using Trellis.Asp;
 
 var builder = WebApplication.CreateBuilder(args);
-
 builder.Services
     .AddControllers()
     .AddScalarValueValidation();
-
 builder.Services.AddTrellisAsp();
 
 var app = builder.Build();
@@ -46,152 +142,118 @@ app.UseScalarValueValidation();
 app.MapControllers();
 app.Run();
 
-public interface IUserService
-{
-    Task<Result<User>> GetByIdAsync(string id, CancellationToken cancellationToken);
-    Task<Result<User>> CreateAsync(CreateUserRequest request, CancellationToken cancellationToken);
-}
-
-public sealed record User(string Id, string Email);
-public sealed record CreateUserRequest(string Email);
-public sealed record UserResponse(string Id, string Email)
-{
-    public static UserResponse From(User user) => new(user.Id, user.Email);
-}
-
 [ApiController]
 [Route("users")]
 public sealed class UsersController(IUserService users) : ControllerBase
 {
     [HttpGet("{id}", Name = nameof(GetById))]
-    public async Task<ActionResult<UserResponse>> GetById(string id, CancellationToken ct)
-    {
-        Result<User> result = await users.GetByIdAsync(id, ct);
-        return result
-            .ToHttpResponse(UserResponse.From)
-            .AsActionResult<UserResponse>();
-    }
+    [ProducesResponseType<UserResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    public Task<ActionResult<UserResponse>> GetById(string id, CancellationToken ct) =>
+        users.GetByIdAsync(id, ct)
+            .ToHttpResponseAsync(user => new UserResponse(user.Id, user.Email))
+            .AsActionResultAsync<UserResponse>();
 
     [HttpPost]
-    public async Task<ActionResult<UserResponse>> Create(CreateUserRequest request, CancellationToken ct)
-    {
-        Result<User> result = await users.CreateAsync(request, ct);
-        return result
-            .ToHttpResponse(
-                UserResponse.From,
-                opts => opts.CreatedAtRoute(
+    [ProducesResponseType<UserResponse>(StatusCodes.Status201Created)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status422UnprocessableEntity)]
+    public Task<ActionResult<UserResponse>> Create(CreateUserRequest request, CancellationToken ct) =>
+        users.CreateAsync(request, ct)
+            .ToHttpResponseAsync(
+                body: user => new UserResponse(user.Id, user.Email),
+                configure: opts => opts.CreatedAtRoute(
                     nameof(GetById),
-                    user => new RouteValueDictionary(new { id = user.Id })))
-            .AsActionResult<UserResponse>();
-    }
-}
-```
-
-Why this works well:
-
-- your service layer stays focused on domain results
-- your controller only handles HTTP concerns
-- success and failure paths stay visible
-
-## Quick start: Minimal APIs
-
-If you prefer Minimal APIs, use the Minimal API helpers instead:
-
-```csharp
-using Microsoft.AspNetCore.Routing;
-using Trellis;
-using Trellis.Asp;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddTrellisAsp();
-builder.Services.AddScalarValueValidationForMinimalApi();
-
-var app = builder.Build();
-app.UseScalarValueValidation();
-
-app.MapGet("/users/{id}", async (
-    string id,
-    IUserService users,
-    CancellationToken ct) =>
-    await users.GetByIdAsync(id, ct)
-        .ToHttpResponseAsync(UserResponse.From))
-    .WithName("GetUser");
-
-app.MapPost("/users", async (
-    CreateUserRequest request,
-    IUserService users,
-    CancellationToken ct) =>
-    await users.CreateAsync(request, ct)
-        .ToHttpResponseAsync(
-            UserResponse.From,
-            opts => opts.CreatedAtRoute(
-                "GetUser",
-                user => new RouteValueDictionary(new { id = user.Id }))));
-
-app.Run();
-
-public interface IUserService
-{
-    Task<Result<User>> GetByIdAsync(string id, CancellationToken cancellationToken);
-    Task<Result<User>> CreateAsync(CreateUserRequest request, CancellationToken cancellationToken);
+                    user => new RouteValueDictionary { ["id"] = user.Id }))
+            .AsActionResultAsync<UserResponse>();
 }
 
 public sealed record User(string Id, string Email);
 public sealed record CreateUserRequest(string Email);
-public sealed record UserResponse(string Id, string Email)
+public sealed record UserResponse(string Id, string Email);
+
+public interface IUserService
 {
-    public static UserResponse From(User user) => new(user.Id, user.Email);
+    Task<Result<User>> GetByIdAsync(string id, CancellationToken ct);
+    Task<Result<User>> CreateAsync(CreateUserRequest request, CancellationToken ct);
 }
 ```
 
-## `AddTrellisAsp()` overloads
+> [!NOTE]
+> `AsActionResult<T>` only exists for the generic `ActionResult<T>` shape. For value-less responses, return `IResult` directly from a Minimal API endpoint or use `IActionResult` in MVC.
 
-There are two registration styles:
+## Body projection
+
+Every generic `ToHttpResponse` overload accepts an optional `body: Func<TDomain, TBody>` projector. The selectors in the options builder (`WithETag`, `WithLastModified`, `Created(selector)`, `CreatedAtRoute(values)`, `WithContentLocation`, `WithRange(selector)`) **always run against the domain value**, not the projected body. This keeps response DTOs free of representation concerns:
 
 ```csharp
-builder.Services.AddTrellisAsp();
+return result.ToHttpResponse(
+    body: product => new ProductResponse(product.Id.Value, product.Name.Value, product.Price.Value),
+    configure: opts => opts
+        .WithETag(product => product.ETag)
+        .CreatedAtRoute("Products_GetById", product => new RouteValueDictionary { ["id"] = product.Id.Value }));
+```
 
-builder.Services.AddTrellisAsp(options =>
+There is **no** `WithBody(...)` builder method. Pass the projector as the second positional argument to `ToHttpResponse` instead.
+
+## Error mapping
+
+Defaults are sourced from `TrellisAspOptions`:
+
+| `Error` type | Default status |
+|---|---|
+| `Error.BadRequest` | `400` |
+| `Error.Unauthorized` | `401` |
+| `Error.Forbidden` | `403` |
+| `Error.NotFound` | `404` |
+| `Error.MethodNotAllowed` | `405` |
+| `Error.NotAcceptable` | `406` |
+| `Error.Conflict` | `409` |
+| `Error.Gone` | `410` |
+| `Error.PreconditionFailed` | `412` |
+| `Error.ContentTooLarge` | `413` |
+| `Error.UnsupportedMediaType` | `415` |
+| `Error.RangeNotSatisfiable` | `416` |
+| `Error.UnprocessableContent` | `422` |
+| `Error.PreconditionRequired` | `428` |
+| `Error.TooManyRequests` | `429` |
+| `Error.InternalServerError` / `Error.Unexpected` | `500` |
+| `Error.NotImplemented` | `501` |
+| `Error.ServiceUnavailable` | `503` |
+
+Override globally:
+
+```csharp
+builder.Services.AddTrellisAsp(opts =>
 {
-    options.MapError<Error.Conflict>(StatusCodes.Status400BadRequest);
+    opts.MapError<Error.Conflict>(StatusCodes.Status400BadRequest);
 });
 ```
 
-Use the parameterless overload when the defaults already match your API. Use the configured overload when you want to override specific mappings.
+Override per call (highest precedence first):
 
-## Default error mapping
+```csharp
+return result.ToHttpResponse(
+    body: order => new OrderResponse(order.Id),
+    configure: opts => opts
+        .WithErrorMapping<Error.Conflict>(StatusCodes.Status409Conflict)
+        .WithErrorMapping(err => err is Error.NotFound ? StatusCodes.Status410Gone : default));
+```
 
-One of the biggest wins of `Trellis.Asp` is that you do not need a custom `switch` statement in every endpoint.
-
-| Trellis error type | Default HTTP status |
-| --- | --- |
-| `Error.UnprocessableContent` | `422 Unprocessable Content` |
-| `Error.BadRequest` | `400 Bad Request` |
-| `Error.Unauthorized` | `401 Unauthorized` |
-| `Error.Forbidden` | `403 Forbidden` |
-| `Error.NotFound` | `404 Not Found` |
-| `Error.MethodNotAllowed` | `405 Method Not Allowed` |
-| `Error.NotAcceptable` | `406 Not Acceptable` |
-| `Error.Conflict` | `409 Conflict` |
-| `Error.Gone` | `410 Gone` |
-| `Error.PreconditionFailed` | `412 Precondition Failed` |
-| `Error.ContentTooLarge` | `413 Content Too Large` |
-| `Error.UnsupportedMediaType` | `415 Unsupported Media Type` |
-| `Error.RangeNotSatisfiable` | `416 Range Not Satisfiable` |
-| `Error.PreconditionRequired` | `428 Precondition Required` |
-| `Error.TooManyRequests` | `429 Too Many Requests` |
-| `Error.InternalServerError` | `500 Internal Server Error` |
-| `Error.Unexpected` | `500 Internal Server Error` |
-| `Error.NotImplemented` | `501 Not Implemented` |
-| `Error.ServiceUnavailable` | `503 Service Unavailable` |
-
-> [!NOTE]
-> Trellis error codes default to the error kind, such as `unprocessable-content` or `not-found`. Some payload-bearing cases expose a per-instance reason code instead.
+Resolution order: `WithErrorMapping(Func<Error,int>)` → `WithErrorMapping<TError>(int)` → `TrellisAspOptions.MapError<TError>(int)` → `500`.
 
 ## Problem Details output
 
-Failures are returned as Problem Details responses, so clients get a standard shape instead of ad hoc JSON.
+Failures are emitted as `application/problem+json`. Companion headers are added automatically:
+
+| Error | Companion header |
+|---|---|
+| `Error.MethodNotAllowed` | `Allow` |
+| `Error.TooManyRequests` / `Error.ServiceUnavailable` | `Retry-After` (when configured) |
+| `Error.RangeNotSatisfiable` | `Content-Range: {Unit} */{CompleteLength}` |
+
+Extensions always carry `code` and `kind`. `Error.InternalServerError` adds `faultId`. Rule violations land under `rules`. **For any `5xx`, `Detail` is replaced with `"An internal error occurred."`** so internal diagnostics never leak.
+
+`Error.UnprocessableContent` is routed to `Results.ValidationProblem(...)`:
 
 ```http
 HTTP/1.1 422 Unprocessable Content
@@ -208,59 +270,182 @@ Content-Type: application/problem+json
 }
 ```
 
-## Scalar value validation
+The `errors` dictionary keys are each `FieldViolation.Field.Path` with the leading `/` trimmed; the values are `Detail ?? ReasonCode`.
 
-This solves a common pain point: value objects are great in your domain, but raw ASP.NET Core model binding does not know how to validate them the way Trellis does.
+## Created responses
 
-### MVC setup
+Three options for `201 Created`. Pick by your AOT requirement and the link source.
 
-For controllers, use the MVC-specific registration:
+| Builder | Location source | AOT-safe |
+|---|---|---|
+| `Created(string locationLiteral)` | Caller-supplied literal | Yes |
+| `Created(Func<TDomain, string> selector)` | Selector over the domain value | Yes |
+| `CreatedAtRoute(string routeName, Func<TDomain, RouteValueDictionary> routeValues)` | `LinkGenerator.GetUriByName` (resolved at execute time) | Yes |
+| `CreatedAtAction(string actionName, Func<TDomain, RouteValueDictionary> routeValues, string? controllerName = null)` | `LinkGenerator.GetUriByAction` | **No** — `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` |
 
 ```csharp
-builder.Services
-    .AddControllers()
-    .AddScalarValueValidation();
-
-var app = builder.Build();
-app.UseScalarValueValidation();
-app.MapControllers();
+app.MapPost("/products", async (CreateProduct cmd, IProductWriter writer, CancellationToken ct) =>
+        (await writer.CreateAsync(cmd, ct)).ToHttpResponse(
+            body: product => new ProductResponse(product.Id.Value, product.Name.Value),
+            configure: opts => opts.CreatedAtRoute(
+                "Products_GetById",
+                product => new RouteValueDictionary { ["id"] = product.Id.Value })))
+    .WithName("Products_Create");
 ```
 
-That registration adds:
+> [!WARNING]
+> Under query-string API versioning, `CreatedAtRoute` route values **must** include `["api-version"] = ApiVersion`. Otherwise the emitted `Location` header omits the version and 404s on dereference (the response itself looks correct).
 
-- JSON converter support for scalar values
-- model binders for route/query/form values
-- a validation filter that returns proper validation responses
+### `WriteOutcome<T>`
 
-### Minimal API setup
+When commands return `Result<WriteOutcome<T>>`, the response is RFC 9110-shaped from the variant:
 
-For Minimal APIs, register JSON support, middleware, and the endpoint filter:
+| `WriteOutcome<T>` | Status |
+|---|---|
+| `Created(value)` | `201 Created` (plus `Location` from `Created`/`CreatedAtRoute`/`CreatedAtAction`) |
+| `Updated(value)` | `200 OK` (or `204 No Content` with `Prefer: return=minimal` and `HonorPrefer()`) |
+| `UpdatedNoContent` | `204 No Content` |
+| `Accepted(value)` | `202 Accepted` (with `Retry-After` when configured) |
+| `AcceptedNoContent` | `202 Accepted` |
 
 ```csharp
-using Trellis.Primitives;
+app.MapPut("/orders/{id:guid}", async (
+        Guid id,
+        UpdateOrderRequest request,
+        IOrderService orders,
+        CancellationToken ct) =>
+    (await orders.UpdateAsync(id, request, ct)).ToHttpResponse(
+        body: order => new OrderResponse(order.Id, order.Total),
+        configure: opts => opts
+            .WithETag(order => order.ETag)
+            .HonorPrefer()));
+```
+
+## Conditional requests
+
+`EvaluatePreconditions()` runs only on `GET` / `HEAD` and only when at least one selector (`WithETag` / `WithLastModified`) is configured. Evaluation order (RFC 9110): `If-Match` → `If-Unmodified-Since` → `If-None-Match` → `If-Modified-Since`. Failed `If-Match` / `If-Unmodified-Since` → `412`; failed `If-None-Match` / `If-Modified-Since` on `GET`/`HEAD` → `304`.
+
+```csharp
+app.MapGet("/products/{id:guid}", async (Guid id, IProductReader reader, CancellationToken ct) =>
+    (await reader.GetAsync(id, ct)).ToHttpResponse(
+        body: product => new ProductResponse(product.Id, product.Name, product.Price, product.ETag),
+        configure: opts => opts
+            .WithETag(product => product.ETag)
+            .WithLastModified(product => product.UpdatedAt)
+            .EvaluatePreconditions()));
+```
+
+For unsafe methods (`PUT`, `POST`), evaluate preconditions **before** the mutation. Use the typed parsers from `ETagHelper`:
+
+```csharp
 using Trellis.Asp;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddScalarValueValidationForMinimalApi();
-
-var app = builder.Build();
-app.UseScalarValueValidation();
-
-app.MapPost("/customers", (CreateCustomerRequest request) => Results.Ok(request))
-    .WithScalarValueValidation();
-
-app.Run();
-
-public sealed record CreateCustomerRequest(EmailAddress Email, FirstName Name);
+EntityTagValue[]? ifMatch = ETagHelper.ParseIfMatch(httpContext.Request);
+EntityTagValue[]? ifNoneMatch = ETagHelper.ParseIfNoneMatch(httpContext.Request);
 ```
 
-### Important distinction
+`ParseIfMatch` returns `null` (header absent), `[]` (present but empty / weak-only — strong-only enforcement), the wildcard, or the parsed strong tags. `ParseIfNoneMatch` returns `null`, `[]`, the wildcard, or the parsed strong/weak tags.
 
-`AddScalarValueValidation()` also exists on `IServiceCollection`, but that convenience overload only configures shared JSON support. It does **not** replace `AddControllers().AddScalarValueValidation()` for MVC apps.
+The aggregate-side concurrency helpers `OptionalETag(...)` / `RequireETag(...)` consume `EntityTagValue[]?`. They live in `Trellis.Core` — see [`trellis-api-core.md`](../api_reference/trellis-api-core.md).
 
-## Optional value objects with `Maybe<T>`
+For "create only if absent" flows (`PUT` / `POST` with `If-None-Match: *`), use `EnforceIfNoneMatchPrecondition`:
 
-`Maybe<T>` is useful when “missing” is valid but “present and invalid” should still fail the request.
+```csharp
+using Trellis.Asp;
+
+var guarded = result.EnforceIfNoneMatchPrecondition(
+    ETagHelper.ParseIfNoneMatch(httpContext.Request));
+```
+
+When the header contains `*` and the result is currently a success, it is replaced with `Error.PreconditionFailed` (`PreconditionKind.IfNoneMatch`). No-op otherwise.
+
+## Prefer header
+
+`HonorPrefer()` honors RFC 7240 `Prefer: return=minimal` / `return=representation` on a `WriteOutcome` response. It always emits `Vary: Prefer`; `Preference-Applied` is emitted only when Trellis honored a preference.
+
+| Sent header | Effect on `WriteOutcome.Updated` |
+|---|---|
+| `Prefer: return=minimal` | `204 No Content` + `Preference-Applied: return=minimal` |
+| `Prefer: return=representation` | `200 OK` with body + `Preference-Applied: return=representation` |
+| (none) | `200 OK` with body (no `Preference-Applied`) |
+
+For raw access to the parsed header:
+
+```csharp
+using Trellis.Asp;
+
+var prefer = PreferHeader.Parse(httpContext.Request);
+if (prefer.ReturnMinimal) { /* … */ }
+```
+
+> [!NOTE]
+> `PreferHeader.HasPreferences` is `true` only when at least one **recognized** standard preference (`return`, `respond-async`, `wait`, `handling`) was parsed. Unknown tokens do not set it.
+
+## Pagination
+
+The `Result<Page<T>>` overload always emits a `PagedResponse<TBody>` JSON envelope. The RFC 8288 `Link` header is added only when `Page.Next` and/or `Page.Previous` cursors are present.
+
+```csharp
+app.MapGet("/products", async (
+        string? cursor,
+        int? limit,
+        IProductReader reader,
+        HttpContext ctx,
+        CancellationToken ct) =>
+    (await reader.ListAsync(cursor, limit ?? 50, ct)).ToHttpResponse(
+        nextUrlBuilder: (next, applied) =>
+            $"{ctx.Request.Scheme}://{ctx.Request.Host}/products?cursor={next.Token}&limit={applied}",
+        body: product => new ProductResponse(product.Id, product.Name)));
+
+public sealed record ProductResponse(string Id, string Name);
+
+public interface IProductReader
+{
+    Task<Result<Page<Product>>> ListAsync(string? cursor, int limit, CancellationToken ct);
+}
+```
+
+Failure on the page result short-circuits through the standard error pipeline (Problem Details, default mapping).
+
+## Range responses
+
+`WithRange(from, to, totalLength)` emits `200 OK` when the configured range covers the whole representation; otherwise `206 Partial Content` with `Content-Range`. The static-range overload clamps `to` to `totalLength - 1`.
+
+```csharp
+app.MapGet("/products", async (IProductReader reader, int? page, int? pageSize, CancellationToken ct) =>
+{
+    var size = Math.Clamp(pageSize ?? 25, 1, 100);
+    var number = Math.Max(page ?? 0, 0);
+    var from = number * size;
+
+    var (items, total) = await reader.ListWithCountAsync(from, size, ct);
+    if (items.Length == 0) return Result.Ok(items).ToHttpResponse();
+
+    var to = from + items.Length - 1;
+    return Result.Ok(items).ToHttpResponse(opts => opts.WithRange(from, to, total));
+});
+```
+
+For byte ranges with full RFC 9110 semantics, evaluate `Range` yourself with `RangeRequestEvaluator.Evaluate(request, completeLength)` and switch on `RangeOutcome`. `RangeRequestEvaluator` returns `FullRepresentation` for non-`GET`, missing `Range`, non-`bytes` units, multi-range, malformed, or empty ranges; only well-formed satisfiable single byte ranges produce `PartialContent`.
+
+## Scalar value validation
+
+`Trellis.Asp` validates value objects implementing `IScalarValue<TSelf, TPrimitive>` at every binding site (route, query, JSON body) and surfaces the result as `Error.UnprocessableContent`.
+
+| Host | Required wiring |
+|---|---|
+| MVC controllers | `services.AddControllers().AddScalarValueValidation();` + `app.UseScalarValueValidation();` |
+| Minimal API | `services.AddScalarValueValidationForMinimalApi();` + `app.UseScalarValueValidation();` + `.WithScalarValueValidation()` per endpoint |
+| Either | `services.AddTrellisAsp();` (registers `TrellisAspOptions` and chains `AddScalarValueValidation()` for **both** MVC and Minimal API JSON pipelines) |
+
+> [!IMPORTANT]
+> The `IServiceCollection`-receiver `AddScalarValueValidation()` only configures shared JSON support. For MVC apps you still need `AddControllers().AddScalarValueValidation()` so the `ScalarValueValidationFilter` and `ScalarValueModelBinderProvider` are registered.
+
+`Maybe<T>` rules:
+
+- Omitted or JSON `null` → `Maybe<T>.None`.
+- Valid value → `Maybe.From(value)`.
+- Invalid value (fails `TValue.TryCreate`) → validation error collected in `ValidationErrorsContext`; the request short-circuits with a validation Problem Details before the handler runs.
 
 ```csharp
 using Trellis;
@@ -272,207 +457,111 @@ public sealed record UpdateCustomerRequest(
     Maybe<Url> Website);
 ```
 
-With scalar value validation enabled:
+> [!WARNING]
+> `AddTrellisAsp` / `AddScalarValueValidation` only wire **scalar** VO converters. **Composite** value objects (multi-field `[OwnedEntity]` types like `ShippingAddress`, `Money`) need an explicit `[JsonConverter(typeof(CompositeValueObjectJsonConverter<MyVo>))]` on the type; otherwise model binding silently bypasses `TryCreate` and an invalid payload reaches the domain layer.
 
-- omitted or `null` optional values become `Maybe<T>.None`
-- valid values become `Maybe.From(value)`
-- invalid values produce a validation error instead of silently becoming `null`
+## Route constraints
 
-## Conditional requests: ETags and concurrency
-
-This solves the “lost update” problem and lets clients cache responses safely.
-
-### GET with representation metadata
-
-Use representation metadata to emit response headers such as `ETag`.
+Bind value objects (any `IParsable<T>`) directly from a route segment.
 
 ```csharp
-using Trellis;
 using Trellis.Asp;
 
-app.MapGet("/products/{id:guid}", (Guid id, ProductDbContext db) =>
-    db.Products
-        .FirstOrDefaultResultAsync(
-            p => p.Id == ProductId.Create(id),
-            new Error.NotFound(new ResourceRef("Resource", id.ToString())) { Detail = "Product not found." })
+// AOT-safe — explicit registration per type
+services.AddTrellisRouteConstraint<ProductId>("ProductId");
+
+// Reflection-based — scans the calling assembly + Trellis.Core for IScalarValue<,> + IParsable<>
+services.AddTrellisRouteConstraints();
+
+app.MapGet("/products/{id:ProductId}", (ProductId id) => Results.Ok(id));
+```
+
+`AddTrellisRouteConstraints` is reflection-based and **not Native AOT compatible**; `AddTrellisRouteConstraint<T>` is AOT-safe.
+
+## Actor providers
+
+`Trellis.Asp.Authorization` hydrates the current `Actor` from JWT/OIDC claims. The `Actor` and `IActorProvider` types themselves live in `Trellis.Authorization`.
+
+```csharp
+using Trellis.Asp.Authorization;
+
+services.AddClaimsActorProvider(opts =>
+{
+    opts.ActorIdClaim = "sub";
+    opts.PermissionsClaim = "permissions";
+});
+
+services.AddEntraActorProvider(opts =>
+{
+    opts.MapPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
+        .Select(c => c.Value)
+        .ToHashSet();
+});
+
+if (env.IsDevelopment())
+{
+    services.AddDevelopmentActorProvider(opts =>
+    {
+        opts.DefaultActorId = "development";
+        opts.DefaultPermissions = new HashSet<string> { "orders:read", "orders:create" };
+    });
+}
+
+// Wraps the previously registered IActorProvider with per-request caching:
+services.AddCachingActorProvider<EntraActorProvider>();
+```
+
+`DevelopmentActorProvider` throws `InvalidOperationException` outside the Development environment regardless of header presence; in Development it reads the `X-Test-Actor` header (JSON: `{ "Id", "Permissions", "ForbiddenPermissions", "Attributes" }`, case-insensitive). See [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md) for `WebApplicationFactory.CreateClientWithActor`.
+
+## Composition
+
+Once the application returns `Result<T>` / `Result<WriteOutcome<T>>`, every cross-cutting concern composes through the same `ToHttpResponse` call — there is no per-endpoint `switch` to keep in sync with the error catalog.
+
+```csharp
+app.MapPut("/products/{id:guid}", async (
+        Guid id,
+        UpdateProductRequest request,
+        IProductService products,
+        HttpContext httpContext,
+        CancellationToken ct) =>
+{
+    var ifMatch = ETagHelper.ParseIfMatch(httpContext.Request);
+    var ifNoneMatch = ETagHelper.ParseIfNoneMatch(httpContext.Request);
+
+    return await products.UpdateAsync(id, request, ifMatch, ct)
+        .EnforceIfNoneMatchPreconditionAsync(ifNoneMatch)
         .ToHttpResponseAsync(
-            ProductResponse.From,
-            opts => opts
+            body: product => new ProductResponse(product.Id, product.Name, product.Price, product.ETag),
+            configure: opts => opts
                 .WithETag(product => product.ETag)
-                .EvaluatePreconditions()));
-
-public sealed record ProductResponse(Guid Id, string Name, decimal Price, string ETag)
-{
-    public static ProductResponse From(Product product) =>
-        new(product.Id.Value, product.Name.Value, product.Price.Value, product.ETag);
-}
-```
-
-If the client sends a matching `If-None-Match`, the response is automatically shortened to `304 Not Modified`.
-
-### PUT with `If-Match`
-
-`ETagHelper.ParseIfMatch(request)` returns `EntityTagValue[]?`, and that typed value flows directly into Trellis concurrency helpers.
-
-```csharp
-using Trellis;
-using Trellis.Asp;
-using Trellis.Primitives;
-
-app.MapPut("/products/{id:guid}", (Guid id, UpdateProductRequest request, ProductDbContext db, HttpContext httpContext) =>
-    db.Products
-        .FirstOrDefaultResultAsync(
-            p => p.Id == ProductId.Create(id),
-            new Error.NotFound(new ResourceRef("Resource", id.ToString())) { Detail = "Product not found." })
-        .OptionalETagAsync(ETagHelper.ParseIfMatch(httpContext.Request))
-        .BindAsync(product => product.UpdatePrice(request.Price))
-        .CheckAsync(_ => db.SaveChangesResultUnitAsync())
-        .MapAsync(product => (WriteOutcome<Product>)new WriteOutcome<Product>.Updated(product))
-        .ToHttpResponseAsync(
-            ProductResponse.From,
-            opts => opts
-                .WithETag(product => product.ETag)
-                .HonorPrefer()));
-
-public sealed record UpdateProductRequest(MonetaryAmount Price);
-public sealed record ProductResponse(Guid Id, string Name, decimal Price, string ETag)
-{
-    public static ProductResponse From(Product product) =>
-        new(product.Id.Value, product.Name.Value, product.Price.Value, product.ETag);
-}
-```
-
-Use:
-
-- `OptionalETag(...)` when `If-Match` is optional
-- `RequireETag(...)` when missing `If-Match` should fail with `428 Precondition Required`
-
-### Create-if-absent with `If-None-Match`
-
-For “only create if this resource does not already exist” flows, use `ParseIfNoneMatch(...)` and `EnforceIfNoneMatchPrecondition(...)`.
-
-```csharp
-var ifNoneMatch = ETagHelper.ParseIfNoneMatch(httpContext.Request); // EntityTagValue[]?
-var guarded = result.EnforceIfNoneMatchPrecondition(ifNoneMatch);
-```
-
-> [!NOTE]
-> `EnforceIfNoneMatchPrecondition(...)` takes `EntityTagValue[]?`, not `string[]`.
-
-## `Prefer` header support
-
-Sometimes a client wants the updated representation back. Sometimes it only wants confirmation that the write succeeded. Trellis supports both without forcing you to hand-roll header parsing.
-
-```csharp
-using Trellis;
-using Trellis.Asp;
-
-app.MapPut("/orders/{id:guid}", async (
-    Guid id,
-    UpdateOrderRequest request,
-    IOrderService orders,
-    CancellationToken ct) =>
-    await orders.UpdateAsync(id, request, ct)
-        .MapAsync(order => (WriteOutcome<Order>)new WriteOutcome<Order>.Updated(order))
-        .ToHttpResponseAsync(
-            OrderResponse.From,
-            opts => opts
-                .WithETag(order => order.ETag)
-                .HonorPrefer()));
-```
-
-Behavior:
-
-- `Prefer: return=minimal` → `204 No Content`
-- `Prefer: return=representation` → `200 OK` with a body
-- `Preference-Applied` is emitted when Trellis honors the preference
-
-If you need raw access to the parsed header:
-
-```csharp
-var prefer = PreferHeader.Parse(httpContext.Request);
-
-if (prefer.ReturnMinimal)
-{
-    // client asked for a minimal response
-}
-```
-
-> [!NOTE]
-> `PreferHeader.HasPreferences` means “at least one recognized standard preference was parsed.” Unknown tokens do not set it.
-
-## Pagination and partial content
-
-For paged item collections, Trellis can return `206 Partial Content` with a `Content-Range` header.
-
-```csharp
-app.MapGet("/products", async (ProductDbContext db, int? page, int? pageSize) =>
-{
-    var size = Math.Clamp(pageSize ?? 25, 1, 100);
-    var number = Math.Max(page ?? 0, 0);
-    var from = number * size;
-
-    var total = await db.Products.CountAsync();
-    var items = await db.Products
-        .OrderBy(p => p.Name)
-        .Skip(from)
-        .Take(size)
-        .Select(ProductResponse.From)
-        .ToArrayAsync();
-
-    if (items.Length == 0)
-        return Results.Ok(items);
-
-    var to = from + items.Length - 1;
-    return Result.Ok(items).ToHttpResponse(opts => opts.WithRange(from, to, total));
+                .HonorPrefer()
+                .WithErrorMapping<Error.Conflict>(StatusCodes.Status409Conflict));
 });
 ```
 
-> [!NOTE]
-> `RangeRequestEvaluator` is the lower-level RFC 9110 byte-range helper. It intentionally returns `FullRepresentation` for many cases: non-`GET` requests, missing `Range`, unsupported units, empty ranges, multiple ranges, and malformed single ranges.
+When you genuinely need a custom payload shape (non-Problem-Details body, endpoint-specific JSON, extra cookies), reach for `MatchAsync` from `Trellis.Core` instead of `ToHttpResponse`. Treat that as the exception, not the rule.
 
-## When to customize the response yourself
+## Practical guidance
 
-The built-in mappers are the default choice. Reach for custom matching only when the endpoint genuinely needs a custom payload shape.
+- **Convert at the API boundary only.** Keep `Result<T>` flowing through your application layer; convert to `IResult` / `ActionResult<T>` exactly once, at the endpoint.
+- **`AddTrellisAsp()` is the one-call setup.** It registers `TrellisAspOptions` and configures both the MVC and Minimal API JSON pipelines for scalar-value / `Maybe<T>` deserialization. You still need `UseScalarValueValidation()` middleware and (for Minimal APIs) `WithScalarValueValidation()` per endpoint.
+- **Document failure status codes.** Add `[ProducesResponseType<ProblemDetails>(...)]` for every spec-listed failure status (`422`, `409`, `403`, `404`, …). The `IEndpointMetadataProvider` on Trellis result types already declares the union of statuses the writer can emit (`200`, `201`, `206`, `304`, `400`, `404`, `412`, `500`); layer your spec-specific metadata on top.
+- **`Result<Unit>` for side-effect commands**. A successful `Result<Unit>` produces `204 No Content` with no body.
+- **Use typed ETag parsers.** `ETagHelper.ParseIfMatch` / `ParseIfNoneMatch` return `EntityTagValue[]?`, which feeds `OptionalETag` / `RequireETag` (Core) and `EnforceIfNoneMatchPrecondition` (Asp) directly.
+- **Versioned `Location` headers.** Under query-string API versioning, every `CreatedAtRoute` call must include `["api-version"] = ApiVersion` in the route values, otherwise the `Location` 404s on dereference and tests still pass.
+- **Avoid controller-level `[Consumes("application/json")]`.** Trigger-style POSTs without bodies (e.g., `POST /orders/{id}/submission`) return `415` for any request without a `Content-Type`. Apply `[Consumes]` per body-bearing action.
+- **Prefer `CreatedAtRoute` over `CreatedAtAction`** for trim/AOT scenarios; `CreatedAtAction` is annotated `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`.
+- **Prove `422` mapping in integration tests.** Exception middleware does not map Trellis `Result` failures — assert at least one business-validation failure surfaces as `422` Problem Details end-to-end.
 
-```csharp
-app.MapPost("/orders", async (
-    CreateOrderRequest request,
-    IOrderService orders,
-    CancellationToken ct) =>
-    await orders.CreateAsync(request, ct).MatchAsync(
-        onSuccess: order => Results.Created($"/orders/{order.Id}", order),
-        onFailure: error => error switch
-        {
-            Error.UnprocessableContent uc => Results.UnprocessableEntity(new
-            {
-                message = "Validation failed",
-                errors = uc.Fields.Items
-                    .GroupBy(v => v.Field.Path)
-                    .ToDictionary(g => g.Key, g => g.Select(v => v.Detail ?? v.ReasonCode).ToArray())
-            }),
-            Error.Conflict c              => Results.Conflict(new { message = c.Detail }),
-            _                              => Results.StatusCode(StatusCodes.Status500InternalServerError)
-        },
-        cancellationToken: ct));
-```
+## Cross-references
 
-Use this approach when you need:
-
-- a non-Problem-Details error body
-- endpoint-specific payload shapes
-- extra headers or cookies beyond the standard helpers
-
-## Best practices
-
-1. **Convert at the API boundary only.** Keep `Result<T>` in your application layer.
-2. **Use MVC-specific or Minimal-API-specific validation setup.** Do not rely on the shared convenience overload alone for MVC.
-3. **Use `Result<Unit>` for side-effect operations.** Trellis maps successful `Result<Unit>` to `204 No Content`.
-4. **Prefer typed ETag helpers.** `ParseIfMatch(...)` and `ParseIfNoneMatch(...)` return `EntityTagValue[]?`, which matches the concurrency APIs.
-5. **Use representation metadata instead of hand-writing headers** when you want `ETag`, `Last-Modified`, `Vary`, or related response metadata.
-
-## Next steps
-
-- Add [FluentValidation Integration](integration-fluentvalidation.md) for richer business validation
-- Add [ASP.NET Core Authorization](integration-asp-authorization.md) when claims need to become an `Actor`
-- Add [Entity Framework Core Integration](integration-ef.md) if your handlers persist aggregates or read models
+- API surface: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- `Result`, `Result<T>`, `Error`, `WriteOutcome<T>`, `Page<T>`, `EntityTagValue`, `OptionalETag` / `RequireETag`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- `Actor`, `IActorProvider`, `IAuthorize`: [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- `IScalarValue<TSelf, TPrimitive>`, `Maybe<T>`, ready-to-use value objects: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- Integration-test helpers (`CreateClientWithActor` for `X-Test-Actor`): [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)
+- Composite value object end-to-end pattern (Recipe 13): [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership)
+- HTTP client side (consuming results): [`integration-http.md`](integration-http.md)
+- FluentValidation pipeline: [`integration-fluentvalidation.md`](integration-fluentvalidation.md)
+- EF Core integration (`FirstOrDefaultResultAsync`, `SaveChangesResultUnitAsync`): [`integration-ef.md`](integration-ef.md)

--- a/docs/docfx_project/articles/integration-db-permissions.md
+++ b/docs/docfx_project/articles/integration-db-permissions.md
@@ -65,6 +65,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Authorization;
 using Trellis.Asp.Authorization;
@@ -95,12 +96,20 @@ public sealed class DatabaseActorProvider(
     }
 }
 
-// Composition root
-services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddJwtBearer(options => configuration.Bind("AzureAd", options));
+// Composition root — wire from Program.cs (or any DI extension method).
+public static class CompositionRoot
+{
+    public static void AddDatabasePermissions(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddHttpContextAccessor();
 
-services.AddScoped<IPermissionRepository, PermissionRepository>();
-services.AddCachingActorProvider<DatabaseActorProvider>();
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options => configuration.Bind("AzureAd", options));
+
+        services.AddScoped<IPermissionRepository, PermissionRepository>();
+        services.AddCachingActorProvider<DatabaseActorProvider>();
+    }
+}
 ```
 
 ## Permission domain model

--- a/docs/docfx_project/articles/integration-db-permissions.md
+++ b/docs/docfx_project/articles/integration-db-permissions.md
@@ -1,62 +1,111 @@
+﻿---
+title: Database-Backed Permissions
+package: Trellis.EntityFrameworkCore
+topics: [efcore, permissions, authorization, actor-provider, claims, abac, tenant, hybrid-auth]
+related_api_reference: [trellis-api-efcore.md, trellis-api-authorization.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Database-Backed Permissions
 
-When JWT app roles are too coarse, too static, or too limited, you need authorization data you can manage in your own system. This pattern keeps **authentication** in your identity provider and moves **permissions** into your application database.
+Implement `IActorProvider` over EF Core so authentication stays in your identity provider while permissions live in the application database, manageable without redeploying.
 
-The good news: you can do that with the existing `IActorProvider` abstraction. You do not need a special Trellis permissions package.
+## Patterns Index
 
-## Table of Contents
+| Goal | Use | See |
+|---|---|---|
+| Map `ClaimsPrincipal` to a Trellis `Actor` from DB-loaded permissions | Custom `IActorProvider` returning `Actor.Create(id, permissions)` | [Database-backed actor provider](#database-backed-actor-provider) |
+| Load a flat permission set for an external user id | EF Core repository projecting `User → Roles → Permissions` to `IReadOnlySet<string>` | [Permission repository](#permission-repository) |
+| Avoid duplicate permission lookups inside one HTTP request | `services.AddCachingActorProvider<T>()` | [DI wiring](#di-wiring) |
+| Use stub actors in Development | `services.AddDevelopmentActorProvider()` | [DI wiring](#di-wiring) |
+| Carry tenant / MFA context alongside permissions | Full `Actor` ctor with `attributes` keyed by `ActorAttributes.*` | [Carrying ABAC attributes](#carrying-abac-attributes) |
+| Enforce a static permission on a command | `IAuthorize.RequiredPermissions` | [Composition](#composition) |
+| Enforce ownership on a loaded resource | `IAuthorizeResource<TResource>` + `Result.Ensure(..., new Error.Forbidden(...))` | [Composition](#composition) |
 
-- [When this pattern helps](#when-this-pattern-helps)
-- [Architecture](#architecture)
-- [A minimal domain model](#a-minimal-domain-model)
-- [Loading permissions from EF Core](#loading-permissions-from-ef-core)
-- [Turning claims into an `Actor`](#turning-claims-into-an-actor)
-- [Dependency injection setup](#dependency-injection-setup)
-- [Seeding and testing](#seeding-and-testing)
+## Use this guide when
 
-## When this pattern helps
+- App roles in the JWT are too coarse, too static, or unavailable to the team that manages authorization.
+- You need permission changes to take effect without a token refresh or auth-config redeploy.
+- You want a single `Actor` shape (permissions + ABAC attributes) feeding both static and resource-based authorization.
 
-Choose database-backed permissions when you need authorization rules that change faster than your identity provider configuration.
+## Surface at a glance
 
-| Approach | Identity source | Permission source | Best fit |
-| --- | --- | --- | --- |
-| JWT roles only | token claims | token claims | small, mostly static systems |
-| Hybrid | token claims | application database | most business applications |
-| Database only | custom auth | application database | non-OIDC or fully custom auth stacks |
+This guide composes existing Trellis surfaces — there is no DB-permissions package. The pieces:
 
-The hybrid model is usually the sweet spot:
+| Type / member | Package | Purpose |
+|---|---|---|
+| `IActorProvider.GetCurrentActorAsync(ct)` | `Trellis.Authorization` | Contract you implement to resolve the current `Actor`. |
+| `Actor.Create(string id, IReadOnlySet<string> permissions)` | `Trellis.Authorization` | Builds an actor with empty `ForbiddenPermissions` and empty `Attributes`. |
+| `new Actor(id, permissions, forbiddenPermissions, attributes)` | `Trellis.Authorization` | Full ctor for ABAC / explicit deny. |
+| `ActorAttributes.TenantId` / `MfaAuthenticated` / etc. | `Trellis.Authorization` | Well-known attribute keys. |
+| `IAuthorize.RequiredPermissions` | `Trellis.Authorization` | Static permission requirement on a command/query. |
+| `IAuthorizeResource<TResource>.Authorize(actor, resource)` | `Trellis.Authorization` | Resource-based authorization gate. |
+| `services.AddCachingActorProvider<T>()` | `Trellis.Asp.Authorization` | Wraps your provider with request-scoped caching. |
+| `services.AddDevelopmentActorProvider()` | `Trellis.Asp.Authorization` | Test-only provider driven by the `X-Test-Actor` header. |
+| `RepositoryBase<TAggregate, TId>` + `db.SaveChangesResultUnitAsync(ct)` | `Trellis.EntityFrameworkCore` | Persist permission changes on the railway. |
 
-- the identity provider proves **who** the user is
-- your database decides **what** the user can do
-- admins can change permissions without redeploying auth config
+Full signatures: [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md), [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md).
 
-## Architecture
+## Installation
 
-```mermaid
-flowchart LR
-    A[JWT or OIDC token] -->|authenticates| B[ASP.NET Core authentication]
-    B -->|ClaimsPrincipal| C[DatabaseActorProvider]
-    C -->|lookup by oid or sub| D[(Application database)]
-    D -->|permissions| C
-    C -->|Actor| E[Trellis authorization pipeline]
+```bash
+dotnet add package Trellis.EntityFrameworkCore
+dotnet add package Trellis.Asp
 ```
 
-In other words:
+`Trellis.Asp` brings `Trellis.Authorization` transitively along with `AddCachingActorProvider<T>` / `AddDevelopmentActorProvider`. EF Core conventions and `SaveChangesResult*Async` come from `Trellis.EntityFrameworkCore`.
 
-- authentication stays outside your app
-- authorization becomes application data
+## Quick start
 
-## A minimal domain model
+The minimal hybrid setup: identity provider authenticates, EF Core supplies permissions, `CachingActorProvider` deduplicates per request.
 
-Start simple. You only need users, roles, permissions, and two many-to-many relationships.
+```csharp
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Authorization;
+using Trellis.Asp.Authorization;
 
-```mermaid
-erDiagram
-    AppUser ||--o{ UserRole : has
-    Role ||--o{ UserRole : "assigned to"
-    Role ||--o{ RolePermission : has
-    Permission ||--o{ RolePermission : "granted by"
+public interface IPermissionRepository
+{
+    Task<IReadOnlySet<string>> GetPermissionsForUserAsync(string externalUserId, CancellationToken ct);
+}
+
+public sealed class DatabaseActorProvider(
+    IHttpContextAccessor accessor,
+    IPermissionRepository repo) : IActorProvider
+{
+    public async Task<Actor> GetCurrentActorAsync(CancellationToken ct = default)
+    {
+        var principal = accessor.HttpContext?.User
+            ?? throw new InvalidOperationException("No HttpContext is available.");
+
+        if (principal.Identity?.IsAuthenticated != true)
+            throw new InvalidOperationException("The current request is not authenticated.");
+
+        var externalId = principal.FindFirstValue("oid")
+            ?? principal.FindFirstValue("sub")
+            ?? throw new InvalidOperationException("No 'oid' or 'sub' claim was found.");
+
+        var permissions = await repo.GetPermissionsForUserAsync(externalId, ct).ConfigureAwait(false);
+        return Actor.Create(externalId, permissions);
+    }
+}
+
+// Composition root
+services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options => configuration.Bind("AzureAd", options));
+
+services.AddScoped<IPermissionRepository, PermissionRepository>();
+services.AddCachingActorProvider<DatabaseActorProvider>();
 ```
+
+## Permission domain model
+
+Keep the model boring: users, roles, permissions, and two many-to-many joins. The integration only needs to project to `IReadOnlySet<string>`.
 
 ```csharp
 namespace MyService.Domain;
@@ -73,7 +122,6 @@ public sealed class Role
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
     public ICollection<AppUser> Users { get; } = [];
     public ICollection<Permission> Permissions { get; } = [];
 }
@@ -82,64 +130,23 @@ public sealed class Permission
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
     public ICollection<Role> Roles { get; } = [];
 }
 
 public static class Permissions
 {
-    public const string OrdersCreate = "orders:create";
-    public const string OrdersApprove = "orders:approve";
-    public const string OrdersRead = "orders:read";
-    public const string OrdersReadAll = "orders:read-all";
+    public const string OrdersCreate   = "orders:create";
+    public const string OrdersRead     = "orders:read";
+    public const string OrdersReadAll  = "orders:read-all";
+    public const string OrdersCancel   = "orders:cancel";
+    public const string OrdersCancelAny = "orders:cancel-any";
 }
 ```
 
-> [!TIP]
-> If your domain already uses Trellis value objects for IDs or names, keep using them. The authorization pattern here does not depend on primitive-only entities.
-
-## Loading permissions from EF Core
-
-The repository has one job: translate an authenticated external identity into a flat permission set.
+A minimal mapping with unique indexes on `ExternalId`, `Role.Name`, and `Permission.Name`:
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
-
-namespace MyService.Application;
-
-public interface IPermissionRepository
-{
-    Task<IReadOnlySet<string>> GetPermissionsForUserAsync(
-        string externalUserId,
-        CancellationToken cancellationToken);
-}
-
-public sealed class PermissionRepository(AppDbContext db) : IPermissionRepository
-{
-    public async Task<IReadOnlySet<string>> GetPermissionsForUserAsync(
-        string externalUserId,
-        CancellationToken cancellationToken)
-    {
-        var permissions = await db.Users
-            .Where(user => user.ExternalId == externalUserId)
-            .SelectMany(user => user.Roles)
-            .SelectMany(role => role.Permissions)
-            .Select(permission => permission.Name)
-            .Distinct()
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return permissions.ToHashSet(StringComparer.Ordinal);
-    }
-}
-```
-
-A minimal EF Core mapping is enough:
-
-```csharp
-using Microsoft.EntityFrameworkCore;
-
-namespace MyService.Infrastructure;
 
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
@@ -149,79 +156,123 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<AppUser>(builder =>
+        modelBuilder.Entity<AppUser>(b =>
         {
-            builder.HasKey(x => x.Id);
-            builder.HasIndex(x => x.ExternalId).IsUnique();
-            builder.HasMany(x => x.Roles)
-                .WithMany(x => x.Users)
-                .UsingEntity("UserRoles");
+            b.HasKey(x => x.Id);
+            b.HasIndex(x => x.ExternalId).IsUnique();
+            b.HasMany(x => x.Roles).WithMany(x => x.Users).UsingEntity("UserRoles");
         });
 
-        modelBuilder.Entity<Role>(builder =>
+        modelBuilder.Entity<Role>(b =>
         {
-            builder.HasKey(x => x.Id);
-            builder.HasIndex(x => x.Name).IsUnique();
-            builder.HasMany(x => x.Permissions)
-                .WithMany(x => x.Roles)
-                .UsingEntity("RolePermissions");
+            b.HasKey(x => x.Id);
+            b.HasIndex(x => x.Name).IsUnique();
+            b.HasMany(x => x.Permissions).WithMany(x => x.Roles).UsingEntity("RolePermissions");
         });
 
-        modelBuilder.Entity<Permission>(builder =>
+        modelBuilder.Entity<Permission>(b =>
         {
-            builder.HasKey(x => x.Id);
-            builder.HasIndex(x => x.Name).IsUnique();
+            b.HasKey(x => x.Id);
+            b.HasIndex(x => x.Name).IsUnique();
         });
     }
 }
 ```
 
-## Turning claims into an `Actor`
+> [!TIP]
+> Centralise permission strings in one `Permissions` class. The same constants feed `IAuthorize.RequiredPermissions`, seed data, admin UI, and tests.
 
-This is the core integration point. The provider reads the authenticated user ID from claims, loads permissions from the database, and returns an `Actor`.
+## Permission repository
+
+The repository has one job: translate an authenticated external identity into a flat permission set. Use ordinal comparison so it matches `Actor`'s lookup semantics.
 
 ```csharp
+using Microsoft.EntityFrameworkCore;
+
+public sealed class PermissionRepository(AppDbContext db) : IPermissionRepository
+{
+    public async Task<IReadOnlySet<string>> GetPermissionsForUserAsync(
+        string externalUserId, CancellationToken ct)
+    {
+        var permissions = await db.Users
+            .Where(u => u.ExternalId == externalUserId)
+            .SelectMany(u => u.Roles)
+            .SelectMany(r => r.Permissions)
+            .Select(p => p.Name)
+            .Distinct()
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return permissions.ToHashSet(StringComparer.Ordinal);
+    }
+}
+```
+
+The result type is exactly the `IReadOnlySet<string>` that `Actor.Create(id, permissions)` accepts — no adapter needed.
+
+## Database-backed actor provider
+
+The provider in [Quick start](#quick-start) is the canonical shape. It does three things:
+
+| Step | Why |
+|---|---|
+| Read `HttpContext.User` from `IHttpContextAccessor` | `IActorProvider` is request-scoped; the principal is already populated by the auth middleware. |
+| Extract `oid` (then fall back to `sub`) | Matches the `EntraActorProvider` precedence; both Entra v1.0 and v2.0 tokens resolve. |
+| Call the repository, then `Actor.Create(...)` | `Actor.Create` snapshots permissions into a `FrozenSet<string>` for O(1) lookups. |
+
+Throwing `InvalidOperationException` on missing context / unauthenticated requests follows the contract documented for `IActorProvider.GetCurrentActorAsync` ([`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md#iactorprovider)).
+
+## Carrying ABAC attributes
+
+When the actor needs more than permissions — tenant id, MFA flag, IP address — use the full `Actor` constructor and the well-known keys on `ActorAttributes`.
+
+```csharp
+using System.Collections.Generic;
 using System.Security.Claims;
-using Microsoft.AspNetCore.Http;
 using Trellis.Authorization;
 
-namespace MyService.Api;
-
-public sealed class DatabaseActorProvider(
-    IHttpContextAccessor httpContextAccessor,
-    IPermissionRepository permissionRepository) : IActorProvider
+public sealed class TenantAwareActorProvider(
+    IHttpContextAccessor accessor,
+    IPermissionRepository repo) : IActorProvider
 {
-    public async Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public async Task<Actor> GetCurrentActorAsync(CancellationToken ct = default)
     {
-        var httpContext = httpContextAccessor.HttpContext
+        var ctx = accessor.HttpContext
             ?? throw new InvalidOperationException("No HttpContext is available.");
-
-        var principal = httpContext.User;
-        if (principal.Identity?.IsAuthenticated != true)
-            throw new InvalidOperationException("The current request is not authenticated.");
+        var principal = ctx.User;
 
         var externalId = principal.FindFirstValue("oid")
             ?? principal.FindFirstValue("sub")
             ?? throw new InvalidOperationException("No 'oid' or 'sub' claim was found.");
 
-        var permissions = await permissionRepository
-            .GetPermissionsForUserAsync(externalId, cancellationToken)
+        var permissions = await repo
+            .GetPermissionsForUserAsync(externalId, ct)
             .ConfigureAwait(false);
 
-        return Actor.Create(externalId, permissions);
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (principal.FindFirstValue("tid") is { } tid)
+            attributes[ActorAttributes.TenantId] = tid;
+        if (ctx.Connection.RemoteIpAddress is { } ip)
+            attributes[ActorAttributes.IpAddress] = ip.ToString();
+
+        return new Actor(
+            id: externalId,
+            permissions: permissions,
+            forbiddenPermissions: new HashSet<string>(StringComparer.Ordinal),
+            attributes: attributes);
     }
 }
 ```
 
-Why this works well:
+Downstream code reads attributes via `actor.GetAttribute(ActorAttributes.TenantId)` and uses them inside `IAuthorizeResource<TResource>` guards or as EF query-filter parameters.
 
-- `IActorProvider` is already asynchronous
-- `Actor.Create(string id, IReadOnlySet<string> permissions)` matches the repository result shape
-- the rest of Trellis authorization continues to work exactly the same way
+## DI wiring
 
-## Dependency injection setup
-
-Use your normal JWT/OIDC authentication, then wrap your DB-backed provider with `AddCachingActorProvider<T>()`.
+| Environment | Registration | Behavior |
+|---|---|---|
+| Production | `services.AddCachingActorProvider<DatabaseActorProvider>()` | Registers the concrete provider as scoped, then wraps it with `CachingActorProvider` so duplicate lookups inside one request reuse the same `Actor`. |
+| Development | `services.AddDevelopmentActorProvider()` | Resolves an `Actor` from the `X-Test-Actor` header; throws outside the Development environment. |
+| Test (in-memory) | `WebApplicationFactoryExtensions.CreateClientWithActor(actor)` | Sends the `X-Test-Actor` header consumed by `DevelopmentActorProvider`. |
 
 ```csharp
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -242,69 +293,72 @@ else
 ```
 
 > [!NOTE]
-> `AddCachingActorProvider<T>()` gives you **request-scoped caching**, not a shared app-wide cache. Multiple resolutions during one HTTP request reuse the same in-flight actor lookup. A later request performs a fresh lookup.
+> `AddCachingActorProvider<T>()` caches per request, not app-wide. Permission changes take effect on the next request — no manual invalidation required.
 
-That usually means:
+## Composition
 
-- no extra invalidation logic is required
-- permission changes take effect on the next request
-- expensive duplicate lookups inside one request are avoided
-
-## Seeding and testing
-
-### Seed roles and permissions
-
-You can seed data at startup, in a migration, or through an admin workflow. The important part is that permission names stay stable.
+A DB-backed `Actor` plugs into both authorization shapes the mediator behavior knows about. Static checks on the command, resource checks on the loaded aggregate. Commands return `Result<Unit>`.
 
 ```csharp
-using Microsoft.EntityFrameworkCore;
+using Trellis;
+using Trellis.Authorization;
+using Trellis.Primitives;
 
-public static class PermissionSeeder
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+public sealed partial class ActorId : RequiredString<ActorId>;
+
+public sealed record Order(OrderId Id, ActorId OwnerId);
+
+public sealed record CancelOrderCommand(OrderId OrderId)
+    : ICommand<Result<Unit>>,
+      IAuthorize,
+      IAuthorizeResource<Order>,
+      IIdentifyResource<Order, OrderId>
 {
-    public static async Task SeedAsync(AppDbContext db, CancellationToken cancellationToken = default)
-    {
-        if (await db.Roles.AnyAsync(cancellationToken))
-            return;
+    public IReadOnlyList<string> RequiredPermissions { get; } = [Permissions.OrdersCancel];
 
-        var create = new Permission
-        {
-            Id = Guid.NewGuid(),
-            Name = Permissions.OrdersCreate,
-            Description = "Create orders"
-        };
+    public OrderId GetResourceId() => OrderId;
 
-        var read = new Permission
-        {
-            Id = Guid.NewGuid(),
-            Name = Permissions.OrdersRead,
-            Description = "Read orders"
-        };
-
-        var salesRep = new Role
-        {
-            Id = Guid.NewGuid(),
-            Name = "SalesRep",
-            Description = "Can create and read orders"
-        };
-
-        salesRep.Permissions.Add(create);
-        salesRep.Permissions.Add(read);
-
-        db.Permissions.AddRange(create, read);
-        db.Roles.Add(salesRep);
-
-        await db.SaveChangesAsync(cancellationToken);
-    }
+    public IResult Authorize(Actor actor, Order order) =>
+        Result.Ensure(
+            order.OwnerId.Value == actor.Id || actor.HasPermission(Permissions.OrdersCancelAny),
+            new Error.Forbidden("orders.cancel")
+                { Detail = "Only the owner can cancel this order." });
 }
 ```
 
-### Testing story
+Pipeline ordering (from [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md#behavioral-notes)):
 
-One of the nice parts of this pattern is that your test strategy barely changes:
+1. `AuthorizationBehavior` resolves the actor via your `IActorProvider`.
+2. Static `IAuthorize.RequiredPermissions` are checked with `actor.HasAllPermissions(...)`.
+3. The resource is loaded (per-command `IResourceLoader<TMessage, TResource>` or shared `SharedResourceLoaderById<TResource, TId>`).
+4. `IAuthorizeResource<TResource>.Authorize(actor, resource)` runs.
+5. The handler executes; on success `TransactionalCommandBehavior` commits via `IUnitOfWork`, mapping DB exceptions to typed `Error.Conflict` through `db.SaveChangesResultUnitAsync(ct)`.
 
-- **unit/application tests** can still use `TestActorProvider`
-- **API tests** can still use `DevelopmentActorProvider` and `CreateClientWithActor(...)`
-- **end-to-end tests** can use real tokens plus seeded permission data
+EF query filters compose with the same `Actor` when a tenant attribute is in scope:
 
-> [!TIP]
-> Keep the permission names in one shared `Permissions` class. It reduces drift between authorization policies, test setup, seed data, and admin UI code.
+```csharp
+modelBuilder.Entity<Order>().HasQueryFilter(o =>
+    o.TenantId == tenantAccessor.CurrentTenantId);
+```
+
+The accessor reads `actor.GetAttribute(ActorAttributes.TenantId)` once per request — `CachingActorProvider` ensures a single DB lookup.
+
+## Practical guidance
+
+- **Permission strings are ordinal.** Match the casing used in seed data, `IAuthorize.RequiredPermissions`, and `actor.HasPermission(...)` exactly. `Actor` uses `StringComparison.Ordinal` everywhere.
+- **Stage in the repository, commit in the pipeline.** Persist permission edits via `RepositoryBase<TAggregate, TId>`; `TransactionalCommandBehavior` calls `IUnitOfWork.CommitAsync(ct)`. Do not call `SaveChangesAsync` directly from a handler when `AddTrellisUnitOfWork<TContext>()` is registered.
+- **Use `SaveChangesResultUnitAsync(ct)` for one-off admin scripts.** Outside the mediator pipeline, this overload returns `Result<Unit>` and maps duplicate-key / FK / concurrency exceptions to `Error.Conflict`.
+- **Rely on request-scoped caching.** `AddCachingActorProvider<T>()` removes the need to memoise permissions yourself; emit a fresh request to pick up changes.
+- **Mirror Entra precedence.** Read `oid` first, then fall back to `sub` — same order as `EntraActorProvider` so DB-backed code coexists with claims-based deployments.
+- **Keep deny-list usage rare.** Add explicit denies to `Actor.ForbiddenPermissions` only when the domain genuinely needs an override; `Actor.HasPermission` already enforces deny-overrides-allow.
+
+## Cross-references
+
+- API surface (authorization primitives): [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- API surface (EF Core repository / save helpers / UoW): [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)
+- `Result<T>`, `Error.Forbidden`, `Error.NotFound`, `Specification<T>`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Built-in `IActorProvider` implementations and DI helpers: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#namespace-trellisaspauthorization)
+- Mediator authorization + transactional behaviors and registration order: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- Test-time actor injection (`CreateClientWithActor`): [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)
+- EF Core integration overview (conventions, interceptors, `SaveChangesResult*`): [`integration-ef.md`](integration-ef.md)

--- a/docs/docfx_project/articles/integration-ef.md
+++ b/docs/docfx_project/articles/integration-ef.md
@@ -1,32 +1,79 @@
+﻿---
+title: Entity Framework Core Integration
+package: Trellis.EntityFrameworkCore
+topics: [efcore, repository, unit-of-work, savechanges, owned-entity, maybe, etag, conventions]
+related_api_reference: [trellis-api-efcore.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Entity Framework Core Integration
 
-**Level:** Intermediate 📚 | **Time:** 30-40 min | **Prerequisites:** [Basics](basics.md)
+`Trellis.EntityFrameworkCore` maps Trellis value objects, `Maybe<T>`, owned composites, and aggregate ETags into EF Core, and turns `SaveChangesAsync` exceptions into `Result<T>` failures so repositories stay on the railway.
 
-Entity Framework Core is usually where clean domain code starts to feel messy: value objects need converters, queries return `null`, and database exceptions leak into application code. `Trellis.EntityFrameworkCore` exists to keep that plumbing predictable.
+## Patterns Index
 
-This guide starts with the smallest useful setup, then builds up to query patterns, save patterns, and the conventions Trellis adds for you.
+| Goal | Use | See |
+|---|---|---|
+| Wire EF conventions for Trellis types (compile-time, AOT-friendly) | `configurationBuilder.ApplyTrellisConventionsFor<TContext>()` | [Conventions and interceptors](#conventions-and-interceptors) |
+| Wire EF conventions via runtime assembly scan | `configurationBuilder.ApplyTrellisConventions(typeof(TContext).Assembly)` | [Conventions and interceptors](#conventions-and-interceptors) |
+| Register `Maybe<T>` query rewriting, ETag, and timestamp interceptors | `optionsBuilder.AddTrellisInterceptors()` | [Conventions and interceptors](#conventions-and-interceptors) |
+| Mark a composite value object as EF-owned | `[OwnedEntity]` on a `partial` class inheriting `ValueObject` | [Owned composites](#owned-composites) |
+| Query for an optional row | `FirstOrDefaultMaybeAsync(predicate, ct)` | [Querying](#querying) |
+| Query for a required row, fail with a typed error | `FirstOrDefaultResultAsync(predicate, error, ct)` | [Querying](#querying) |
+| Filter / order an `IQueryable<T>` by a `Maybe<TInner>` property | `WhereHasValue` / `WhereEquals` / `OrderByMaybe` (and friends) | [Querying Maybe properties](#querying-maybe-properties) |
+| Save and surface DB failures as `Error` (no UoW) | `db.SaveChangesResultAsync(ct)` / `db.SaveChangesResultUnitAsync(ct)` | [Saving](#saving) |
+| Stage aggregate changes; let the pipeline commit | `RepositoryBase<TAggregate, TId>` + `AddTrellisUnitOfWork<TContext>()` | [Repositories and unit of work](#repositories-and-unit-of-work) |
+| Commit staged changes outside the pipeline | `IUnitOfWork.CommitAsync(ct)` | [Repositories and unit of work](#repositories-and-unit-of-work) |
+| Update a `Maybe<T>` scalar via `ExecuteUpdate` | `SetMaybeValue(...)` / `SetMaybeNone(...)` | [Bulk updates over Maybe](#bulk-updates-over-maybe) |
+| Index a `Maybe<T>` property without TRLS016 | `entityTypeBuilder.HasTrellisIndex(x => x.M)` | [Indexing Maybe properties](#indexing-maybe-properties) |
 
-## Table of Contents
+## Use this guide when
 
-- [Quick start](#quick-start)
-- [Querying without null checks everywhere](#querying-without-null-checks-everywhere)
-- [Saving without exception-driven flow](#saving-without-exception-driven-flow)
-- [What `ApplyTrellisConventions` actually does](#what-applytrellisconventions-actually-does)
-- [Reflection-free alternative: `ApplyTrellisConventionsFor<TContext>()`](#reflection-free-alternative-applytrellisconventionsfortcontext)
-- [Optimistic concurrency with ETags](#optimistic-concurrency-with-etags)
-- [When to use `Maybe<T>` vs `Result<T>`](#when-to-use-maybet-vs-resultt)
-- [Manual EF Core setup without the package](#manual-ef-core-setup-without-the-package)
+- You persist Trellis aggregates with EF Core and want value-object mapping, ETag concurrency, and timestamp interceptors wired by convention.
+- You want repository methods that return `Maybe<T>` / `Result<T>` instead of `null` and exceptions.
+- You need a deterministic commit boundary — repositories stage, the mediator pipeline commits.
 
-## Quick start
+## Surface at a glance
 
-If you want Trellis value objects, Trellis-friendly query helpers, and save helpers that return `Result<T>`, this is the minimum setup:
+`Trellis.EntityFrameworkCore` exposes one configuration entry point, one interceptor entry point, a query/save extension surface, an aggregate repository base, and a unit-of-work abstraction.
+
+| Type / member | Kind | Purpose |
+|---|---|---|
+| `ModelConfigurationBuilderExtensions.ApplyTrellisConventions(params Assembly[])` | Conventions | Runtime scan; registers scalar converters, `Maybe<T>` / composite / `Money` / ETag / transient conventions. |
+| `GeneratedTrellisConventions.ApplyTrellisConventionsFor<TContext>()` | Conventions (source-generated) | Compile-time discovery alternative; no reflection. |
+| `DbContextOptionsBuilderExtensions.AddTrellisInterceptors([TimeProvider])` | Interceptors | Singleton `MaybeQueryInterceptor`, `ScalarValueQueryInterceptor`, `AggregateETagInterceptor`, `EntityTimestampInterceptor`. |
+| `OwnedEntityAttribute` | Attribute | Marks a `partial ValueObject` as EF-owned; generator emits the private parameterless constructor. |
+| `QueryableExtensions.FirstOrDefaultMaybeAsync<T>` / `SingleOrDefaultMaybeAsync<T>` | Query | Returns `Task<Maybe<T>>`; absence → `Maybe<T>.None`. |
+| `QueryableExtensions.FirstOrDefaultResultAsync<T>` | Query | Returns `Task<Result<T>>`; absence → **the exact `Error` you supplied** (does not invent one). |
+| `QueryableExtensions.Where(Specification<T>)` | Query | Applies a Trellis specification expression. |
+| `MaybeQueryableExtensions.WhereHasValue` / `WhereNone` / `WhereEquals` / `WhereLessThan` / `WhereLessThanOrEqual` / `WhereGreaterThan` / `WhereGreaterThanOrEqual` / `OrderByMaybe` / `OrderByMaybeDescending` / `ThenByMaybe` / `ThenByMaybeDescending` | Query | Translate `Maybe<TInner>` predicates and ordering to the mapped storage member. |
+| `MaybeUpdateExtensions.SetMaybeValue<T>` / `SetMaybeNone<T>` | Bulk update | `ExecuteUpdate` setters for scalar `Maybe<T>` properties. |
+| `MaybeEntityTypeBuilderExtensions.HasTrellisIndex<T>` | Model builder | Indexes a `Maybe<T>` property by resolving to its storage member (avoids TRLS016). |
+| `DbContextExtensions.SaveChangesResultAsync(...)` | Save | `Task<Result<int>>`. Maps `DbUpdateConcurrencyException` / duplicate-key / FK violations to `Error.Conflict`. |
+| `DbContextExtensions.SaveChangesResultUnitAsync(...)` | Save | `Task<Result<Unit>>` overload when row count is not needed. |
+| `RepositoryBase<TAggregate, TId>` | Aggregate repo base | `FindByIdAsync` (Maybe), `QueryAsync(spec)`, `ExistsAsync`, `CountAsync`, `Add`, `Remove`, `RemoveByIdAsync` (`Task<Result<Unit>>`). Staging only — never calls `SaveChanges`. |
+| `IUnitOfWork.CommitAsync(ct)` | Commit boundary | `Task<Result<Unit>>`. Implemented by `EfUnitOfWork<TContext>`. |
+| `TransactionalCommandBehavior<TMessage, TResponse>` | Pipeline behavior | Auto-commits after a successful `ICommand<TResponse>` handler; only fires for commands. |
+| `UnitOfWorkServiceCollectionExtensions.AddTrellisUnitOfWork<TContext>()` / `AddTrellisUnitOfWorkWithoutBehavior<TContext>()` | DI | Registers `EfUnitOfWork<TContext>` (scoped) and inserts the commit behavior innermost. |
+| `DbExceptionClassifier.IsDuplicateKey` / `IsForeignKeyViolation` / `ExtractConstraintDetail` | Diagnostics | Cross-provider DB exception classification used by the save helpers. |
+| `MaybeModelExtensions.GetMaybePropertyMappings()` / `ToMaybeMappingDebugString()` | Diagnostics | Inspect resolved `Maybe<T>` storage members. |
+| `TrellisPersistenceMappingException` | Exception | Thrown when a persisted scalar value object value fails materialization. |
+
+Full signatures: [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md).
+
+## Installation
 
 ```bash
 dotnet add package Trellis.EntityFrameworkCore
 ```
 
+The package bundles `Trellis.EntityFrameworkCore.Generator.dll` under `analyzers/dotnet/cs/`. Installing the package is enough to attach the `[OwnedEntity]` and `ApplyTrellisConventionsFor<TContext>` source generators — there is no separate generator NuGet package.
+
+## Quick start
+
 ```csharp
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Trellis;
 using Trellis.EntityFrameworkCore;
 using Trellis.Primitives;
@@ -41,17 +88,10 @@ public sealed class Customer : Aggregate<CustomerId>
     public CustomerName Name { get; private set; } = null!;
     public EmailAddress Email { get; private set; } = null!;
 
-    private Customer()
-        : base(CustomerId.NewUniqueV7())
-    {
-    }
+    private Customer() : base(CustomerId.NewUniqueV7()) { }
 
-    public static Result<Customer> Create(CustomerName name, EmailAddress email) =>
-        Result.Ok(new Customer
-        {
-            Name = name,
-            Email = email
-        });
+    public static Customer Create(CustomerName name, EmailAddress email) =>
+        new() { Name = name, Email = email };
 }
 
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
@@ -59,7 +99,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<Customer> Customers => Set<Customer>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
-        configurationBuilder.ApplyTrellisConventions(typeof(CustomerId).Assembly);
+        configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -71,36 +111,90 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         });
     }
 }
-```
 
-Register EF Core and Trellis interceptors in DI:
-
-```csharp
-using Microsoft.EntityFrameworkCore;
-using Trellis.EntityFrameworkCore;
-
+// Composition root
 services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(connectionString)
         .AddTrellisInterceptors());
+
+services.AddTrellisBehaviors();
+services.AddTrellisUnitOfWork<AppDbContext>();
 ```
 
-> [!TIP]
-> `ApplyTrellisConventions(...)` is the main entry point for model configuration. `AddTrellisInterceptors()` is the main entry point for runtime save behavior. You usually want both.
+`ApplyTrellisConventionsFor<TContext>()` configures the model. `AddTrellisInterceptors()` configures runtime save/query behavior. `AddTrellisUnitOfWork<TContext>()` registers `IUnitOfWork` and the auto-commit pipeline behavior. You usually want all three.
 
-## Querying without null checks everywhere
+## Conventions and interceptors
 
-The main problem in repository code is not querying itself. It is answering the question, “What does absence mean here?”
+Two configuration entry points and one interceptor registration cover model setup.
 
-- Use `Maybe<T>` when “not found” is normal and the caller should decide what it means.
-- Use `Result<T>` when “not found” is already an error at the repository boundary.
+| Member | When to use |
+|---|---|
+| `ApplyTrellisConventionsFor<TContext>()` | Default. Source-generated, compile-time discovery. Walks reachable types from `TContext.DbSet<T>` properties. No reflection, no `MakeGenericType`. |
+| `ApplyTrellisConventions(params Assembly[])` | Fallback when the `DbContext` is not in the current compilation, or when you need to pass extra assemblies for composite value object discovery. Always includes `Trellis.Primitives`. |
+| `AddTrellisInterceptors([TimeProvider])` | Always. Registers the four singleton interceptors. The `TimeProvider` overload constructs a fresh `EntityTimestampInterceptor(timeProvider)`. |
+
+Both convention paths register the same set: scalar converters, `MaybeConvention`, `CompositeValueObjectConvention`, `MoneyConvention`, `AggregateETagConvention`, `AggregateTransientPropertyConvention`, `ValueObjectMappingGuardConvention`.
+
+> [!WARNING]
+> `ApplyTrellisConventionsFor<TContext>()` only discovers `DbContext` types defined in the current compilation. Calling it for a context excluded from generation throws `InvalidOperationException`. Use the reflection-based overload in that case.
+
+> [!WARNING]
+> `ApplyTrellisConventions(...)` only discovers composite value objects in the assemblies you pass in (plus `Trellis.Primitives`). If a composite type lives in another assembly, include it.
+
+## Owned composites
+
+Composite value objects use **owned-type** mapping, not scalar conversion. Mark them with `[OwnedEntity]` so the generator emits the private parameterless constructor EF Core needs for materialization.
+
+```csharp
+using Trellis;
+using Trellis.EntityFrameworkCore;
+
+namespace MyApp.Domain;
+
+[OwnedEntity]
+public partial class Address : ValueObject
+{
+    public string Street { get; private set; }
+    public string City   { get; private set; }
+    public string State  { get; private set; }
+
+    public Address(string street, string city, string state)
+    {
+        Street = street;
+        City   = city;
+        State  = state;
+    }
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Street;
+        yield return City;
+        yield return State;
+    }
+}
+```
+
+Rules enforced by analyzers and conventions:
+
+- The class must be `partial` and inherit `ValueObject`.
+- Use `{ get; private set; }` — `{ get; init; }` is flagged by `TRLS022` (round-trip not guaranteed).
+- A `Maybe<T>` over an owned composite stays inline when EF Core can model it safely; when the owned value contains nested owned types or non-nullable value-type members, Trellis switches to a separate owned table to avoid invalid nullable inline mapping.
+
+## Querying
+
+Choose the return type by what absence means.
+
+| Method | Returns | Use when |
+|---|---|---|
+| `FirstOrDefaultMaybeAsync(predicate, ct)` | `Task<Maybe<T>>` | Absence is data; the caller decides what it means. |
+| `SingleOrDefaultMaybeAsync(predicate, ct)` | `Task<Maybe<T>>` | Same, but throws if more than one matches. |
+| `FirstOrDefaultResultAsync(predicate, notFoundError, ct)` | `Task<Result<T>>` | The repository owns the failure; pass the exact `Error` to return. |
+| `Where(Specification<T>)` | `IQueryable<T>` | Compose a reusable Trellis specification into a query. |
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using Trellis;
 using Trellis.EntityFrameworkCore;
-using Trellis.Primitives;
-
-namespace MyApp.Data;
 
 public sealed class CustomerRepository(AppDbContext db)
 {
@@ -116,34 +210,66 @@ public sealed class CustomerRepository(AppDbContext db)
 ```
 
 > [!IMPORTANT]
-> `FirstOrDefaultResultAsync(...)` returns **the exact `Error` you pass in**. It does not automatically create a `Error.NotFound`.
+> `FirstOrDefaultResultAsync(...)` returns **the exact `Error` you pass in**. It does not synthesize an `Error.NotFound`.
 
-### Query flow at a glance
+### Querying Maybe properties
 
-```mermaid
-flowchart LR
-    A[Repository query] --> B{Can absence be valid?}
-    B -->|Yes| C[Return Maybe<T>]
-    B -->|No| D[Return Result<T>]
-    C --> E[Caller decides what no value means]
-    D --> F[Repository supplies the exact Error]
+Prefer the `MaybeQueryableExtensions` helpers over raw `GetValueOrDefault(...)` expressions — they translate to the mapped storage member directly and side-step `TRLS013`.
+
+| Helper | SQL semantics |
+|---|---|
+| `WhereHasValue(x => x.M)` | `WHERE storage IS NOT NULL` |
+| `WhereNone(x => x.M)` | `WHERE storage IS NULL` |
+| `WhereEquals(x => x.M, value)` | `WHERE storage = value` |
+| `WhereLessThan` / `WhereLessThanOrEqual` / `WhereGreaterThan` / `WhereGreaterThanOrEqual` | Comparison against `value` (requires `IComparable<TInner>`). |
+| `OrderByMaybe` / `OrderByMaybeDescending` / `ThenByMaybe` / `ThenByMaybeDescending` | Order by the mapped storage member. |
+
+```csharp
+using Trellis.EntityFrameworkCore;
+
+var dueSoon = await db.Tasks
+    .WhereHasValue(t => t.DueDate)
+    .WhereLessThanOrEqual(t => t.DueDate, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)))
+    .OrderByMaybe(t => t.DueDate)
+    .ToListAsync(ct);
 ```
 
-## Saving without exception-driven flow
+For projections that unwrap `Maybe<T>`, filter with `WhereHasValue` (or `.Where(x => x.M.HasValue)` — `TRLS013` recognises that exact prior shape) **before** the projection.
 
-The next pain point is `SaveChangesAsync()`: it succeeds with a row count, but failures come back as exceptions. Trellis wraps that pattern so your repository can stay on the railway.
+The `MaybeQueryInterceptor` (registered by `AddTrellisInterceptors()`) also rewrites natural patterns inside `Where` / `Select` / `Specification.ToExpression()`: `o.X.HasValue`, `o.X.HasNoValue`, `o.X.Value`, `o.X.GetValueOrDefault(d)`, `o.X == Maybe<T>.None`. The helpers above are still preferred when they exist.
 
-Use:
+### Indexing Maybe properties
 
-- `SaveChangesResultAsync(...)` when you care about the row count
-- `SaveChangesResultUnitAsync(...)` when success/failure is enough
+EF Core's `HasIndex(x => x.M)` cannot resolve a `Maybe<T>` selector to its storage member, so it triggers `TRLS016`. Use the Trellis helper:
+
+```csharp
+modelBuilder.Entity<Order>().HasTrellisIndex(x => x.PromisedDate);
+modelBuilder.Entity<Order>().HasTrellisIndex(x => new { x.CustomerId, x.PromisedDate });
+```
+
+## Saving
+
+Two save helpers, distinguished only by the success payload.
+
+| Helper | Returns | Use when |
+|---|---|---|
+| `SaveChangesResultAsync(ct)` and `SaveChangesResultAsync(acceptAllChangesOnSuccess, ct)` | `Task<Result<int>>` | You need the affected row count. |
+| `SaveChangesResultUnitAsync(ct)` and `SaveChangesResultUnitAsync(acceptAllChangesOnSuccess, ct)` | `Task<Result<Unit>>` | Success/failure is enough. |
+
+Failure mapping (identical for both):
+
+| EF Core failure | Trellis result |
+|---|---|
+| `DbUpdateConcurrencyException` | `new Error.Conflict(null, "concurrency.modified")` |
+| Duplicate-key `DbUpdateException` | `new Error.Conflict(null, "duplicate.key")` |
+| Foreign-key `DbUpdateException` | `new Error.Conflict(null, "referential.integrity")` |
+
+Connection failures, timeouts, and `OperationCanceledException` are **not** caught — they propagate.
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using Trellis;
 using Trellis.EntityFrameworkCore;
-
-namespace MyApp.Data;
 
 public sealed class CustomerRepository(AppDbContext db)
 {
@@ -152,229 +278,129 @@ public sealed class CustomerRepository(AppDbContext db)
         db.Customers.Add(customer);
         return await db.SaveChangesResultUnitAsync(ct);
     }
-
-    public async Task<Result<int>> SaveAsync(CancellationToken ct) =>
-        await db.SaveChangesResultAsync(ct);
 }
 ```
 
-### How save failures are mapped
-
-| EF Core failure | Trellis result |
-| --- | --- |
-| `DbUpdateConcurrencyException` | `Error.Conflict` (`conflict.error`) |
-| Duplicate key `DbUpdateException` | `Error.Conflict` (`conflict.error`) |
-| Foreign key `DbUpdateException` | `Error.Conflict` (`domain.error`) |
-
 > [!NOTE]
-> The Trellis save helpers call EF Core’s `SaveChangesAsync(...)` internally. The public API you should use is `SaveChangesResultAsync(...)` or `SaveChangesResultUnitAsync(...)`.
+> Analyzer `TRLS015` flags direct `SaveChangesAsync` calls in non-UoW contexts; use the result-returning helpers instead. In a UoW context (see below), repositories should not call save helpers at all — let the pipeline commit.
 
-### Preferred approach: RepositoryBase + IUnitOfWork
+### Bulk updates over Maybe
 
-For CQRS applications using the Trellis Mediator pipeline, use `RepositoryBase<TAggregate, TId>` with `IUnitOfWork` instead of calling `SaveChangesResultAsync` directly. Repositories stage changes; the `TransactionalCommandBehavior` pipeline behavior auto-commits after successful command handlers.
+For `ExecuteUpdate` over scalar `Maybe<T>` properties, use the dedicated setters; they map to the storage member directly. Composite owned `Maybe<T>` is not supported and will throw.
 
 ```csharp
-// Repository — staging only, never calls SaveChanges
-public class OrderRepository(AppDbContext db) : RepositoryBase<Order, OrderId>(db)
+using Trellis.EntityFrameworkCore;
+
+await db.Tasks
+    .Where(t => t.Status == "open")
+    .ExecuteUpdateAsync(s => s
+        .SetMaybeValue(t => t.SnoozedUntil, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)))
+        .SetMaybeNone(t => t.AssignedTo),
+        ct);
+```
+
+## Repositories and unit of work
+
+The preferred pattern for command-driven applications: repositories stage changes, the mediator pipeline commits.
+
+`RepositoryBase<TAggregate, TId>` provides:
+
+| Member | Returns | Notes |
+|---|---|---|
+| `FindByIdAsync(id, ct)` | `Task<Maybe<TAggregate>>` | Tracked. Override `BuildFindByIdQuery()` to add `.Include(...)`. |
+| `QueryAsync(spec, ct)` | `Task<IReadOnlyList<TAggregate>>` | No-tracking by default via `BuildQueryBase()`. |
+| `ExistsAsync(id, ct)` / `ExistsAsync(spec, ct)` | `Task<bool>` | Lightweight existence check; respects `BuildQueryBase()` filters. |
+| `CountAsync(spec, ct)` | `Task<int>` | Counts matches. |
+| `Add(aggregate)` | `void` | Stages insert. No-op if already tracked. |
+| `Remove(aggregate)` | `void` | Stages delete. |
+| `RemoveByIdAsync(id, ct)` | `Task<Result<Unit>>` | `DbSet.FindAsync` → stage delete; missing row → `Error.NotFound`. Respects EF 8 global query filters. |
+
+`RepositoryBase` **never** calls `SaveChanges`. Commit is owned by `IUnitOfWork.CommitAsync(ct)`, which returns `Task<Result<Unit>>` and is implemented by `EfUnitOfWork<TContext>` over `SaveChangesResultUnitAsync`.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Trellis;
+using Trellis.EntityFrameworkCore;
+
+public sealed class OrderRepository(AppDbContext db) : RepositoryBase<Order, OrderId>(db)
 {
     protected override IQueryable<Order> BuildFindByIdQuery() =>
         DbSet.Include(o => o.LineItems);
 }
 
-// Command handler — pure domain logic, no persistence concerns
-public async ValueTask<Result<Order>> Handle(ShipOrderCommand cmd, CancellationToken ct)
+public sealed class ShipOrderHandler(OrderRepository orders) : ICommandHandler<ShipOrderCommand, Result<Order>>
 {
-    var maybe = await _orders.FindByIdAsync(cmd.OrderId, ct);
-    return maybe
-        .ToResult(new Error.NotFound(ResourceRef.For<Order>(cmd.OrderId)) { Detail = "Order not found." })
-        .Bind(order => order.Ship());
-    // TransactionalCommandBehavior auto-commits the tracked changes on success.
+    public async ValueTask<Result<Order>> Handle(ShipOrderCommand cmd, CancellationToken ct) =>
+        (await orders.FindByIdAsync(cmd.OrderId, ct))
+            .ToResult(new Error.NotFound(ResourceRef.For<Order>(cmd.OrderId)) { Detail = "Order not found." })
+            .Bind(order => order.Ship());
+    // No SaveChanges call. TransactionalCommandBehavior commits on success.
 }
-
-// DI registration — call AddTrellisUnitOfWork after AddTrellisBehaviors
-// so the commit behavior runs innermost (closest to the handler).
-services.AddTrellisBehaviors();
-services.AddTrellisUnitOfWork<AppDbContext>();
 ```
 
-## What `ApplyTrellisConventions` actually does
-
-Most teams adopt the package for one reason: they do not want to hand-write `HasConversion(...)` for every value object. That is the first benefit, but not the only one.
-
-When you call `ApplyTrellisConventions(...)`, Trellis:
-
-- scans the assemblies you pass in for Trellis value object types
-- always includes built-in Trellis primitives for scalar value objects
-- registers scalar converters up front so EF Core treats those types as scalar properties
-- applies `Maybe<T>` conventions
-- applies composite value object conventions
-- applies `Money` conventions
-- marks aggregate `ETag` as a concurrency token
-- ignores transient aggregate properties such as `IsChanged`
-
-### A subtle but important detail about composite value objects
-
-Composite value objects are not treated like scalar converters. They follow **owned-type conventions**.
-
-That matters because:
-
-- a composite value object becomes structured EF Core mapping, not a single scalar column
-- `Maybe<T>` around an owned composite can stay inline **only when EF Core can model it safely**
-- when a `Maybe<T>` owned value has nested owned types or non-nullable value-type members, Trellis moves it to a separate owned table instead of generating invalid nullable inline mapping
-
-> [!WARNING]
-> `ApplyTrellisConventions(...)` only discovers composite value objects in the assemblies you explicitly pass in. If a composite type lives in another assembly, include that assembly too.
-
-## Reflection-free alternative: `ApplyTrellisConventionsFor<TContext>()`
-
-For AOT-published or trim-sensitive applications, Trellis ships a Roslyn source generator that emits a compile-time-discovered alternative to the reflection-based path:
+DI registration:
 
 ```csharp
-public class AppDbContext : DbContext
-{
-    public DbSet<Customer> Customers => Set<Customer>();
-    public DbSet<Order> Orders => Set<Order>();
+services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString)
+        .AddTrellisInterceptors());
 
-    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
-        configurationBuilder.ApplyTrellisConventionsFor<AppDbContext>();
-}
+services.AddTrellisBehaviors();           // outer behaviors first
+services.AddTrellisUnitOfWork<AppDbContext>(); // commit behavior goes innermost
 ```
 
-The generator walks every concrete `DbContext`-derived type in your project, follows each `DbSet<T>`'s reachable property graph (recursing into composite value objects, and unwrapping `Nullable<T>` and `Maybe<T>`), classifies the discovered Trellis value object types by their base-type chain, and emits explicit converter and convention registrations. The result is a `partial`-free, reflection-free dispatch:
+> [!IMPORTANT]
+> Call `AddTrellisUnitOfWork<TContext>()` **after** `AddTrellisBehaviors()`. The transactional behavior is inserted after the last `IPipelineBehavior<,>` registration so it runs innermost — closest to the handler — keeping commit failures visible to logging, tracing, and exception behaviors.
 
-- no runtime assembly scanning
-- no calls to `Type.MakeGenericType`, `Assembly.GetTypes`, or `Activator.CreateInstance`
-- behaviorally equivalent to `ApplyTrellisConventions(typeof(SomethingInThisAssembly).Assembly)` for the entity types reachable from `TContext`'s `DbSet<>` properties
+`TransactionalCommandBehavior<TMessage, TResponse>` only fires for `ICommand<TResponse>` (queries are skipped at the type-constraint level). On handler success it calls `unitOfWork.CommitAsync(ct)`; if commit fails, it returns `TResponse.CreateFailure(error)`. EF Core's implicit transaction around `SaveChanges` makes the staged changes commit atomically.
 
-> [!NOTE]
-> The generator only discovers `DbContext` types defined in the **current** compilation. It does not scan referenced assemblies. If your `DbContext` lives in a separate project, define the call to `ApplyTrellisConventionsFor<TContext>()` from that project too.
-> Composite and scalar value object types may live in any referenced assembly — the reachability walk crosses assembly boundaries through entity properties.
+For background jobs or non-mediator code, inject `IUnitOfWork` directly and call `CommitAsync`. Use `AddTrellisUnitOfWorkWithoutBehavior<TContext>()` to skip the pipeline behavior registration.
 
-> [!NOTE]
-> Calling `ApplyTrellisConventionsFor<T>()` for a `T` that has no generated body (e.g. a private nested `DbContext` excluded from generation) throws `InvalidOperationException` at runtime. Use the reflection-based `ApplyTrellisConventions(...)` for such cases.
+## Optimistic concurrency
 
-## Maybe property convention
+Once `ApplyTrellisConventions*` and `AddTrellisInterceptors()` are wired:
 
-`Maybe<T>` solves a domain problem—optional values—while EF Core still needs a storage strategy.
+- the aggregate `ETag` is configured as a concurrency token,
+- a new `ETag` is generated on **Added** and **Modified** aggregates,
+- aggregate roots are also promoted when loaded dependents change, so concurrency works at the aggregate boundary.
 
-Trellis handles two common cases for you:
+A losing writer surfaces as `DbUpdateConcurrencyException` → `new Error.Conflict(null, "concurrency.modified")` from `SaveChangesResult*Async` (and therefore from `IUnitOfWork.CommitAsync` / the transactional pipeline behavior). You do **not** configure `AggregateETagConvention` or `AggregateETagInterceptor` directly — they are internal types reached through the supported public entry points.
 
-- `Maybe<T>` over a scalar value object maps through scalar conversion rules
-- `Maybe<T>` over an owned composite value object follows owned-type rules
+## Composition
 
-For owned composites, Trellis prefers inline nullable columns when EF Core can represent them safely. If the owned value contains nested owned types or non-nullable value-type members, Trellis switches to a separate owned table instead.
-
-That keeps your domain model expressive without forcing you to hand-author the tricky nullability mapping yourself.
-
-## Optimistic concurrency with ETags
-
-Concurrency bugs are hard to reason about after the fact. Trellis gives aggregates an `ETag` story that works with EF Core instead of around it.
-
-You do **not** configure internal convention or interceptor types directly. The supported public API is:
-
-- `ApplyTrellisConventions(...)`
-- `AddTrellisInterceptors()`
-
-Once those are registered:
-
-- aggregate `ETag` is configured as a concurrency token
-- a new ETag is generated when an aggregate is **Added**
-- a new ETag is generated when an aggregate is **Modified**
-- aggregate roots can also be promoted when loaded dependents changed, so concurrency still works at the aggregate boundary
+Once the read returns `Maybe<T>` or `Result<T>`, it composes with the rest of Trellis:
 
 ```csharp
 using Trellis;
 using Trellis.EntityFrameworkCore;
-using Trellis.Primitives;
 
-namespace MyApp.Data;
-
-public sealed class OrderId : RequiredGuid<OrderId>;
-
-public sealed class Order : Aggregate<OrderId>
+public sealed class ShipOrderHandler(OrderRepository orders) : ICommandHandler<ShipOrderCommand, Result<Order>>
 {
-    public string Description { get; private set; } = string.Empty;
-
-    private Order()
-        : base(OrderId.NewUniqueV7())
-    {
-    }
-
-    public static Order Create(string description) =>
-        new()
-        {
-            Description = description
-        };
-
-    public void Rename(string description) => Description = description;
+    public async ValueTask<Result<Order>> Handle(ShipOrderCommand cmd, CancellationToken ct) =>
+        (await orders.FindByIdAsync(cmd.OrderId, ct))
+            .ToResult(new Error.NotFound(ResourceRef.For<Order>(cmd.OrderId)) { Detail = "Order not found." })
+            .Ensure(order => !order.IsCancelled,
+                new Error.Conflict(ResourceRef.For<Order>(cmd.OrderId), "order.cancelled"))
+            .Bind(order => order.Ship());
+    // TransactionalCommandBehavior commits on Ok.
 }
 ```
 
-```csharp
-public sealed class OrderRepository(AppDbContext db)
-{
-    public async Task<Result<Unit>> UpdateAsync(Order order, CancellationToken ct)
-    {
-        db.Orders.Update(order);
-        return await db.SaveChangesResultUnitAsync(ct);
-    }
-}
-```
+For non-pipeline scenarios, the equivalent is `await uow.CommitAsync(ct)` after the domain `Bind` chain returns `Ok`.
 
-If another writer changed the same aggregate first, EF Core throws `DbUpdateConcurrencyException` and Trellis converts that to `Error.Conflict` with the standard `conflict.error` code.
+## Practical guidance
 
-## When to use `Maybe<T>` vs `Result<T>`
+- **Pick the return type by intent.** `Maybe<T>` when absence is data; `Result<T>` when the repository owns the failure; `Result<Unit>` for commands; `bool` for existence checks.
+- **Stage in repositories, commit in the pipeline.** Do not call `SaveChangesResult*Async` from inside a repository when `AddTrellisUnitOfWork<TContext>()` is registered — that double-commits or hides commit failures from outer behaviors.
+- **Prefer `ApplyTrellisConventionsFor<TContext>()`.** Compile-time discovery, no reflection, no `MakeGenericType`. Fall back to the assembly-scan overload only when the `DbContext` lives in another compilation.
+- **Use the `Maybe` query helpers, not raw `GetValueOrDefault(...)` expressions.** They translate to the mapped storage member directly and avoid `TRLS013` / `TRLS016`.
+- **`[OwnedEntity]` classes are `partial` with `{ get; private set; }`.** `{ get; init; }` is flagged by `TRLS022`.
+- **Pass `CancellationToken` everywhere.** Every helper, repository method, and `CommitAsync` accepts one.
 
-This is the repository design rule that keeps your application layer clear.
+## Cross-references
 
-| Return type | Use it when | Example |
-| --- | --- | --- |
-| `Maybe<T>` | absence is data, not failure | “Find customer by email” |
-| `Result<T>` | the repository should decide the failure | “Load required customer” |
-| `Result<Unit>` | command succeeded or failed | save, delete, update |
-| `bool` | you only need existence | uniqueness checks |
-
-### Practical rule of thumb
-
-- Query by optional business key? Start with `Maybe<T>`.
-- Load a required resource for a command handler? Use `Result<T>`.
-- Persist changes? Use `SaveChangesResultUnitAsync(...)`.
-
-## Manual EF Core setup without the package
-
-Some teams prefer to keep EF Core mapping explicit. That is fine—you just take on the wiring yourself.
-
-```csharp
-using Microsoft.EntityFrameworkCore;
-using Trellis.Primitives;
-
-protected override void OnModelCreating(ModelBuilder modelBuilder)
-{
-    modelBuilder.Entity<Customer>(builder =>
-    {
-        builder.HasKey(x => x.Id);
-
-        builder.Property(x => x.Id)
-            .HasConversion(id => id.Value, value => CustomerId.Create(value));
-
-        builder.Property(x => x.Name)
-            .HasConversion(name => name.Value, value => CustomerName.Create(value))
-            .HasMaxLength(100);
-
-        builder.Property(x => x.Email)
-            .HasConversion(email => email.Value, value => EmailAddress.Create(value))
-            .HasMaxLength(254);
-    });
-}
-```
-
-That approach works, but you now own:
-
-- converter registration for every scalar value object property
-- structured mapping for composite value objects
-- nullable/owned rules for `Maybe<T>`
-- concurrency token wiring for aggregate ETags
-- exception-to-result translation on save
-
-> [!TIP]
-> If your model uses more than a handful of Trellis types, the package usually pays for itself very quickly.
+- API surface: [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)
+- `Result<T>`, `Maybe<T>`, `Error`, `Aggregate<TId>`, `Specification<T>`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Recipes (specifications with `Maybe<T>`, repository patterns, UoW): [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md)
+- Mediator pipeline behaviors and registration order: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- Analyzer rules referenced here (`TRLS013`, `TRLS015`, `TRLS016`, `TRLS022`): [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md)

--- a/docs/docfx_project/articles/integration-entra-testing.md
+++ b/docs/docfx_project/articles/integration-entra-testing.md
@@ -1,81 +1,151 @@
-# Testing with Azure Entra ID Tokens
+﻿---
+title: Testing With Azure Entra ID Tokens
+package: Trellis.Testing.AspNetCore
+topics: [testing, entra, msal, ropc, integration-test, webfactory, e2e, actor]
+related_api_reference: [trellis-api-testing-aspnetcore.md, trellis-api-asp.md, trellis-api-authorization.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Testing With Azure Entra ID Tokens
 
-**Level:** Advanced 📙 | **Time:** 20-30 min | **Prerequisites:** [Testing](integration-testing.md), [ASP.NET Core Authorization](integration-asp-authorization.md)
+`Trellis.Testing.AspNetCore` ships an MSAL-backed token provider so a small set of E2E integration tests can drive the *real* authentication path — Entra issuance, JWT validation, claim mapping, and `EntraActorProvider` — instead of bypassing it with `X-Test-Actor`.
 
-Most Trellis integration tests should use `CreateClientWithActor(...)`. It is fast and perfect when you only want to test authorization behavior inside your app.
+## Patterns Index
 
-But sometimes that is not enough.
+| Goal | Use | See |
+|---|---|---|
+| Fast hermetic auth tests (no network, no clock) | `factory.CreateClientWithActor(actorId, permissions...)` | [Choosing a client helper](#choosing-a-client-helper) |
+| Acquire a real Entra token by named test user | `new MsalTestTokenProvider(options).AcquireTokenAsync(testUserName, ct)` | [Token provider](#token-provider) |
+| Build an `HttpClient` with `Authorization: Bearer <token>` | `factory.CreateClientWithEntraTokenAsync(tokenProvider, testUserName, ct)` | [Authenticated test client](#authenticated-test-client) |
+| Bind tenant + scopes + test users from configuration | `MsalTestOptions` + `IConfiguration.Bind` | [Configuration](#configuration) |
+| Share token cache across tests in a class | One `MsalTestTokenProvider` per `IClassFixture` | [Fixture pattern](#fixture-pattern) |
+| Gate slow E2E tests out of inner-loop runs | `[Trait("Category", "E2E")]` (xUnit) | [Practical guidance](#practical-guidance) |
 
-If you need to verify the **real authentication path**—token issuance, JWT validation, claim mapping, and `EntraActorProvider`—you need real Entra tokens. That is what `MsalTestTokenProvider` is for.
+## Use this guide when
 
-## When should you use this?
+- You already have hermetic header-based authorization tests via `CreateClientWithActor` and want a *small* additional suite that exercises real Entra issuance and JWT validation end-to-end.
+- You need to verify that `EntraActorProvider` (and your `MapPermissions` / `MapAttributes` overrides) project a real Entra token into the `Actor` you expect.
+- You operate a dedicated Entra **test** tenant whose lifecycle you control — separate app registration, separate test users, MFA disabled.
+- You can keep credentials in user-secrets locally and CI secrets in pipelines — never in source.
 
-Use real Entra tokens when you want confidence in:
+## Surface at a glance
 
-- Azure Entra ID issuing the token you expect
-- ASP.NET Core JWT validation
-- your claim-to-permission mapping
-- `EntraActorProvider` behavior in production-like conditions
+The Entra E2E surface is three types in `Trellis.Testing.AspNetCore` plus one extension method on `WebApplicationFactory<TEntryPoint>`.
 
-Use `CreateClientWithActor(...)` when you only need to test:
+| API | Kind | Returns | Purpose |
+|---|---|---|---|
+| `MsalTestOptions` | `sealed class` | — | `TenantId`, `ClientId`, `Scopes`, `TestUsers` (named credentials). Bind from `IConfiguration`. |
+| `TestUserCredentials` | `sealed class` | — | `Username`, `Password`, `ExpectedPermissions` for one named test user. |
+| `MsalTestTokenProvider(MsalTestOptions options)` | ctor | — | Builds a public-client MSAL app for `ClientId`/`TenantId` on `AzureCloudInstance.AzurePublic`. |
+| `MsalTestTokenProvider.AcquireTokenAsync(string testUserName, CancellationToken)` | instance | `Task<string>` | ROPC token acquisition. MSAL caches results per provider instance. Throws `KeyNotFoundException` if the user is not configured, `MsalException` on acquisition failure. |
+| `WebApplicationFactoryExtensions.CreateClientWithEntraTokenAsync<TEntryPoint>(factory, tokenProvider, testUserName, ct)` | extension | `Task<HttpClient>` | Acquires a token via the provider and sets `Authorization: Bearer <token>` on a fresh client. |
 
-- application authorization rules
-- handler behavior
-- endpoint behavior
+`MsalTestTokenProvider` and `CreateClientWithEntraTokenAsync` are annotated `[RequiresUnreferencedCode]` because MSAL relies on reflection and is not AOT-compatible.
 
-```mermaid
-flowchart LR
-    A[Fast integration tests] --> B[X-Test-Actor header]
-    C[Full auth pipeline tests] --> D[MsalTestTokenProvider]
-    D --> E[Bearer token]
-    E --> F[JWT validation]
-    F --> G[EntraActorProvider]
-```
+Full signatures: [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md).
 
-## Install the package
+## Installation
 
 ```bash
-dotnet add package Trellis.Testing
+dotnet add package Trellis.Testing.AspNetCore
 ```
 
-## How it works
+The package depends on `Microsoft.AspNetCore.Mvc.Testing`, `Trellis.Authorization`, and MSAL (`Microsoft.Identity.Client`). Reference it from test projects only.
 
-`MsalTestTokenProvider` uses the MSAL ROPC flow against a dedicated test tenant:
+## Quick start
 
-- one Entra test tenant
-- one public client app registration
-- test users with known passwords
-- MFA disabled for those test users
+Bind `MsalTestOptions` from configuration, hand the provider to `CreateClientWithEntraTokenAsync`, then call your real API exactly as production callers would.
+
+```csharp
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Trellis.Testing.AspNetCore;
+using Xunit;
+
+[JsonSerializable(typeof(CreateOrderRequest))]
+internal partial class ApiJsonContext : JsonSerializerContext { }
+
+public sealed record CreateOrderRequest(string CustomerId, int Quantity);
+
+public sealed class Program { }
+
+public sealed class OrdersEntraTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly MsalTestTokenProvider _tokens;
+
+    public OrdersEntraTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+
+        var configuration = new ConfigurationBuilder()
+            .AddUserSecrets<OrdersEntraTests>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var options = new MsalTestOptions();
+        configuration.GetSection("EntraTest").Bind(options);
+        _tokens = new MsalTestTokenProvider(options);
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task Sales_rep_can_create_orders()
+    {
+        var client = await _factory.CreateClientWithEntraTokenAsync(_tokens, "salesRep");
+
+        var response = await client.PostAsJsonAsync(
+            "/api/orders",
+            new CreateOrderRequest("customer-1", 2),
+            ApiJsonContext.Default.CreateOrderRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}
+```
+
+Commands invoked behind `/api/orders` still return `Result<Unit>` — the assertion is on the HTTP status produced by `Trellis.Asp` mapping.
+
+## Choosing a client helper
+
+| Helper | Path exercised | Network? | Determinism |
+|---|---|---|---|
+| `factory.CreateClientWithActor(actorId, perms...)` | Test actor provider → `Actor` | None (in-process) | Fully deterministic |
+| `factory.CreateClientWithActor(actor)` | Same, with `ForbiddenPermissions` and `Attributes` | None | Fully deterministic |
+| `factory.CreateClientWithEntraTokenAsync(provider, testUserName, ct)` | Entra ID → JWT validation → `EntraActorProvider` → `Actor` | Live calls to Microsoft Entra | Non-deterministic (network + token expiry) |
+
+Use `CreateClientWithActor` for the bulk of authorization coverage (handler logic, command rules, `IAuthorize`, `IAuthorizeResource<T>`). Reserve `CreateClientWithEntraTokenAsync` for a small confidence suite that proves real tokens still flow into the `Actor` you expect.
+
+`CreateClientWithActor` is documented in [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#webapplicationfactoryextensions); `EntraActorProvider` semantics live in [`integration-asp-authorization.md`](integration-asp-authorization.md#entra-id-provider).
+
+## Tenant prerequisites
+
+`MsalTestTokenProvider` uses MSAL ROPC. ROPC is intentionally restricted by Entra and requires a tenant configured for it.
+
+| Requirement | Why |
+|---|---|
+| Dedicated test tenant | Never reuse a production tenant for credential-based test flows. |
+| App registration: single tenant, **Allow public client flows = Yes** | ROPC is a public-client grant; a confidential client cannot use it. |
+| Test users created in the tenant | ROPC needs a real user principal. |
+| MFA disabled for test users | ROPC cannot perform interactive MFA challenges. |
+| App roles assigned to test users via Enterprise Application | Without role assignments, tokens authenticate but carry no `roles` claims. |
+| Scope: `api://<clientId>/.default` (or your custom scope) | ROPC fails with `AADSTS650057` on an unknown scope. |
 
 > [!WARNING]
-> ROPC is acceptable for automated test tenants. It is not a production authentication pattern.
+> ROPC is deprecated for production authentication. Use it only for automated tests against a dedicated test tenant whose users are excluded from MFA.
 
-## Tenant setup checklist
+## Configuration
 
-### 1. Create a dedicated test tenant
+Bind `MsalTestOptions` from any `IConfiguration` source. Locally, prefer `dotnet user-secrets`; in CI, environment variables with the `EntraTest__` prefix.
 
-Never reuse a production tenant for automated tests.
-
-### 2. Register a public client app
-
-In the app registration:
-
-- supported account type: single tenant
-- allow public client flows: **Yes**
-
-### 3. Assign app roles to test users
-
-Create users that match the permission profiles you want to test, then assign roles through the Enterprise Application.
-
-### 4. Disable MFA for those test users
-
-ROPC does not support interactive MFA.
-
-## Store configuration safely
-
-Local development should use `dotnet user-secrets`. CI should use environment variables.
-
-### Local secrets
+### Local user-secrets
 
 ```bash
 dotnet user-secrets set "EntraTest:TenantId" "<tenant-id>"
@@ -84,13 +154,11 @@ dotnet user-secrets set "EntraTest:Scopes:0" "api://<client-id>/.default"
 
 dotnet user-secrets set "EntraTest:TestUsers:salesRep:Username" "salesrep@contoso-test.onmicrosoft.com"
 dotnet user-secrets set "EntraTest:TestUsers:salesRep:Password" "<password>"
-dotnet user-secrets set "EntraTest:TestUsers:admin:Username" "admin@contoso-test.onmicrosoft.com"
-dotnet user-secrets set "EntraTest:TestUsers:admin:Password" "<password>"
+dotnet user-secrets set "EntraTest:TestUsers:salesRep:ExpectedPermissions:0" "orders:create"
+dotnet user-secrets set "EntraTest:TestUsers:salesRep:ExpectedPermissions:1" "orders:read"
 ```
 
 ### CI environment variables
-
-Configuration binding uses the `EntraTest__` prefix and double underscores for nesting.
 
 ```yaml
 env:
@@ -101,9 +169,7 @@ env:
   EntraTest__TestUsers__salesRep__Password: ${{ secrets.ENTRA_TEST_SALESREP_PASSWORD }}
 ```
 
-## Bind configuration into `MsalTestOptions`
-
-`MsalTestTokenProvider` takes `MsalTestOptions`, so keep the test setup boring and explicit.
+### Binding code
 
 ```csharp
 using Microsoft.Extensions.Configuration;
@@ -117,42 +183,118 @@ var configuration = new ConfigurationBuilder()
 var options = new MsalTestOptions();
 configuration.GetSection("EntraTest").Bind(options);
 
+if (string.IsNullOrWhiteSpace(options.TenantId) || string.IsNullOrWhiteSpace(options.ClientId))
+    throw new InvalidOperationException("Configure EntraTest:TenantId and EntraTest:ClientId before running Entra E2E tests.");
+
 var tokenProvider = new MsalTestTokenProvider(options);
 ```
 
-> [!TIP]
-> Keep one `MsalTestTokenProvider` instance per fixture or test class. MSAL caches tokens per provider instance.
+## Token provider
 
-## First working test
+`MsalTestTokenProvider` wraps an MSAL `IPublicClientApplication`. The constructor builds it once for the configured `ClientId`/`TenantId`; `AcquireTokenAsync` performs ROPC against the named user.
 
-The simplest happy path is: create the token provider once, create a client for a named test user, then call the real API.
+| Concern | Behavior |
+|---|---|
+| Token cache | MSAL caches per provider instance — keep one provider per fixture or class. |
+| Unknown user name | `KeyNotFoundException` listing configured user keys. |
+| Acquisition failure | `MsalException` (e.g. `AADSTS50126` invalid credentials, `AADSTS50076` MFA required, `AADSTS7000218` not a public client). |
+| AOT | `[RequiresUnreferencedCode]` — MSAL is not trim/AOT-compatible. |
+| Cancellation | `CancellationToken` flows into `ExecuteAsync`. |
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis.Testing.AspNetCore;
+
+public sealed class TokenSmokeTests
+{
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task Provider_returns_non_empty_token_for_named_user()
+    {
+        var options = new MsalTestOptions
+        {
+            TenantId = Environment.GetEnvironmentVariable("EntraTest__TenantId")!,
+            ClientId = Environment.GetEnvironmentVariable("EntraTest__ClientId")!,
+            Scopes = [$"api://{Environment.GetEnvironmentVariable("EntraTest__ClientId")}/.default"],
+            TestUsers =
+            {
+                ["salesRep"] = new TestUserCredentials
+                {
+                    Username = Environment.GetEnvironmentVariable("EntraTest__TestUsers__salesRep__Username")!,
+                    Password = Environment.GetEnvironmentVariable("EntraTest__TestUsers__salesRep__Password")!,
+                    ExpectedPermissions = ["orders:create", "orders:read"],
+                }
+            }
+        };
+
+        var provider = new MsalTestTokenProvider(options);
+
+        var token = await provider.AcquireTokenAsync("salesRep", CancellationToken.None);
+
+        token.Should().NotBeNullOrWhiteSpace();
+    }
+}
+```
+
+## Authenticated test client
+
+`CreateClientWithEntraTokenAsync` is a thin glue method: acquire a token, build a fresh `HttpClient` from the factory, set `Authorization: Bearer <token>`. Use it whenever you would have written that boilerplate by hand.
 
 ```csharp
 using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json.Serialization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Trellis.Testing.AspNetCore;
+using Xunit;
+
+public sealed class Program { }
+
+public sealed class OrdersAuthenticationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly MsalTestTokenProvider _tokens;
+
+    public OrdersAuthenticationTests(WebApplicationFactory<Program> factory, MsalTestTokenProvider tokens)
+    {
+        _factory = factory;
+        _tokens = tokens;
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task Bearer_token_reaches_protected_endpoint()
+    {
+        var client = await _factory.CreateClientWithEntraTokenAsync(_tokens, "salesRep");
+
+        var response = await client.GetAsync("/api/orders");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+}
+```
+
+## Fixture pattern
+
+MSAL caches tokens per provider instance, so share **one** `MsalTestTokenProvider` across every test that needs the same credentials. xUnit's `IClassFixture<T>` is the simplest seam.
+
+```csharp
+using System;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Trellis.Testing.AspNetCore;
 using Xunit;
 
-[JsonSerializable(typeof(CreateOrderRequest))]
-internal partial class ApiJsonContext : JsonSerializerContext
-{
-}
+public sealed class Program { }
 
-public sealed class Program
+public sealed class EntraTestFixture : IDisposable
 {
-}
-
-public sealed record CreateOrderRequest(string CustomerId, int Quantity);
-
-public sealed class EntraTestFixture
-{
-    public EntraTestFixture(WebApplicationFactory<Program> factory)
+    public EntraTestFixture()
     {
-        Factory = factory;
+        Factory = new WebApplicationFactory<Program>();
 
         var configuration = new ConfigurationBuilder()
             .AddUserSecrets<EntraTestFixture>(optional: true)
@@ -162,83 +304,71 @@ public sealed class EntraTestFixture
         var options = new MsalTestOptions();
         configuration.GetSection("EntraTest").Bind(options);
 
-        if (string.IsNullOrWhiteSpace(options.TenantId) ||
-            string.IsNullOrWhiteSpace(options.ClientId))
-        {
-            throw new InvalidOperationException("Configure EntraTest before running Entra token tests.");
-        }
+        if (string.IsNullOrWhiteSpace(options.TenantId) || string.IsNullOrWhiteSpace(options.ClientId))
+            throw new InvalidOperationException("Configure EntraTest before running Entra E2E tests.");
 
-        TokenProvider = new MsalTestTokenProvider(options);
+        Tokens = new MsalTestTokenProvider(options);
+        Options = options;
     }
 
     public WebApplicationFactory<Program> Factory { get; }
+    public MsalTestTokenProvider Tokens { get; }
+    public MsalTestOptions Options { get; }
 
-    public MsalTestTokenProvider TokenProvider { get; }
+    public void Dispose() => Factory.Dispose();
 }
 
-public sealed class OrdersEntraTests : IClassFixture<WebApplicationFactory<Program>>
+public sealed class OrdersScenarioTests : IClassFixture<EntraTestFixture>
 {
-    private readonly EntraTestFixture _fixture;
+    private readonly EntraTestFixture _fx;
 
-    public OrdersEntraTests(WebApplicationFactory<Program> factory)
-    {
-        _fixture = new EntraTestFixture(factory);
-    }
+    public OrdersScenarioTests(EntraTestFixture fx) => _fx = fx;
 
     [Fact]
-    public async Task Sales_rep_can_create_orders()
+    [Trait("Category", "E2E")]
+    public async Task Admin_can_list_orders()
     {
-        var client = await _fixture.Factory.CreateClientWithEntraTokenAsync(
-            _fixture.TokenProvider,
-            "salesRep");
-
-        var response = await client.PostAsJsonAsync(
-            "/api/orders",
-            new CreateOrderRequest("customer-1", 2),
-            ApiJsonContext.Default.CreateOrderRequest);
-
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var client = await _fx.Factory.CreateClientWithEntraTokenAsync(_fx.Tokens, "admin");
+        var response = await client.GetAsync("/api/orders");
+        response.IsSuccessStatusCode.Should().BeTrue();
     }
 }
 ```
 
-## Verifying roles and permissions
+`TestUserCredentials.ExpectedPermissions` is the right place to record what each named user is *supposed* to receive — assert it once per fixture so a missing role assignment in the tenant fails noisily rather than silently producing 403s in unrelated tests.
 
-If you store the expected permissions in configuration, you can use them for sanity checks in your test setup.
+## Common ROPC failure codes
 
-```bash
-dotnet user-secrets set "EntraTest:TestUsers:salesRep:ExpectedPermissions:0" "orders:create"
-dotnet user-secrets set "EntraTest:TestUsers:salesRep:ExpectedPermissions:1" "orders:read"
-```
+| MSAL error | Usually means | Fix |
+|---|---|---|
+| `AADSTS50126` | Invalid username or password | Reset the test-user password; re-bind secret. |
+| `AADSTS50076` | MFA required | Exclude test users from MFA in the test tenant. |
+| `AADSTS7000218` | App registration is not a public client | Set "Allow public client flows" to **Yes**. |
+| `AADSTS650057` | Invalid scope | Use `api://<clientId>/.default` (or the custom scope you exposed). |
+| Token issued, app sees no permissions | App roles not assigned to the user | Assign roles via Enterprise Applications → Users and groups. |
 
-That is useful when you want the test fixture to verify the tenant still matches the documented role model.
+## Composition
 
-## Common failure modes
+Entra E2E tests sit alongside the rest of the Trellis test surface, not on top of it.
 
-| Error | Usually means | Fix |
-| --- | --- | --- |
-| `AADSTS50126` | username or password is wrong | reset the test user password |
-| `AADSTS50076` | MFA is required | exclude test users from MFA |
-| `AADSTS7000218` | app is not configured as public client | enable public client flows |
-| `AADSTS650057` | wrong scope | use `api://{clientId}/.default` |
-| token authenticates but app sees no permissions | app roles were not assigned | assign users/groups in Enterprise Applications |
+- **With `CreateClientWithActor`.** Cover authorization rules with the header-based helper; cover *real-token plumbing* with `CreateClientWithEntraTokenAsync`. They share the same `WebApplicationFactory<TEntryPoint>` and assertion vocabulary.
+- **With `WithFakeTimeProvider` / `ReplaceDbProvider`.** Both still apply when an Entra-authenticated client is in play — fake the clock, swap the EF provider, then call `CreateClientWithEntraTokenAsync` against the modified factory. See [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#dependency-replacement-helpers).
+- **With `EntraActorProvider`.** The provider under test is the same one wired in production via `AddEntraActorProvider(...)`; an Entra E2E test is the only place where overrides to `MapPermissions` / `MapAttributes` are exercised against real claim shapes. See [`integration-asp-authorization.md`](integration-asp-authorization.md#customizing-claim-mapping).
+- **With Trellis result pipelines.** Commands invoked behind authenticated endpoints still return `Result<Unit>`; assertions remain on HTTP status mapped by `Trellis.Asp`.
 
 ## Practical guidance
 
-### Keep these tests small in number
+- **Keep this suite small.** A handful of scenarios per role is enough to prove the auth pipeline works. Duplicating every authorization test against a real tenant is waste.
+- **Gate with a trait.** `[Trait("Category", "E2E")]` (xUnit) lets local runs use `--filter "Category!=E2E"` and keeps inner-loop builds fast and offline.
+- **One provider per fixture.** MSAL caches by provider instance — sharing a provider across tests in a class costs one network round-trip per token, not one per test.
+- **Treat the test tenant as disposable infrastructure.** Script the app registration and role assignments; do not rely on manual portal edits.
+- **Never log access tokens.** They are valid bearer credentials against your test tenant. Log only the resulting HTTP status and (if needed) decoded `oid`/`roles` claims.
+- **Bind options once.** Reading `IConfiguration` and constructing the provider in fixture setup keeps tests readable and prevents per-test token thrash.
+- **Prefer `dotnet user-secrets` locally.** Environment variables are fine for CI but leak into shell history.
 
-They validate the real auth pipeline, so they are slower and more environment-dependent than header-based integration tests.
+## Cross-references
 
-### Use them as confidence tests, not as your entire suite
-
-A few targeted scenarios usually go much further than duplicating every authorization test with real tokens.
-
-### Isolate the tenant
-
-Treat the test tenant as disposable infrastructure, not as a shared long-lived environment with manual changes.
-
-## Next steps
-
-- [Testing](integration-testing.md)
-- [Mediator Pipeline](integration-mediator.md)
-- [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md)
+- API surface: [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)
+- Header-based test client (`CreateClientWithActor`) and `Actor` shape: [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#webapplicationfactoryextensions)
+- Production `EntraActorProvider`, `MapPermissions`, `MapAttributes`: [`integration-asp-authorization.md`](integration-asp-authorization.md) and [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- ASP response mapping (status codes the assertions check against): [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)

--- a/docs/docfx_project/articles/integration-entra-testing.md
+++ b/docs/docfx_project/articles/integration-entra-testing.md
@@ -258,10 +258,25 @@ public sealed class OrdersAuthenticationTests : IClassFixture<WebApplicationFact
     private readonly WebApplicationFactory<Program> _factory;
     private readonly MsalTestTokenProvider _tokens;
 
-    public OrdersAuthenticationTests(WebApplicationFactory<Program> factory, MsalTestTokenProvider tokens)
+    public OrdersAuthenticationTests(WebApplicationFactory<Program> factory)
     {
         _factory = factory;
-        _tokens = tokens;
+        // For brevity, construct one provider per test class. Real suites share a single
+        // provider across tests via IClassFixture — see "Fixture pattern" below.
+        _tokens = new MsalTestTokenProvider(new MsalTestOptions
+        {
+            TenantId = Environment.GetEnvironmentVariable("EntraTest__TenantId")!,
+            ClientId = Environment.GetEnvironmentVariable("EntraTest__ClientId")!,
+            Scopes = [$"api://{Environment.GetEnvironmentVariable("EntraTest__ClientId")}/.default"],
+            TestUsers =
+            {
+                ["salesRep"] = new TestUserCredentials
+                {
+                    Username = Environment.GetEnvironmentVariable("EntraTest__TestUsers__salesRep__Username")!,
+                    Password = Environment.GetEnvironmentVariable("EntraTest__TestUsers__salesRep__Password")!,
+                }
+            }
+        });
     }
 
     [Fact]

--- a/docs/docfx_project/articles/integration-fluentvalidation.md
+++ b/docs/docfx_project/articles/integration-fluentvalidation.md
@@ -1,30 +1,58 @@
+﻿---
+title: FluentValidation Integration
+package: Trellis.FluentValidation
+topics: [validation, fluentvalidation, error-mapping, unprocessable-content, mediator-pipeline, json-pointer, aot]
+related_api_reference: [trellis-api-fluentvalidation.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # FluentValidation Integration
 
-**Level:** Intermediate 📚 | **Time:** 20-30 min | **Prerequisites:** [Basics](basics.md)
+`Trellis.FluentValidation` plugs FluentValidation validators into the Trellis Mediator validation stage and converts standalone `ValidationResult` runs into `Result<T>` failures backed by `Error.UnprocessableContent`.
 
-FluentValidation is great at describing validation rules. Trellis is great at keeping application flow on the success/failure railway. `Trellis.FluentValidation` connects those two worlds so you can validate once and stay inside `Result<T>`.
+## Patterns Index
 
-This article starts with the everyday case first, then covers null handling, async rules, and when `ToResult(...)` is the better fit.
+| Goal | Use | See |
+|---|---|---|
+| Wire validators into the Mediator pipeline (AOT-safe) | `services.AddTrellisFluentValidation()` + explicit `AddScoped<IValidator<T>, ...>()` | [Mediator integration](#mediator-integration) |
+| Wire validators with assembly scanning (non-AOT) | `services.AddTrellisFluentValidation(typeof(...).Assembly)` | [Mediator integration](#mediator-integration) |
+| Run a validator outside Mediator and stay in `Result<T>` | `validator.ValidateToResult(value)` | [Standalone validation](#standalone-validation) |
+| Same as above for async rules (DB / I/O) | `validator.ValidateToResultAsync(value, cancellationToken: ct)` | [Standalone validation](#standalone-validation) |
+| Convert an existing `ValidationResult` you already have | `validationResult.ToResult(value)` | [Converting an existing validationresult](#converting-an-existing-validationresult) |
+| Reject a `null` request without invoking FluentValidation | `ValidateToResult` / `ValidateToResultAsync` (built-in null short-circuit) | [Null input](#null-input) |
+| Aggregate FluentValidation + `IValidate` failures into one 422 | `AddTrellisFluentValidation()` alongside `IValidate.Validate()` on the message | [Composing with ivalidate](#composing-with-ivalidate) |
 
-## Table of Contents
+## Use this guide when
 
-- [Quick start](#quick-start)
-- [What the adapter gives you](#what-the-adapter-gives-you)
-- [Validating in application services](#validating-in-application-services)
-- [Validating inside domain factories](#validating-inside-domain-factories)
-- [Async validation](#async-validation)
-- [Null input behavior](#null-input-behavior)
-- [Converting an existing `ValidationResult`](#converting-an-existing-validationresult)
-- [Mediator integration: `AddTrellisFluentValidation()`](#mediator-integration-addtrellisfluentvalidation)
+- You already use FluentValidation and want failures to surface as `Error.UnprocessableContent` instead of exceptions or hand-rolled translations.
+- You send messages through `Trellis.Mediator` and want validators to run automatically inside `ValidationBehavior<TMessage,TResponse>` without per-handler boilerplate.
+- You need RFC 6901 JSON Pointer paths (`/Lines/0/Memo`) on validation failures so the ASP boundary renders them under the right field.
 
-## Quick start
+## Surface at a glance
 
-If you already use FluentValidation, the adapter adds a very small API surface:
+`Trellis.FluentValidation` exposes one DI extension class, one open-generic adapter, and one set of `Result<T>` extension methods.
+
+| Member | Receiver | Returns | Purpose |
+|---|---|---|---|
+| `AddTrellisFluentValidation()` | `IServiceCollection` | `IServiceCollection` | Registers the open-generic adapter as `IMessageValidator<>`. AOT/trim-safe, idempotent. |
+| `AddTrellisFluentValidation(params Assembly[])` | `IServiceCollection` | `IServiceCollection` | Same as above, then scans assemblies for concrete `IValidator<T>` types and registers each scoped. **Not AOT/trim-safe** (`[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`). |
+| `FluentValidationMessageValidatorAdapter<TMessage>` | — (DI-resolved) | `IMessageValidator<TMessage>` | Runs every injected `IValidator<TMessage>` sequentially, aggregates failures into one `Error.UnprocessableContent`. Forwards the ambient `CancellationToken`. |
+| `ValidateToResult<T>(value, paramName?, message?)` | `IValidator<T>` | `Result<T>` | Synchronous validate-and-convert. Short-circuits `null` input without invoking FluentValidation. |
+| `ValidateToResultAsync<T>(value, paramName?, message?, ct)` | `IValidator<T>` | `Task<Result<T>>` | Asynchronous validate-and-convert. Forwards `CancellationToken` to `ValidateAsync`. |
+| `ToResult<T>(value, paramName?)` | `ValidationResult` | `Result<T>` | Converts a pre-computed `ValidationResult` to `Result<T>`; preserves the validated value on success. |
+
+Full signatures: [trellis-api-fluentvalidation.md](../api_reference/trellis-api-fluentvalidation.md).
+
+## Installation
 
 ```bash
 dotnet add package FluentValidation
 dotnet add package Trellis.FluentValidation
 ```
+
+## Quick start
+
+Run a FluentValidation validator and stay inside `Result<T>`. No DI, no Mediator — just the standalone helper.
 
 ```csharp
 using FluentValidation;
@@ -49,89 +77,60 @@ var request = new CreateUserRequest("sam@example.com", "Sam", "Taylor");
 Result<CreateUserRequest> result = validator.ValidateToResult(request);
 ```
 
-On success, you get `Result.Ok(request)`. On failure, you get a Trellis validation failure with grouped field errors.
+On success: `Result.Ok(request)`. On failure: `Result.Fail<CreateUserRequest>(new Error.UnprocessableContent(EquatableArray.Create(violations)))` with one `FieldViolation` per FluentValidation failure.
 
-## What the adapter gives you
+## Standalone validation
 
-The goal is simple: stop translating `ValidationResult` by hand.
+Use the `IValidator<T>` extension methods when validators are not driven by the Mediator pipeline — domain factories, application services, or any code path that already holds an `IValidator<T>` instance.
 
-Public helpers:
+| Helper | Sync/async | Null input |
+|---|---|---|
+| `ValidateToResult<T>` | sync | Returns `Fail` without calling `validator.Validate` |
+| `ValidateToResultAsync<T>` | async | Returns `Fail` without calling `validator.ValidateAsync` |
 
-```csharp
-Result<T> ValidateToResult<T>(
-    this IValidator<T> validator,
-    T value,
-    [CallerArgumentExpression(nameof(value))] string paramName = "value",
-    string? message = null);
-
-Task<Result<T>> ValidateToResultAsync<T>(
-    this IValidator<T> validator,
-    T value,
-    [CallerArgumentExpression(nameof(value))] string paramName = "value",
-    string? message = null,
-    CancellationToken cancellationToken = default);
-
-Result<T> ToResult<T>(
-    this ValidationResult validationResult,
-    T value,
-    [CallerArgumentExpression(nameof(value))] string paramName = "value");
-```
-
-What those helpers do for you:
-
-- return the validated value on success
-- convert FluentValidation failures into `new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty) { Detail = ... }`
-- preserve grouped field errors
-- use caller argument expressions for better root-level field names
-- short-circuit `null` input before FluentValidation runs
-
-> [!NOTE]
-> The real methods use `[CallerArgumentExpression]` for `paramName`. That means `validator.ValidateToResult(command)` can automatically report `"command"` as the field name for root-level failures or null input.
-
-## Validating in application services
-
-This is the most common use case: validate a request, then continue with domain logic only if validation succeeded.
+Both helpers forward `paramName` from `[CallerArgumentExpression]`, so root-level failures and null-input failures carry the caller's variable name as the field path.
 
 ```csharp
+using System.Threading;
+using System.Threading.Tasks;
 using FluentValidation;
 using Trellis;
 using Trellis.FluentValidation;
 
-public sealed record RegisterUserRequest(string Email, string FirstName, string LastName);
+public interface IUserRepository
+{
+    Task<bool> EmailExistsAsync(string email, CancellationToken cancellationToken);
+}
+
+public sealed record RegisterUserRequest(string Email);
 
 public sealed class RegisterUserRequestValidator : AbstractValidator<RegisterUserRequest>
 {
-    public RegisterUserRequestValidator()
+    public RegisterUserRequestValidator(IUserRepository repository)
     {
-        RuleFor(x => x.Email).NotEmpty().EmailAddress();
-        RuleFor(x => x.FirstName).NotEmpty();
-        RuleFor(x => x.LastName).NotEmpty();
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress()
+            .MustAsync(async (email, ct) => !await repository.EmailExistsAsync(email, ct))
+            .WithMessage("Email is already registered.");
     }
 }
 
-public sealed record User(string Email, string FirstName, string LastName);
-
 public sealed class UserService(RegisterUserRequestValidator validator)
 {
-    public Result<User> Register(RegisterUserRequest request) =>
-        validator.ValidateToResult(request)
-            .Map(valid => new User(valid.Email, valid.FirstName, valid.LastName));
+    public Task<Result<RegisterUserRequest>> RegisterAsync(
+        RegisterUserRequest request,
+        CancellationToken cancellationToken) =>
+        validator.ValidateToResultAsync(request, cancellationToken: cancellationToken);
 }
 ```
 
-Why this reads well:
+### Validating inside domain factories
 
-- validation stays near the request boundary
-- the rest of the method only deals with valid input
-- the return type stays `Result<T>` all the way through
-
-## Validating inside domain factories
-
-Sometimes the thing you are validating is not an incoming DTO. It is the aggregate or value object you just constructed.
-
-`InlineValidator<T>` works well for that:
+`InlineValidator<T>` keeps invariant rules close to the type that owns them. The factory returns `Result<T>` directly.
 
 ```csharp
+using System;
 using FluentValidation;
 using Trellis;
 using Trellis.FluentValidation;
@@ -166,61 +165,9 @@ public sealed class Product : Entity<Guid>
 }
 ```
 
-This keeps invariant validation close to the type that owns the invariant.
+### Null input
 
-## Async validation
-
-Use the async helper when your rules hit the database, a remote API, or any other I/O.
-
-```csharp
-using FluentValidation;
-using Trellis;
-using Trellis.FluentValidation;
-
-public interface IUserRepository
-{
-    Task<bool> EmailExistsAsync(string email, CancellationToken cancellationToken);
-}
-
-public sealed record RegisterUserRequest(string Email);
-
-public sealed class RegisterUserRequestValidator : AbstractValidator<RegisterUserRequest>
-{
-    public RegisterUserRequestValidator(IUserRepository repository)
-    {
-        RuleFor(x => x.Email)
-            .NotEmpty()
-            .EmailAddress()
-            .MustAsync(async (email, cancellationToken) =>
-                !await repository.EmailExistsAsync(email, cancellationToken))
-            .WithMessage("Email is already registered.");
-    }
-}
-
-public sealed class UserService(RegisterUserRequestValidator validator)
-{
-    public async Task<Result<RegisterUserRequest>> RegisterAsync(
-        RegisterUserRequest request,
-        CancellationToken cancellationToken)
-    {
-        var validated = await validator.ValidateToResultAsync(
-            request,
-            cancellationToken: cancellationToken);
-
-        if (validated.IsFailure)
-            return Result.Fail<RegisterUserRequest>(validated.Error);
-
-        return Result.Ok(validated.Value);
-    }
-}
-```
-
-> [!TIP]
-> Pass the cancellation token through. `ValidateToResultAsync(...)` forwards it to `validator.ValidateAsync(...)`.
-
-## Null input behavior
-
-Null request models are easy to forget because FluentValidation usually assumes you already have an instance. The adapter closes that gap.
+`ValidateToResult` / `ValidateToResultAsync` reject `null` before invoking FluentValidation. The captured `paramName` becomes the field path; the optional `message` parameter overrides the default `'{paramName}' must not be empty.`.
 
 ```csharp
 using FluentValidation;
@@ -232,20 +179,14 @@ string? alias = null;
 var validator = new InlineValidator<string?>();
 validator.RuleFor(x => x).NotEmpty();
 
-Result<string?> result = validator.ValidateToResult(
-    alias,
-    message: "Alias is required.");
+Result<string?> result = validator.ValidateToResult(alias, message: "Alias is required.");
 ```
 
-Important behavior:
-
-- if `value` is `null`, the adapter does **not** call `validator.Validate(...)`
-- it returns a validation failure immediately
-- the field name comes from the caller expression unless you override the message
+`validator.Validate(null!)` is **not** called; the helper synthesizes a single `FieldViolation` for `paramName` with reason code `"validation.error"`.
 
 ## Converting an existing `ValidationResult`
 
-Sometimes you already have a `ValidationResult` because you ran FluentValidation directly or you are integrating with older code. Use `ToResult(...)` in that case.
+When validation already happened (legacy code, custom orchestration, or a manual `validator.Validate(value)` call), use `ToResult(value)` to fold the `ValidationResult` into the railway.
 
 ```csharp
 using FluentValidation;
@@ -259,25 +200,25 @@ var validator = new InlineValidator<CreateUserRequest>();
 validator.RuleFor(x => x.Email).NotEmpty().EmailAddress();
 
 var request = new CreateUserRequest("invalid-email");
-ValidationResult validationResult = validator.Validate(request);
+ValidationResult validation = validator.Validate(request);
 
-Result<CreateUserRequest> result = validationResult.ToResult(request);
+Result<CreateUserRequest> result = validation.ToResult(request);
 ```
 
-That is the right helper when:
+`ToResult` only null-checks `validationResult` itself — it does not reject a `null` `value`. Use `ValidateToResult` when null-input rejection matters.
 
-- validation already happened elsewhere
-- you only need the Trellis conversion step
-- you want to preserve the original validated value
+## Mediator integration
 
-## Mediator integration: `AddTrellisFluentValidation()`
+`AddTrellisFluentValidation()` registers `FluentValidationMessageValidatorAdapter<TMessage>` as the open-generic `IMessageValidator<TMessage>`. The existing `ValidationBehavior<TMessage,TResponse>` discovers it automatically — no second pipeline behavior is added.
 
-If you use [`Trellis.Mediator`](integration-mediator.md), you do **not** need to call `validator.ValidateToResult(...)` by hand inside every handler. `AddTrellisFluentValidation()` plugs FluentValidation into the unified `ValidationBehavior` stage so every `IValidator<TMessage>` registered for the message runs automatically before the handler is invoked, and its failures aggregate with any `IValidate.Validate()` failures into a single `Error.UnprocessableContent` response.
-
-### Wiring
+| Overload | AOT/trim | Behavior |
+|---|---|---|
+| `AddTrellisFluentValidation()` | Safe | Registers the open-generic adapter once. Idempotent. You register each `IValidator<T>` explicitly. |
+| `AddTrellisFluentValidation(params Assembly[])` | **Not safe** (`[RequiresUnreferencedCode]`, `[RequiresDynamicCode]`) | Calls the parameterless overload, then scans the supplied assemblies for concrete `IValidator<T>` types and registers them as scoped. Deduplicates `(serviceType, implementationType)` pairs against existing registrations. Tolerates `ReflectionTypeLoadException`. |
 
 ```csharp
 using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
 
@@ -285,25 +226,34 @@ builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scop
 builder.Services.AddTrellisBehaviors();
 builder.Services.AddTrellisFluentValidation();
 
-// Register every validator explicitly (AOT-friendly):
 builder.Services.AddScoped<IValidator<SubmitBatchTransfersCommand>, SubmitBatchTransfersValidator>();
 ```
 
-The parameterless overload registers an open-generic `FluentValidationMessageValidatorAdapter<TMessage>` as `IMessageValidator<>`. This is **AOT-friendly**: open-generic DI registration is a first-class NativeAOT pattern, and no reflection over assemblies happens on the hot path.
-
-For non-AOT apps that prefer assembly scanning:
+For non-AOT apps, scan instead:
 
 ```csharp
 builder.Services.AddTrellisFluentValidation(typeof(SubmitBatchTransfersValidator).Assembly);
 ```
 
-The scanning overload is annotated `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`. Use the parameterless overload + explicit `AddScoped<IValidator<T>, ...>()` for trimming/AOT scenarios.
+### Adapter behavior
+
+| Situation | Result |
+|---|---|
+| No `IValidator<TMessage>` registered | `Result.Ok()` — no allocations |
+| All registered validators pass | `Result.Ok()` |
+| One or more validators report failures | `Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(violations)))` aggregating every failure |
+| FluentValidation `PropertyName` is null/whitespace | Pointer derived from `typeof(TMessage).Name` |
+| FluentValidation `ErrorCode` is null/whitespace | `FieldViolation.ReasonCode` defaults to `"validation.error"` |
+| `CancellationToken` cancelled mid-run | Forwarded to `validator.ValidateAsync`; cancellation propagates |
+
+Validators run **sequentially** and every failure is collected — the adapter does not short-circuit on the first failing validator.
 
 ### Composing with `IValidate`
 
-A message can implement `IValidate` (for cross-cutting business invariants) **and** have one or more `IValidator<TMessage>` implementations (for property-shaped rules) registered in DI. The `ValidationBehavior` runs every source and merges all `Error.UnprocessableContent` failures into one response — callers see the full violation list in a single round trip:
+A message can implement `Trellis.Mediator.IValidate` for cross-cutting business invariants and also have one or more `IValidator<TMessage>` implementations registered for property-shaped rules. `ValidationBehavior<TMessage,TResponse>` runs every source and merges all `Error.UnprocessableContent` failures into a single response.
 
 ```csharp
+using System.Collections.Generic;
 using FluentValidation;
 using Mediator;
 using Trellis;
@@ -315,7 +265,6 @@ public sealed record SubmitBatchTransfersCommand(
     IReadOnlyList<BatchTransferLine> Lines)
     : ICommand<Result<BatchTransferReceipt>>, IValidate
 {
-    // Cross-cutting business invariant — awkward in FluentValidation:
     public IResult Validate()
     {
         var violations = new List<FieldViolation>();
@@ -329,7 +278,7 @@ public sealed record SubmitBatchTransfersCommand(
 
         return violations.Count == 0
             ? Result.Ok()
-            : Result.Fail(new Error.UnprocessableContent(EquatableArray.Create([.. violations])));
+            : Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(violations.ToArray())));
     }
 }
 
@@ -337,7 +286,6 @@ public sealed class SubmitBatchTransfersValidator : AbstractValidator<SubmitBatc
 {
     public SubmitBatchTransfersValidator()
     {
-        // Property-shaped rules — natural fit for FluentValidation:
         RuleFor(c => c.Metadata.Reference)
             .NotEmpty().Matches(@"^BATCH-\d{4}-\d{3}$");
 
@@ -349,37 +297,65 @@ public sealed class SubmitBatchTransfersValidator : AbstractValidator<SubmitBatc
 
 A request that violates both sources at once produces one 422 with **every** violation aggregated under its proper JSON Pointer.
 
+> [!NOTE]
+> Any non-`UnprocessableContent` failure (`Error.Conflict`, `Error.Forbidden`, …) returned by `IValidate` or any validator short-circuits the stage immediately and propagates as-is. Aggregation only applies to `UnprocessableContent`.
+
 ### JSON Pointer normalization
 
-FluentValidation reports property names in its own dotted-with-brackets shape: `Metadata.Reference`, `Lines[0].Memo`. The Trellis adapter translates those into RFC 6901 JSON Pointers before placing them on `FieldViolation.Pointer`:
+The adapter and `ToResult` translate FluentValidation property names to RFC 6901 JSON Pointers before constructing `InputPointer`. The same `JsonPointerNormalizer` is used in both code paths.
 
-| FluentValidation property | `FieldViolation.Pointer` |
-| --- | --- |
-| `Reference` (root property) | `/Reference` |
-| `Metadata.Reference` (nested) | `/Metadata/Reference` |
-| `Lines[0].Memo` (indexer) | `/Lines/0/Memo` |
-| `Items[0].Tags[2]` (multi-indexer) | `/Items/0/Tags/2` |
+| FluentValidation `PropertyName` | `FieldViolation.Field` |
+|---|---|
+| `Email` | `/Email` |
+| `Address.PostCode` | `/Address/PostCode` |
+| `Items[0].Sku` | `/Items/0/Sku` |
+| `Items[0].Tags[2]` | `/Items/0/Tags/2` |
 
-Special characters in segments are escaped per RFC 6901 (`~` → `~0`, `/` → `~1`). Property names that already start with `/` are passed through unchanged.
+Special characters in segments are escaped per RFC 6901 (`~` → `~0`, `/` → `~1`). Names that already begin with `/` are passed through unchanged.
 
-The pre-existing `validationResult.ToResult(value)` helper applies the same normalization, so direct callers benefit from the fix too.
+## Composition
 
-### Failure-source semantics
+Once a validation step yields `Result<T>`, it composes with the rest of Trellis (`Bind`, `Map`, `Ensure`, async variants). For commands that produce no payload, return `Result<Unit>`.
 
-- All `Error.UnprocessableContent` failures (from `IValidate` and every `IMessageValidator<TMessage>`) merge into a single response.
-- Any non-UPC failure (`Error.Conflict`, `Error.Forbidden`, …) returned by any validator short-circuits the stage immediately and is propagated as-is. This lets `IValidate` model "this is a domain rule violation, not a field problem" without losing exit semantics.
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Trellis;
+using Trellis.FluentValidation;
 
+public sealed record RegisterUserRequest(string Email, string FirstName, string LastName);
+public sealed record User(string Email, string FirstName, string LastName);
 
-### Good defaults
+public interface IUserRepository
+{
+    Task<Result<Unit>> AddAsync(User user, CancellationToken cancellationToken);
+}
 
-- validate requests at the application boundary
-- use `InlineValidator<T>` for domain invariants when it keeps the type simpler
-- use `ValidateToResultAsync(...)` for rules that touch I/O
-- use `ToResult(...)` only when you already have a `ValidationResult`
+public sealed class UserService(
+    IValidator<RegisterUserRequest> validator,
+    IUserRepository repository)
+{
+    public Task<Result<Unit>> RegisterAsync(RegisterUserRequest request, CancellationToken ct) =>
+        validator.ValidateToResultAsync(request, cancellationToken: ct)
+            .MapAsync(valid => new User(valid.Email, valid.FirstName, valid.LastName), ct)
+            .BindAsync((user, token) => repository.AddAsync(user, token), ct);
+}
+```
 
-### What the resulting errors look like
+## Practical guidance
 
-Failures are Trellis validation errors, so they use Trellis error conventions such as the standard `validation.error` code.
+- **Prefer the parameterless `AddTrellisFluentValidation()` overload.** It is AOT/trim-safe and idempotent. Register each `IValidator<T>` explicitly with `AddScoped`.
+- **Reach for `ValidateToResultAsync` whenever rules touch I/O.** It forwards `CancellationToken` straight to `validator.ValidateAsync`.
+- **Use `ToResult` only when you already hold a `ValidationResult`.** For all other paths use `ValidateToResult` / `ValidateToResultAsync` so null input is rejected before FluentValidation runs.
+- **Combine `IValidate` and FluentValidation for layered rules.** Cross-field invariants live on `IValidate.Validate()`; per-property rules live in the validator. Both contribute to a single aggregated 422.
+- **Let pointer normalization carry structure.** Do not pre-format property names — the adapter handles dotted chains and indexers automatically.
+- **Validators do not parse primitives.** Keep primitive-to-value-object parsing at the transport seam; validate already-shaped commands and value objects.
 
-> [!WARNING]
-> `Trellis.FluentValidation` is an adapter. It does not replace FluentValidation features, rule syntax, or DI registration. You still configure validators the normal FluentValidation way.
+## Cross-references
+
+- API surface: [trellis-api-fluentvalidation.md](../api_reference/trellis-api-fluentvalidation.md)
+- `Result<T>`, `Error.UnprocessableContent`, `FieldViolation`, `InputPointer`: [trellis-api-core.md](../api_reference/trellis-api-core.md)
+- Mediator validation behavior: [trellis-api-mediator.md](../api_reference/trellis-api-mediator.md)
+- ASP.NET 422 rendering: [trellis-api-asp.md](../api_reference/trellis-api-asp.md)
+- Cookbook recipes: [trellis-api-cookbook.md](../api_reference/trellis-api-cookbook.md)

--- a/docs/docfx_project/articles/integration-http.md
+++ b/docs/docfx_project/articles/integration-http.md
@@ -1,29 +1,49 @@
-# HTTP Integration
+﻿---
+title: HTTP Client Integration
+package: Trellis.Http
+topics: [http, httpclient, json, status-mapping, maybe, optional-payload, disposal]
+related_api_reference: [trellis-api-http.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# HTTP Client Integration
 
-**Level:** Beginner 📗 | **Time:** 10-15 min | **Prerequisites:** [Basics](basics.md)
+`Trellis.Http` bridges `Task<HttpResponseMessage>` into `Task<Result<HttpResponseMessage>>` and `Task<Result<T>>` pipelines so calling code stops mixing status-code branching, exception flow, and JSON deserialization.
 
-When you call another HTTP service, the hard part is rarely `HttpClient`. The hard part is turning status codes, empty bodies, and bad payloads into errors your application can reason about.
+## Patterns Index
 
-`Trellis.Http` gives you that bridge. You keep using `HttpClient`, but you can map responses into `Result<T>` and `Result<Maybe<T>>` without falling back to exception-driven flow.
+| Goal | Use | See |
+|---|---|---|
+| Bridge a raw `HttpClient` call into a result pipeline (no body inspection) | `ToResultAsync()` or `ToResultAsync(statusMap)` | [Status mapping](#status-mapping) |
+| Map one well-known status (404 / 401 / 409) to a typed `Error` | `HandleNotFoundAsync` / `HandleUnauthorizedAsync` / `HandleConflictAsync` | [Single-status handlers](#single-status-handlers) |
+| Map *many* statuses with a status switch | `ToResultAsync(Func<HttpStatusCode, Error?>)` | [Multi-status status switch](#multi-status-status-switch) |
+| Map statuses by inspecting the response body | `ToResultAsync(Func<HttpResponseMessage, CancellationToken, Task<Error?>>, ct)` | [Body-aware mapping](#body-aware-mapping) |
+| Read a *required* JSON body | `ReadJsonAsync<T>(jsonTypeInfo, ct)` | [Reading JSON](#reading-json) |
+| Read an *optional* body (allow empty / 204 / 205 / JSON `null`) | `ReadJsonMaybeAsync<T>(jsonTypeInfo, ct)` | [Reading JSON](#reading-json) |
+| Treat `404` as "resource absent" (return `Maybe.None`) | `ReadJsonOrNoneOn404Async<T>(jsonTypeInfo, ct)` | [Reading JSON](#reading-json) |
 
-## What problem does this solve?
+## Use this guide when
 
-Without Trellis, HTTP client code often turns into a mix of:
+- You call another HTTP service from .NET and want results, not exceptions, for expected statuses.
+- You need to deserialize JSON into a typed payload while keeping AOT-friendly source-generated metadata.
+- You want a single primitive (`ToResultAsync`) instead of `EnsureSuccessStatusCode` + manual `if (response.StatusCode == ...)` branching.
 
-- `EnsureSuccessStatusCode()`
-- manual `if (response.StatusCode == ...)`
-- ad-hoc JSON null checks
-- exception handling that leaks transport concerns into business code
+## Surface at a glance
 
-With Trellis, you describe the outcomes you expect and keep composing with the rest of your result pipeline.
+`Trellis.Http` exposes one static class, `HttpResponseExtensions`, with eight extension methods.
 
-```mermaid
-flowchart LR
-    A[HttpClient call] --> B[ToResultAsync / Handle*Async / ReadJsonOrNoneOn404Async]
-    B --> C[ReadJsonAsync / ReadJsonMaybeAsync]
-    C --> D[Result<T> or Result<Maybe<T>>]
-    D --> E[Bind / Map / Tap / Ensure]
-```
+| Method | Receiver | Returns | Purpose |
+|---|---|---|---|
+| `ToResultAsync(statusMap?, ct)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Bridge into a result pipeline. With no map, 2xx → `Ok`, non-2xx → typed Trellis failure. With a map, return `null` to pass through. |
+| `ToResultAsync(mapper, ct)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Body-aware bridge. Async mapper invoked **only** on non-success status codes. |
+| `HandleNotFoundAsync(error)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Map `404` to a typed `Fail`. |
+| `HandleUnauthorizedAsync(error)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Map `401` to a typed `Fail`. |
+| `HandleConflictAsync(error)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Map `409` to a typed `Fail`. |
+| `ReadJsonAsync<T>(jsonTypeInfo, ct)` | `Task<Result<HttpResponseMessage>>` | `Task<Result<T>>` | Required-payload deserialization. Empty / `null` / invalid JSON / `204` / `205` → `Fail`. `T : notnull`. |
+| `ReadJsonMaybeAsync<T>(jsonTypeInfo, ct)` | `Task<Result<HttpResponseMessage>>` | `Task<Result<Maybe<T>>>` | Optional-payload deserialization. `204` / `205` / empty / JSON `null` → `Ok(Maybe.None)`. Invalid JSON throws `JsonException` (intentional). `T : notnull`. |
+| `ReadJsonOrNoneOn404Async<T>(jsonTypeInfo, ct)` | `Task<HttpResponseMessage>` | `Task<Result<Maybe<T>>>` | Terminal optional-resource read. `404` → `Ok(Maybe.None)`; other non-2xx use strict mapping. `T : notnull`. |
+
+Full signatures: [`trellis-api-http.md`](../api_reference/trellis-api-http.md).
 
 ## Installation
 
@@ -31,30 +51,15 @@ flowchart LR
 dotnet add package Trellis.Http
 ```
 
-## The v3 surface
-
-`Trellis.Http` is a single static class &mdash; `HttpResponseExtensions` &mdash; with a small canonical method set.
-
-| Method | Receiver | Purpose |
-| --- | --- | --- |
-| `ToResultAsync(statusMap?)` | `Task<HttpResponseMessage>` | Bridge into `Task<Result<HttpResponseMessage>>`. With no map, 2xx stays `Ok` and non-2xx becomes a typed Trellis failure. With a map, return `null` to pass through. |
-| `ToResultAsync(mapper, ct)` | `Task<HttpResponseMessage>` | Body-aware bridge. Async mapper invoked only on non-success status codes. Replaces the v1 `HandleFailureAsync<TContext>`. |
-| `HandleNotFoundAsync(error)` | `Task<HttpResponseMessage>` | Map 404 to `Fail`. |
-| `HandleConflictAsync(error)` | `Task<HttpResponseMessage>` | Map 409 to `Fail`. |
-| `HandleUnauthorizedAsync(error)` | `Task<HttpResponseMessage>` | Map 401 to `Fail`. |
-| `ReadJsonAsync<T>(jsonTypeInfo, ct)` | `Task<Result<HttpResponseMessage>>` | Read and deserialize the body. Required-payload semantics: empty / `null` / invalid JSON / `204` / `205` &rarr; `Fail`. |
-| `ReadJsonMaybeAsync<T>(jsonTypeInfo, ct)` | `Task<Result<HttpResponseMessage>>` | Optional-payload variant. `204`, `205`, empty body, JSON `null` &rarr; `Ok(Maybe.None)`. Invalid JSON throws `JsonException` (intentional). |
-| `ReadJsonOrNoneOn404Async<T>(jsonTypeInfo, ct)` | `Task<HttpResponseMessage>` | Terminal optional-resource variant. `404` &rarr; `Ok(Maybe.None)`; other non-2xx statuses use strict mapping. |
-
-> [!TIP]
-> `ReadJsonAsync<T>` and `ReadJsonMaybeAsync<T>` require `T : notnull`. Use them with real payload types, not nullable reference types.
-
 ## Quick start
 
-The most common case: call an endpoint, map one expected status code, then deserialize JSON.
+Call an endpoint, map one expected failure status, read a required payload.
 
 ```csharp
+using System.Net.Http;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Trellis;
 using Trellis.Http;
 
@@ -65,32 +70,35 @@ public sealed record UserDto(string Id, string DisplayName);
 
 public sealed class UserDirectoryClient(HttpClient httpClient)
 {
-    public Task<Result<UserDto>> GetUserAsync(string userId, CancellationToken cancellationToken) =>
-        httpClient.GetAsync($"users/{userId}", cancellationToken)
+    public Task<Result<UserDto>> GetUserAsync(string userId, CancellationToken ct) =>
+        httpClient.GetAsync($"users/{userId}", ct)
             .HandleNotFoundAsync(new Error.NotFound(ResourceRef.For<UserDto>(userId)) { Detail = $"User {userId} not found" })
-            .ReadJsonAsync(ApiJsonContext.Default.UserDto, cancellationToken);
+            .ReadJsonAsync(ApiJsonContext.Default.UserDto, ct);
 }
 ```
 
-## Status handling
+## Status mapping
 
-Why handle status codes before deserializing? Because it keeps transport failures obvious and prevents "try to read JSON from an error page" bugs.
+Handle status codes **before** reading the body. This keeps transport failures separate from payload bugs.
 
-### Single-status convenience handlers
+### Single-status handlers
 
-Use these when you know which failures are part of the contract.
+Use these when one specific failure status is part of the contract.
 
 | Handler | HTTP status | Produces |
-| --- | --- | --- |
+|---|---|---|
 | `HandleNotFoundAsync` | `404` | `Error.NotFound` |
 | `HandleUnauthorizedAsync` | `401` | `Error.Unauthorized` |
 | `HandleConflictAsync` | `409` | `Error.Conflict` |
 
-Each handler operates on `Task<HttpResponseMessage>` &mdash; the *entry point* of the chain. After it the result is `Task<Result<HttpResponseMessage>>` and the next operator is `ReadJsonAsync` / `ReadJsonMaybeAsync`.
+Each operates on `Task<HttpResponseMessage>` (the entry point of the chain). The next operator is `ReadJsonAsync` / `ReadJsonMaybeAsync`.
 
 ```csharp
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Trellis;
 using Trellis.Http;
 
@@ -110,12 +118,24 @@ public sealed class OrdersClient(HttpClient httpClient)
 }
 ```
 
-### Multi-status mapping with `ToResultAsync(statusMap)`
+### Multi-status status switch
 
-Use `ToResultAsync` with a `Func<HttpStatusCode, Error?>` when you need to map multiple statuses, including 403, ranges, or "everything that is not 2xx". Returning `null` lets the response flow through; returning an `Error` short-circuits the chain.
+For more than one mapped status, use `ToResultAsync(Func<HttpStatusCode, Error?>)`. Return `null` to pass through; return an `Error` to short-circuit the chain.
 
 ```csharp
+using System;
 using System.Net;
+using System.Net.Http;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Http;
+
+[JsonSerializable(typeof(ProductDto))]
+internal partial class ProductsJsonContext : JsonSerializerContext { }
+
+public sealed record ProductDto(string Id, string Name);
 
 public sealed class ProductsClient(HttpClient httpClient)
 {
@@ -128,20 +148,31 @@ public sealed class ProductsClient(HttpClient httpClient)
                 _ when (int)status >= 500 => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = $"upstream {status}" },
                 _ when (int)status >= 400 => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = $"client error {status}" },
                 _ => null,
-            })
+            }, ct)
             .ReadJsonAsync(ProductsJsonContext.Default.ProductDto, ct);
 }
 ```
 
-This single primitive subsumes the v1 `HandleClientError`, `HandleServerError`, `HandleForbidden`, and `EnsureSuccess` verbs.
+### Body-aware mapping
 
-### Body-aware mapping with `ToResultAsync(mapper, ct)`
-
-When status code alone is not enough, supply a `Func<HttpResponseMessage, CancellationToken, Task<Error?>>`. The mapper is invoked **only** for non-success responses and may read the body, headers, or problem-details payload to build a richer error.
+When status alone is not enough, supply `Func<HttpResponseMessage, CancellationToken, Task<Error?>>`. The mapper is invoked **only** on non-success responses and may read body, headers, or problem-details payload.
 
 ```csharp
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Http;
+
+[JsonSerializable(typeof(CreateInvoiceRequest))]
+[JsonSerializable(typeof(InvoiceDto))]
+internal partial class InvoicesJsonContext : JsonSerializerContext { }
+
+public sealed record CreateInvoiceRequest(string CustomerId, decimal Total);
+public sealed record InvoiceDto(string Id, decimal Total);
 
 public sealed class InvoicesClient(HttpClient httpClient)
 {
@@ -161,70 +192,101 @@ public sealed class InvoicesClient(HttpClient httpClient)
 }
 ```
 
-Capture additional caller state via closure &mdash; the v1 `TContext` channel is gone (it was redundant).
+Capture caller state via closure — the v1 `TContext` channel is gone (it was redundant).
 
 ## Reading JSON
 
-Why split this into two helpers? Because "missing payload is a bug" and "missing payload is acceptable" are different cases.
+Three read modes, distinguished by what "no payload" means.
 
-### `ReadJsonAsync` &mdash; payload required
+### `ReadJsonAsync<T>` — required payload
 
-- non-success status &rarr; `Fail<InternalServerError>`
-- `204 NoContent` / `205 ResetContent` &rarr; `Fail`
-- `null`, empty body, or invalid JSON &rarr; `Fail`
+| Outcome | Result |
+|---|---|
+| 2xx + valid JSON | `Ok(value)` |
+| 2xx + `null` body / empty / invalid JSON / `204` / `205` | `Fail` |
+| Non-2xx | `Fail` (passes through prior failure or maps via strict default) |
 
-### `ReadJsonMaybeAsync` &mdash; payload optional
+### `ReadJsonMaybeAsync<T>` — optional payload
 
-- non-success status &rarr; `Fail<InternalServerError>`
-- `204`, `205`, empty content, JSON `null` &rarr; `Ok(Maybe.None)`
-- valid JSON body &rarr; `Ok(Maybe.From(value))`
+| Outcome | Result |
+|---|---|
+| 2xx + valid JSON | `Ok(Maybe.From(value))` |
+| 2xx + `204` / `205` / empty / JSON `null` | `Ok(Maybe.None)` |
+| 2xx + invalid JSON | **throws** `JsonException` (response disposed first) |
+| Non-2xx | `Fail` |
 
-### `ReadJsonOrNoneOn404Async` &mdash; resource optional
+### `ReadJsonOrNoneOn404Async<T>` — optional resource
 
-- `404 NotFound` &rarr; `Ok(Maybe.None)`
-- other non-success status &rarr; typed Trellis failure via strict status mapping
-- `204`, `205`, empty content, JSON `null` &rarr; `Ok(Maybe.None)`
-- valid JSON body &rarr; `Ok(Maybe.From(value))`
+| Outcome | Result |
+|---|---|
+| 2xx + valid JSON | `Ok(Maybe.From(value))` |
+| 2xx + `204` / `205` / empty / JSON `null` | `Ok(Maybe.None)` |
+| `404` | `Ok(Maybe.None)` |
+| Other non-2xx | `Fail` (typed Trellis failure via strict mapping) |
 
 > [!WARNING]
-> `ReadJsonMaybeAsync` does **not** catch `JsonException`. Use it when "optional body" is allowed, not when you want malformed JSON silently treated as "no value". The response is still disposed before the exception escapes.
+> `ReadJsonMaybeAsync` does NOT catch `JsonException`. Use it when "optional body" is allowed, not when malformed JSON should be silent. The response is still disposed before the exception escapes.
 
 ## Disposal contract
 
-The library owns `HttpResponseMessage` disposal on terminal or transformative paths:
+`Trellis.Http` owns `HttpResponseMessage` disposal on terminal and transformative paths.
 
-- `ToResultAsync` (both overloads) and `Handle*Async` dispose the response on the `Fail` path.
-- `ReadJsonAsync`, `ReadJsonMaybeAsync`, and `ReadJsonOrNoneOn404Async` always dispose after reading, success or failure.
-- Pass-through paths (success from bare `ToResultAsync`, non-matching `Handle*Async`, mapper returning `null`) leave disposal to the caller until the chain reaches `ReadJson*`.
+| Path | Disposes? |
+|---|---|
+| `ToResultAsync` (both overloads) on the `Fail` branch | Yes |
+| `Handle*Async` on the matching status (`Fail` branch) | Yes |
+| Pass-through (success from bare `ToResultAsync`, non-matching `Handle*Async`, mapper returning `null`) | No — caller owns until the chain reaches `ReadJson*` |
+| `ReadJsonAsync` / `ReadJsonMaybeAsync` / `ReadJsonOrNoneOn404Async` | Yes — always, success or failure |
 
-In practice: **once you call `ReadJson*`, you no longer need to dispose the response yourself.**
+In practice: once you call any `ReadJson*`, you no longer need to dispose the response yourself.
 
-## Composing HTTP with the rest of Trellis
+## Composition
 
-Once an HTTP call becomes `Result<T>`, it composes naturally with `Bind`, `Map`, `Ensure`, etc.:
+Once an HTTP call becomes `Result<T>`, it composes with the rest of Trellis (`Bind`, `Map`, `Ensure`, etc.).
 
 ```csharp
-public Task<Result<PaymentReceiptDto>> ChargeAsync(string productId, CancellationToken ct) =>
-    httpClient.GetAsync($"inventory/{productId}", ct)
-        .ToResultAsync()
-        .ReadJsonAsync(CheckoutJsonContext.Default.InventoryCheckDto, ct)
-        .EnsureAsync(
-            inventory => inventory.InStock,
-            new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(productId)), "validation.error") { Detail = "Out of stock." })))
-        .BindAsync(
-            (_, token) => httpClient.PostAsync($"payments/{productId}", null, token)
-                .ToResultAsync()
-                .ReadJsonAsync(CheckoutJsonContext.Default.PaymentReceiptDto, token),
-            ct);
+using System.Net.Http;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Http;
+
+[JsonSerializable(typeof(InventoryCheckDto))]
+[JsonSerializable(typeof(PaymentReceiptDto))]
+internal partial class CheckoutJsonContext : JsonSerializerContext { }
+
+public sealed record InventoryCheckDto(bool InStock);
+public sealed record PaymentReceiptDto(string Id);
+
+public sealed class CheckoutClient(HttpClient httpClient)
+{
+    public Task<Result<PaymentReceiptDto>> ChargeAsync(string productId, CancellationToken ct) =>
+        httpClient.GetAsync($"inventory/{productId}", ct)
+            .ToResultAsync()
+            .ReadJsonAsync(CheckoutJsonContext.Default.InventoryCheckDto, ct)
+            .EnsureAsync(
+                inventory => inventory.InStock,
+                new Error.UnprocessableContent(EquatableArray.Create(
+                    new FieldViolation(InputPointer.ForProperty(nameof(productId)), "validation.error") { Detail = "Out of stock." })))
+            .BindAsync(
+                (_, token) => httpClient.PostAsync($"payments/{productId}", null, token)
+                    .ToResultAsync()
+                    .ReadJsonAsync(CheckoutJsonContext.Default.PaymentReceiptDto, token),
+                ct);
+}
 ```
 
 ## Practical guidance
 
-- **Prefer source-generated JSON metadata** &mdash; keeps the chain AOT-friendly and matches the `JsonTypeInfo<T>` overloads.
-- **Use optional reads intentionally.** If `404` means absence, use `ReadJsonOrNoneOn404Async`; if it is an error, let bare `ToResultAsync()` produce a failure or map it with `HandleNotFoundAsync`.
-- **Always pass the `CancellationToken`.** Every Trellis HTTP helper accepts it for a reason.
-- **Need a sync receiver?** Wrap with `Task.FromResult(response)`. In practice every `HttpClient` call is already async, so this is rarely necessary.
+- **Use source-generated JSON metadata.** Keeps the chain AOT-friendly and matches the `JsonTypeInfo<T>` overloads.
+- **Pick the right read mode.** `404` means absence → `ReadJsonOrNoneOn404Async`. `404` is an error → bare `ToResultAsync()` or `HandleNotFoundAsync`.
+- **Always pass `CancellationToken`.** Every helper accepts it.
+- **One status mapper, not many.** Prefer `ToResultAsync(statusMap)` over chaining multiple `Handle*Async` calls when you map more than one status.
 
-## Breaking changes from v1
+## Cross-references
 
-The v1 surface (60+ overloads) has been collapsed. The deleted verbs &mdash; `HandleForbidden*`, `HandleClientError*`, `HandleServerError*`, `EnsureSuccess` / `EnsureSuccessAsync`, `HandleFailureAsync<TContext>`, every sync overload, every `Result<HttpResponseMessage>`-receiver overload &mdash; are all expressible with `ToResultAsync(statusMap)` or `ToResultAsync(mapper, ct)`. The renamed verbs are `ReadResultFromJsonAsync` &rarr; `ReadJsonAsync` and `ReadResultMaybeFromJsonAsync` &rarr; `ReadJsonMaybeAsync`. See the [API reference](../api_reference/trellis-api-http.md#breaking-changes-from-v1) for the full migration table.
+- API surface: [`trellis-api-http.md`](../api_reference/trellis-api-http.md)
+- `Result<T>` and `Maybe<T>` semantics: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Cookbook recipe (HTTP client → result pipelines): [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md)
+- Migration from v1 (full collapsed-verbs table): [`trellis-api-http.md` → Breaking changes](../api_reference/trellis-api-http.md#breaking-changes-from-v1)

--- a/docs/docfx_project/articles/integration-http.md
+++ b/docs/docfx_project/articles/integration-http.md
@@ -34,7 +34,7 @@ audience: [developer]
 
 | Method | Receiver | Returns | Purpose |
 |---|---|---|---|
-| `ToResultAsync(statusMap?, ct)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Bridge into a result pipeline. With no map, 2xx → `Ok`, non-2xx → typed Trellis failure. With a map, return `null` to pass through. |
+| `ToResultAsync(statusMap?)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Bridge into a result pipeline. With no map, 2xx → `Ok`, non-2xx → typed Trellis failure. With a map, return `null` to pass through. (No `CancellationToken` parameter — let the upstream `*Async` call carry it.) |
 | `ToResultAsync(mapper, ct)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Body-aware bridge. Async mapper invoked **only** on non-success status codes. |
 | `HandleNotFoundAsync(error)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Map `404` to a typed `Fail`. |
 | `HandleUnauthorizedAsync(error)` | `Task<HttpResponseMessage>` | `Task<Result<HttpResponseMessage>>` | Map `401` to a typed `Fail`. |
@@ -148,7 +148,7 @@ public sealed class ProductsClient(HttpClient httpClient)
                 _ when (int)status >= 500 => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = $"upstream {status}" },
                 _ when (int)status >= 400 => new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = $"client error {status}" },
                 _ => null,
-            }, ct)
+            })
             .ReadJsonAsync(ProductsJsonContext.Default.ProductDto, ct);
 }
 ```

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -1,35 +1,52 @@
-﻿# Mediator Pipeline
+﻿---
+title: Mediator Pipeline
+package: Trellis.Mediator
+topics: [mediator, command, query, pipeline, behaviors, authorization, validation, telemetry]
+related_api_reference: [trellis-api-mediator.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Mediator Pipeline
 
-**Level:** Intermediate 📘 | **Time:** 20-25 min | **Prerequisites:** [Basics](basics.md), [ASP.NET Core Authorization](integration-asp-authorization.md)
+`Trellis.Mediator` registers result-aware pipeline behaviors around the [Mediator](https://github.com/martinothamar/Mediator) library so handlers stay focused on business work while exception safety, tracing, logging, authorization, and validation run as composable pre/post stages.
 
-Handlers should focus on business work. Authorization, validation, tracing, and exception safety should happen around them, not inside them.
+## Patterns Index
 
-That is what `Trellis.Mediator` gives you: result-aware pipeline behaviors for the [Mediator](https://github.com/martinothamar/Mediator) library.
+| Goal | Use | See |
+|---|---|---|
+| Register the standard Trellis behaviors | `services.AddTrellisBehaviors()` | [Quick start](#quick-start) |
+| Inspect or override the canonical behavior order | `ServiceCollectionExtensions.PipelineBehaviors` | [Pipeline order](#pipeline-order) |
+| Gate a message on static permissions | Implement `IAuthorize` on the message | [Permission authorization](#permission-authorization) |
+| Authorize against a loaded resource (ownership, tenancy) | Implement `IAuthorizeResource<T>` and register a loader | [Resource authorization](#resource-authorization) |
+| Reuse one loader across many commands for the same resource | `IIdentifyResource<T, TId>` + `SharedResourceLoaderById<T, TId>` | [Shared resource loaders](#shared-resource-loaders) |
+| Self-validate a message | Implement `IValidate.Validate()` | [Validation](#validation) |
+| Plug FluentValidation into the same stage | `services.AddTrellisFluentValidation()` | [FluentValidation adapter](#fluentvalidation-adapter) |
+| Show `Error.Detail` in logs/traces (dev only) | `AddTrellisBehaviors(o => o.IncludeErrorDetail = true)` | [Telemetry redaction](#telemetry-redaction) |
+| Convert thrown exceptions to typed failures | `ExceptionBehavior` (always-on) | [Exception safety net](#exception-safety-net) |
 
-## Why use it?
+## Use this guide when
 
-Without a pipeline, handlers tend to accumulate cross-cutting concerns:
+- You are wiring `Trellis.Mediator` into a Web API or Worker host and need the canonical behavior registration.
+- You want to move authorization or validation off your handlers and into the pipeline.
+- You want consistent OpenTelemetry spans and structured logs for every command/query.
+- You need to plug FluentValidation (or another validation library) into the same validation stage as `IValidate`.
 
-- permission checks
-- resource ownership checks
-- input validation
-- trace/log boilerplate
-- try/catch safety nets
+## Surface at a glance
 
-With `Trellis.Mediator`, those concerns become opt-in behaviors.
+| Type / member | Kind | Purpose |
+|---|---|---|
+| `AddTrellisBehaviors()` | DI extension | Registers the five always-on behaviors (idempotent). |
+| `AddTrellisBehaviors(Action<TrellisMediatorTelemetryOptions>)` | DI extension | Same, with telemetry options (e.g., `IncludeErrorDetail`). |
+| `AddResourceAuthorization(params Assembly[])` | DI extension | Scans assemblies for `IAuthorizeResource<>`, loaders, and shared loaders. |
+| `AddResourceAuthorization<TMessage, TResource, TResponse>()` | DI extension | Explicit registration (AOT/trimming friendly). |
+| `AddSharedResourceLoader<TMessage, TResource, TId>()` | DI extension | Bridges an `IIdentifyResource<T,TId>` message to a `SharedResourceLoaderById<T,TId>`. |
+| `IValidate` | Interface | Message-side hook; `IResult Validate()` runs before the handler. |
+| `IMessageValidator<TMessage>` | Interface | DI-resolved async validator; aggregated by `ValidationBehavior`. |
+| `TrellisMediatorTelemetryOptions.IncludeErrorDetail` | Property | Opt-in to include `Error.Detail` in logs/traces (default `false`). |
+| `TracingBehavior<,>.ActivitySourceName` | `const string` | `"Trellis.Mediator"` — add this to your OpenTelemetry config. |
+| `ServiceCollectionExtensions.PipelineBehaviors` | Property | Ordered behavior list for AOT `MediatorOptions.PipelineBehaviors`. |
 
-```mermaid
-flowchart TD
-    A[Message] --> B[ExceptionBehavior]
-    B --> C[TracingBehavior]
-    C --> D[LoggingBehavior]
-    D --> E[AuthorizationBehavior]
-    E --> F{Resource auth registered?}
-    F -->|yes| G[ResourceAuthorizationBehavior]
-    F -->|no| H[ValidationBehavior]
-    G --> H[ValidationBehavior]
-    H --> I[Handler]
-```
+Full signatures: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md).
 
 ## Installation
 
@@ -39,104 +56,117 @@ dotnet add package Trellis.Mediator
 
 ## Quick start
 
-Start by registering Mediator and the core Trellis behaviors.
+Register Mediator with the **scoped** lifetime, add the Trellis behaviors, and your handlers immediately get exception safety, tracing, logging, authorization, and validation.
 
 ```csharp
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Authorization;
 using Trellis.Mediator;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
 builder.Services.AddTrellisBehaviors();
+
+var app = builder.Build();
+app.Run();
+
+public sealed record PublishDocumentCommand(string DocumentId)
+    : ICommand<Result<Unit>>, IAuthorize
+{
+    public IReadOnlyList<string> RequiredPermissions => ["documents:publish"];
+}
+
+public sealed class PublishDocumentHandler : ICommandHandler<PublishDocumentCommand, Result<Unit>>
+{
+    public ValueTask<Result<Unit>> Handle(PublishDocumentCommand command, CancellationToken cancellationToken) =>
+        ValueTask.FromResult(Result.Ok(Unit.Value));
+}
 ```
 
 > [!IMPORTANT]
-> Pass `opts => opts.ServiceLifetime = ServiceLifetime.Scoped`. The Trellis pipeline behaviors are registered as scoped (they depend on per-request services such as `IActorProvider`, `IUnitOfWork`, and `IMessageValidator<>` adapters). The Mediator default lifetime is **Singleton**, which fails ASP.NET's root-scope validation as soon as the first behavior tries to resolve a scoped dependency. `Scoped` is the right lifetime for any host that has a request scope (Web API, Worker with scoped processing, etc.).
+> Pass `opts => opts.ServiceLifetime = ServiceLifetime.Scoped`. The Trellis behaviors depend on per-request services (`IActorProvider`, `IUnitOfWork`, `IMessageValidator<>` adapters). Mediator's default lifetime is `Singleton`, which fails ASP.NET's root-scope validation as soon as a behavior tries to resolve a scoped dependency.
 
-That registration adds these behaviors, in this order:
+## Pipeline order
 
-| Behavior | Runs for | What it does |
-| --- | --- | --- |
-| `ExceptionBehavior` | all messages | Converts unhandled exceptions into `new Error.InternalServerError("fault-id") { Detail = ... }` failures |
-| `TracingBehavior` | all messages | Creates an OpenTelemetry activity. Tags failures with stable `error.code` / `error.type`; redacts `Error.Detail` by default (see [Redacting `Error.Detail`](#redacting-errordetail-in-logs-and-traces)) |
-| `LoggingBehavior` | all messages | Logs execution and failures. Emits `Error.Code` for failed responses; redacts `Error.Detail` by default (see [Redacting `Error.Detail`](#redacting-errordetail-in-logs-and-traces)) |
-| `AuthorizationBehavior` | messages implementing `IAuthorize` | Enforces required permissions |
-| `ValidationBehavior` | **all messages** | Runs `IValidate.Validate()` (when implemented) AND every registered `IMessageValidator<TMessage>` (e.g., the FluentValidation adapter); aggregates `Error.UnprocessableContent` failures from every source into one response |
+`AddTrellisBehaviors()` registers the five always-on behaviors in this fixed order (outermost → innermost). The opt-in entries in rows 5 and 7 slot in only when their registration helpers are called.
 
-> [!NOTE]
-> `ResourceAuthorizationBehavior` is **not** included by `AddTrellisBehaviors()`. It is only added when you call `AddResourceAuthorization(...)`.
+| # | Behavior | Runs for | What it does |
+|---|---|---|---|
+| 1 | `ExceptionBehavior` | all messages | Catches everything except `OperationCanceledException`; returns `Error.InternalServerError`. |
+| 2 | `TracingBehavior` | all messages | Opens an `Activity` under `"Trellis.Mediator"`; tags `error.code` / `error.type` on failure. |
+| 3 | `LoggingBehavior` | all messages | Structured start/end with elapsed ms; emits `Error.Code` on failure. |
+| 4 | `AuthorizationBehavior` | `IAuthorize` messages | Resolves the actor and checks `RequiredPermissions`. |
+| 5 | `ResourceAuthorizationBehavior` *(opt-in)* | `IAuthorizeResource<T>` messages | Loads the resource and calls `Authorize(actor, resource)`. Inserted by `AddResourceAuthorization(...)` immediately before `ValidationBehavior`. |
+| 6 | `ValidationBehavior` | all messages | Runs `IValidate.Validate()` and every `IMessageValidator<TMessage>`; aggregates `Error.UnprocessableContent`. |
+| 7 | `TransactionalCommandBehavior` *(opt-in, EFCore)* | `ICommand<TResponse>` | `IUnitOfWork.CommitAsync` on success. Register **after** `AddTrellisBehaviors()` so it lands innermost. |
 
-## Permission-based authorization
+The first five live in `ServiceCollectionExtensions.PipelineBehaviors` for the AOT-friendly source-generator path; assign that list to `MediatorOptions.PipelineBehaviors` when configuring `AddMediator`.
 
-Use `IAuthorize` when a command or query always needs the same permission set.
+## Permission authorization
+
+Implement `IAuthorize` when a message always requires the same permission set. `AuthorizationBehavior` resolves the current `Actor` from `IActorProvider` and rejects with `new Error.Forbidden("authorization.insufficient.permissions") { Detail = "Insufficient permissions." }` when any required permission is missing.
 
 ```csharp
+using System.Collections.Generic;
 using Mediator;
 using Trellis;
 using Trellis.Authorization;
 
-public sealed record PublishDocumentCommand(Guid DocumentId)
+public sealed record PublishDocumentCommand(string DocumentId)
     : ICommand<Result<Unit>>, IAuthorize
 {
-    public IReadOnlyList<string> RequiredPermissions => ["Documents.Publish"];
+    public IReadOnlyList<string> RequiredPermissions => ["documents:publish"];
 }
 ```
 
-When this command goes through the pipeline:
+`AuthorizationBehavior` performs no I/O — it only reads from the resolved `Actor`. Use `IAuthorizeResource<T>` (next section) when the answer depends on the resource itself.
 
-1. `AuthorizationBehavior` asks `IActorProvider` for the current actor
-2. it calls `actor.HasAllPermissions(RequiredPermissions)`
-3. if the actor is missing any permission, the pipeline returns `new Error.Forbidden("authorization.insufficient.permissions") { Detail = "Insufficient permissions." }`
+## Resource authorization
 
-## Resource-based authorization
+Use `IAuthorizeResource<TResource>` when authorization depends on the resource (ownership, tenancy, state). The pipeline loads the resource first, then calls `message.Authorize(actor, resource)`.
 
-Static permissions are not enough when the answer depends on the resource itself. For example: “the caller must have `Documents.Edit`, and they must own this document.”
+`ResourceAuthorizationBehavior` is **opt-in**: it is added only when you call `AddResourceAuthorization(...)`. Without that call the behavior never runs even if the message implements `IAuthorizeResource<T>`.
 
-### Step 1: put the rule on the message
+### Per-message loader
+
+Use `ResourceLoaderById<TMessage, TResource, TId>` for the common "message has an id, repository loads by id" case.
 
 ```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Trellis;
 using Trellis.Authorization;
 using Trellis.Mediator;
 
 public sealed record Document(Guid Id, string OwnerId, string Title);
 
-public sealed record RenameDocumentCommand(Guid DocumentId, string Title)
-    : ICommand<Result<Document>>,
-      IAuthorize,
-      IAuthorizeResource<Document>,
-      IValidate
+public interface IDocumentRepository
 {
-    public IReadOnlyList<string> RequiredPermissions => ["Documents.Edit"];
+    Task<Result<Document>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<Result<Document>> RenameAsync(Document document, string title, CancellationToken cancellationToken);
+}
+
+public sealed record RenameDocumentCommand(Guid DocumentId, string Title)
+    : ICommand<Result<Document>>, IAuthorize, IAuthorizeResource<Document>
+{
+    public IReadOnlyList<string> RequiredPermissions => ["documents:edit"];
 
     public IResult Authorize(Actor actor, Document resource) =>
         actor.IsOwner(resource.OwnerId)
             ? Result.Ok()
-            : Result.Fail(new Error.Forbidden("policy.id") { Detail = "Only the owner can rename this document." });
-
-    public IResult Validate() =>
-        string.IsNullOrWhiteSpace(Title)
-            ? Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(Title)), "validation.error") { Detail = "Title is required." })))
-            : Result.Ok();
-}
-```
-
-### Step 2: add a resource loader
-
-`ResourceLoaderById<TMessage, TResource, TId>` handles the common “message contains an id, repository loads by id” case.
-
-```csharp
-using Trellis;
-using Trellis.Authorization;
-
-public interface IDocumentRepository
-{
-    Task<Result<Document>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
-    Task<Result<Document>> RenameAsync(
-        Document document,
-        string title,
-        CancellationToken cancellationToken = default);
+            : Result.Fail(new Error.Forbidden("documents.rename") { Detail = "Only the owner can rename this document." });
 }
 
 public sealed class RenameDocumentResourceLoader(IDocumentRepository repository)
@@ -144,84 +174,107 @@ public sealed class RenameDocumentResourceLoader(IDocumentRepository repository)
 {
     protected override Guid GetId(RenameDocumentCommand message) => message.DocumentId;
 
-    protected override Task<Result<Document>> GetByIdAsync(
-        Guid id,
-        CancellationToken cancellationToken) =>
+    protected override Task<Result<Document>> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
         repository.GetByIdAsync(id, cancellationToken);
 }
-```
 
-### Step 3: register resource authorization
-
-```csharp
-using Trellis.Mediator;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
-builder.Services.AddTrellisBehaviors();
-builder.Services.AddResourceAuthorization(
-    typeof(RenameDocumentCommand).Assembly,
-    typeof(RenameDocumentResourceLoader).Assembly);
-```
-
-Now the order for `RenameDocumentCommand` becomes:
-
-1. permission check
-2. resource load + `Authorize(actor, resource)`
-3. validation
-4. handler
-
-> [!TIP]
-> For AOT or trimming-sensitive apps, use explicit registration:
->
-> ```csharp
-> builder.Services.AddResourceAuthorization<RenameDocumentCommand, Document, Result<Document>>();
-> builder.Services.AddScoped<IResourceLoader<RenameDocumentCommand, Document>, RenameDocumentResourceLoader>();
-> ```
-
-## Writing handlers stays simple
-
-Once the pipeline owns authorization and validation, the handler can stay focused.
-
-```csharp
-using Mediator;
-using Trellis;
-
-public sealed class RenameDocumentHandler(IDocumentRepository repository)
-    : ICommandHandler<RenameDocumentCommand, Result<Document>>
+public static class Composition
 {
-    public async ValueTask<Result<Document>> Handle(
-        RenameDocumentCommand command,
-        CancellationToken cancellationToken)
+    public static void Configure(WebApplicationBuilder builder)
     {
-        var documentResult = await repository.GetByIdAsync(command.DocumentId, cancellationToken);
-        if (!documentResult.TryGetValue(out var document))
-            return Result.Fail<Document>(documentResult.Error!);
-
-        return await repository.RenameAsync(document, command.Title, cancellationToken);
+        builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
+        builder.Services.AddTrellisBehaviors();
+        builder.Services.AddResourceAuthorization(typeof(RenameDocumentCommand).Assembly);
     }
 }
 ```
 
-## Validation behavior details
+For the `RenameDocumentCommand` above, the per-request order becomes: permission check → resource load + `Authorize(actor, resource)` → validation → handler.
 
-Why call this out? Because `ValidationBehavior` is the single, unified validation stage. It runs for **every** message and pulls failures from two independent sources:
+### Shared resource loaders
 
-1. **`IValidate.Validate()`** on the message itself — for cross-cutting business invariants that are awkward to express as property rules (e.g., "the batch must be non-empty" or "no line may target the source account").
-2. **Every `IMessageValidator<TMessage>` registered in DI** — the extension seam used by `Trellis.FluentValidation` (and any other validator package) to plug into the same stage without occupying its own pipeline slot.
-
-### Aggregation rules
-
-- All `Error.UnprocessableContent` failures from both sources are merged into a single response whose `Fields` array contains every reported violation. The pipeline never returns "the first failure"; the caller always gets the full list in one round trip.
-- Any **non-UPC** failure (`Error.Conflict`, `Error.Forbidden`, …) returned by any validator short-circuits the stage immediately and is propagated as-is. No further validators are consulted. This lets `IValidate` express "this is not a field problem, this is a domain rule violation":
+When several commands authorize against the same resource, register one `SharedResourceLoaderById<TResource, TId>` and let messages declare `IIdentifyResource<TResource, TId>`. Assembly scanning auto-bridges them; explicit registration uses `AddSharedResourceLoader<,,>`.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Authorization;
+using Trellis.Mediator;
+
+public sealed record Order(Guid Id, string OwnerId);
+
+public interface IOrderRepository
+{
+    Task<Result<Order>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+}
+
+public sealed class OrderResourceLoader(IOrderRepository repository)
+    : SharedResourceLoaderById<Order, Guid>
+{
+    public override Task<Result<Order>> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        repository.GetByIdAsync(id, cancellationToken);
+}
+
+public sealed record CancelOrderCommand(Guid OrderId)
+    : ICommand<Result<Unit>>, IAuthorizeResource<Order>, IIdentifyResource<Order, Guid>
+{
+    public Guid GetResourceId() => OrderId;
+
+    public IResult Authorize(Actor actor, Order resource) =>
+        actor.IsOwner(resource.OwnerId)
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("orders.cancel") { Detail = "Only the owner can cancel this order." });
+}
+
+public static class Composition
+{
+    public static void Configure(WebApplicationBuilder builder)
+    {
+        builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
+        builder.Services.AddTrellisBehaviors();
+        builder.Services.AddScoped<SharedResourceLoaderById<Order, Guid>, OrderResourceLoader>();
+
+        // Explicit (AOT/trimming friendly):
+        builder.Services.AddResourceAuthorization<CancelOrderCommand, Order, Result<Unit>>();
+        builder.Services.AddSharedResourceLoader<CancelOrderCommand, Order, Guid>();
+
+        // Equivalent via assembly scan (not AOT-friendly):
+        // builder.Services.AddResourceAuthorization(typeof(CancelOrderCommand).Assembly);
+    }
+}
+```
+
+> [!TIP]
+> Explicit `IResourceLoader<TMessage, TResource>` registrations always win over the shared-loader bridge.
+
+## Validation
+
+`ValidationBehavior` runs for every message and pulls violations from two sources.
+
+| Source | Use it for |
+|---|---|
+| `IValidate.Validate()` on the message | Cross-field invariants and domain rules awkward to express as property checks. |
+| `IEnumerable<IMessageValidator<TMessage>>` from DI | Property-level validation, FluentValidation adapter, or any custom validator package. |
+
+**Aggregation rules**
+
+- All `Error.UnprocessableContent` failures from both sources are merged into a single `Error.UnprocessableContent` whose `Fields` and `Rules` collect every reported violation. The caller never gets "the first failure" — they get the full list in one round trip.
+- An `Error.UnprocessableContent` with empty `Fields` and empty `Rules` still short-circuits the handler.
+- A non-`Error.UnprocessableContent` failure (e.g., `Error.Conflict`, `Error.Forbidden`) returned by any source short-circuits the stage immediately and is propagated as-is.
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
 using Mediator;
 using Trellis;
 using Trellis.Mediator;
 
-public sealed record ArchiveDocumentCommand(Guid DocumentId, bool IsArchived)
+public sealed record ArchiveDocumentCommand(string DocumentId, bool IsArchived)
     : ICommand<Result<Unit>>, IValidate
 {
     public IResult Validate() =>
@@ -229,103 +282,198 @@ public sealed record ArchiveDocumentCommand(Guid DocumentId, bool IsArchived)
             ? Result.Ok()
             : Result.Fail(new Error.Conflict(null, "domain.violation") { Detail = "Only archived documents can be processed." });
 }
+
+public sealed class ArchiveDocumentHandler : ICommandHandler<ArchiveDocumentCommand, Result<Unit>>
+{
+    public ValueTask<Result<Unit>> Handle(ArchiveDocumentCommand command, CancellationToken cancellationToken) =>
+        ValueTask.FromResult(Result.Ok(Unit.Value));
+}
 ```
 
-### Plugging in FluentValidation
+### Custom `IMessageValidator<TMessage>`
 
-Add the optional `Trellis.FluentValidation` package and call `AddTrellisFluentValidation()` to make every `IValidator<TMessage>` registered for the message participate in the same validation stage:
+Implement `IMessageValidator<TMessage>` to plug an arbitrary async validator into the same stage as `IValidate`. Field-level violations should be wrapped in `Error.UnprocessableContent` so they aggregate with other validators' output.
 
 ```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Mediator;
+
+public sealed record CreateUserCommand(string Email)
+    : ICommand<Result<Unit>>;
+
+public interface IUserDirectory
+{
+    Task<bool> IsEmailTakenAsync(string email, CancellationToken cancellationToken);
+}
+
+public sealed class UniqueEmailValidator(IUserDirectory directory)
+    : IMessageValidator<CreateUserCommand>
+{
+    public async ValueTask<IResult> ValidateAsync(CreateUserCommand message, CancellationToken cancellationToken)
+    {
+        var taken = await directory.IsEmailTakenAsync(message.Email, cancellationToken).ConfigureAwait(false);
+        return taken
+            ? Result.Fail(new Error.UnprocessableContent(EquatableArray.Create(
+                new FieldViolation(InputPointer.ForProperty(nameof(message.Email)), "email.taken") { Detail = "Email already in use." })))
+            : Result.Ok();
+    }
+}
+
+public static class Composition
+{
+    public static void Register(IServiceCollection services) =>
+        services.AddScoped<IMessageValidator<CreateUserCommand>, UniqueEmailValidator>();
+}
+```
+
+### FluentValidation adapter
+
+Add the optional `Trellis.FluentValidation` package and call `AddTrellisFluentValidation()` to surface every registered `IValidator<TMessage>` through `IMessageValidator<TMessage>`. The adapter normalizes FluentValidation property paths (e.g., `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/Lines/0/Memo`) so `Error.UnprocessableContent.Fields` has a consistent pointer shape regardless of which source produced each violation.
+
+```csharp
+using System.Collections.Generic;
 using FluentValidation;
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
 
-builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
-builder.Services.AddTrellisBehaviors();
-builder.Services.AddTrellisFluentValidation();
-builder.Services.AddScoped<IValidator<SubmitBatchTransfersCommand>, SubmitBatchTransfersValidator>();
+public sealed record TransferLine(string TargetAccount, decimal Amount, string? Memo);
+
+public sealed record SubmitBatchTransfersCommand(string SourceAccount, IReadOnlyList<TransferLine> Lines)
+    : ICommand<Result<Unit>>;
+
+public sealed class SubmitBatchTransfersValidator : AbstractValidator<SubmitBatchTransfersCommand>
+{
+    public SubmitBatchTransfersValidator()
+    {
+        RuleFor(x => x.SourceAccount).NotEmpty();
+        RuleForEach(x => x.Lines).ChildRules(line =>
+        {
+            line.RuleFor(l => l.TargetAccount).NotEmpty();
+            line.RuleFor(l => l.Amount).GreaterThan(0);
+        });
+    }
+}
+
+public static class Composition
+{
+    public static void Configure(WebApplicationBuilder builder)
+    {
+        builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
+        builder.Services.AddTrellisBehaviors();
+        builder.Services.AddTrellisFluentValidation();
+        builder.Services.AddScoped<IValidator<SubmitBatchTransfersCommand>, SubmitBatchTransfersValidator>();
+    }
+}
 ```
 
-`AddTrellisFluentValidation()` registers an open-generic `FluentValidationMessageValidatorAdapter<>` as `IMessageValidator<>`. The adapter normalizes FluentValidation property names (e.g., `Metadata.Reference`, `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/Metadata/Reference`, `/Lines/0/Memo`) so the resulting `Error.UnprocessableContent.Fields` has consistent pointer shapes regardless of which validation source produced each violation.
+See [FluentValidation Integration](integration-fluentvalidation.md#mediator-integration) for the AOT vs. assembly-scanning registration overloads.
 
-See [FluentValidation Integration](integration-fluentvalidation.md#mediator-integration-addtrellisfluentvalidation) for the full Mediator-pipeline section, including the AOT vs. assembly-scanning overloads.
+## Exception safety net
 
-## Exception behavior details
+`ExceptionBehavior` is the outermost behavior. It:
 
-`ExceptionBehavior` is a safety net, not a design goal.
+- Catches every unhandled exception **except** `OperationCanceledException` (which propagates so cancellation flows correctly).
+- Logs the exception, then returns `TResponse.CreateFailure(new Error.InternalServerError(Guid.NewGuid().ToString("N")) { Detail = "An unexpected error occurred while processing the request." })`.
 
-- unexpected exception → logged, then returned as `new Error.InternalServerError("fault-id") { Detail = ... }`
-- `OperationCanceledException` → **not** swallowed; it flows through normally
+The generated `"N"`-format Guid is the fault correlation id surfaced in `Error.Code` so operators can join the failed response to the logged stack trace.
 
 > [!WARNING]
-> Do not use exceptions for expected business outcomes. Return `Result<T>` failures instead and let `ExceptionBehavior` handle only true surprises.
+> Don't use exceptions for expected business outcomes — return `Result<T>` failures instead and let `ExceptionBehavior` handle only true surprises.
 
-## Full application setup
+## Telemetry
+
+`TracingBehavior` opens an `Activity` per message under the activity source `"Trellis.Mediator"` (also exposed as the constant `TracingBehavior<,>.ActivitySourceName`). Add it to your OpenTelemetry tracing config or you will get no spans:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+builder.Services.AddOpenTelemetry().WithTracing(tracing =>
+    tracing.AddSource("Trellis.Mediator"));
+```
+
+On a failed result, both `LoggingBehavior` and `TracingBehavior` always emit:
+
+- `Error.Code` (operator-defined identifier, e.g., `"orders.cancel"`).
+- The stable `Error` type name (e.g., `Error.Forbidden`) on the activity as `error.type`.
+
+`LoggingBehavior` writes Information on success and Warning on failure; `TracingBehavior` sets `ActivityStatusCode.Error` on the failure path.
+
+### Telemetry redaction
+
+The free-text `Error.Detail` string is **redacted by default** because it is frequently composed from user input or domain payloads (an order id, an email, a free-text validation message) and must not flow into log aggregators or distributed traces without explicit opt-in.
+
+To opt in (typically development only, or environments verified PII-free):
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Mediator;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
+builder.Services.AddTrellisBehaviors(options => options.IncludeErrorDetail = true);
+```
+
+The `error.code` tag and the `Error.Code` value are operator-defined identifiers and are always emitted regardless of this setting.
+
+## Composition
+
+Resource authorization, FluentValidation, and the EF Core unit-of-work behavior compose into one pipeline. Register Trellis behaviors first, then any extension validators, then the actor provider, and finally `AddTrellisUnitOfWork<TContext>()` so the transactional behavior lands innermost (closest to the handler) and commit failures stay visible to outer logging/tracing.
+
+```csharp
+using Mediator;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Trellis.Asp.Authorization;
+using Trellis.EntityFrameworkCore;
+using Trellis.FluentValidation;
 using Trellis.Mediator;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
 builder.Services.AddTrellisBehaviors();
+builder.Services.AddTrellisFluentValidation();
 builder.Services.AddResourceAuthorization(typeof(Program).Assembly);
 
 if (builder.Environment.IsDevelopment())
     builder.Services.AddDevelopmentActorProvider();
 else
     builder.Services.AddEntraActorProvider();
+
+builder.Services.AddTrellisUnitOfWork<AppDbContext>();
+
+var app = builder.Build();
+app.Run();
 ```
 
 ## Practical guidance
 
-### Keep permission checks coarse, resource checks precise
+- **Use the `Scoped` Mediator lifetime.** All Trellis behaviors depend on per-request services; `Singleton` (the Mediator default) fails the root-scope check on first request.
+- **`IAuthorize` for coarse gates, `IAuthorizeResource<T>` for fine rules.** Static permissions (`documents:edit`) belong on `IAuthorize`; ownership / tenancy / state rules belong on `IAuthorizeResource<T>`.
+- **Prefer shared resource loaders.** Register one `SharedResourceLoaderById<TResource, TId>` per resource and let messages implement `IIdentifyResource<,>` — avoids one loader class per command.
+- **Don't forget `AddResourceAuthorization(...)`.** Implementing `IAuthorizeResource<T>` is not enough; the behavior must be registered or it never runs.
+- **Keep `IValidate.Validate()` synchronous and cheap.** It runs on every request. Push I/O-bound checks into an `IMessageValidator<TMessage>` (which is async) or into the handler.
+- **Return `Result<Unit>` from commands** (not bare `Result`), and never throw for expected business outcomes — `ExceptionBehavior` is for surprises only.
+- **Leave `IncludeErrorDetail = false` in production.** `Error.Detail` is free text and may contain PII.
+- **Add the `"Trellis.Mediator"` activity source** to your OpenTelemetry config or you will not see mediator spans.
 
-Use `IAuthorize` for broad gates like `Documents.Edit`. Use `IAuthorizeResource<T>` for ownership, tenancy, or state-specific rules.
+## Cross-references
 
-### Register resource authorization intentionally
-
-If you forget `AddResourceAuthorization(...)`, the resource authorization behavior will not run.
-
-### Keep `Validate()` fast
-
-`IValidate.Validate()` is synchronous. Use it for cheap checks. Put I/O-heavy validation in handlers or separate validators.
-
-### Trace source name
-
-`TracingBehavior` uses the activity source name:
-
-- `Trellis.Mediator`
-
-That is the source to add to your OpenTelemetry configuration when you want mediator spans.
-
-### Redacting `Error.Detail` in logs and traces
-
-Both `LoggingBehavior` and `TracingBehavior` emit the **stable** error identity for failed responses:
-
-- `LoggingBehavior` includes `error.Code` in the Warning-level "Handled" message
-- `TracingBehavior` tags the activity with `error.code` and `error.type` and sets `ActivityStatusCode.Error`
-
-The free-text `Error.Detail` string is **redacted by default** — it is frequently composed from user input or domain payloads (an order id, an email address, a free-text validation message) and must not flow into log aggregators or distributed traces without explicit opt-in.
-
-To opt in (e.g. in development, or in environments where you have verified no PII can flow through any `Error.Detail`):
-
-```csharp
-builder.Services.AddTrellisBehaviors(opts => opts.IncludeErrorDetail = true);
-```
-
-Or mutate the singleton directly after registration:
-
-```csharp
-builder.Services.AddTrellisBehaviors();
-builder.Services.AddSingleton(new TrellisMediatorTelemetryOptions { IncludeErrorDetail = true });
-```
-
-The `error.code` tag and the `Error.Code` value are operator-defined identifiers and are always emitted regardless of this setting.
-
-## Next steps
-
-- [Observability & Monitoring](integration-observability.md)
-- [Testing](integration-testing.md)
-- [trellis-api-mediator.md](../api_reference/trellis-api-mediator.md)
+- API surface: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- `Result<T>`, `Maybe<T>`, `Error` semantics: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Authorization primitives (`Actor`, `IAuthorize`, `IAuthorizeResource`, loaders): [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- FluentValidation integration article: [integration-fluentvalidation.md](integration-fluentvalidation.md)
+- ASP.NET integration (`IActorProvider` wiring): [integration-asp-authorization.md](integration-asp-authorization.md)
+- Observability article: [integration-observability.md](integration-observability.md)

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -1,216 +1,292 @@
-# Observability & Monitoring
+﻿---
+title: Observability And Monitoring
+package: Trellis.ServiceDefaults
+topics: [observability, opentelemetry, tracing, logging, redaction, mediator, primitives]
+related_api_reference: [trellis-api-servicedefaults.md, trellis-api-mediator.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Observability and Monitoring
 
-**Level:** Intermediate 📘 | **Time:** 15-20 min | **Prerequisites:** [Basics](basics.md)
+Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `ActivitySource`s — `Trellis.Mediator`, `Trellis.Primitives`, and `Trellis.Core` — wired through the canonical `AddTrellis(...)` composition root.
 
-Observability matters most when something fails between layers: an HTTP call returns a conflict, a mediator command fails authorization, or a value object rejects input. Trellis exposes tracing hooks for exactly those boundaries.
+## Patterns Index
+
+| Goal | Use | See |
+|---|---|---|
+| Wire mediator tracing + logging via the composition root | `services.AddTrellis(o => o.UseMediator())` | [Default registration](#default-registration) |
+| Subscribe an OTel `TracerProvider` to mediator spans | `tracing.AddSource("Trellis.Mediator")` | [Tracing](#tracing) |
+| Subscribe to value-object spans (validation/parsing) | `tracing.AddPrimitiveValueObjectInstrumentation()` | [Tracing](#tracing) |
+| Subscribe to ROP spans (deep `Bind` / `Map` debugging) | `tracing.AddResultsInstrumentation()` | [Tracing](#tracing) |
+| Read structured per-message logs with elapsed-ms outcomes | Built in via `LoggingBehavior<,>` | [Logging](#logging) |
+| Allow `Error.Detail` into telemetry (non-PII environments only) | `o.UseMediator(t => t.IncludeErrorDetail = true)` | [Redaction](#redaction) |
+| Add business tags to the mediator span from a handler | `Activity.Current?.SetTag(...)` | [Custom enrichment](#custom-enrichment) |
+| Get HTTP / DB / runtime metrics | Standard OTel instrumentation packages | [Metrics](#metrics) |
+
+## Use this guide when
+
+- You are wiring observability into a Trellis composition root and want the same span/log surface as `AddTrellisBehaviors()` produces.
+- You need to know exactly which tags `TracingBehavior<,>` writes on success vs. failure, and what `LoggingBehavior<,>` emits.
+- You are deciding which `ActivitySource`s to subscribe to — and which to leave off because they are noisy.
+- You need to confirm that `Error.Detail` is redacted by default and how to opt in.
+
+## Surface at a glance
+
+| Surface | Type / API | Emits | Subscribed via |
+|---|---|---|---|
+| Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddSource(TracingBehavior<,>.ActivitySourceName)` (value: `"Trellis.Mediator"`) |
+| Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Information` start, `Information` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider |
+| Redaction | `TrellisMediatorTelemetryOptions` (`Trellis.Mediator`) | Controls whether `Error.Detail` flows into the activity status description and log message | DI singleton, configured via `o.UseMediator(t => ...)` or `AddTrellisBehaviors(t => ...)` |
+| Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | One `Activity` per `TryCreate` / `Parse` on a `Required*<TSelf>` value object | `tracing.AddPrimitiveValueObjectInstrumentation()` |
+| Result / ROP tracing | `Trellis.Core` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddResultsInstrumentation()` |
+| Composition root | `TrellisServiceBuilder.UseMediator(Action<TrellisMediatorTelemetryOptions>?)` | Registers the five canonical behaviors and the telemetry options | `services.AddTrellis(o => o.UseMediator(...))` |
+
+Full signatures: [`trellis-api-servicedefaults.md`](../api_reference/trellis-api-servicedefaults.md), [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md), [`trellis-api-core.md`](../api_reference/trellis-api-core.md).
 
 ## Installation
 
 ```bash
-dotnet add package OpenTelemetry
+dotnet add package Trellis.ServiceDefaults
 dotnet add package OpenTelemetry.Extensions.Hosting
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
 ```
 
-## The short version
+`Trellis.Core` already references the OpenTelemetry SDK so `AddResultsInstrumentation()` and `AddPrimitiveValueObjectInstrumentation()` work without extra packages. The exporter and ASP.NET Core / HTTP instrumentation packages above are standard OTel — Trellis does not wrap them.
 
-Trellis can emit spans from three useful places:
+## Quick start
 
-| Source | Activity source name | Best use |
-| --- | --- | --- |
-| Mediator pipeline | `Trellis.Mediator` | command/query tracing |
-| Primitive value objects | `Trellis.Primitives` | validation and parsing boundaries |
-| Result operations | `Trellis.Core` | deep ROP debugging |
-
-```mermaid
-flowchart LR
-    A[ASP.NET Core request] --> B[Trellis.Mediator]
-    B --> C[Your ActivitySource]
-    C --> D[Trellis.Primitives]
-    C --> E[Trellis.Http / other dependencies]
-    D --> F[OpenTelemetry exporter]
-    E --> F
-    B --> F
-```
-
-## Start with the low-noise option
-
-For most apps, the best first step is:
-
-- add the mediator source
-- add primitive value object instrumentation
-- keep full result instrumentation off until you need deep debugging
+Register Trellis (which wires `TracingBehavior<,>` and `LoggingBehavior<,>` into the mediator pipeline) and subscribe an OpenTelemetry `TracerProvider` to the mediator activity source.
 
 ```csharp
+using Mediator;
+using OpenTelemetry.Trace;
 using Trellis;
+using Trellis.Mediator;
+using Trellis.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMediator();
+builder.Services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator());
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
-        .AddSource("Trellis.Mediator")
+        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
+        .AddPrimitiveValueObjectInstrumentation()
+        .AddOtlpExporter());
+
+var app = builder.Build();
+app.Run();
+
+public sealed record CreateOrder(string CustomerId, decimal Total) : ICommand<Result<Unit>>;
+
+public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Result<Unit>>
+{
+    public ValueTask<Result<Unit>> Handle(CreateOrder command, CancellationToken cancellationToken)
+        => ValueTask.FromResult(Result.Ok());
+}
+```
+
+Every dispatch of `CreateOrder` now produces:
+
+- one `Activity` named `"CreateOrder"` under source `"Trellis.Mediator"`, and
+- two structured log entries (`Handling CreateOrder`, `Handled CreateOrder in N.NNms`).
+
+## Default registration
+
+`AddTrellis(o => o.UseMediator())` is the canonical entry point. It calls `AddTrellisBehaviors()` and is **idempotent** — `UseFluentValidation`, `UseResourceAuthorization`, and `UseEntityFrameworkUnitOfWork<TContext>` all imply `UseMediator`, so repeating the call cannot duplicate registrations.
+
+| Wiring step | What it adds |
+|---|---|
+| `o.UseMediator()` | Registers `ExceptionBehavior<,>`, `TracingBehavior<,>`, `LoggingBehavior<,>`, `AuthorizationBehavior<,>`, `ValidationBehavior<,>` and a default `TrellisMediatorTelemetryOptions` (Detail redacted). |
+| `o.UseMediator(t => t.IncludeErrorDetail = true)` | Same, but replaces the options singleton so `Error.Detail` flows into telemetry. |
+
+Pipeline order (outermost → innermost) is: Exception → Tracing → Logging → Authorization → (ResourceAuthorization, opt-in) → Validation → (Transactional, opt-in via `UseEntityFrameworkUnitOfWork<TContext>`). Every inner behavior runs *inside* the `Trellis.Mediator` activity, so its logs and child spans inherit the same trace and span correlation IDs. See [`trellis-api-mediator.md` → Canonical pipeline order](../api_reference/trellis-api-mediator.md#canonical-pipeline-order).
+
+## Tracing
+
+Trellis ships three independent `ActivitySource`s. Subscribe to each on its own merits.
+
+| Source | Constant | Volume | When to subscribe |
+|---|---|---|---|
+| `"Trellis.Mediator"` | `TracingBehavior<,>.ActivitySourceName` | One span per mediator message | Always — this is the primary failure-localisation surface. |
+| `"Trellis.Primitives"` | (internal — use `AddPrimitiveValueObjectInstrumentation()`) | One span per `TryCreate` / `Parse` on a `Required*<TSelf>` value object | When you need to see *why* input validation rejected a request at the edge. |
+| `"Trellis.Core"` | `RopTrace.ActivitySourceName` (= `"Trellis.Core"`) | One span per individual `Result` operation (`Bind`, `Map`, `Tap`, …) | Only for break-glass diagnostics — high cardinality, high volume. |
+
+`TracingBehavior<,>` writes the following on every dispatched message:
+
+| Outcome | Activity status | Tags written |
+|---|---|---|
+| Handler returns success | `ActivityStatusCode.Ok` | (none) |
+| Handler returns `Result.Fail(error)` | `ActivityStatusCode.Error` | `error.code` = `error.Code`; `error.type` = stable error class name (e.g. `Error.NotFound`); `StatusDescription` left empty unless `IncludeErrorDetail = true` |
+| Handler throws | `ActivityStatusCode.Error` | `error.type` = exception type name; the exception is **rethrown**; the exception message is **not** copied into telemetry |
+
+```csharp
+using Mediator;
+using OpenTelemetry.Trace;
+using Trellis.Mediator;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
         .AddPrimitiveValueObjectInstrumentation()
         .AddOtlpExporter());
 ```
 
-> [!TIP]
-> `AddPrimitiveValueObjectInstrumentation()` is often the best default because it shows where input validation succeeds or fails without tracing every `Bind`, `Map`, and `Tap`.
-
-## When to enable `AddResultsInstrumentation()`
-
-`AddResultsInstrumentation()` traces Railway-Oriented Programming operations from `Trellis.Core`.
-
-That is powerful, but noisy.
+To enable ROP forensics during an investigation, add `.AddResultsInstrumentation()` on top — and remove it again when the investigation is over.
 
 ```csharp
-using Trellis;
-
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .AddSource("Trellis.Mediator")
+        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
         .AddPrimitiveValueObjectInstrumentation()
         .AddResultsInstrumentation()
         .AddConsoleExporter());
 ```
 
-Use it when you need to answer questions like:
+> [!WARNING]
+> `AddResultsInstrumentation()` is a debugging tool. It traces every `Bind`, `Map`, and `Tap` and can flood your collector. Keep it off in production unless you have an active incident.
 
-- which `Bind` step failed?
-- where did a result switch from success to failure?
-- which branch in a long workflow produced the error?
+## Logging
+
+`LoggingBehavior<,>` is registered alongside `TracingBehavior<,>` and uses source-generated `LoggerMessage` methods — no allocation on the hot path. It emits exactly three messages per dispatch:
+
+| Stage | Level | Template |
+|---|---|---|
+| Entry | `Information` | `Handling {MessageName}` |
+| Success exit | `Information` | `Handled {MessageName} in {ElapsedMs:0.00}ms` |
+| Failure exit | `Warning` | `Handled {MessageName} in {ElapsedMs:0.00}ms — Failed: {ErrorSummary}` |
+
+`{MessageName}` is `typeof(TMessage).Name`. `{ErrorSummary}` is `error.Code` by default; it becomes `error.GetDisplayMessage()` (which includes `Error.Detail`) only when `IncludeErrorDetail = true`. Because the log entries are written inside the mediator activity, every entry already carries the trace/span IDs propagated by your logging provider's OTel integration.
+
+```csharp
+builder.Logging.AddOpenTelemetry(o =>
+{
+    o.IncludeFormattedMessage = true;
+    o.IncludeScopes = true;
+    o.AddOtlpExporter();
+});
+```
+
+## Redaction
+
+`TrellisMediatorTelemetryOptions.IncludeErrorDetail` is the single redaction switch. It defaults to `false`. Both `TracingBehavior<,>` and `LoggingBehavior<,>` consume it.
+
+| Setting | `error.Code` | `error.type` | `Error.Detail` |
+|---|---|---|---|
+| `IncludeErrorDetail = false` (default) | Emitted | Emitted | Redacted from `Activity.StatusDescription` and from log messages |
+| `IncludeErrorDetail = true` | Emitted | Emitted | Included in `Activity.StatusDescription` and the failure log message |
+
+Configure via the composition root:
+
+```csharp
+services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator(telemetry => telemetry.IncludeErrorDetail = builder.Environment.IsDevelopment()));
+```
+
+Or directly when not using `AddTrellis(...)`:
+
+```csharp
+services.AddTrellisBehaviors(telemetry => telemetry.IncludeErrorDetail = false);
+```
 
 > [!WARNING]
-> `AddResultsInstrumentation()` is a debugging tool, not a default production recommendation. It can create a lot of spans.
+> `Error.Detail` is the only Trellis-emitted field that may carry user input or domain payloads (an order id, an email address, a free-text validation message). `Error.Code` and the stable error type name are operator-defined identifiers and remain PII-free regardless of this setting.
 
-## What mediator tracing gives you
+## Metrics
 
-If you use `AddTrellisBehaviors()`, `TracingBehavior` creates an activity for every mediator message.
+Trellis does not register an OpenTelemetry `Meter` and emits no framework counters or histograms. Use the standard OpenTelemetry instrumentation packages for runtime, ASP.NET Core, and HTTP-client metrics:
 
-On success:
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddRuntimeInstrumentation()
+        .AddOtlpExporter());
+```
 
-- status → `Ok`
+For per-message latency dashboards, derive metrics from the mediator activity (`Trellis.Mediator`) or from the `Handled {MessageName} in {ElapsedMs:0.00}ms` log entries — both already carry the elapsed time.
 
-On failure:
+## Custom enrichment
 
-- status → `Error`
-- tag `error.type`
-- tag `error.code`
-
-That makes failed command/query execution easy to spot in any OpenTelemetry backend.
-
-## Manual business instrumentation still matters
-
-Framework spans tell you **where** something failed. Your own spans explain **what the business operation was doing**.
+`TracingBehavior<,>` opens its activity *before* the inner behaviors run, so any code inside the handler (or in inner behaviors) can tag the same activity through `Activity.Current`.
 
 ```csharp
 using System.Diagnostics;
-using System.Net.Http.Json;
-using System.Text.Json.Serialization;
+using Mediator;
 using Trellis;
-using Trellis.Http;
 
-[JsonSerializable(typeof(CreateOrderRequest))]
-[JsonSerializable(typeof(OrderReceiptDto))]
-internal partial class OrdersJsonContext : JsonSerializerContext
+public sealed record SubmitInvoice(string CustomerId, decimal Amount) : ICommand<Result<Unit>>;
+
+public sealed class SubmitInvoiceHandler : ICommandHandler<SubmitInvoice, Result<Unit>>
 {
-}
-
-public sealed record CreateOrderRequest(string CustomerId, decimal Amount);
-public sealed record OrderReceiptDto(string OrderId, decimal Amount);
-
-public sealed class CheckoutClient(HttpClient httpClient)
-{
-    private static readonly ActivitySource ActivitySource = new("Acme.Checkout");
-
-    public async Task<Result<OrderReceiptDto>> SubmitAsync(
-        CreateOrderRequest request,
-        CancellationToken cancellationToken)
+    public ValueTask<Result<Unit>> Handle(SubmitInvoice command, CancellationToken cancellationToken)
     {
-        using var activity = ActivitySource.StartActivity("Checkout.Submit");
-        activity?.SetTag("order.customer_id", request.CustomerId);
-        activity?.SetTag("order.amount", request.Amount);
+        Activity.Current?.SetTag("invoice.customer_id", command.CustomerId);
+        Activity.Current?.SetTag("invoice.amount", command.Amount);
 
-        var result = await httpClient.PostAsJsonAsync(
-                "orders",
-                request,
-                OrdersJsonContext.Default.CreateOrderRequest,
-                cancellationToken)
-            .HandleConflictAsync(new Error.Conflict(null, "conflict") { Detail = "An order with the same data already exists." })
-            .ReadJsonAsync(OrdersJsonContext.Default.OrderReceiptDto, cancellationToken);
-
-        if (result.IsFailure)
-        {
-            activity?.SetStatus(ActivityStatusCode.Error, result.Error.Detail);
-            activity?.SetTag("error.code", result.Error.Code);
-            activity?.SetTag("error.type", result.Error.GetType().Name);
-        }
-        else
-        {
-            activity?.SetStatus(ActivityStatusCode.Ok);
-        }
-
-        return result;
+        return ValueTask.FromResult(Result.Ok());
     }
 }
 ```
 
-## Why error codes matter in traces
+For broader cross-cutting enrichment (every span, not just mediator messages), use a standard OpenTelemetry `BaseProcessor<Activity>` registered on the `TracerProviderBuilder` — Trellis does not provide a wrapper because the OTel SDK already does.
 
-Trellis errors carry machine-readable codes such as:
+## Composition
 
-- `validation.error`
-- `not.found.error`
-- `forbidden.error`
-
-Those codes are better than free-form log messages when you want dashboards, alerts, or grouped failure analysis.
-
-## Suggested production setup
-
-If you are sending data to a real collector, add sampling and keep the sources intentional.
+The mediator activity is the natural parent for any spans your business code opens around the same operation. Open a child `ActivitySource` from your application, and it will be correlated with the `Trellis.Mediator` activity (and any ASP.NET Core request span above it) automatically.
 
 ```csharp
-using OpenTelemetry.Trace;
+using System.Diagnostics;
+using Mediator;
 using Trellis;
 
-builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing => tracing
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .AddSource("Trellis.Mediator")
-        .AddPrimitiveValueObjectInstrumentation()
-        .SetSampler(new TraceIdRatioBasedSampler(0.1))
-        .AddOtlpExporter());
+public sealed record SettleBatch(string BatchId) : ICommand<Result<Unit>>;
+
+public sealed class SettleBatchHandler : ICommandHandler<SettleBatch, Result<Unit>>
+{
+    private static readonly ActivitySource Source = new("Acme.Billing");
+
+    public ValueTask<Result<Unit>> Handle(SettleBatch command, CancellationToken cancellationToken)
+    {
+        using var activity = Source.StartActivity("Billing.SettleBatch");
+        activity?.SetTag("batch.id", command.BatchId);
+
+        return ValueTask.FromResult(Result.Ok());
+    }
+}
+```
+
+Subscribe to the new source the same way:
+
+```csharp
+tracing.AddSource("Acme.Billing");
 ```
 
 ## Practical guidance
 
-### Prefer signal over volume
+- **Subscribe to `Trellis.Mediator` always.** It is one span per message and is the cheapest lever for failure localisation.
+- **Add `AddPrimitiveValueObjectInstrumentation()` early.** Validation traces are the clearest signal for "why is this request being rejected at the edge?".
+- **Treat `AddResultsInstrumentation()` as break-glass.** Turn it on for an incident, turn it off afterwards.
+- **Keep `IncludeErrorDetail = false` in production.** Code + type are sufficient for dashboards and alerts; flip it on per-environment only when you have audited every `Error.Detail` write site.
+- **Sample at the collector or via OTel.** Trellis does not sample. Set `SetSampler(new TraceIdRatioBasedSampler(0.1))` on the `TracerProvider` if you need to throttle.
+- **Use `error.code` for grouping.** It is stable across releases (e.g. `validation.error`, `not.found.error`, `forbidden.error`) and far better than free-form messages.
 
-If every `Result` operation is traced, the interesting span can get buried. Start small.
+## Cross-references
 
-### Use business spans for expensive workflows
-
-Examples:
-
-- checkout
-- invoice generation
-- approval workflows
-- cross-service orchestration
-
-### Use primitive traces to understand bad inputs
-
-If you want to know why requests are failing validation at the edge, `Trellis.Primitives` is usually the clearest signal.
-
-### Use result tracing only when needed
-
-Turn on `AddResultsInstrumentation()` when debugging a complicated pipeline, then turn it back down.
-
-## Next steps
-
-- [Mediator Pipeline](integration-mediator.md)
-- [HTTP Integration](integration-http.md)
-- [Testing](integration-testing.md)
+- Composition-root API: [`trellis-api-servicedefaults.md`](../api_reference/trellis-api-servicedefaults.md)
+- Mediator behaviors, redaction options, pipeline order: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- ROP `ActivitySource` and `AddResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Primitive value-object instrumentation: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- Mediator integration article: [`integration-mediator.md`](integration-mediator.md)
+- HTTP-client integration article: [`integration-http.md`](integration-http.md)

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -1,5 +1,5 @@
 ﻿---
-title: Observability And Monitoring
+title: Observability and Monitoring
 package: Trellis.ServiceDefaults
 topics: [observability, opentelemetry, tracing, logging, redaction, mediator, primitives]
 related_api_reference: [trellis-api-servicedefaults.md, trellis-api-mediator.md, trellis-api-core.md]

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -1,718 +1,512 @@
-# Setting Up Single Sign-On (SSO)
+﻿---
+title: Single Sign-On Integration
+package: Trellis.Asp
+topics: [sso, entra, openid, jwt, claims, actor, multi-tenant]
+related_api_reference: [trellis-api-asp.md, trellis-api-authorization.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Single Sign-On Integration
 
-**Level:** Intermediate | **Time:** 30-45 min | **Prerequisites:** [ASP.NET Core Authorization](integration-asp-authorization.md), [Testing with Entra ID Tokens](integration-entra-testing.md)
+`Trellis.Asp.Authorization` (shipped inside the `Trellis.Asp` package) turns an authenticated `JwtBearer` principal from any OIDC issuer (Entra ID, Auth0, Okta, Google, Keycloak) into a frozen `Actor` so handlers and endpoints stop parsing JWTs.
 
-By the end of this guide, your API will authenticate users via SSO and map their identity to Trellis's `Actor` model.
+## Patterns Index
 
-This guide starts from the Trellis ASP template:
+| Goal | Use | See |
+|---|---|---|
+| Validate Entra ID v2.0 tokens and project them onto an `Actor` | `AddJwtBearer` + `AddEntraActorProvider(options?)` | [Entra ID provider](#entra-id-provider) |
+| Validate any flat-claim OIDC token (Auth0, Okta, Google) | `AddJwtBearer` + `AddClaimsActorProvider(options?)` | [Generic OIDC provider](#generic-oidc-provider) |
+| Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddCachingActorProvider<T>()` | [Nested-claim providers](#nested-claim-providers) |
+| Use `roles` for app permissions (Entra app roles) | Default `EntraActorOptions.MapPermissions` | [Claim mapping](#claim-mapping) |
+| Use delegated scopes (`scp`) for permissions | Override `EntraActorOptions.MapPermissions` | [Scope and permission extraction](#scope-and-permission-extraction) |
+| Accept multi-tenant Entra tokens and pin allowed tenants | `JwtBearerOptions.TokenValidationParameters` + read `ActorAttributes.TenantId` | [Multi-tenant Entra](#multi-tenant-entra) |
+| Use a fake actor in Development without a real IdP | `AddDevelopmentActorProvider(options?)` + `X-Test-Actor` header | [Development defaults](#development-defaults) |
+| Combine SSO with Trellis authorization rules | `IAuthorize` / `IAuthorizeResource<T>` via Mediator | [Composition](#composition) |
 
-```bash
-dotnet new trellis-asp
-```
+## Use this guide when
 
-It is written for startup teams and indie developers who want a practical path to:
+- You front a Trellis service with `JwtBearer` and need a single, predictable `Actor` shape regardless of which OIDC provider issued the token.
+- You want one configuration story for Entra (app roles), Auth0/Okta (delegated scopes), Google (sign-in only), and Keycloak (nested role claims).
+- You need a Development-only seam (`X-Test-Actor`) that fail-closes outside `IsDevelopment()`.
+- You need to host a multi-tenant Entra app and pin which tenants may call your API.
 
-1. sign users in with a major identity provider
-2. validate tokens in the API
-3. translate claims into a Trellis `Actor`
-4. protect endpoints with `[Authorize]` and Trellis authorization
+## Surface at a glance
 
-## What You'll Build
+`Trellis.Asp.Authorization` (namespace inside the `Trellis.Asp` package) exposes one set of DI extensions and four `IActorProvider` implementations.
 
-You will wire an external identity provider into the Trellis ASP template so your API can:
+| API | Kind | Purpose |
+|---|---|---|
+| `AddEntraActorProvider(this IServiceCollection, Action<EntraActorOptions>?)` | DI extension | Scoped `IActorProvider` → `EntraActorProvider` (Entra v2.0 claim shape). |
+| `AddClaimsActorProvider(this IServiceCollection, Action<ClaimsActorOptions>?)` | DI extension | Scoped `IActorProvider` → `ClaimsActorProvider` (configurable flat-claim mapping). |
+| `AddDevelopmentActorProvider(this IServiceCollection, Action<DevelopmentActorOptions>?)` | DI extension | Scoped `IActorProvider` → `DevelopmentActorProvider`; reads `X-Test-Actor` JSON header; throws outside `IsDevelopment()`. |
+| `AddCachingActorProvider<T>(this IServiceCollection)` where `T : class, IActorProvider` | DI extension | Wraps `T` in `CachingActorProvider` so a single resolution task is shared per request. |
+| `EntraActorOptions` | Options | `IdClaimType`, `MapPermissions`, `MapForbiddenPermissions`, `MapAttributes`. |
+| `ClaimsActorOptions` | Options | `ActorIdClaim` (default `"sub"`), `PermissionsClaim` (default `"permissions"`). Verbatim claim-type match. |
+| `DevelopmentActorOptions` | Options | `DefaultActorId`, `DefaultPermissions`, `ThrowOnMalformedHeader`. |
+| `ActorAttributes` (in `Trellis.Authorization`) | Constants | Well-known attribute keys: `TenantId`, `PreferredUsername`, `AuthorizedParty`, `AuthorizedPartyAcr`, `AuthContextClassReference`, `IpAddress`, `MfaAuthenticated`. |
 
-1. accept a bearer token
-2. validate that token
-3. create an `Actor` from the authenticated user
-4. authorize requests using Trellis permissions and attributes
+Full signatures: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md).
 
-```mermaid
-flowchart LR
-    Browser[Browser or mobile app]
-    Idp[Entra ID / Google / OIDC provider]
-    Token[JWT or ID token]
-    Api[ASP.NET Core API]
-    Provider[EntraActorProvider or ClaimsActorProvider]
-    Actor[Actor]
-    Authz[Authorize attribute / IAuthorize]
-
-    Browser --> Idp
-    Idp --> Token
-    Token --> Api
-    Api --> Provider
-    Provider --> Actor
-    Actor --> Authz
-```
-
-Trellis authorization revolves around `Actor`, which contains:
-
-- `Id`
-- `Permissions`
-- `ForbiddenPermissions`
-- `Attributes`
-
-Scoped permissions use `Actor.PermissionScopeSeparator`, which is `':'`. A scoped permission looks like `todos:read:tenant-123` only if **you** choose that naming scheme; Trellis itself only guarantees the separator character.
-
-> [!TIP]
-> Read [ASP.NET Core Authorization](integration-asp-authorization.md) first if you want the full mental model behind `Actor`, `IActorProvider`, and `IAuthorize`.
-
-## Prerequisites
-
-Before you start, make sure you have:
-
-1. **.NET installed** and the Trellis template available:
-   ```bash
-   dotnet new trellis-asp
-   ```
-2. **A running template project**:
-   ```bash
-   dotnet run --project .\Api\src\Api.csproj
-   ```
-3. **An identity provider account**:
-   - Microsoft Entra admin access for Part 1
-   - Google Cloud Console access for Part 2
-   - Okta/Auth0/Keycloak or another OIDC issuer for Part 3
-4. **A frontend or API client** that can obtain tokens
-   - browser SPA
-   - Postman
-   - curl plus a token copied from your frontend
-5. **A clear local callback URL** for your frontend, such as:
-   - `http://localhost:3000/auth/callback`
-   - `http://localhost:5173/auth/callback`
-
-> [!WARNING]
-> The Trellis ASP template ships with `DevelopmentActorProvider` for Development only. It throws outside Development. Keep it for fast local testing, but do not expect real SSO to work until you run the app in a non-Development environment.
-
-## Part 1: Microsoft Entra ID (Azure AD)
-
-This is the simplest production path because Trellis already includes `AddEntraActorProvider()`, and `EntraActorProvider` understands common Entra claims out of the box.
-
-### Step 1: Register Your App in Azure Portal
-
-1. Open **Azure Portal**.
-2. Go to **Microsoft Entra ID** -> **App registrations** -> **New registration**.
-3. Name the app something like `TodoSample.Api`.
-4. Choose the account type that matches your product:
-   - **Single tenant** for internal company apps
-   - **Multitenant** for SaaS apps used by many organizations
-5. Click **Register**.
-6. Copy these values:
-   - **Directory (tenant) ID**
-   - **Application (client) ID**
-7. If you have a browser frontend, add its redirect URI under **Authentication**.
-8. If you want Trellis permissions from Entra roles, create **App roles** such as:
-   - `todos:read`
-   - `todos:create`
-   - `todos:update`
-   - `todos:delete`
-9. Assign those roles to users or groups through **Enterprise applications** -> your app -> **Users and groups**.
-
-**Screenshot target:** You should be looking at **Entra ID -> App registrations -> Your app -> Overview**, then **Authentication**, then **App roles**.
-
-> [!WARNING]
-> If you forget the frontend redirect URI, sign-in succeeds at Entra but the browser never gets back to your app.
-
-### Step 2: Configure `appsettings.json`
-
-In `Api\src\appsettings.json`, add an `Authentication` section:
-
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*",
-  "Authentication": {
-    "Authority": "https://login.microsoftonline.com/<tenant-id>/v2.0",
-    "Audience": "<api-client-id>"
-  }
-}
-```
-
-Replace:
-
-1. `<tenant-id>` with the Entra tenant ID
-2. `<api-client-id>` with the app registration client ID
-
-For local secrets, user secrets are fine:
+## Installation
 
 ```bash
-dotnet user-secrets --project .\Api\src\Api.csproj set "Authentication:Authority" "https://login.microsoftonline.com/<tenant-id>/v2.0"
-dotnet user-secrets --project .\Api\src\Api.csproj set "Authentication:Audience" "<api-client-id>"
+dotnet add package Trellis.Asp
 ```
 
-### Step 3: Wire Up Authentication in `Program.cs`
+The actor providers ship in `Trellis.Asp` under namespace `Trellis.Asp.Authorization`. Domain primitives (`Actor`, `IActorProvider`, `ActorAttributes`) come from `Trellis.Authorization`. The legacy `Trellis.Asp.Authorization` package was absorbed into `Trellis.Asp`.
 
-The Trellis ASP template already has authorization, but it does not enable real authentication yet. Make these two changes.
+## Quick start
 
-#### 3.1 Update `Api\src\Program.cs`
-
-Change the `AddPresentation(...)` call so `DependencyInjection.cs` can read configuration:
+Validate Entra v2.0 tokens with the standard ASP.NET Core `JwtBearer` middleware, register `EntraActorProvider`, and read the resolved `Actor` from a protected endpoint.
 
 ```csharp
-builder.Services
-    .AddPresentation(builder.Configuration, builder.Environment)
-    .AddApplication()
-    .AddAntiCorruptionLayer(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=todos.db");
-```
-
-Then add authentication middleware before authorization:
-
-```csharp
-app.UseHttpsRedirection();
-
-if (!app.Environment.IsDevelopment())
-    app.UseAuthentication();
-
-app.UseAuthorization();
-```
-
-#### 3.2 Update `Api\src\DependencyInjection.cs`
-
-Replace the current development/production actor-provider block with this:
-
-```csharp
-namespace TodoSample.Api;
-
-using System.Collections.Generic;
-using Asp.Versioning.Conventions;
+using System.Linq;
+using System.Threading;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-using Scalar.AspNetCore;
-using ServiceLevelIndicators;
-using TodoSample.Api.Middleware;
-using Trellis.Asp;
 using Trellis.Asp.Authorization;
-
-internal static class DependencyInjection
-{
-    public static IServiceCollection AddPresentation(
-        this IServiceCollection services,
-        IConfiguration configuration,
-        IHostEnvironment environment)
-    {
-        services.ConfigureOpenTelemetry();
-        services.ConfigureServiceLevelIndicators();
-        services.AddProblemDetails();
-        services.AddControllers().AddScalarValueValidation();
-        services.AddApiVersioning()
-                .AddMvc(options => options.Conventions.Add(new VersionByNamespaceConvention()))
-                .AddApiExplorer()
-                .AddOpenApi(options => options.Document.AddScalarTransformers());
-        services.AddScoped<ErrorHandlingMiddleware>();
-        services.AddHealthChecks();
-
-        services.AddAuthorization(options =>
-        {
-            if (!environment.IsDevelopment())
-            {
-                options.FallbackPolicy = new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .Build();
-            }
-        });
-
-        if (environment.IsDevelopment())
-        {
-            services.AddDevelopmentActorProvider(options =>
-            {
-                options.DefaultActorId = "development";
-                options.DefaultPermissions = new HashSet<string>
-                {
-                    "todos:read",
-                    "todos:create",
-                    "todos:update"
-                };
-            });
-        }
-        else
-        {
-            var auth = configuration.GetSection("Authentication");
-
-            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddJwtBearer(options =>
-                {
-                    options.Authority = auth["Authority"];
-                    options.Audience = auth["Audience"];
-                });
-
-            services.AddEntraActorProvider();
-        }
-
-        return services;
-    }
-
-    private static IServiceCollection ConfigureOpenTelemetry(this IServiceCollection services)
-    {
-        static void configureResource(ResourceBuilder r) => r.AddService(
-            serviceName: "TodoSampleService",
-            serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown");
-
-        services.AddOpenTelemetry()
-            .ConfigureResource(configureResource)
-            .WithMetrics(builder =>
-            {
-                builder.AddAspNetCoreInstrumentation();
-                builder.AddServiceLevelIndicatorInstrumentation();
-                builder.AddMeter(
-                    "Microsoft.AspNetCore.Hosting",
-                    "Microsoft.AspNetCore.Server.Kestrel",
-                    "System.Net.Http");
-                builder.AddOtlpExporter();
-            })
-            .WithTracing(builder =>
-            {
-                builder.AddAspNetCoreInstrumentation();
-                builder.AddPrimitiveValueObjectInstrumentation();
-                builder.AddOtlpExporter();
-            });
-
-        return services;
-    }
-
-    private static IServiceCollection ConfigureServiceLevelIndicators(this IServiceCollection services)
-    {
-        services.AddServiceLevelIndicator(options =>
-        {
-            options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
-        })
-        .AddMvc()
-        .AddApiVersion();
-
-        return services;
-    }
-}
-```
-
-### Step 4: Map Entra Claims to Trellis `Actor`
-
-The happy-path setup is simple because `EntraActorProvider` already maps the most useful claims.
-
-| `Actor` field | Default Entra mapping |
-| --- | --- |
-| `Id` | `oid` / object identifier |
-| `Permissions` | `roles` and `ClaimTypes.Role` |
-| `ForbiddenPermissions` | empty set |
-| `Attributes["tid"]` | tenant ID |
-| `Attributes["preferred_username"]` | preferred username |
-| `Attributes["azp"]` | authorized party |
-| `Attributes["azpacr"]` | client auth method |
-| `Attributes["acrs"]` | auth context class reference |
-| `Attributes["ip_address"]` | current request IP |
-| `Attributes["mfa"]` | derived from `amr == "mfa"` |
-
-That means this works without extra mapping code:
-
-```csharp
-builder.Services.AddEntraActorProvider();
-```
-
-If you want to customize permissions later, do it in one place:
-
-```csharp
-builder.Services.AddEntraActorProvider(options =>
-{
-    options.MapPermissions = claims => claims
-        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase)
-                 || string.Equals(c.Type, System.Security.Claims.ClaimTypes.Role, StringComparison.OrdinalIgnoreCase))
-        .Select(c => c.Value)
-        .ToHashSet(StringComparer.Ordinal);
-});
-```
-
-> [!TIP]
-> Use Entra app roles for coarse-grained permissions first. It is the quickest way to get Trellis permission checks working.
-
-### Step 5: Protect Your Endpoints
-
-Add a simple controller so you can see the mapped actor:
-
-```csharp
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Trellis.Authorization;
 
-namespace TodoSample.Api.Controllers;
+var builder = WebApplication.CreateBuilder(args);
+var auth = builder.Configuration.GetSection("Authentication");
 
-[ApiController]
-[Route("api/[controller]")]
-public sealed class MeController(IActorProvider actorProvider) : ControllerBase
-{
-    [Authorize]
-    [HttpGet]
-    public async Task<IResult> Get(CancellationToken cancellationToken)
-    {
-        var actor = await actorProvider.GetCurrentActorAsync(cancellationToken);
-
-        return Results.Ok(new
-        {
-            actor.Id,
-            Permissions = actor.Permissions.OrderBy(p => p).ToArray(),
-            TenantId = actor.GetAttribute(ActorAttributes.TenantId),
-            Mfa = actor.GetAttribute(ActorAttributes.MfaAuthenticated)
-        });
-    }
-}
-```
-
-Then use Trellis permissions in application code:
-
-```csharp
-if (!actor.HasPermission("todos:read"))
-    return Result.Fail(new Error.Forbidden("policy.id") { Detail = "Missing todos:read permission." });
-```
-
-For tenant-scoped permissions, keep using `':'` as the separator:
-
-```csharp
-if (!actor.HasPermission("todos:read", tenantId))
-    return Result.Fail(new Error.Forbidden("policy.id") { Detail = "Missing tenant-scoped permission." });
-```
-
-### Step 6: Test It
-
-#### Fast local testing with `DevelopmentActorProvider`
-
-1. Run the app normally:
-   ```bash
-   dotnet run --project .\Api\src\Api.csproj
-   ```
-2. Send an `X-Test-Actor` header:
-
-```powershell
-$actor = '{"Id":"local-user","Permissions":["todos:read","todos:create"],"ForbiddenPermissions":[],"Attributes":{"tid":"local-tenant","mfa":"false"}}'
-Invoke-RestMethod https://localhost:5001/api/me -Headers @{ "X-Test-Actor" = $actor }
-```
-
-#### Real Entra token testing on your machine
-
-Run the app in a non-Development environment so the Entra path executes:
-
-```powershell
-$env:ASPNETCORE_ENVIRONMENT = "Staging"
-dotnet run --project .\Api\src\Api.csproj
-```
-
-Then call the API with a real bearer token:
-
-```powershell
-Invoke-RestMethod https://localhost:5001/api/me -Headers @{ Authorization = "Bearer <access-token>" }
-```
-
-If you want automated tests against real Entra tokens, use the patterns in [Testing with Entra ID Tokens](integration-entra-testing.md).
-
-> [!WARNING]
-> If the token validates but `actor.Permissions` is empty, the usual cause is that Entra app roles were created but never assigned to the user or group.
-
-## Part 2: Google OAuth (OpenID Connect)
-
-Google is usually the fastest consumer-facing option. The main difference from Entra is that Google gives you identity first, while your app usually decides permissions.
-
-### Step 1: Create OAuth Credentials in Google Cloud Console
-
-1. Open **Google Cloud Console**.
-2. Go to **APIs & Services** -> **OAuth consent screen** and configure your app name.
-3. Go to **Credentials** -> **Create Credentials** -> **OAuth client ID**.
-4. Choose **Web application**.
-5. Add your frontend origins and redirect URIs, for example:
-   - `http://localhost:5173`
-   - `http://localhost:5173/auth/callback`
-6. Copy the **Client ID**.
-
-**Screenshot target:** You should be looking at **Google Cloud Console -> APIs & Services -> Credentials** with an OAuth 2.0 client ID visible.
-
-> [!WARNING]
-> Google redirect URI matching is exact. A missing trailing path segment such as `/auth/callback` will break sign-in.
-
-### Step 2: Configure `appsettings.json`
-
-Use Google as the token issuer:
-
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*",
-  "Authentication": {
-    "Authority": "https://accounts.google.com",
-    "Audience": "<google-client-id>",
-    "ActorIdClaim": "sub",
-    "PermissionsClaim": "permissions"
-  }
-}
-```
-
-### Step 3: Wire Up Google Authentication
-
-For Google, use `ClaimsActorProvider`. It is the generic Trellis provider for JWT/OIDC claims.
-
-Replace the non-development branch in `Api\src\DependencyInjection.cs` with this version:
-
-```csharp
-var auth = configuration.GetSection("Authentication");
-
-services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = auth["Authority"];
-        options.Audience = auth["Audience"];
-        options.TokenValidationParameters.ValidIssuers =
-        [
-            "https://accounts.google.com",
-            "accounts.google.com"
-        ];
+        options.Audience  = auth["Audience"];
+    });
+
+builder.Services.AddAuthorization();
+builder.Services.AddEntraActorProvider();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationToken ct) =>
+{
+    var actor = await actorProvider.GetCurrentActorAsync(ct);
+    return Results.Ok(new
+    {
+        actor.Id,
+        Permissions = actor.Permissions.OrderBy(p => p).ToArray(),
+        TenantId = actor.GetAttribute(ActorAttributes.TenantId),
+        Mfa      = actor.GetAttribute(ActorAttributes.MfaAuthenticated),
+    });
+});
+
+app.Run();
+```
+
+Matching `appsettings.json`:
+
+```json
+{
+  "Authentication": {
+    "Authority": "https://login.microsoftonline.com/<tenant-id>/v2.0",
+    "Audience":  "<api-client-id>"
+  }
+}
+```
+
+> [!NOTE]
+> The actor provider extracts an `Actor` from `HttpContext.User`. It does not validate tokens — keep `AddJwtBearer` (or any other authentication scheme) in front of it.
+
+## Provider configuration
+
+Pick one provider per environment. The choice is driven by token shape, not by sign-in protocol.
+
+| Provider | Use when |
+|---|---|
+| `EntraActorProvider` | Issuer is Microsoft Entra ID v2.0 and you want `oid` / `roles` / `tid` / `amr` mapped out of the box. |
+| `ClaimsActorProvider` | Token has a flat actor-id claim and a flat permissions claim (Auth0 `permissions`, Okta `scp`, custom OIDC). |
+| Subclass of `ClaimsActorProvider` | Token has nested or computed claims (Keycloak `realm_access.roles`, claims merged from a database). |
+| `DevelopmentActorProvider` | Local development or integration tests — `IsDevelopment()` only. |
+
+### Entra ID provider
+
+Use `AddEntraActorProvider` for Microsoft Entra ID (Azure AD) v2.0 tokens. The default mapping recognizes the standard Entra claim set without extra configuration.
+
+```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+var auth = configuration.GetSection("Authentication");
+
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = auth["Authority"];   // https://login.microsoftonline.com/<tenant-id>/v2.0
+        options.Audience  = auth["Audience"];    // api client id (no api:// prefix for v2.0 audiences)
+    });
+
+services.AddEntraActorProvider();
+```
+
+`EntraActorProvider` derives from `ClaimsActorProvider` and overrides `GetCurrentActorAsync` to apply the Entra-specific delegates. When `IdClaimType` is the default long objectidentifier URI it falls back to the short `"oid"` claim before failing. See `EntraActorOptions` defaults in [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#entraactoroptions).
+
+### Generic OIDC provider
+
+For any provider whose token exposes the actor id and permissions as flat claim types — Auth0, Okta, Google, or a custom IdP — register `ClaimsActorProvider` and name the two claim types.
+
+```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+var auth = configuration.GetSection("Authentication");
+
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = auth["Authority"];   // e.g. https://your-tenant.auth0.com/
+        options.Audience  = auth["Audience"];    // your API audience
     });
 
 services.AddClaimsActorProvider(options =>
 {
-    options.ActorIdClaim = auth["ActorIdClaim"] ?? "sub";
+    options.ActorIdClaim     = auth["ActorIdClaim"]     ?? "sub";
     options.PermissionsClaim = auth["PermissionsClaim"] ?? "permissions";
 });
 ```
 
-Use the same `Program.cs` changes from Part 1:
+| Provider | Typical `ActorIdClaim` | Typical `PermissionsClaim` |
+|---|---|---|
+| Auth0 (RBAC) | `sub` | `permissions` |
+| Okta (custom claim) | `sub` | `permissions` (or `scp` — see [Scope and permission extraction](#scope-and-permission-extraction)) |
+| Google sign-in | `sub` | none — token only proves identity; load app permissions from your own store |
+
+If the token only proves identity (Google is the canonical case), `Actor.Permissions` will be empty. That is a valid starting point: gate endpoints with `[Authorize]` for "signed in" and load fine-grained permissions from your database via a custom `IActorProvider` (see [Composition](#composition)).
+
+### Nested-claim providers
+
+`ClaimsActorOptions` matches `Claim.Type` verbatim — no JSON-path traversal. When a token contains a nested object (e.g. Keycloak's `{ "realm_access": { "roles": [...] } }`), the JWT handler stores the value as a raw JSON string under claim type `"realm_access"`. Subclass `ClaimsActorProvider` to project it.
 
 ```csharp
-builder.Services
-    .AddPresentation(builder.Configuration, builder.Environment)
-    .AddApplication()
-    .AddAntiCorruptionLayer(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=todos.db");
+using System;
+using System.Collections.Frozen;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Trellis.Asp.Authorization;
+using Trellis.Authorization;
+
+internal sealed record RealmAccess([property: JsonPropertyName("roles")] string[] Roles);
+
+[JsonSerializable(typeof(RealmAccess))]
+internal partial class KeycloakJsonContext : JsonSerializerContext { }
+
+public sealed class KeycloakActorProvider(
+    IHttpContextAccessor accessor,
+    IOptions<ClaimsActorOptions> options) : ClaimsActorProvider(accessor, options)
+{
+    public override Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var identity = HttpContextAccessor.HttpContext?.User.Identities
+            .FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity
+            ?? throw new InvalidOperationException("No authenticated user.");
+
+        var sub = identity.FindFirst(Options.ActorIdClaim)?.Value
+            ?? throw new InvalidOperationException($"Claim '{Options.ActorIdClaim}' missing.");
+
+        var raw = identity.FindFirst("realm_access")?.Value;
+        var roles = raw is null
+            ? FrozenSet<string>.Empty
+            : (JsonSerializer.Deserialize(raw, KeycloakJsonContext.Default.RealmAccess)?.Roles
+                ?? Array.Empty<string>()).ToFrozenSet();
+
+        return Task.FromResult(Actor.Create(sub, roles));
+    }
+}
+
+services.AddCachingActorProvider<KeycloakActorProvider>();
 ```
 
+`AddCachingActorProvider<T>` registers `T` as scoped and wraps it with `CachingActorProvider`, so the JSON parse runs once per request even if multiple handlers ask for the actor.
+
+## JWT validation options
+
+Trellis does not own JWT validation — that lives in `Microsoft.AspNetCore.Authentication.JwtBearer`. The fields `JwtBearerHandler` validates flow into Trellis as follows:
+
+| `JwtBearerOptions` setting | Effect on Trellis |
+|---|---|
+| `Authority` | Determines OIDC discovery / signing keys. If validation fails, `HttpContext.User` is unauthenticated and any actor provider throws `InvalidOperationException("No authenticated user.")`. |
+| `Audience` (or `TokenValidationParameters.ValidAudiences`) | Must match the token `aud`. Mismatched audiences never reach the actor provider — the request is rejected with `401`. |
+| `TokenValidationParameters.ValidIssuers` | Required when `Authority` does not match the literal `iss` claim (Google emits both `https://accounts.google.com` and `accounts.google.com`). |
+| `TokenValidationParameters.ValidateIssuer = false` | Multi-tenant Entra requires this; tenant pinning then lives in `MapAttributes` or a custom validator. See [Multi-tenant Entra](#multi-tenant-entra). |
+| `Events.OnTokenValidated` | The hook for synthesizing extra `Claim` instances before Trellis sees them — useful when your IdP issues identity but your app issues permissions. |
+
 ```csharp
-app.UseHttpsRedirection();
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
 
-if (!app.Environment.IsDevelopment())
-    app.UseAuthentication();
-
-app.UseAuthorization();
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://accounts.google.com";
+        options.Audience  = configuration["Authentication:Audience"];
+        options.TokenValidationParameters.ValidIssuers =
+        [
+            "https://accounts.google.com",
+            "accounts.google.com",
+        ];
+    });
 ```
 
-### Step 4: Map Google Claims to Trellis `Actor`
+## Claim mapping
 
-With this setup:
+Each provider exposes a small surface of mapping options. The full default tables (claim names, attribute keys, fall-back rules) live in [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#entraactoroptions); this section covers the everyday overrides.
 
-1. `Actor.Id` comes from Google `sub`
-2. `Actor.Permissions` comes from whatever claim you choose as `PermissionsClaim`
-3. if your Google token does not contain permission claims, `Actor.Permissions` is just empty
+### Synthesizing app permissions during token validation
 
-That is still a valid starting point. Many startup apps begin with:
-
-1. `[Authorize]` for "signed-in users only"
-2. application-level permissions loaded later from their own database
-
-If you want to add app permissions during token validation, create flat `permissions` claims:
+When the IdP only issues identity, add permission claims in `OnTokenValidated`. `ClaimsActorProvider` aggregates every `Claim` whose `Type` matches `PermissionsClaim` via `FindAll`, so multiple `Claim` instances of the same type are flattened automatically.
 
 ```csharp
-services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = auth["Authority"];
-        options.Audience = auth["Audience"];
+        options.Audience  = auth["Audience"];
         options.Events = new JwtBearerEvents
         {
             OnTokenValidated = context =>
             {
-                if (context.Principal?.Identity is not System.Security.Claims.ClaimsIdentity identity)
+                if (context.Principal?.Identity is not ClaimsIdentity identity)
                     return Task.CompletedTask;
 
-                identity.AddClaim(new System.Security.Claims.Claim("permissions", "todos:read"));
+                identity.AddClaim(new Claim("permissions", "todos:read"));
 
                 var email = identity.FindFirst("email")?.Value;
-                if (!string.IsNullOrWhiteSpace(email) &&
-                    email.EndsWith("@yourcompany.com", StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(email)
+                    && email.EndsWith("@yourcompany.com", StringComparison.OrdinalIgnoreCase))
                 {
-                    identity.AddClaim(new System.Security.Claims.Claim("permissions", "todos:create"));
+                    identity.AddClaim(new Claim("permissions", "todos:create"));
                 }
 
                 return Task.CompletedTask;
-            }
+            },
         };
-    });
-```
-
-> [!NOTE]
-> `ClaimsActorProvider` only maps a flat actor ID claim and a flat permissions claim. If you also need `Actor.Attributes` or forbidden permissions from Google claims, create a custom `IActorProvider` and optionally wrap it with `AddCachingActorProvider<T>()`.
-
-### Step 5: Test It
-
-1. Keep local day-to-day development on `DevelopmentActorProvider`.
-2. Run the app in `Staging` to exercise Google token validation:
-
-```powershell
-$env:ASPNETCORE_ENVIRONMENT = "Staging"
-dotnet run --project .\Api\src\Api.csproj
-```
-
-3. Sign in through your frontend.
-4. Send the returned token to your API:
-
-```powershell
-Invoke-RestMethod https://localhost:5001/api/me -Headers @{ Authorization = "Bearer <google-token>" }
-```
-
-If `/api/me` returns an `Id`, your SSO path is working.
-
-## Part 3: Generic OIDC Provider
-
-### The Pattern (works with Okta, Auth0, Keycloak, etc.)
-
-The Trellis pattern for any OIDC provider is:
-
-1. validate the token with ASP.NET Core authentication
-2. map a stable user claim to `Actor.Id`
-3. map a flat permissions or roles claim to `Actor.Permissions`
-4. optionally switch to a custom provider if you need database-backed permissions or attributes
-
-Use this `appsettings.json` shape:
-
-```json
-{
-  "Authentication": {
-    "Authority": "https://your-provider.example.com",
-    "Audience": "your-api-audience",
-    "ActorIdClaim": "sub",
-    "PermissionsClaim": "permissions"
-  }
-}
-```
-
-Then use this registration:
-
-```csharp
-var auth = configuration.GetSection("Authentication");
-
-services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddJwtBearer(options =>
-    {
-        options.Authority = auth["Authority"];
-        options.Audience = auth["Audience"];
     });
 
 services.AddClaimsActorProvider(options =>
 {
-    options.ActorIdClaim = auth["ActorIdClaim"] ?? "sub";
-    options.PermissionsClaim = auth["PermissionsClaim"] ?? "permissions";
+    options.ActorIdClaim     = "sub";
+    options.PermissionsClaim = "permissions";
 });
 ```
 
-Provider-specific tips:
+> [!NOTE]
+> `ClaimsActorProvider` only reads two claim types and never writes to `Actor.Attributes` or `Actor.ForbiddenPermissions`. Anything richer — ABAC attributes, deny lists, or computed permissions — belongs on `EntraActorProvider` (via `MapAttributes` / `MapForbiddenPermissions`) or a subclass. The full ABAC story is in [ASP.NET Core Authorization → Customizing claim mapping](integration-asp-authorization.md#customizing-claim-mapping).
 
-1. **Okta** often uses `scp` or custom permissions claims.
-2. **Auth0** often uses `permissions`.
-3. **Keycloak** often uses `roles`, but nested role payloads may need normalization first.
+### Customizing the Entra mapping
 
-If your provider emits permissions in a flat claim, you are done.
+`EntraActorOptions` has three independent delegates and one identifier knob.
 
-If your provider only proves identity and you load permissions from your own database, use a custom provider and cache it per request:
-
-```csharp
-services.AddCachingActorProvider<DatabaseActorProvider>();
-```
-
-That pattern is useful when:
-
-1. the token contains `sub` but no app permissions
-2. you need tenant-specific permissions from your own data store
-3. you want custom `Actor.Attributes`
+| Member | Default | Override to... |
+|---|---|---|
+| `IdClaimType` | long `objectidentifier` URI (falls back to short `"oid"`) | Use `sub`, an employee ID, or a custom claim. |
+| `MapPermissions` | union of `roles` and `ClaimTypes.Role` | Flatten Entra app roles into fine-grained permissions; merge DB-sourced grants. |
+| `MapForbiddenPermissions` | empty `HashSet<string>` | Project a deny-list claim. |
+| `MapAttributes` | `tid`, `preferred_username`, `azp`, `azpacr`, `acrs` from claims; `ip_address` from connection; `mfa` from any `amr == "mfa"` | Add tenant-scoped or request-scoped attributes. |
 
 > [!WARNING]
-> `ClaimsActorProvider` does not understand nested JSON claims like Keycloak `realm_access.roles`. Flatten them into regular claims during token validation or use a custom provider.
+> Any exception thrown from `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped by `EntraActorProvider` as `InvalidOperationException("EntraActorOptions.<delegate> threw an exception while mapping the authenticated user's claims.")`. The provider never silently defaults.
 
-## Development vs Deployed Environments
+## Scope and permission extraction
 
-Use `DevelopmentActorProvider` locally so you can iterate without a real identity provider. In every deployed environment (staging, production, etc.) use the **same SSO provider** — just point at different tenants or client IDs via configuration.
+Two common shapes for "what is this token allowed to do":
 
-> [!WARNING]
-> Do **not** use a different auth provider in staging than in production. Auth bugs are subtle — if staging uses Google and production uses Entra, you will miss token-format and claim-mapping issues until they hit real users.
-
-### Environment-specific configuration
-
-The only thing that changes between staging and production is the config values, not the provider type.
-
-#### `Api\src\appsettings.Staging.json`
-
-```json
-{
-  "Authentication": {
-    "Authority": "https://login.microsoftonline.com/<staging-tenant-id>/v2.0",
-    "Audience": "<staging-api-client-id>"
-  }
-}
-```
-
-#### `Api\src\appsettings.Production.json`
-
-```json
-{
-  "Authentication": {
-    "Authority": "https://login.microsoftonline.com/<prod-tenant-id>/v2.0",
-    "Audience": "<prod-api-client-id>"
-  }
-}
-```
-
-### Registration pattern
+**App roles (Entra application permissions).** Each role is a separate claim of type `roles`. The default `MapPermissions` already collects them.
 
 ```csharp
-if (environment.IsDevelopment())
-{
-    services.AddDevelopmentActorProvider();
-}
-else
-{
-    var auth = configuration.GetSection("Authentication");
-    services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
-        {
-            options.Authority = auth["Authority"];
-            options.Audience = auth["Audience"];
-        });
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
 
-    services.AddEntraActorProvider(); // Same provider everywhere
-}
+services.AddEntraActorProvider(options =>
+{
+    var rolePermissionMap = new Dictionary<string, string[]>(StringComparer.Ordinal)
+    {
+        ["Catalog.Admin"]  = ["products:read", "products:write", "products:delete"],
+        ["Catalog.Reader"] = ["products:read"],
+    };
+
+    options.MapPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(c => rolePermissionMap.TryGetValue(c.Value, out var perms) ? perms : Array.Empty<string>())
+        .ToHashSet(StringComparer.Ordinal);
+});
+```
+
+**Delegated scopes.** Entra (and many other OAuth servers) emit a single `scp` claim whose value is a space-separated string. Split it before flattening into permissions.
+
+```csharp
+services.AddEntraActorProvider(options =>
+{
+    options.MapPermissions = claims => claims
+        .Where(c => string.Equals(c.Type, "scp", StringComparison.OrdinalIgnoreCase))
+        .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        .ToHashSet(StringComparer.Ordinal);
+});
+```
+
+Trellis does not enforce a permission naming convention — pick one (`products:read` or `Products.Read`) and stay consistent. Scoped permissions use `Actor.PermissionScopeSeparator` (`':'`); `actor.HasPermission("products:read", tenantId)` checks for the joined string `products:read:<tenantId>`. See [`trellis-api-authorization.md → Actor`](../api_reference/trellis-api-authorization.md#actor).
+
+## Multi-tenant Entra
+
+A multi-tenant Entra app accepts tokens from any tenant the app is consented in. `Authority` becomes `https://login.microsoftonline.com/common/v2.0` (or `/organizations/v2.0`), the token's `iss` is per-tenant, and your API decides which tenants are allowed.
+
+```csharp
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Trellis.Asp.Authorization;
+
+var allowedTenants = configuration.GetSection("Authentication:AllowedTenants").Get<string[]>()
+    ?? Array.Empty<string>();
+
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://login.microsoftonline.com/common/v2.0";
+        options.Audience  = configuration["Authentication:Audience"];
+
+        options.TokenValidationParameters.ValidateIssuer = false;
+        options.TokenValidationParameters.IssuerValidator = (issuer, _, _) =>
+            issuer.StartsWith("https://login.microsoftonline.com/", StringComparison.Ordinal)
+                ? issuer
+                : throw new SecurityTokenInvalidIssuerException($"Untrusted issuer '{issuer}'.");
+    });
+
+services.AddEntraActorProvider();
+```
+
+Then enforce the tenant allow-list inside handlers using the `tid` attribute the default `MapAttributes` already populates:
+
+```csharp
+using System.Linq;
+using Trellis;
+using Trellis.Authorization;
+
+var tenantId = actor.GetAttribute(ActorAttributes.TenantId);
+
+if (tenantId is null || !allowedTenants.Contains(tenantId, StringComparer.Ordinal))
+    return Result.Fail(new Error.Forbidden("tenant.not-allowed") { Detail = $"Tenant '{tenantId}' is not provisioned." });
 ```
 
 > [!TIP]
-> If you use separate Azure AD tenants for staging and production, create an app registration in each tenant with the same redirect URIs and permission scopes. This gives you full isolation while keeping the auth code path identical.
+> Tenant-scoped permissions ride on the same `Actor.HasPermission(name, scope)` helper: `actor.HasPermission("documents:read", tenantId)` checks `documents:read:<tenantId>`.
 
-## Common Pitfalls
+## Development defaults
+
+`AddDevelopmentActorProvider` reads an `X-Test-Actor` JSON header (case-insensitive property names) and falls back to a configurable default actor when the header is missing. It throws `InvalidOperationException` whenever `IHostEnvironment.IsDevelopment()` is `false` — including in Production with no header — which is the fail-closed safety net.
+
+```csharp
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Trellis.Asp.Authorization;
+
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services.AddDevelopmentActorProvider(options =>
+    {
+        options.DefaultActorId         = "developer@local";
+        options.DefaultPermissions     = new HashSet<string> { "todos:read", "todos:create" };
+        options.ThrowOnMalformedHeader = false;
+    });
+}
+else
+{
+    builder.Services.AddEntraActorProvider();
+}
+```
+
+Send a header from any HTTP client to impersonate a specific actor:
+
+```powershell
+$actor = '{"Id":"local-user","Permissions":["todos:read","todos:create"],"ForbiddenPermissions":[],"Attributes":{"tid":"local-tenant","mfa":"false"}}'
+Invoke-RestMethod https://localhost:5001/me -Headers @{ "X-Test-Actor" = $actor }
+```
+
+For test clients, `WebApplicationFactoryExtensions.CreateClientWithActor(...)` writes the same header (see [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)).
 
 > [!WARNING]
-> **Redirect URI mismatch** is the number-one setup error. The URI in your identity provider must exactly match your frontend callback URI.
+> Use the **same SSO provider** in staging and production — only `Authority` and `Audience` should differ between environments. A staging path that swaps `EntraActorProvider` for `ClaimsActorProvider` (or vice versa) will hide token-format and claim-mapping bugs until they hit real users.
 
-> [!WARNING]
-> **Audience mismatch** means the token was issued for the wrong app. Make sure `Authentication:Audience` matches the token's `aud` claim.
+## Composition
 
-> [!WARNING]
-> **CORS failures look like auth failures.** If your browser app runs on `http://localhost:5173` and your API runs somewhere else, configure CORS before blaming OIDC.
+SSO sits on top of three Trellis seams: actor resolution, mediator authorization, and result pipelines.
 
-> [!WARNING]
-> **DevelopmentActorProvider is Development-only.** If `ASPNETCORE_ENVIRONMENT` is not `Development`, Trellis will not allow the `X-Test-Actor` shortcut.
+- **Actor resolution.** Every `IActorProvider` is scoped, so handlers, behaviors, and endpoints see the same `Actor` for the duration of a request. `AddCachingActorProvider<T>()` decorates any inner provider — Entra, Claims, or your subclass — without changing handler code.
+- **Mediator pipeline.** Once an `IActorProvider` is registered, `AuthorizationBehavior<TMessage, TResponse>` enforces `IAuthorize.RequiredPermissions` and `IAuthorizeResource<T>.Authorize(actor, resource)` and short-circuits the pipeline with a typed `Error.Forbidden`. Commands return `Result<Unit>`; ASP integration maps `Error.Forbidden` to RFC 7807 `403`.
+- **Result pipelines.** Inside handlers, `Actor` predicates return `bool`, so `Result.Ensure(actor.HasPermission(...), new Error.Forbidden(...))` plugs straight into `Bind` / `Map` chains.
 
-> [!WARNING]
-> **Permissions are case-sensitive.** `todos:read` and `Todos.Read` are different strings. Pick one naming convention and stay consistent.
+```csharp
+using System.Collections.Generic;
+using Mediator;
+using Trellis;
+using Trellis.Authorization;
 
-> [!WARNING]
-> **Do not use `preferred_username` or email as your stable actor ID** when the provider gives you a better immutable identifier like `oid` or `sub`.
+public sealed record DeleteDocumentCommand(string DocumentId)
+    : ICommand<Result<Unit>>, IAuthorize
+{
+    public IReadOnlyList<string> RequiredPermissions { get; } = ["documents:delete"];
+}
+```
 
-## Next Steps
+The full mediator + resource-loader wiring (and the `AddResourceAuthorization<TResource, TId, TLoader>` helper) is documented in [ASP.NET Core Authorization → Mediator integration](integration-asp-authorization.md#mediator-integration).
 
-Now that sign-in works:
+## Practical guidance
 
-1. read [ASP.NET Core Authorization](integration-asp-authorization.md) for deeper `Actor`, `IAuthorize`, and resource-authorization patterns
-2. read [Testing with Entra ID Tokens](integration-entra-testing.md) if you want end-to-end token validation tests
-3. move coarse permissions into provider roles first, then add database-backed permissions only when you actually need them
-4. add tenant or business attributes to `Actor.Attributes` when your authorization rules go beyond simple role checks
+- **Never authorize on `preferred_username`.** It is a display claim and can change. Use `oid` (Entra) or `sub` (everyone else).
+- **Use `ActorAttributes` constants.** `actor.GetAttribute(ActorAttributes.TenantId)` survives renames; `actor.GetAttribute("tid")` does not.
+- **Keep one mapping site.** Flatten roles to permissions inside `MapPermissions` once, not in every handler.
+- **Pick one naming convention for permissions.** `todos:read` and `Todos.Read` are different strings — `Actor.Permissions` is a `FrozenSet<string>` with ordinal comparison.
+- **Wrap expensive providers** with `AddCachingActorProvider<T>()` so DB-backed permission lookups run once per request.
+- **Keep `AddDevelopmentActorProvider` behind `IsDevelopment()`.** The provider also fails closed at runtime, but the registration discipline avoids accidental dependency on `X-Test-Actor` from staging integration tests.
+- **Match the audience exactly.** The number-one cause of "token validates somewhere else but not here" is `Audience` not matching the token's `aud` claim.
+- **Let mapper exceptions bubble.** A buggy `MapPermissions` becomes `InvalidOperationException("EntraActorOptions.MapPermissions threw ...")`; surfacing it during development reveals bad role tables faster than a silent fallback.
+
+## Cross-references
+
+- ASP DI surface (actor providers, options, response mapping): [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- Domain primitives (`Actor`, `IActorProvider`, `IAuthorize`, `IAuthorizeResource<T>`, `ActorAttributes`): [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- `Result`, `Error.Forbidden`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Deeper authorization patterns (claim mapping, ABAC, mediator integration, resource loaders): [ASP.NET Core Authorization](integration-asp-authorization.md)
+- End-to-end token-validation tests against real Entra: [Testing with Entra ID Tokens](integration-entra-testing.md)
+- Test-client `X-Test-Actor` helper: [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)

--- a/docs/docfx_project/articles/integration-testing.md
+++ b/docs/docfx_project/articles/integration-testing.md
@@ -1,91 +1,82 @@
-# Testing
+﻿---
+title: Integration Testing
+package: Trellis.Testing
+topics: [testing, assertions, result, maybe, fakerepository, webfactory, actor-headers]
+related_api_reference: [trellis-api-testing-reference.md, trellis-api-testing-aspnetcore.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Integration Testing
 
-**Level:** Intermediate 📘 | **Time:** 20-30 min | **Prerequisites:** [Basics](basics.md), [Mediator Pipeline](integration-mediator.md)
+`Trellis.Testing` and `Trellis.Testing.AspNetCore` keep tests aligned with production code: success and failure stay typed (`Result<T>`, `Maybe<T>`, closed `Error` ADT), authorization stays explicit, and ASP.NET Core integration tests run against the real pipeline.
 
-Good Trellis tests read like the production code they protect: success and failure are values, authorization is explicit, and integration tests exercise the real pipeline.
+## Patterns Index
 
-`Trellis.Testing` gives you purpose-built assertions, fakes, and test helpers for that style.
+| Goal | Use | See |
+|---|---|---|
+| Assert a sync `Result<T>` succeeded / failed | `result.Should().BeSuccess()` / `.BeFailureOfType<TError>()` | [Result assertions](#result-assertions) |
+| Assert an async `Result<T>` succeeded / failed | `await task.BeSuccessAsync()` / `.BeFailureAsync()` (extension on `Task`/`ValueTask`) | [Result assertions](#result-assertions) |
+| Assert a `Maybe<T>` carries / is empty | `maybe.Should().HaveValue()` / `.BeNone()` | [Maybe assertions](#maybe-assertions) |
+| Assert error code / detail / payload type | `error.Should().HaveCode(...)` / `.HaveDetailContaining(...)` / `.BeOfType<TError>()` | [Error assertions](#error-assertions) |
+| Assert a validation field violation | `unprocessable.Should().HaveFieldError(...)` | [Validation error assertions](#validation-error-assertions) |
+| Stub a repository with unique-constraint and not-found semantics | `new FakeRepository<TAggregate, TId>().WithUniqueConstraint(...)` | [FakeRepository](#fakerepository) |
+| Provide an actor inside a unit test | `new TestActorProvider(id, perms)` / `.WithActor(...)` scope | [TestActorProvider](#testactorprovider) |
+| Send `X-Test-Actor` from an integration test client | `factory.CreateClientWithActor(...)` | [WebApplicationFactory helpers](#webapplicationfactory-helpers) |
+| Replace EF provider in `WebApplicationFactory` | `services.ReplaceDbProvider<TContext>(...)` | [WebApplicationFactory helpers](#webapplicationfactory-helpers) |
+| Replace a resource loader for tests | `services.ReplaceResourceLoader<TMessage, TResource>(...)` | [WebApplicationFactory helpers](#webapplicationfactory-helpers) |
+| Pin time deterministically in integration tests | `factory.WithFakeTimeProvider(out var fake)` | [WebApplicationFactory helpers](#webapplicationfactory-helpers) |
+| Replay a `.http` file against the test host | `HttpFileParser.ParseFile` + `HttpFileRunner.RunAsync` + `HttpFileAssertions.AssertExpectationsMet` | [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#http-file-replay-helpers) |
+| Acquire a real Entra token in gated E2E tests | `MsalTestTokenProvider` + `factory.CreateClientWithEntraTokenAsync(...)` | [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#msal--entra-e2e-token-helpers) |
+
+## Use this guide when
+
+- You are writing handler / domain unit tests that consume Trellis `Result<T>`, `Maybe<T>`, or the closed `Error` ADT.
+- You are writing ASP.NET Core integration tests with `WebApplicationFactory<TEntryPoint>` and need actor headers, DI replacement, deterministic time, or `.http` replay.
+- You want fakes (`FakeRepository<,>`, `TestActorProvider`) instead of hand-rolled mocks for repositories and authorization.
+
+## Surface at a glance
+
+| Type | Package | Purpose |
+|---|---|---|
+| `ResultAssertions<TValue>` | `Trellis.Testing` | FluentAssertions surface for sync `Result<T>` (success, failure, error code/detail). |
+| `ResultAssertionsAsyncExtensions` | `Trellis.Testing` | `BeSuccessAsync` / `BeFailureAsync` / `BeFailureOfTypeAsync` on `Task<Result<T>>` and `ValueTask<Result<T>>`. |
+| `MaybeAssertions<T>` | `Trellis.Testing` | `HaveValue` / `BeNone` / `HaveValueEqualTo` / `HaveValueMatching`. |
+| `ErrorAssertions` | `Trellis.Testing` | `HaveCode` / `HaveDetail(Containing)` / `BeOfType<TError>` against the closed `Error` ADT. |
+| `ValidationErrorAssertions` | `Trellis.Testing` | Field-shape assertions over `Error.UnprocessableContent`. |
+| `UnwrapExtensions` | `Trellis.Testing` | Test-only `Unwrap()` / `UnwrapError()` (sync, async, `Result<Unit>`, `Maybe<T>`). |
+| `FakeRepository<TAggregate, TId>` | `Trellis.Testing` | In-memory repository with unique-constraint, not-found, and domain-event capture. |
+| `FakeSharedResourceLoader<TResource, TId>` | `Trellis.Testing` | Test double over `SharedResourceLoaderById<TResource, TId>` backed by `FakeRepository`. |
+| `TestActorProvider` / `TestActorScope` | `Trellis.Testing` | `IActorProvider` for handler tests, with scoped `WithActor(...)` overrides. |
+| `AggregateTestMutator` | `Trellis.Testing` | `SetMaybeField` / `ClearMaybeField` for whitebox aggregate setup. |
+| `WebApplicationFactoryExtensions` | `Trellis.Testing.AspNetCore` | `CreateClientWithActor(...)`, `CreateClientWithEntraTokenAsync(...)`. |
+| `WebApplicationFactoryTimeExtensions` | `Trellis.Testing.AspNetCore` | `WithFakeTimeProvider(...)` and `DefaultTestStartInstant` (`2024-01-01T00:00:00Z`). |
+| `ServiceCollectionExtensions` | `Trellis.Testing.AspNetCore` | `ReplaceResourceLoader<,>` / `ReplaceSingleton<T>`. |
+| `ServiceCollectionDbProviderExtensions` | `Trellis.Testing.AspNetCore` | `ReplaceDbProvider<TContext>(...)` for SQLite/in-memory swaps. |
+| `MsalTestTokenProvider` (+ `MsalTestOptions`, `TestUserCredentials`) | `Trellis.Testing.AspNetCore` | MSAL ROPC token acquisition for gated E2E tests against a dedicated test tenant. |
+| `HttpFileParser` / `HttpFileRunner` / `HttpFileAssertions` | `Trellis.Testing.AspNetCore.Http` | Parse, run, and assert `.http` files against a `WebApplicationFactory` client. |
+
+Full signatures: [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md).
 
 ## Installation
 
 ```bash
 dotnet add package Trellis.Testing
+dotnet add package Trellis.Testing.AspNetCore
 ```
 
-## What problem does this solve?
+`Trellis.Testing.AspNetCore` already references `Trellis.Testing`; install the second package only when the test project owns ASP.NET Core integration tests.
 
-The package helps you avoid common test friction:
+## Quick start
 
-- noisy assertions against `Result<T>` and `Maybe<T>`
-- brittle repository mocks
-- hand-built actor headers for integration tests
-- repeated boilerplate for test errors and validation failures
-
-## Start here: result assertions
-
-When a handler returns `Result<T>`, assert on the result directly instead of unpacking booleans yourself.
+A handler test that asserts both the success path and an expected typed failure, using `FakeRepository` for persistence and `TestActorProvider` for authorization context.
 
 ```csharp
-using FluentAssertions;
-using Trellis;
-using Trellis.Testing;
-
-var success = Result.Ok(42);
-success.Should().BeSuccess().Which.Should().Be(42);
-
-var failure = Result.Fail<int>(new Error.NotFound(new ResourceRef("Resource", "123")) { Detail = "Order 123 not found" });
-failure.Should().BeFailureOfType<Error.NotFound>();
-failure.Should().HaveErrorCode("not.found.error");
-failure.Should().HaveErrorDetail("Order 123 not found");
-```
-
-### Async assertions
-
-This detail matters: async assertions are extensions on `Task<Result<T>>` and `ValueTask<Result<T>>` directly.
-
-```csharp
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Trellis;
-using Trellis.Testing;
-
-Task<Result<int>> taskResult = Task.FromResult(Result.Ok(42));
-ValueTask<Result<int>> valueTaskResult = ValueTask.FromResult(Result.Ok(7));
-
-(await taskResult.BeSuccessAsync()).Which.Should().Be(42);
-(await valueTaskResult.BeSuccessAsync()).Which.Should().Be(7);
-```
-
-> [!WARNING]
-> Do **not** write `await result.Should().BeSuccessAsync()`. The async helpers are not extensions on `ResultAssertions<T>`.
-
-## `Maybe<T>` and `Error` assertions
-
-Use the Trellis-specific assertions so failures explain the intent of the test.
-
-```csharp
-using FluentAssertions;
-using Trellis;
-using Trellis.Testing;
-
-var maybeName = Maybe.From("Ada");
-maybeName.Should().HaveValue().Which.Should().Be("Ada");
-
-var none = Maybe<string>.None;
-none.Should().BeNone();
-
-var error = new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("email"), "validation.error") { Detail = "Email is required." }));
-error.Should().HaveCode("validation.error");
-error.Should().HaveDetailContaining("required");
-```
-
-## `FakeRepository`: fast handler tests without mocks
-
-If you are testing application handlers, `FakeRepository<TAggregate, TId>` is usually better than mocking repository calls by hand.
-
-```csharp
-using FluentAssertions;
-using Trellis;
+using Trellis.Authorization;
 using Trellis.Testing;
 
 public sealed record OrderId(Guid Value);
@@ -97,87 +88,215 @@ public sealed class Order : Aggregate<OrderId>
     public string Email { get; }
 }
 
+var actorProvider = new TestActorProvider("user-1", "Orders.Read", "Orders.Write");
+var actor = await actorProvider.GetCurrentActorAsync();
+
+actor.HasPermission("Orders.Read").Should().BeTrue();
+
 var repo = new FakeRepository<Order, OrderId>()
     .WithUniqueConstraint(order => order.Email);
 
 var order = new Order(new OrderId(Guid.NewGuid()), "ada@example.com");
 
-await repo.SaveAsync(order).BeSuccessAsync();
+(await repo.SaveAsync(order, CancellationToken.None)).Should().BeSuccess();
+(await repo.GetByIdAsync(order.Id)).Should().BeSuccess().Which.Should().BeSameAs(order);
+
+var duplicate = new Order(new OrderId(Guid.NewGuid()), "ada@example.com");
+(await repo.SaveAsync(duplicate, CancellationToken.None))
+    .Should().BeFailureOfType<Error.Conflict>();
+```
+
+## Result assertions
+
+Every command returns `Result<Unit>`. Assert on results directly instead of unpacking booleans by hand.
+
+| Assertion | Receiver | Notes |
+|---|---|---|
+| `BeSuccess()` | `Result<T>` via `.Should()` | `AndWhich.Which` exposes the value. |
+| `BeFailure()` | `Result<T>` via `.Should()` | `AndWhich.Which` exposes the `Error`. |
+| `BeFailureOfType<TError>()` | `Result<T>` via `.Should()` | Asserts the closed-ADT case (e.g. `Error.NotFound`). |
+| `HaveValue(expected)` / `HaveValueMatching(predicate)` / `HaveValueEquivalentTo(expected)` | `Result<T>` via `.Should()` | Value-shape checks without `.Which`. |
+| `HaveErrorCode(code)` / `HaveErrorDetail(text)` / `HaveErrorDetailContaining(substring)` | `Result<T>` via `.Should()` | Error-shape checks. |
+| `BeSuccessAsync()` / `BeFailureAsync()` / `BeFailureOfTypeAsync<TError>()` | `Task<Result<T>>` **or** `ValueTask<Result<T>>` directly | **Not** an extension on `ResultAssertions<T>` — see warning below. |
+
+```csharp
+using System.Threading.Tasks;
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+var success = Result.Ok(42);
+success.Should().BeSuccess().Which.Should().Be(42);
+
+var notFound = Result.Fail<int>(
+    new Error.NotFound(ResourceRef.For("Order", "123")) { Detail = "Order 123 not found" });
+
+notFound.Should().BeFailureOfType<Error.NotFound>();
+notFound.Should().HaveErrorCode("not.found.error");
+notFound.Should().HaveErrorDetailContaining("Order 123");
+
+Task<Result<int>> taskResult = Task.FromResult(success);
+ValueTask<Result<int>> valueTaskResult = ValueTask.FromResult(Result.Ok(7));
+
+(await taskResult.BeSuccessAsync()).Which.Should().Be(42);
+(await valueTaskResult.BeSuccessAsync()).Which.Should().Be(7);
+```
+
+> [!WARNING]
+> Do **not** write `await result.Should().BeSuccessAsync()`. Async assertions are extensions on `Task<Result<T>>` and `ValueTask<Result<T>>`, not on `ResultAssertions<T>`. Call them directly on the awaitable.
+
+## Maybe assertions
+
+```csharp
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+Maybe.From("Ada").Should().HaveValue().Which.Should().Be("Ada");
+Maybe<string>.None.Should().BeNone();
+Maybe.From("Ada").Should().HaveValueEqualTo("Ada");
+```
+
+`HaveValueMatching(predicate)` and `HaveValueEquivalentTo(expected)` are also available; full signatures in [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md#maybeassertionst).
+
+## Error assertions
+
+`Error` is a closed ADT (see [`trellis-api-core.md`](../api_reference/trellis-api-core.md)). Assert on the case, not on a string discriminator.
+
+```csharp
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+Error error = new Error.NotFound(ResourceRef.For("Order", "123"))
+{
+    Detail = "Order 123 not found",
+};
+
+error.Should().BeOfType<Error.NotFound>()
+    .Which.Resource.Should().Be(ResourceRef.For("Order", "123"));
+
+error.Should().HaveCode("not.found.error");
+error.Should().HaveDetailContaining("123");
+```
+
+> [!NOTE]
+> `Error.Instance` was removed in v3. The ASP wire layer synthesizes `ProblemDetails.Instance` from the request URL plus any `ResourceRef` carried by the typed payload. Assert against `Error.NotFound.Resource` (or the equivalent typed field), not a string `Instance`.
+
+### Validation error assertions
+
+`Error.UnprocessableContent` carries an `EquatableArray<FieldViolation>`. Use the dedicated assertions instead of pattern-matching the array yourself.
+
+```csharp
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+var error = new Error.UnprocessableContent(EquatableArray.Create(
+    new FieldViolation(InputPointer.ForProperty("email"), "validation.error")
+    {
+        Detail = "Email is required.",
+    }));
+
+error.Should().HaveFieldError("email");
+error.Should().HaveFieldErrorWithDetail("email", "Email is required.");
+error.Should().HaveFieldCount(1);
+```
+
+`HaveFieldError` accepts either `"email"` or `"/email"` — the field name is normalized via `InputPointer.ForProperty`.
+
+## FakeRepository
+
+`FakeRepository<TAggregate, TId>` mirrors the production `IRepository` contract and adds a result-shape surface for tests that need to assert on persistence failures. It is almost always preferable to a hand-rolled mock.
+
+| Surface | Members | Use from |
+|---|---|---|
+| Setup (mirrors `RepositoryBase<TAggregate, TId>`) | `Add(TAggregate)`, `Remove(TAggregate)`, `RemoveByIdAsync(TId, ct)` | Production handlers; test setup that exercises the real `IRepository` contract. |
+| Result-shape (fake-only) | `SaveAsync(TAggregate, ct)`, `DeleteAsync(TId, ct)` — both `Task<Result<Unit>>` | Tests that explicitly assert on conflict-result or not-found-result handling. |
+| Read | `GetByIdAsync(TId, ct)` → `Task<Result<TAggregate>>`, `FindByIdAsync(TId, ct)` → `Task<Maybe<TAggregate>>`, `FindAsync(predicate)`, `WhereAsync(predicate)`, `WhereAsync(Specification<TAggregate>)` | Test bodies. |
+| Inspection | `Count`, `Exists(TId)`, `Get(TId)`, `GetAll()`, `Clear()`, `PublishedEvents` | Test assertions. |
+| Constraint registration | `WithUniqueConstraint(Func<TAggregate, object?>)` | Test setup; eagerly enforced by `Add` (throws `InvalidOperationException`) and at-call by `SaveAsync` (returns `Error.Conflict`). |
+
+Detail strings:
+
+- `GetByIdAsync` / `DeleteAsync` / `RemoveByIdAsync` not-found: `"{AggregateTypeName} with ID {id} not found"`.
+- Unique-constraint conflict from `SaveAsync`: `"A {AggregateTypeName} with the same value already exists."`
+
+```csharp
+using System;
+using System.Threading;
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+public sealed record OrderId(Guid Value);
+
+public sealed class Order : Aggregate<OrderId>
+{
+    public Order(OrderId id, string email) : base(id) => Email = email;
+    public string Email { get; }
+}
+
+var repo = new FakeRepository<Order, OrderId>()
+    .WithUniqueConstraint(order => order.Email);
+
+var order = new Order(new OrderId(Guid.NewGuid()), "ada@example.com");
+
+(await repo.SaveAsync(order, CancellationToken.None)).Should().BeSuccess();
 (await repo.GetByIdAsync(order.Id)).Should().BeSuccess().Which.Should().BeSameAs(order);
 repo.Exists(order.Id).Should().BeTrue();
 repo.Count.Should().Be(1);
+
+var dupe = new Order(new OrderId(Guid.NewGuid()), "ada@example.com");
+(await repo.SaveAsync(dupe, CancellationToken.None))
+    .Should().BeFailureOfType<Error.Conflict>();
 ```
 
-Important details from the current API:
+> [!NOTE]
+> `SaveAsync` / `DeleteAsync` are not on `RepositoryBase<TAggregate, TId>`. If a handler accepts the `IRepository` contract, it cannot call them; use the staging API (`Add` / `Remove` / `RemoveByIdAsync`) instead. See cookbook **Recipe 16 — Unit of work in handlers**.
 
-- `SaveAsync` returns `Task<Result<Unit>>`
-- `DeleteAsync` returns `Task<Result<Unit>>`
-- unique constraint conflicts return `Error.Conflict`
-- missing aggregates use details like `"{AggregateTypeName} with ID {id} not found"`
+## TestActorProvider
 
-## `TestActorProvider`: authorization tests without plumbing
-
-When you want to test permission checks or resource ownership, use `TestActorProvider`.
+`TestActorProvider` is an `IActorProvider` for unit tests. Use the `(string userId, params string[] permissions)` constructor for the simple case and the `(Actor)` constructor when the test needs `ForbiddenPermissions` or `Attributes`.
 
 ```csharp
+using System.Collections.Generic;
 using FluentAssertions;
 using Trellis.Authorization;
 using Trellis.Testing;
 
-var actorProvider = new TestActorProvider("admin", "Orders.Read", "Orders.Write");
+var provider = new TestActorProvider("admin", "Orders.Read", "Orders.Write");
 
-await using var scope = actorProvider.WithActor("user-1", "Orders.Read");
-var actor = await actorProvider.GetCurrentActorAsync();
-
-actor.Id.Should().Be("user-1");
-actor.HasPermission("Orders.Read").Should().BeTrue();
-actor.HasPermission("Orders.Write").Should().BeFalse();
-```
-
-There is also an overload that accepts a full `Actor`, which is useful when you need:
-
-- `ForbiddenPermissions`
-- `Attributes`
-
-## Building failures for tests
-
-Use the standard `Result` and `Error` factory methods directly — no special test builder needed.
-
-```csharp
-using Trellis;
-
-var success = Result.Ok(42);
-var notFound = Result.Fail<int>(new Error.NotFound(new ResourceRef("Resource", "123")) { Detail = "Order 123 not found" });
-var forbidden = Result.Fail<int>(new Error.Forbidden("policy.id") { Detail = "Not allowed." });
-```
-
-`new Error.NotFound(new ResourceRef("Resource", "123")) { Detail = "Order 123 not found" }` produces:
-
-- detail: `Order 123 not found`
-- instance: `123`
-
-## HTTP integration tests with actor headers
-
-When your app uses `DevelopmentActorProvider`, `CreateClientWithActor` is the easiest way to exercise authorization through the HTTP pipeline.
-
-### Convenience overload
-
-```csharp
-using Microsoft.AspNetCore.Mvc.Testing;
-using Trellis.Testing.AspNetCore;
-
-public sealed class Program
+await using (provider.WithActor("user-1", "Orders.Read"))
 {
+    var actor = await provider.GetCurrentActorAsync();
+    actor.Id.Should().Be("user-1");
+    actor.HasPermission("Orders.Read").Should().BeTrue();
+    actor.HasPermission("Orders.Write").Should().BeFalse();
 }
 
-WebApplicationFactory<Program> factory = default!;
+var richActor = new Actor(
+    id: "user-2",
+    permissions: new HashSet<string> { "Orders.Read" },
+    forbiddenPermissions: new HashSet<string> { "Orders.Delete" },
+    attributes: new Dictionary<string, string> { ["tenant"] = "acme" });
 
-var client = factory.CreateClientWithActor("user-1", "Orders.Create", "Orders.Read");
+await using (provider.WithActor(richActor))
+{
+    var actor = await provider.GetCurrentActorAsync();
+    actor.Attributes["tenant"].Should().Be("acme");
+}
 ```
 
-### Full `Actor` overload
+`WithActor` returns a `TestActorScope` (`IAsyncDisposable`/`IDisposable`) that restores the previous actor when disposed.
 
-Use this when the test needs more than id + granted permissions.
+## WebApplicationFactory helpers
+
+The ASP.NET Core integration helpers live in `Trellis.Testing.AspNetCore`. Configure DI through `ConfigureTestServices` **before** `CreateClient()`; do not mutate the service collection afterward.
+
+### Authenticated test clients
+
+`CreateClientWithActor` writes the `X-Test-Actor` header that the development/test actor provider expects (id, permissions, forbidden permissions, attributes).
 
 ```csharp
 using System.Collections.Generic;
@@ -185,29 +304,28 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Trellis.Authorization;
 using Trellis.Testing.AspNetCore;
 
-public sealed class Program
-{
-}
-
 WebApplicationFactory<Program> factory = default!;
 
-var actor = new Actor(
-    id: "user-1",
+var simpleClient = factory.CreateClientWithActor("user-1", "Orders.Read", "Orders.Write");
+
+var richActor = new Actor(
+    id: "user-2",
     permissions: new HashSet<string> { "Orders.Read" },
     forbiddenPermissions: new HashSet<string> { "Orders.Delete" },
     attributes: new Dictionary<string, string> { ["tenant"] = "acme" });
 
-var client = factory.CreateClientWithActor(actor);
+var richClient = factory.CreateClientWithActor(richActor);
 ```
 
-> [!NOTE]
-> The `X-Test-Actor` header includes `Id`, `Permissions`, `ForbiddenPermissions`, and `Attributes`. That matches what `DevelopmentActorProvider` expects.
+For real Entra tokens in gated E2E suites, use `MsalTestTokenProvider` plus `factory.CreateClientWithEntraTokenAsync(provider, testUserName, ct)`. Full surface: [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#msaltesttokenprovider).
 
-## Replacing infrastructure in integration tests
+### Replacing services
 
-Two helpers are especially useful in `WebApplicationFactory`-based tests.
-
-### Swap the EF Core provider
+| Helper | Effect |
+|---|---|
+| `services.ReplaceSingleton<TService>(instance)` | Removes all `TService` registrations and adds the supplied singleton. |
+| `services.ReplaceResourceLoader<TMessage, TResource>(factory)` | Removes existing `IResourceLoader<TMessage, TResource>` registrations and adds the supplied scoped factory. |
+| `services.ReplaceDbProvider<TContext>(configureOptions)` | Removes the existing `TContext`, `DbContextOptions<TContext>`, and EF Core provider-scoped services, then re-registers via `AddDbContext<TContext>(configureOptions)`. |
 
 ```csharp
 using Microsoft.AspNetCore.Hosting;
@@ -216,13 +334,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Trellis.Testing.AspNetCore;
 
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
-{
-}
-
-public sealed class Program
-{
-}
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options) { }
 
 public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
 {
@@ -232,7 +344,7 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         _connection.Open();
 
-        builder.ConfigureServices(services =>
+        builder.ConfigureTestServices(services =>
             services.ReplaceDbProvider<AppDbContext>(options => options.UseSqlite(_connection)));
     }
 
@@ -247,53 +359,84 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
 > [!WARNING]
 > `ReplaceDbProvider<TContext>` re-registers the context via `AddDbContext<TContext>`. If your app uses `AddDbContextFactory` or `AddPooledDbContextFactory`, replace those registrations directly instead.
 
-### Replace a resource loader
+### Deterministic time
+
+`WithFakeTimeProvider` registers a `FakeTimeProvider` as the singleton `TimeProvider`. The `out` overloads default to `WebApplicationFactoryTimeExtensions.DefaultTestStartInstant` (`2024-01-01T00:00:00Z`).
 
 ```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Trellis;
-using Trellis.Authorization;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Time.Testing;
 using Trellis.Testing.AspNetCore;
 
-public sealed record GetOrderQuery(string OrderId);
-public sealed record OrderResource(string Id);
+WebApplicationFactory<Program> factory = default!;
 
-public sealed class FakeOrderLoader : IResourceLoader<GetOrderQuery, OrderResource>
+factory = factory.WithFakeTimeProvider(out var fakeTime);
+fakeTime.Advance(System.TimeSpan.FromDays(3));
+```
+
+## Composition
+
+Once a handler returns `Result<T>` (or a command returns `Result<Unit>`), the testing surface composes naturally with the rest of Trellis: chain `Bind`/`Map`/`Ensure` on production code, then assert on the terminal result with `BeSuccess` / `BeFailureOfType<TError>`.
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Trellis;
+using Trellis.Authorization;
+using Trellis.Testing;
+
+public sealed record OrderId(Guid Value);
+
+public sealed class Order : Aggregate<OrderId>
 {
-    public Task<Result<OrderResource>> LoadAsync(
-        GetOrderQuery message,
-        CancellationToken cancellationToken) =>
-        Task.FromResult(Result.Ok(new OrderResource(message.OrderId)));
+    public Order(OrderId id, string email) : base(id) => Email = email;
+    public string Email { get; }
 }
 
-var services = new ServiceCollection();
-services.ReplaceResourceLoader<GetOrderQuery, OrderResource>(_ => new FakeOrderLoader());
+public sealed record PlaceOrder(string Email);
+
+public sealed class PlaceOrderHandler(FakeRepository<Order, OrderId> repo, TestActorProvider actors)
+{
+    public async Task<Result<OrderId>> HandleAsync(PlaceOrder cmd, CancellationToken ct)
+    {
+        var actor = await actors.GetCurrentActorAsync(ct);
+        if (!actor.HasPermission("Orders.Write"))
+            return Result.Fail<OrderId>(new Error.Forbidden("Orders.Write"));
+
+        var order = new Order(new OrderId(Guid.NewGuid()), cmd.Email);
+        var save = await repo.SaveAsync(order, ct);
+        return save.Map(_ => order.Id);
+    }
+}
+
+var repo = new FakeRepository<Order, OrderId>().WithUniqueConstraint(o => o.Email);
+var actors = new TestActorProvider("user-1", "Orders.Write");
+var handler = new PlaceOrderHandler(repo, actors);
+
+(await handler.HandleAsync(new PlaceOrder("ada@example.com"), CancellationToken.None))
+    .Should().BeSuccess();
+
+(await handler.HandleAsync(new PlaceOrder("ada@example.com"), CancellationToken.None))
+    .Should().BeFailureOfType<Error.Conflict>();
 ```
 
 ## Practical guidance
 
-### Prefer fakes over mocks for repositories
+- **Prefer fakes over mocks for repositories.** `FakeRepository` reproduces real not-found behavior, unique constraints, and domain-event capture; mocks usually drift from the real `IRepository` contract.
+- **Pick the right repository surface.** Production handlers should consume the staging API (`Add` / `Remove` / `RemoveByIdAsync`). The fake-only `SaveAsync` / `DeleteAsync` (both `Task<Result<Unit>>`) exist so tests can assert on conflict / not-found result shapes.
+- **Assert on error case, not error string.** Use `BeFailureOfType<TError>()` against the closed `Error` ADT; the typed payload (`Error.NotFound.Resource`, `Error.Conflict.ReasonCode`, etc.) carries the meaningful state.
+- **Async assertions live on the awaitable.** `BeSuccessAsync` / `BeFailureAsync` / `BeFailureOfTypeAsync` are extensions on `Task<Result<T>>` and `ValueTask<Result<T>>` — not on `ResultAssertions<T>`. `Unwrap()` / `UnwrapError()` are test-only; never copy them into production code.
+- **Use the rich `Actor` overload when authorization is non-trivial.** When a policy reads `ForbiddenPermissions` or `Attributes`, pass a full `Actor` to `TestActorProvider` and `CreateClientWithActor`; the simple `(id, perms)` overload only sets granted permissions.
+- **Configure DI before `CreateClient()`.** Use `ConfigureTestServices` for `ReplaceSingleton` / `ReplaceResourceLoader` / `ReplaceDbProvider`; mutating services after the host is built has no effect.
+- **Default to deterministic time.** `factory.WithFakeTimeProvider(out var fake)` starts at `2024-01-01T00:00:00Z` so tests asserting on absolute timestamps do not flake. Use the explicit-instant overload only when a fixture needs a specific date.
+- **Keep Entra-token tests gated.** `CreateClientWithActor` covers fast local and CI tests. Use `CreateClientWithEntraTokenAsync` + `MsalTestTokenProvider` only for E2E suites against a dedicated test tenant with MFA disabled for test users.
 
-`FakeRepository` behaves more like the real thing:
+## Cross-references
 
-- not-found behavior
-- unique constraints
-- domain event capture
-
-### Assert on error codes when it matters
-
-Trellis default error codes end in `.error`, which makes them good assertion targets.
-
-### Use the actor overload when authorization rules are richer
-
-If your policy uses forbidden permissions or attributes, pass a real `Actor` to `CreateClientWithActor`.
-
-### Keep Entra token tests separate
-
-Use `CreateClientWithActor` for fast local and CI tests. Use real tokens only when you need to validate the full authentication pipeline.
-
-## Next steps
-
-- [Testing with Azure Entra ID Tokens](integration-entra-testing.md)
-- [Mediator Pipeline](integration-mediator.md)
-- [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md)
+- API surface (assertions, fakes, actor provider): [`trellis-api-testing-reference.md`](../api_reference/trellis-api-testing-reference.md)
+- API surface (WebApplicationFactory, `.http` replay, MSAL): [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md)
+- `Result<T>`, `Maybe<T>`, closed `Error` ADT, `ResourceRef`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Authorization primitives (`Actor`, `IActorProvider`): [`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md)
+- Cookbook recipes (incl. **Recipe 16 — Unit of work in handlers**): [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md)

--- a/docs/docfx_project/articles/integration.md
+++ b/docs/docfx_project/articles/integration.md
@@ -1,6 +1,30 @@
+﻿---
+title: Integration Guides
+package: Trellis (multiple)
+topics: [integration, http, mediator, ef, asp, fluentvalidation, sso, testing, observability]
+related_api_reference: [trellis-api-core.md, trellis-api-mediator.md, trellis-api-asp.md, trellis-api-efcore.md, trellis-api-fluentvalidation.md, trellis-api-http.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Integration
 
 When you adopt Trellis, the hard part is rarely `Result<T>` itself. The real work is making it feel natural in HTTP APIs, validation, persistence, authorization, and observability. These guides show the pieces that fit around Trellis in real applications.
+
+## Patterns Index
+
+| Goal | Article | Topics |
+|---|---|---|
+| Map `Result<T>` to HTTP responses (MVC, Minimal APIs, Problem Details, ETags, `Prefer`) | [ASP.NET Core](integration-aspnet.md) | asp, http, problem-details |
+| Authorize HTTP requests with actor-based claims | [ASP.NET Authorization](integration-asp-authorization.md) | asp, authorization, actor |
+| Call HTTP APIs and bridge responses into `Result<T>` / `Maybe<T>` | [HTTP Client](integration-http.md) | http, httpclient, json |
+| Add validator-based input checks at the application boundary | [FluentValidation](integration-fluentvalidation.md) | validation, fluentvalidation |
+| Persist aggregates with EF Core and explicit failure mapping | [Entity Framework Core](integration-ef.md) | ef, persistence, repository |
+| Apply pipeline behaviors (validation, logging, transactions) around handlers | [Mediator](integration-mediator.md) | mediator, pipeline |
+| Configure least-privilege database permissions | [Database Permissions](integration-db-permissions.md) | ef, security, permissions |
+| Sign users in via external identity providers | [SSO](integration-sso.md) | sso, authentication |
+| Test against Microsoft Entra in integration tests | [Entra Testing](integration-entra-testing.md) | testing, entra, sso |
+| Write integration tests for Trellis-based services | [Testing](integration-testing.md) | testing, integration |
+| Trace, correlate, and diagnose production behavior | [Observability](integration-observability.md) | observability, opentelemetry, tracing |
 
 > [!TIP]
 > If you are building a web API, start with [ASP.NET Core Integration](integration-aspnet.md). It gives you the cleanest end-to-end path from domain results to HTTP responses.
@@ -96,3 +120,12 @@ From there:
 ## Next step
 
 Go to [ASP.NET Core Integration](integration-aspnet.md).
+
+## Cross-references
+
+- Core `Result<T>` / `Maybe<T>` / `Error` semantics: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Mediator pipeline behaviors: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- ASP.NET Core response mapping surface: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- EF Core integration surface: [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)
+- FluentValidation integration surface: [`trellis-api-fluentvalidation.md`](../api_reference/trellis-api-fluentvalidation.md)
+- HttpClient extensions surface: [`trellis-api-http.md`](../api_reference/trellis-api-http.md)

--- a/docs/docfx_project/articles/intro.md
+++ b/docs/docfx_project/articles/intro.md
@@ -1,3 +1,11 @@
+﻿---
+title: Introduction
+package: Trellis (multiple)
+topics: [overview, railway-oriented-programming, ddd, value-objects, error-handling, getting-started]
+related_api_reference: [trellis-api-core.md, trellis-api-primitives.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Introduction
 
 Trellis is for the moment when your codebase has outgrown "just use strings and throw exceptions." It gives you a structure for writing application code that stays readable as validation, business rules, persistence, and HTTP concerns pile up.

--- a/docs/docfx_project/articles/maybe-type.md
+++ b/docs/docfx_project/articles/maybe-type.md
@@ -1,19 +1,83 @@
-﻿# Why Maybe<T>?
+﻿---
+title: Maybe Type
+package: Trellis.Core
+topics: [maybe, optional, none, nullable, json, ef-core, validation, linq]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Maybe Type
 
-C# already gives you `T?`, `Nullable<T>`, and plain old `null`. So why does Trellis add `Maybe<T>`?
+`Maybe<T>` is Trellis' explicit, composable optional. It models *expected absence* in the domain so optional values flow through `Map`/`Bind`/LINQ and convert to `Result<T>` at the boundary where absence becomes an error.
 
-Because sometimes you do not just need “a value that might be missing.” You need that optional value to be:
+## Patterns Index
 
-- explicit in your domain model
-- composable in a pipeline
-- easy to convert into `Result<T>` when absence becomes an error
+| Goal | Use | See |
+|---|---|---|
+| Wrap a possibly-null value | `Maybe.From(value)` / `Maybe<T>.None` / implicit `T → Maybe<T>` | [Creating values](#creating-values) |
+| Read a value without throwing | `Match`, `TryGetValue`, `GetValueOrDefault` | [Reading values](#reading-values) |
+| Transform an optional value | `Map`, `Bind`, `Where`, `Tap`, `Or` | [Transforming values](#transforming-values) |
+| Compose multiple optionals | LINQ `from … from … select` (`Select`/`SelectMany`) | [LINQ query syntax](#linq-query-syntax) |
+| Pull the first/only present item out of a sequence | `TryFirst`, `TryLast`, `Choose` | [Collections](#collections) |
+| Validate an optional input ("null OK; if present, must be valid") | `Maybe.Optional(value, validate)` | [Boundary validation](#boundary-validation) |
+| Enforce cross-field invariants over `Maybe<T>` properties | `MaybeInvariant.AllOrNone` / `Requires` / `MutuallyExclusive` / `ExactlyOne` / `AtLeastOne` | [Multi-field invariants](#multi-field-invariants) |
+| Convert `Maybe<T>` ↔ `Result<T>` | `ToResult(error)` / `ToResultAsync(...)` / `Result<T>.ToMaybe()` | [Bridging to Result](#bridging-to-result) |
+| Convert `Maybe<T>` ↔ nullable | `AsMaybe()` / `AsNullable()` | [Interop with nullable](#interop-with-nullable) |
+| Serialize `Maybe<scalar value object>` over JSON | `MaybeScalarValueJsonConverter` (Trellis.Asp) | [JSON serialization](#json-serialization) |
+| Query a `Maybe<T>` column in EF Core | `MaybeQueryableExtensions` / `AddTrellisInterceptors()` (Trellis.EntityFrameworkCore) | [EF Core integration](#ef-core-integration) |
 
-That is the job of `Maybe<T>`.
+## Use this guide when
 
-> [!TIP]
-> `Maybe<T>` is not a replacement for every nullable value in your application. It shines when optionality is part of the **domain** and needs to compose with Trellis result flows.
+- You want optionality to be **part of the domain model** rather than a per-call nullability annotation.
+- You need optional values that compose with `Result<T>` pipelines and tolerate `Bind`/`Map`/`Match`/LINQ.
+- A value is allowed to be missing partway through a workflow but must become a typed `Error` at the boundary.
+- You map domain models to EF Core columns or JSON payloads where "present vs. absent" is meaningful.
 
-## Start Here: the Smallest Useful Example
+For ordinary nullable primitives on a DTO or for plain nullable interop, prefer `T?` / `Nullable<T>`.
+
+## Surface at a glance
+
+`Maybe<T>` is a `readonly struct` defined in `Trellis.Core`. `default(Maybe<T>)` equals `Maybe<T>.None` (analyzer **TRLS019** flags explicit `default(Maybe<T>)` and recommends `Maybe<T>.None`).
+
+| Member | Kind | Purpose |
+|---|---|---|
+| `Maybe.From<T>(T? value) where T : notnull` | static factory (non-generic class) | Wraps a nullable; `null` → `None`. |
+| `Maybe<T>.From(T? value)` | static factory (generic struct) | Same as above with explicit `T`. |
+| `Maybe<T>.None` | static property | The empty instance. |
+| `implicit operator Maybe<T>(T value)` | conversion | Lets a bare `T` flow into a `Maybe<T>` slot. |
+| `HasValue` / `HasNoValue` | properties | Presence flags. |
+| `Value` | property | Throws on `None`. Hidden from IntelliSense; analyzer **TRLS003** flags unguarded reads. Use `Match`/`TryGetValue`/`GetValueOrDefault`. |
+| `GetValueOrThrow(string?)` | method | Throwing extractor with optional message. |
+| `GetValueOrDefault(T)` / `GetValueOrDefault(Func<T>)` | methods | Non-throwing extractors (eager / deferred). |
+| `TryGetValue(out T)` | method | TryParse-style extractor. |
+| `Map<TResult>(Func<T, TResult>)` | method | Transform present value. |
+| `Bind<TResult>(Func<T, Maybe<TResult>>)` | method | Flat-map. |
+| `Match<TResult>(Func<T, TResult> some, Func<TResult> none)` | method | Branch on presence. |
+| `Where(Func<T, bool>)` | method | Keep value only if predicate holds. |
+| `Tap(Action<T>)` | method | Side effect on present value. |
+| `Or(T)` / `Or(Func<T>)` / `Or(Maybe<T>)` / `Or(Func<Maybe<T>>)` | methods | Fallback (eager / deferred / maybe / deferred maybe). |
+| `Equals(Maybe<T>)` / `Equals(T?)` / `==` / `!=` (vs `T`, `object?`, `Maybe<T>`) | equality | Structural equality including raw values. |
+| `MaybeExtensions.AsMaybe<T>` / `AsNullable<T>` | extension methods | `T?` (struct or class) → `Maybe<T>` and back. |
+| `MaybeExtensions.ToResult<T>(Error)` / `ToResult(Func<Error>)` | extension methods | Bridge to `Result<T>`. |
+| `MaybeExtensionsAsync.ToResultAsync` / `MatchAsync` | extension methods | `Task`/`ValueTask` overloads of `ToResult` and `Match`. |
+| `MaybeChooseExtensions.Choose` | extension methods | Flatten `IEnumerable<Maybe<T>>` (with optional projector). |
+| `MaybeCollectionExtensions.TryFirst` / `TryLast` (with optional predicate) | extension methods | First/last hit as `Maybe<T>`. |
+| `MaybeLinqExtensions.Select` / `SelectMany` | extension methods | Enables LINQ query syntax. |
+| `Maybe.Optional<TIn, TOut>(TIn?, Func<TIn, Result<TOut>>)` | static method (class & struct overloads) | "Null OK; if present, validate." Returns `Result<Maybe<TOut>>`. |
+| `MaybeInvariant.AllOrNone` / `Requires` / `MutuallyExclusive` / `ExactlyOne` / `AtLeastOne` | static methods | Cross-field invariants returning `Result<Unit>`. |
+| `Result<T>.ToMaybe()` / `ToMaybeAsync()` | extension methods (Result side) | Failure → `None`. |
+
+Full signatures: [trellis-api-core.md](../api_reference/trellis-api-core.md).
+
+## Installation
+
+```bash
+dotnet add package Trellis.Core
+```
+
+JSON converters for `Maybe<scalar value object>` ship in `Trellis.Asp`. EF Core query/update helpers ship in `Trellis.EntityFrameworkCore`.
+
+## Quick start
 
 ```csharp
 using Trellis;
@@ -21,153 +85,77 @@ using Trellis;
 Maybe<string> middleName = Maybe.From("Byron");
 Maybe<string> noNickname = Maybe<string>.None;
 
-Console.WriteLine(middleName.HasValue); // True
-Console.WriteLine(noNickname.HasValue); // False
+string display = middleName.Match(
+    some: name => name,
+    none: () => "(none)");
 
-var displayName = middleName.Match(
-    some => some,
-    () => "(none)");
+Result<string> required = noNickname.ToResult(
+    new Error.NotFound(ResourceRef.For("Nickname", "primary"))
+    {
+        Detail = "A nickname is required for the marketing payload.",
+    });
 ```
 
-## The Problem `Maybe<T>` Solves
+## Creating values
 
-The issue with plain nullable values is not that they are bad. The issue is that they stop being expressive once the code becomes more domain-driven.
-
-Consider an entity with an optional phone number:
+| Form | Result |
+|---|---|
+| `Maybe.From(value)` | `Some(value)` if non-null, otherwise `None`. |
+| `Maybe<T>.From(value)` | Same, with explicit type. |
+| `Maybe<T>.None` | The empty instance (preferred over `default(Maybe<T>)`). |
+| `Maybe<T> m = value;` | Implicit conversion from `T`. Useful in expression-bodied returns. |
+| `Maybe.From((string?)null)` | `None`. |
+| `value.AsMaybe()` (`T : class` or `T : struct` via `T?`) | Extension form — handy in LINQ. |
 
 ```csharp
 using Trellis;
 
-public sealed record PhoneNumber(string Value);
-
-public sealed class Customer
-{
-    public Maybe<PhoneNumber> Phone { get; }
-
-    public Customer(Maybe<PhoneNumber> phone) => Phone = phone;
-}
-```
-
-That says something precise:
-
-- the customer may or may not have a phone number
-- **if** there is a phone number, it is a real `PhoneNumber`
-- “empty phone number” is not a separate fake concept inside the value object
-
-That is usually clearer than pushing optionality down into the value object itself.
-
-## When `Maybe<T>` Is Better Than `T?`
-
-### Use `Maybe<T>` when...
-
-| Scenario | Why `Maybe<T>` helps |
-| --- | --- |
-| Optional value objects | It keeps the value object valid and moves optionality to the containing model |
-| Optional data in a pipeline | It composes with `Map`, `Bind`, `Where`, `Tap`, and `ToResult(...)` |
-| Absence should become a domain error later | `ToResult(...)` makes that conversion explicit |
-| You want equality and operators for optional values | `Maybe<T>` supports `Equals`, `==`, and `!=` |
-
-### Use `T?` when...
-
-| Scenario | Better choice |
-| --- | --- |
-| Optional primitives on DTOs | `int?`, `DateTime?`, `decimal?` |
-| Optional strings or references with no pipeline needs | `string?`, `User?` |
-| Interop with APIs that already use nullable reference types | `T?` |
-| Performance-sensitive code where nullable semantics are enough | `T?` / `Nullable<T>` |
-
-> [!NOTE]
-> A practical rule: use `Maybe<T>` for **optional domain values** that need Trellis composition. Use `T?` for ordinary nullable data.
-
-## Creating `Maybe<T>` Values
-
-### Some value
-
-```csharp
-using Trellis;
-
-Maybe<string> some = Maybe.From("Ada");
-Maybe<string> alsoSome = Maybe<string>.From("Ada");
+Maybe<string> some         = Maybe.From("Ada");
+Maybe<string> alsoSome     = Maybe<string>.From("Ada");
 Maybe<string> implicitSome = "Ada";
-```
-
-### No value
-
-```csharp
-using Trellis;
-
-Maybe<string> none = Maybe<string>.None;
-Maybe<int> missingCount = Maybe<int>.None;
-```
-
-### Null becomes `None`
-
-```csharp
-using Trellis;
+Maybe<int>    missingCount = Maybe<int>.None;
 
 string? input = null;
-Maybe<string> maybeName = Maybe.From(input);
-
-Console.WriteLine(maybeName.HasValue); // False
+Maybe<string> fromNullable = Maybe.From(input);  // None
 ```
 
-## Reading Values Safely
+## Reading values
 
-The problem with optional values is not creating them. It is consuming them without littering your code with `if` statements.
+`Value` exists but throws on `None` and is gated by analyzer **TRLS003**. Prefer the safe readers below.
 
-### `Match`
-
-```csharp
-using Trellis;
-
-Maybe<string> nickname = Maybe.From("Countess");
-
-var display = nickname.Match(
-    some => $"Nickname: {some}",
-    () => "No nickname on file");
-```
-
-### `TryGetValue`
+| API | When to use |
+|---|---|
+| `Match(some, none)` | You always want a result, branched on presence. |
+| `TryGetValue(out var v)` | Imperative early-return style. |
+| `GetValueOrDefault(fallback)` | Eager fallback when constructing it is cheap. |
+| `GetValueOrDefault(() => fallback)` | Deferred fallback (expensive default, allocations). |
+| `GetValueOrThrow("msg")` | Genuinely unexpected absence (programmer error). |
 
 ```csharp
 using Trellis;
 
 Maybe<int> count = Maybe.From(3);
 
-if (count.TryGetValue(out var value))
-    Console.WriteLine(value);
+int total = count.Match(
+    some: n => n,
+    none: () => 0);
+
+if (count.TryGetValue(out var n))
+    Console.WriteLine(n);
+
+string title = Maybe<string>.None.GetValueOrDefault("Untitled");
+string lazy  = Maybe<string>.None.GetValueOrDefault(() => $"generated-{Guid.NewGuid():N}");
 ```
 
-### `GetValueOrDefault`
+## Transforming values
 
-```csharp
-using Trellis;
-
-Maybe<string> title = Maybe<string>.None;
-
-var value = title.GetValueOrDefault("Untitled");
-var lazyValue = title.GetValueOrDefault(() => "Generated title");
-```
-
-> [!WARNING]
-> `Value` throws when the `Maybe<T>` is empty. Prefer `Match`, `TryGetValue`, or `GetValueOrDefault(...)`.
-
-## Transforming Optional Values
-
-This is where `Maybe<T>` starts to earn its keep.
-
-### `Map`
-
-```csharp
-using Trellis;
-
-Maybe<string> email = Maybe.From("ada@example.com");
-Maybe<string> upper = email.Map(value => value.ToUpperInvariant());
-```
-
-### `Bind`
-
-Use `Bind` when the next step also returns a `Maybe<T>`.
+| Operator | Signature | Behaviour |
+|---|---|---|
+| `Map` | `Maybe<T>.Map<TResult>(Func<T, TResult>)` | Project the inner value; `None` propagates. |
+| `Bind` | `Maybe<T>.Bind<TResult>(Func<T, Maybe<TResult>>)` | Flat-map for the next step that itself returns `Maybe<TResult>`. |
+| `Where` | `Maybe<T>.Where(Func<T, bool>)` | Drop the value to `None` when the predicate is `false`. |
+| `Tap` | `Maybe<T>.Tap(Action<T>)` | Run a side effect on the present value, return `this` unchanged. |
+| `Or` | `Or(T)` / `Or(Func<T>)` / `Or(Maybe<T>)` / `Or(Func<Maybe<T>>)` | First-non-none fallback chain. |
 
 ```csharp
 using Trellis;
@@ -175,124 +163,22 @@ using Trellis;
 static Maybe<string> GetManagerEmail(string userId) =>
     userId == "42" ? Maybe.From("manager@example.com") : Maybe<string>.None;
 
-var email = Maybe.From("42")
+Maybe<string> upperEmail = Maybe.From("ada@example.com")
+    .Map(value => value.ToUpperInvariant());
+
+Maybe<string> chained = Maybe.From("42")
     .Bind(GetManagerEmail);
+
+Maybe<int> validQuantity = Maybe.From(3).Where(v => v > 0);
+
+Maybe<string> name = Maybe<string>.None
+    .Or(Maybe.From("Ada Lovelace"))
+    .Or("Unknown");
 ```
 
-### `Where`
+## Equality
 
-```csharp
-using Trellis;
-
-Maybe<int> quantity = Maybe.From(3);
-Maybe<int> validQuantity = quantity.Where(value => value > 0);
-```
-
-### `Tap`
-
-```csharp
-using Trellis;
-
-var maybeUser = Maybe.From("Ada")
-    .Tap(value => Console.WriteLine($"Found {value}"));
-```
-
-### `Or`
-
-```csharp
-using Trellis;
-
-Maybe<string> preferred = Maybe<string>.None;
-Maybe<string> legal = Maybe.From("Ada Lovelace");
-
-var name = preferred.Or(legal).Or("Unknown");
-```
-
-## Converting `Maybe<T>` to `Result<T>`
-
-This is the most important bridge in day-to-day Trellis usage.
-
-The problem it solves: sometimes “missing” is fine in the middle of the workflow, but becomes a real error at the boundary.
-
-```csharp
-using Trellis;
-
-Maybe<string> maybeEmail = Maybe<string>.None;
-
-Result<string> emailResult = maybeEmail.ToResult(
-    new Error.NotFound(ResourceRef.For("Email", "primary")) { Detail = "Primary email address was not found" });
-```
-
-There is also a lazy overload when creating the error is expensive or needs runtime context.
-
-```csharp
-using Trellis;
-
-var result = Maybe<string>.None.ToResult(
-    () => new Error.NotFound(ResourceRef.For("Email", "primary")) { Detail = "Primary email address was not found" });
-```
-
-## Converting `Result<T>` to `Maybe<T>`
-
-Sometimes you want the opposite tradeoff: “keep the value if successful, otherwise treat it as missing.”
-
-```csharp
-using Trellis;
-
-Maybe<string> existing = Result.Ok("Ada").ToMaybe();
-Maybe<string> missing = Result.Fail<string>(new Error.NotFound(ResourceRef.For("User")) { Detail = "User not found" }).ToMaybe();
-```
-
-Use this only when dropping the error is the right thing to do.
-
-## Optional Input with `Maybe.Optional(...)`
-
-A very common problem at system boundaries is “null is acceptable, but if a value is present, it must be valid.”
-
-That is exactly what `Maybe.Optional(...)` is for.
-
-### Reference input
-
-```csharp
-using Trellis;
-
-static Result<string> NonEmpty(string value) =>
-    string.IsNullOrWhiteSpace(value)
-        ? Result.Fail<string>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("nickname"), "validation.error") { Detail = "Value is required" })))
-        : Result.Ok(value);
-
-string? input = "Countess";
-
-Result<Maybe<string>> result = Maybe.Optional(input, NonEmpty);
-```
-
-### Nullable value-type input
-
-```csharp
-using Trellis;
-
-static Result<int> Positive(int value) =>
-    value > 0
-        ? Result.Ok(value)
-        : Result.Fail<int>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty("quantity"), "validation.error") { Detail = "Value must be positive" })));
-
-int? input = 3;
-
-Result<Maybe<int>> result = Maybe.Optional(input, Positive);
-```
-
-What `Maybe.Optional(...)` does:
-
-- `null` / no value -> success with `Maybe<T>.None`
-- value present and valid -> success with `Maybe.From(...)`
-- value present and invalid -> failure with the validation error
-
-## Equality and Operators
-
-This is another easy detail to miss.
-
-> [!TIP]
-> `Maybe<T>` supports `Equals`, `==`, and `!=`.
+`Maybe<T>` implements `IEquatable<Maybe<T>>` and `IEquatable<T>`, with `==` / `!=` overloads against `T`, `object?`, and `Maybe<T>`. Two `None` values are equal; two `Some` values are equal iff their inner values are.
 
 ```csharp
 using Trellis;
@@ -307,15 +193,15 @@ Console.WriteLine(none == Maybe<int>.None);     // True
 Console.WriteLine(some.Equals(Maybe.From(42))); // True
 ```
 
-## LINQ Query Syntax
+## LINQ query syntax
 
-Optional values often read nicely in query form.
+`MaybeLinqExtensions` adds `Select` and `SelectMany`, so multiple `Maybe<T>` values compose via query syntax. Any `None` in the chain short-circuits the entire query to `None`.
 
 ```csharp
 using Trellis;
 
 Maybe<string> first = Maybe.From("Ada");
-Maybe<string> last = Maybe.From("Lovelace");
+Maybe<string> last  = Maybe.From("Lovelace");
 
 Maybe<string> fullName =
     from f in first
@@ -323,65 +209,201 @@ Maybe<string> fullName =
     select $"{f} {l}";
 ```
 
-If any step is `None`, the whole query becomes `None`.
+## Collections
 
-## Collection Helpers
-
-Trellis also adds a few helpers that make working with collections of optional values pleasant.
-
-### `TryFirst` and `TryLast`
+| Helper | Returns | Notes |
+|---|---|---|
+| `IEnumerable<T>.TryFirst()` | `Maybe<T>` | First element, or `None` if empty. |
+| `IEnumerable<T>.TryFirst(predicate)` | `Maybe<T>` | First match, or `None`. |
+| `IEnumerable<T>.TryLast()` / `TryLast(predicate)` | `Maybe<T>` | Last element / last match. |
+| `IEnumerable<Maybe<T>>.Choose()` | `IEnumerable<T>` | Drops `None`s, yields inner values. |
+| `IEnumerable<Maybe<T>>.Choose(selector)` | `IEnumerable<TResult>` | Drops `None`s, projects inner values. |
 
 ```csharp
 using Trellis;
 
 var numbers = new[] { 1, 2, 3, 4 };
-
-Maybe<int> first = numbers.TryFirst();
-Maybe<int> even = numbers.TryFirst(n => n % 2 == 0);
-Maybe<int> last = numbers.TryLast();
-```
-
-### `Choose`
-
-```csharp
-using Trellis;
+Maybe<int> firstEven = numbers.TryFirst(n => n % 2 == 0);
 
 IEnumerable<Maybe<string>> names =
 [
     Maybe.From("Ada"),
     Maybe<string>.None,
-    Maybe.From("Grace")
+    Maybe.From("Grace"),
 ];
 
-IEnumerable<string> values = names.Choose();
-IEnumerable<int> lengths = names.Choose(name => name.Length);
+IEnumerable<string> defined = names.Choose();
+IEnumerable<int>    lengths = names.Choose(name => name.Length);
 ```
 
-## `Maybe<T>` and no-payload results
+## Boundary validation
 
-Sometimes the next question is: “what if my operation has no payload?”
+`Maybe.Optional` is the canonical "null is acceptable, but if a value is present it must be valid" primitive. It returns `Result<Maybe<TOut>>`:
 
-For no-payload Trellis results:
+| Input | Result |
+|---|---|
+| `null` (or `Nullable<T>` without value) | `Ok(Maybe<TOut>.None)` |
+| Value present, validator returns `Ok(v)` | `Ok(Maybe.From(v))` |
+| Value present, validator returns `Fail(e)` | `Fail(e)` |
 
-- prefer `Result.Ok()` for a successful outcome (returns `Result<Unit>`)
-- use `Result<Unit>` when the operation only needs success/failure
+Both reference (`where TIn : class`) and value-type (`where TIn : struct`) overloads exist.
 
 ```csharp
 using Trellis;
 
-Result<Unit> ok = Result.Ok();
+static Result<string> NonEmpty(string value) =>
+    string.IsNullOrWhiteSpace(value)
+        ? Result.Fail<string>(new Error.UnprocessableContent(EquatableArray.Create(
+            new FieldViolation(InputPointer.ForProperty("nickname"), "validation.error")
+            {
+                Detail = "Value is required",
+            })))
+        : Result.Ok(value);
+
+string? input = "Countess";
+Result<Maybe<string>> result = Maybe.Optional(input, NonEmpty);
 ```
 
-## Practical Rules of Thumb
+## Multi-field invariants
 
-- Use `Maybe<T>` for optional **domain values**, especially value objects
-- Keep optionality on the containing model, not inside a value object's invariants
-- Use `ToResult(...)` when absence should become a real error
-- Use `Maybe.Optional(...)` for boundary validation of optional inputs
-- Use `ToMaybe()` only when you truly want to discard the error
-- Prefer safe readers like `Match`, `TryGetValue`, and `GetValueOrDefault(...)`
+`MaybeInvariant` enforces shape rules across several `Maybe<T>` fields and returns `Result<Unit>`. Failures are collected as `Error.UnprocessableContent` with one `FieldViolation` per offending field; field paths are normalized via `InputPointer.ForProperty(name)`.
 
-## Next Steps
+| Helper | Rule | Available arities |
+|---|---|---|
+| `AllOrNone` | All fields present, or all absent. | 2, 3, 4 |
+| `Requires` | If `source` is present, `required` must be too. | 2 |
+| `MutuallyExclusive` | At most one field present. | 2, 3 |
+| `ExactlyOne` | Exactly one field present. | 2, 3 |
+| `AtLeastOne` | At least one field present. | 2, 3 |
 
-- Read [Error Handling](error-handling.md) for the errors typically paired with `ToResult(...)`
-- Read [Advanced Features](advanced-features.md) for LINQ, tuple destructuring, and parallel flows
+```csharp
+using Trellis;
+
+Result<Unit> shape = MaybeInvariant.ExactlyOne(
+    command.Email, command.Phone, "email", "phone");
+```
+
+## Bridging to Result
+
+The most important conversion in day-to-day Trellis usage: turn "missing" into a typed `Error` at the boundary.
+
+| Direction | API | Notes |
+|---|---|---|
+| `Maybe<T>` → `Result<T>` (eager error) | `maybe.ToResult(error)` | Allocates the `Error` even on success. |
+| `Maybe<T>` → `Result<T>` (lazy error) | `maybe.ToResult(() => error)` | Use when error construction is expensive or context-dependent. |
+| `Task<Maybe<T>>` → `Task<Result<T>>` | `maybeTask.ToResultAsync(error)` / `ToResultAsync(() => error)` | `Task` and `ValueTask` overloads available. |
+| `Task<Maybe<T>>` → branch | `maybeTask.MatchAsync(some, none)` | Sync- and async-delegate overloads. |
+| `Result<T>` → `Maybe<T>` | `result.ToMaybe()` / `resultTask.ToMaybeAsync()` | Failures collapse to `None`; the error is dropped. |
+
+```csharp
+using Trellis;
+
+Maybe<string> maybeEmail = Maybe<string>.None;
+
+Result<string> required = maybeEmail.ToResult(
+    new Error.NotFound(ResourceRef.For("Email", "primary"))
+    {
+        Detail = "Primary email address was not found",
+    });
+
+Result<string> requiredLazy = Maybe<string>.None.ToResult(
+    () => new Error.NotFound(ResourceRef.For("Email", "primary"))
+    {
+        Detail = "Primary email address was not found",
+    });
+
+Maybe<string> backToMaybe = Result.Ok("Ada").ToMaybe();
+```
+
+Use `ToMaybe()` only when discarding the error is genuinely correct.
+
+## Interop with nullable
+
+`MaybeExtensions` provides round-trip helpers between `Maybe<T>` and the BCL nullable forms.
+
+| API | Receiver | Returns | Notes |
+|---|---|---|---|
+| `AsMaybe<T>(this T?)` `where T : struct` | nullable value type | `Maybe<T>` | `null` → `None`. |
+| `AsMaybe<T>(this T)` `where T : class` | nullable reference | `Maybe<T>` | `null` → `None`. |
+| `AsNullable<T>(in this Maybe<T>)` `where T : struct` | `Maybe<T>` | `T?` | `None` → `null`. |
+
+```csharp
+using Trellis;
+
+int? raw = 7;
+Maybe<int> maybeQty = raw.AsMaybe();
+
+string? maybeName = "Ada";
+Maybe<string> nameMaybe = maybeName.AsMaybe();
+
+int? back = maybeQty.AsNullable();
+```
+
+## JSON serialization
+
+`Trellis.Asp` ships `MaybeScalarValueJsonConverter<TValue, TPrimitive>` and a `MaybeScalarValueJsonConverterFactory` that registers it for any `Maybe<TScalar>` where `TScalar` is a Trellis scalar value object. Absence serializes as JSON `null`; deserialization participates in the validation-error scope used by `ScalarValueValidationFilter` / `ScalarValueValidationEndpointFilter`.
+
+There is no built-in System.Text.Json converter for arbitrary `Maybe<T>` in `Trellis.Core` itself — pair with a scalar value object or supply your own converter.
+
+See [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md) for converter signatures and validation wiring.
+
+## EF Core integration
+
+`Trellis.EntityFrameworkCore` discovers `Maybe<T>` properties via `MaybeConvention` and maps them to a generated `_camelCase` storage member, so direct `.Value` / `.HasValue` / `GetValueOrDefault(d)` calls in LINQ predicates do not translate by default. Two supported paths:
+
+| Approach | API | Use when |
+|---|---|---|
+| Explicit query helpers | `MaybeQueryableExtensions.WhereHasValue` / `WhereNone` / `WhereEquals` / `WhereLessThan(OrEqual)` / `WhereGreaterThan(OrEqual)` plus `OrderByMaybe` / `ThenByMaybe(Descending)` | You want predictable SQL without registering interceptors. |
+| Interceptor rewriting | `optionsBuilder.AddTrellisInterceptors()` (registers `MaybeQueryInterceptor`) | You want natural `.HasValue` / `.Value` / `GetValueOrDefault(d)` syntax to translate. |
+| Repo lookups returning optionals | `IQueryable<T>.FirstOrDefaultMaybeAsync` / `SingleOrDefaultMaybeAsync` | Replace EF's `null` returns with `Maybe<T>.None`. |
+| Indexing a `Maybe<T>` column | `entityTypeBuilder.HasTrellisIndex(x => x.M)` | Avoids analyzer **TRLS016** by targeting the storage member. |
+| `ExecuteUpdate` over `Maybe<T>` | `MaybeUpdateExtensions.SetMaybeValue(...)` / `SetMaybeNone(...)` | Set Some / clear via bulk update. |
+
+Without one of these, raw `.Value` or `GetValueOrDefault(sentinel)` in EF queries either throws at materialization or fails to translate. Analyzer **TRLS013** flags `.Value` in Select-family LINQ projections (in-memory).
+
+See [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md) for full signatures and conventions.
+
+## Composition
+
+Once `Maybe<T>` and `Result<T>` are in the same pipeline they compose via `ToResult` / `ToMaybe` and the standard result combinators:
+
+```csharp
+using Trellis;
+
+public sealed record Customer(string Id, Maybe<string> Email);
+
+static Result<Customer> Load(string id) => /* ... */ Result.Ok(new Customer(id, Maybe.From("ada@example.com")));
+static Task<Result<Unit>> SendWelcomeAsync(string email, CancellationToken ct) => /* ... */ Task.FromResult(Result.Ok());
+
+public Task<Result<Unit>> WelcomeAsync(string id, CancellationToken ct) =>
+    Load(id)
+        .Bind(customer => customer.Email.ToResult(
+            new Error.UnprocessableContent(EquatableArray.Create(
+                new FieldViolation(InputPointer.ForProperty("email"), "validation.error")
+                {
+                    Detail = "Customer has no email address on file.",
+                }))))
+        .BindAsync((email, token) => SendWelcomeAsync(email, token), ct);
+```
+
+For the "no payload" success case, prefer `Result<Unit>` (`Result.Ok()` returns `Result<Unit>`); `Maybe<T>` is for *values*, not for "success/failure".
+
+## Practical guidance
+
+- Use `Maybe<T>` for optional **domain values**, especially value objects; keep optionality on the containing entity rather than encoded inside a value object's invariants.
+- Prefer `Maybe<T>.None` over `default(Maybe<T>)` (analyzer **TRLS019**).
+- Prefer safe readers (`Match`, `TryGetValue`, `GetValueOrDefault`) over `Value` (analyzer **TRLS003**).
+- Use `Maybe.Optional` at boundaries when "null OK; if present, must validate."
+- Use `MaybeInvariant.*` for cross-field shape rules instead of bespoke `if`/`else` ladders.
+- Use `ToResult` to lift absence into a typed `Error` at the boundary; use `ToMaybe()` only when discarding the error is genuinely correct.
+- For EF Core, prefer the `MaybeQueryableExtensions.WhereXxx` helpers; otherwise register `AddTrellisInterceptors()` to make natural syntax translate.
+- For ordinary nullable primitives on DTOs, keep using `T?` — `Maybe<T>` is not a blanket replacement for `Nullable<T>`.
+
+## Cross-references
+
+- API surface: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Errors typically paired with `ToResult(...)`: [Error Handling](error-handling.md)
+- LINQ query syntax, tuple destructuring, parallel flows: [Advanced Features](advanced-features.md)
+- JSON converter for `Maybe<scalar value object>`: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- EF Core query/update/index helpers and interceptors: [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)
+- Cookbook recipes that use `Maybe<T>`: [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md)

--- a/docs/docfx_project/articles/migration.md
+++ b/docs/docfx_project/articles/migration.md
@@ -137,13 +137,13 @@ result.TryGetError(out var err);
 
 ### Error becomes a closed ADT
 
-v1 `Error` was a `class` with 18 hand-written subclasses (`ValidationError`, `NotFoundError`, …) and static factory helpers (`Error.Validation(...)`, `Error.NotFound(...)`).
+v1 `Error` was a `class` with 18 hand-written subclasses (`ValidationError`, `NotFoundError`, …) and static factory helpers (`Error.Validation(...)`, `Error.NotFound(...)`). <!-- v1-stale-ok -->
 
 v2 `Error` is an `abstract record` with **20 nested `sealed record` cases** (`Error.NotFound`, `Error.UnprocessableContent`, …). The base constructor is `private` so the catalog is closed; there are no static factories.
 
 ```csharp
 // v1
-return Result.Failure<Order>(Error.NotFound("Order missing"));
+return Result.Failure<Order>(Error.NotFound("Order missing")); // v1-stale-ok
 
 // v2
 return Result.Fail<Order>(new Error.NotFound(ResourceRef.For<Order>(id)) { Detail = "Order missing" });

--- a/docs/docfx_project/articles/migration.md
+++ b/docs/docfx_project/articles/migration.md
@@ -1,217 +1,308 @@
-﻿# Migrating from FunctionalDDD
+﻿---
+title: Migrating from v1 to v2
+package: Trellis (multiple)
+topics: [migration, breaking-changes, v1-to-v2, result-unit, error-adt, package-renames]
+related_api_reference: [trellis-api-core.md, trellis-api-asp.md, trellis-api-mediator.md, trellis-api-http.md, trellis-api-statemachine.md, trellis-api-analyzers.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Migrating from v1 to v2
 
-Migrating from `FunctionalDdd.*` to `Trellis.*` is mostly a **rename exercise**, not a redesign.
+A package- and namespace-rename combined with a tightened public surface. Per-package "Breaking changes from v1" sections in `api_reference/` are the authoritative source of truth; this guide is the cross-cutting index and the recommended migration order.
 
-That is good news: you usually do **not** need to rethink your domain model or rewrite your pipelines. You need to update package names, namespaces, and a few integration method names.
+## Patterns Index
+
+| Old API / artifact | New API / artifact | See |
+|---|---|---|
+| `Result.Success(...)` / `Result.Failure(...)` | `Result.Ok(...)` / `Result.Fail(...)` | [Result and Error renames](#result-and-error-renames-trelliscore) |
+| Implicit `T → Result<T>` / `Error → Result<T>` | Explicit `Result.Ok(value)` / `Result.Fail<T>(error)` | [Result and Error renames](#result-and-error-renames-trelliscore) |
+| `Result.SuccessIf` / `Result.FailureIf` / `*Async` variants | Inline ternary | [Removed factories](#removed-factories) |
+| `Result.FromException(ex)` | `Result.Try` / `Result.TryAsync` or `new Error.InternalServerError(...)` | [Removed factories](#removed-factories) |
+| Non-generic `Result` instance type | `Result<Unit>` (ADR-005) | [Non-generic Result removed (ADR-005)](#non-generic-result-removed-adr-005) |
+| `result.Value` getter | `TryGetValue` / `Match` / `var (ok, v, err) = result;` | [Accessor changes](#accessor-changes) |
+| `Error` open class hierarchy + `Error.X("msg")` factories | `Error` closed ADT + `new Error.X(payload) { Detail = "msg" }` | [Error becomes a closed ADT](#error-becomes-a-closed-adt) |
+| `MatchErrorExtensions.MatchError(...)` | `Match(...)` + `switch` over the closed ADT | [Removed extensions](#removed-extensions) |
+| `FlattenValidationErrorsExtensions` | `Combine` (auto-merges `Error.UnprocessableContent.Fields` / `.Rules`) | [Removed extensions](#removed-extensions) |
+| `Error.Instance` field | Synthesized by ASP wire layer from request URL + `ResourceRef` | [Removed extensions](#removed-extensions) |
+| `Trellis.Asp.WriteOutcome<T>` | `Trellis.WriteOutcome<T>` (in `Trellis.Core`) | [ASP.NET Core (Trellis.Asp)](#aspnet-core-trellisasp) |
+| `Trellis.Stateless` package + namespace | `Trellis.StateMachine` package + namespace | [State machine (Trellis.StateMachine)](#state-machine-trellisstatemachine) |
+| `ReadResultFromJsonAsync<T>` | `ReadJsonAsync<T>` | [HTTP (Trellis.Http)](#http-trellishttp) |
+| `ReadResultMaybeFromJsonAsync<T>` | `ReadJsonMaybeAsync<T>` | [HTTP (Trellis.Http)](#http-trellishttp) |
+| `HandleForbidden*` / `HandleClientError*` / `HandleServerError*` / `EnsureSuccess*` / `HandleFailureAsync<TContext>` | `ToResultAsync(statusMap)` or body-aware `ToResultAsync(mapper, ct)` | [HTTP (Trellis.Http)](#http-trellishttp) |
+| Sync HTTP receivers (`HttpResponseMessage` / `Result<HRM>`) | Async-only canonical chain | [HTTP (Trellis.Http)](#http-trellishttp) |
+| `Trellis.Results` package | `Trellis.Core` package (CLR namespace unchanged) | [Package map](#package-map-legacy--current) |
+| `Trellis.DomainDrivenDesign` package | Folded into `Trellis.Core` | [Package map](#package-map-legacy--current) |
+| `Trellis.Primitives.Generator` package | Bundled in `Trellis.Core.nupkg` | [Package map](#package-map-legacy--current) |
+| `Trellis.AspSourceGenerator` package | Bundled in `Trellis.Asp.nupkg` | [Package map](#package-map-legacy--current) |
+| `Trellis.EntityFrameworkCore.Generator` package | Bundled in `Trellis.EntityFrameworkCore.nupkg` | [Package map](#package-map-legacy--current) |
+| `Trellis.Asp.Authorization` package | Folded into `Trellis.Asp.nupkg` (namespace unchanged) | [Package map](#package-map-legacy--current) |
+| OpenTelemetry source `"Trellis.Results"` | `"Trellis.Core"` (`RopTrace.ActivitySourceName`) | [Observability](#observability) |
+| Analyzer IDs `TRLSGEN001`..`TRLSGEN103` | `TRLS031`..`TRLS038` | [Analyzer ID renames](#analyzer-id-renames) |
+
+## Use this guide when
+
+- You are upgrading a service from a v1 `Trellis.*` surface (`Trellis.Results`, `Trellis.DomainDrivenDesign`, `Trellis.Stateless`, `Trellis.Asp.Authorization`, `Trellis.AspSourceGenerator`, `Trellis.EntityFrameworkCore.Generator`, `Trellis.Primitives.Generator`) to the consolidated v2 packages.
+- You hit `CS0029` after pulling v2 because implicit `T → Result<T>` and `Error → Result<T>` operators were removed.
+- You hit `CS1061` reading `result.Value` — the throwing getter was deleted.
+- You hit `CS0117` calling `Result.Success(...)` / `Result.Failure(...)` / `Result.SuccessIf(...)` / `Result.FromException(...)`.
+- Your handlers return `Task<Result>` and you need to migrate to `Task<Result<Unit>>` per ADR-005.
+- You consumed the v1 `Trellis.Http` surface (60+ overloads) and need the canonical seven-method shape.
+
+## Surface at a glance
+
+| Category | What changed | Authoritative diff |
+|---|---|---|
+| Result factories | `Success`/`Failure` renamed to `Ok`/`Fail`; deferred / conditional / exception factories removed | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Result accessors | `.Value` getter removed; `.Error` is `Error?` and never throws | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Implicit conversions | Removed on `Result<T>`; explicit factory required | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Non-generic `Result` instance type | Removed; use `Result<Unit>`. `Result` is now a static factory class only. | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1), [ADR-005](../adr/ADR-005-reintroduce-unit.md) |
+| `Error` model | Open `class` + 18 subclasses + static factories → `abstract record` with 20 nested `sealed record` cases | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Removed extensions | `MatchError`, `FlattenValidationErrors`, `Error.Instance` field | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Package merges | DDD, Primitives generator, Asp source generator, EF Core generator, Asp authorization | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| `WriteOutcome<T>` move | `Trellis.Asp.WriteOutcome<T>` → `Trellis.WriteOutcome<T>` (in `Trellis.Core`) | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| Test helper namespace | `Trellis.Results.Tests.*` → `Trellis.Core.Tests.*` | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| OTel `ActivitySource` name | `"Trellis.Results"` → `"Trellis.Core"` | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
+| HTTP surface | 60+ overloads collapsed to one static class with seven methods; all sync removed; new disposal contract | [`trellis-api-http.md` → Breaking changes from v1](../api_reference/trellis-api-http.md#breaking-changes-from-v1) |
+| State machine | Package and namespace renamed `Trellis.Stateless` → `Trellis.StateMachine`; public surface otherwise identical | [`trellis-api-statemachine.md` → Breaking changes from v1](../api_reference/trellis-api-statemachine.md#breaking-changes-from-v1) |
+| Analyzer IDs | `TRLSGEN001`–`TRLSGEN103` renamed to `TRLS031`–`TRLS038` | [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md) |
 
 > [!TIP]
-> Start with a mechanical rename, then let the compiler and analyzers show you the handful of places that still need attention.
+> Start with package and namespace rewrites, then run a build. The compiler will surface most remaining work via `CS0029`, `CS0117`, `CS1061`, and `CS1593`.
 
-## What changes and what does not
+## Result and Error renames (Trellis.Core)
 
-### What changes
+The full row-by-row diff (with migration notes) lives in [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1). Headlines below.
 
-- NuGet package names
-- namespaces
-- a few instrumentation method names
-- references to the old Ardalis specification package
+### Renamed factories
 
-### What does not
+| v1 | v2 |
+|---|---|
+| `Result.Success(value)` / `Result.Success<T>(...)` / `Result.Success()` | `Result.Ok(value)` / `Result.Ok<T>(...)` / `Result.Ok()` |
+| `Result.Failure<T>(error)` / `Result.Failure(error)` | `Result.Fail<T>(error)` / `Result.Fail(error)` |
 
-- core `Result<T>` / `Maybe<T>` usage
-- `Bind`, `Map`, `Tap`, `Ensure`, `Combine`, `Match`
-- aggregate and entity patterns
-- most application-layer code shape
+`IsSuccess` / `IsFailure` are **not** renamed — predicates read as questions and stay long-form.
 
-## Package mapping
+### Removed factories
 
-| Old package | New package |
-| --- | --- |
-| `FunctionalDdd.RailwayOrientedProgramming` | `Trellis.Core` |
-| `FunctionalDdd.DomainDrivenDesign` | `Trellis.Core` |
-| `FunctionalDdd.PrimitiveValueObjects` | `Trellis.Primitives` |
-| `FunctionalDdd.PrimitiveValueObjectGenerator` | _bundled inside `Trellis.Core` (no separate package)_ |
-| `FunctionalDdd.Asp` | `Trellis.Asp` |
-| `FunctionalDdd.Http` | `Trellis.Http` |
-| `FunctionalDdd.FluentValidation` | `Trellis.FluentValidation` |
-
-Optional new packages with no direct one-to-one predecessor include:
-
-- `Trellis.Analyzers`
-- `Trellis.Testing`
-- `Trellis.StateMachine`
-
-## Step 1: update package references
-
-If you centralize package versions in `Directory.Packages.props`, this is the fastest path.
-
-### Before
-
-```xml
-<ItemGroup>
-  <PackageVersion Include="FunctionalDdd.RailwayOrientedProgramming" Version="2.x.x" />
-  <PackageVersion Include="FunctionalDdd.DomainDrivenDesign" Version="2.x.x" />
-  <PackageVersion Include="FunctionalDdd.Asp" Version="2.x.x" />
-  <PackageVersion Include="FunctionalDdd.PrimitiveValueObjects" Version="2.x.x" />
-  <PackageVersion Include="FunctionalDdd.PrimitiveValueObjectGenerator" Version="2.x.x" />
-</ItemGroup>
-```
-
-### After
-
-```xml
-<ItemGroup>
-  <PackageVersion Include="Trellis.Core" Version="3.x.x" />
-  <PackageVersion Include="Trellis.Asp" Version="3.x.x" />
-  <PackageVersion Include="Trellis.Primitives" Version="3.x.x" />
-  <!-- Trellis.Core.Generator is bundled inside Trellis.Core; no separate package -->
-  <PackageVersion Include="Trellis.Analyzers" Version="3.x.x" />
-</ItemGroup>
-```
-
-If you do not use central package management, update each project file directly.
-
-## Step 2: update namespaces
-
-The most important namespace change is this:
-
-| Old | New |
-| --- | --- |
-| `using FunctionalDdd;` | `using Trellis;` |
-| `using FunctionalDdd.PrimitiveValueObjects;` | `using Trellis.Primitives;` |
-
-### Why this matters
-
-Core result and DDD primitives live in `Trellis`.
-
-Ready-to-use value objects such as `EmailAddress`, `FirstName`, and `Money` live in `Trellis.Primitives`.
-
-A common migration pattern is therefore:
+`Result.Success(Func<T>)`, `Result.Failure<T>(Func<Error>)`, `Result.SuccessIf`, `Result.FailureIf`, `Result.SuccessIfAsync`, `Result.FailureIfAsync`, `Result.FromException` / `Result.FromException<T>` were removed. Migration patterns:
 
 ```csharp
-using Trellis;
-using Trellis.Primitives;
+// Deferred factory: inline the call
+Result.Ok(funcOk());
+Result.Fail<T>(errorFactory());
+
+// Conditional: use a ternary
+return cond ? Result.Ok(value) : Result.Fail<T>(error);
+
+// Async conditional: parens are required because await binds tighter than ?:
+return (await predicate()) ? Result.Ok(value) : Result.Fail<T>(error);
+
+// Exception → result: use Try / TryAsync, or build the error explicitly
+return Result.Try(() => DoWork());
+return Result.Fail<T>(new Error.InternalServerError(faultId) { Detail = ex.Message, Cause = ex });
 ```
 
-## Step 3: update instrumentation names
+`OperationCanceledException` is always rethrown by `Try` / `TryAsync` rather than mapped.
 
-If you enabled OpenTelemetry integration, rename these extension methods:
-
-| Old | New |
-| --- | --- |
-| `.AddFunctionalDddRopInstrumentation()` | `.AddResultsInstrumentation()` |
-| `.AddFunctionalDddCvoInstrumentation()` | `.AddPrimitiveValueObjectInstrumentation()` |
-
-## Step 4: use native Trellis specifications
-
-Use native Trellis specifications from `Trellis.Core`.
+### Implicit conversions removed
 
 ```csharp
-using System.Linq.Expressions;
-using Trellis;
+// v1 (compiles)
+Result<int> r = 5;
+Result<int> r = error;
 
-public sealed class Customer
-{
-    public bool IsActive { get; init; }
-}
-
-public sealed class ActiveCustomerSpecification : Specification<Customer>
-{
-    public override Expression<Func<Customer, bool>> ToExpression() =>
-        customer => customer.IsActive;
-}
+// v2 (CS0029) — use the explicit factory
+Result<int> r = Result.Ok(5);
+Result<int> r = Result.Fail<int>(error);
 ```
 
-## Step 5: fix the small but important gotchas
+The compiler flags every site with `CS0029`.
 
-### Use `Result.Ok()` for no-payload success
+### Accessor changes
 
-If older no-payload snippets use a dedicated sentinel value, replace that usage with non-generic `Result`:
+`Result<T>.Value` is gone. `Result<T>.Error` stays but is now `Error?` and never throws.
 
 ```csharp
-using Trellis;
+// v2 — extract the value
+if (result.TryGetValue(out var v)) { /* use v */ }
+result.Match(onSuccess: v => ..., onFailure: e => ...);
+var (ok, v, err) = result;            // Deconstruct
 
-var success = Result.Ok();
+// v2 — read the error (never throws)
+if (result.Error is { } error) { /* use error */ }
+result.TryGetError(out var err);
 ```
 
-### Error-code comparisons should use the current Trellis codes
+`Maybe<T>.Value` still exists but is hidden from IntelliSense and gated by analyzer `TRLS003` — guard with `HasValue` / `TryGetValue` / `Match` / `GetValueOrDefault`. The two types do not have symmetric value-access ergonomics.
 
-Trellis error codes use the standard `.error` suffix for the built-in error families, for example:
+### Error becomes a closed ADT
 
-- `validation.error`
-- `not.found.error`
-- `forbidden.error`
-- `unexpected.error`
+v1 `Error` was a `class` with 18 hand-written subclasses (`ValidationError`, `NotFoundError`, …) and static factory helpers (`Error.Validation(...)`, `Error.NotFound(...)`).
 
-### Built-in value objects belong in `Trellis.Primitives`
-
-If migration leaves you with missing type errors for `EmailAddress`, `FirstName`, `Money`, and similar types, add the correct namespace import rather than forcing everything into `Trellis`.
-
-## A simple before/after example
-
-### Before
+v2 `Error` is an `abstract record` with **20 nested `sealed record` cases** (`Error.NotFound`, `Error.UnprocessableContent`, …). The base constructor is `private` so the catalog is closed; there are no static factories.
 
 ```csharp
-using FunctionalDdd;
-using FunctionalDdd.PrimitiveValueObjects;
+// v1
+return Result.Failure<Order>(Error.NotFound("Order missing"));
 
-var result = FirstName.TryCreate(firstName)
-    .Combine(EmailAddress.TryCreate(email));
+// v2
+return Result.Fail<Order>(new Error.NotFound(ResourceRef.For<Order>(id)) { Detail = "Order missing" });
 ```
 
-### After
+C# verifies exhaustiveness against the closed catalog when you `switch` on the cases.
+
+### Removed extensions
+
+| v1 | v2 replacement |
+|---|---|
+| `result.MatchError(onValidation: ..., onNotFound: ..., onUnexpected: ...)` | `result.Match(_ => ..., e => e switch { Error.NotFound nf => ..., Error.UnprocessableContent uc => ..., _ => ... })` |
+| `result.FlattenValidationErrors()` | `Result.Combine(...)` automatically merges `Error.UnprocessableContent.Fields` and `.Rules` |
+| `error.Instance` field | Synthesized by the ASP wire layer from request URL + any `ResourceRef` carried by the typed payload |
+
+### Non-generic Result removed (ADR-005)
+
+The non-generic `Result` instance type (peer to `Result<T>`) was removed. `Result` is now a `public static partial class` factory only. For no-payload success/failure, use `Result<Unit>` — returned by parameterless `Result.Ok()`, `Result.Fail(error)`, `Result.Ensure(...)`, `Result.Try(...)` factories. `Trellis.Unit` is a public `readonly record struct` with a single value (`Unit.Default`).
 
 ```csharp
-using Trellis;
-using Trellis.Primitives;
+// v1
+public async ValueTask<Result> Handle(SubmitOrderCommand cmd, CancellationToken ct) { ... }
 
-var result = FirstName.TryCreate(firstName)
-    .Combine(EmailAddress.TryCreate(email));
+// v2 (ADR-005)
+public async ValueTask<Result<Unit>> Handle(SubmitOrderCommand cmd, CancellationToken ct) { ... }
 ```
 
-The code shape stays the same. That is the pattern you should expect throughout the migration.
+In lambdas after `.Bind(...)` / `BindAsync(...)`, accept the `Unit` argument explicitly: `_ =>` or `(Unit _) =>`. `AsUnit()` on `Result<T>` now returns `Result<Unit>` (it bridges value-bearing chains back to a no-payload terminal without crossing a type boundary). Background and trade-off analysis: [ADR-005](../adr/ADR-005-reintroduce-unit.md).
 
-## Recommended migration workflow
+> [!IMPORTANT]
+> `default(Result<T>)` is a **failure** carrying `new Error.Unexpected("default_initialized")`. Always construct via `Result.Ok(...)` / `Result.Fail(...)`. Analyzer `TRLS019` flags explicit `default(Result<T>)` at call sites.
 
-1. Update package references.
-2. Replace namespaces.
-3. Fix instrumentation names.
-4. Replace any old specification package usage.
-5. Build.
-6. Run tests.
-7. Add `Trellis.Analyzers` if you want the compiler to help enforce current patterns.
+## HTTP (Trellis.Http)
 
-## Verification
+The v1 surface (60+ overloads across two static classes) collapsed to one static class with seven methods. There are no shims or compatibility redirects — this is a clean, pre-GA cut.
 
-After the rename, run your normal verification commands:
+| v1 | v2 |
+|---|---|
+| `ReadResultFromJsonAsync<T>` (sync, `Result<HRM>`, `Task<HRM>`, `Task<Result<HRM>>`) | `ReadJsonAsync<T>(this Task<Result<HttpResponseMessage>>, JsonTypeInfo<T>, CancellationToken)` |
+| `ReadResultMaybeFromJsonAsync<T>` (all shapes) | `ReadJsonMaybeAsync<T>(this Task<Result<HttpResponseMessage>>, JsonTypeInfo<T>, CancellationToken)` |
+| `HandleNotFound` / `HandleConflict` / `HandleUnauthorized` (all shapes) | `Handle{NotFound,Conflict,Unauthorized}Async(this Task<HttpResponseMessage>, Error.{NotFound,Conflict,Unauthorized})` |
+| `HandleForbidden*` | **Removed.** Use `ToResultAsync(status => status == HttpStatusCode.Forbidden ? new Error.Forbidden(...) : null)`. |
+| `HandleClientError*` (4xx) / `HandleServerError*` (5xx) | **Removed.** Use `ToResultAsync(statusMap)` with a `switch` over `HttpStatusCode`. |
+| `EnsureSuccess` / `EnsureSuccessAsync` (all shapes) | **Removed.** Use `ToResultAsync(status => (int)status >= 400 ? error : null)` or body-aware `ToResultAsync(mapper, ct)`. |
+| `HandleFailureAsync<TContext>` | **Removed.** Use body-aware `ToResultAsync(mapper, ct)`; capture additional state via closure. |
+| Sync receivers (`HttpResponseMessage`, `Result<HRM>`) | **Removed.** Wrap with `Task.FromResult(...)` if needed; in practice every `HttpClient` call is already async. |
 
-```bash
-dotnet build
-dotnet test
+Plus a new disposal contract: `Trellis.Http` disposes the underlying `HttpResponseMessage` on terminal and transformative paths; pass-through paths leave disposal to the caller until the chain reaches `ReadJson*`.
+
+Full table and explanations: [`trellis-api-http.md` → Breaking changes from v1](../api_reference/trellis-api-http.md#breaking-changes-from-v1). Practical recipes: [`integration-http.md`](integration-http.md).
+
+## State machine (Trellis.StateMachine)
+
+```diff
+- <PackageReference Include="Trellis.Stateless" Version="..." />
++ <PackageReference Include="Trellis.StateMachine" Version="..." />
+
+- using Trellis.Stateless;
++ using Trellis.StateMachine;
 ```
 
-## Bottom line
+The public surface is otherwise identical — `StateMachineExtensions.FireResult<TState, TTrigger>(...)` and `LazyStateMachine<TState, TTrigger>` are unchanged. The underlying [Stateless](https://github.com/dotnet-state-machine/stateless) library is still referenced directly, so `StateMachine<TState, TTrigger>` from the `Stateless` namespace remains visible in user code. There is no metapackage redirect — update the `PackageReference` directly. Full notes: [`trellis-api-statemachine.md` → Breaking changes from v1](../api_reference/trellis-api-statemachine.md#breaking-changes-from-v1).
 
-For most codebases, the migration is intentionally boring:
+## ASP.NET Core (Trellis.Asp)
 
-- rename packages
-- rename namespaces
-- fix a few integration points
-- keep your domain logic largely unchanged
+Two cross-cutting changes affect ASP consumers:
 
-That is exactly what you want from a rebrand-style migration.
+- **`WriteOutcome<T>` moved to `Trellis.Core`.** The type, its case records, and member shapes are unchanged; only the assembly and namespace move. Replace `using Trellis.Asp;` with `using Trellis;` for any file that names `WriteOutcome<T>` directly. ASP-specific HTTP mapping stays in `Trellis.Asp` via `ToHttpResponse(...)` / `ToHttpResponseAsync(...)` and the typed MVC adapters `AsActionResult<T>()` / `AsActionResultAsync<T>()`.
+- **`Trellis.Asp.Authorization` package was folded into `Trellis.Asp.nupkg`.** The actor providers (`ClaimsActorProvider`, `EntraActorProvider`, `DevelopmentActorProvider`, `CachingActorProvider`) and the `AddTrellisAspAuthorization()` extension are unchanged; the namespace stays `Trellis.Asp.Authorization`. Drop the standalone `PackageReference`. `Trellis.Asp` now transitively brings in `Trellis.Authorization`.
 
-## Framework changes after the rename
+Both rows are documented in [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) (the `WriteOutcome` move and the package-merge entries). The current ASP API surface lives in [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md).
 
-Beyond the rename, Trellis also ships package-level API changes. Each is described in detail in the relevant API reference; this section is the scannable index.
+## Mediator (Trellis.Mediator)
 
-### `Trellis.Http` slim package
+Mediator does not have its own v1 breaking-changes section; the migration impact is downstream of two `Trellis.Core` changes:
 
-`Trellis.Http` collapsed from 60+ overloads to a single seven-method static class. The full migration table lives in [`docs/docfx_project/api_reference/trellis-api-http.md`](../api_reference/trellis-api-http.md#breaking-changes-from-v1); the headlines:
+- Handlers that returned `Task<Result>` now return `Task<Result<Unit>>` (ADR-005). Update handler signatures and adjust trailing `_ =>` lambdas.
+- Pipeline behaviors are constrained by `IFailureFactory<TResponse>`. With `Result<Unit>` as the canonical no-payload response, the constraint is satisfied without any new shape.
 
-- **Renamed:** `ReadResultFromJsonAsync` &rarr; `ReadJsonAsync`, `ReadResultMaybeFromJsonAsync` &rarr; `ReadJsonMaybeAsync` (single canonical shape on `Task<Result<HttpResponseMessage>>`).
-- **Removed verbs:** `HandleForbidden*`, `HandleClientError*`, `HandleServerError*`, `EnsureSuccess` / `EnsureSuccessAsync`, `HandleFailureAsync<TContext>`. All are expressible via the new `ToResultAsync(statusMap)` (status-only map) or body-aware `ToResultAsync(mapper, ct)` overload.
-- **Removed shapes:** every sync overload, every `HttpResponseMessage`-receiver overload, every `Result<HttpResponseMessage>`-receiver overload. The canonical chain is `Task<HttpResponseMessage>` &rarr; `ToResultAsync` / `Handle*Async` &rarr; `ReadJson*Async`.
-- **New disposal contract:** `Trellis.Http` now disposes the underlying `HttpResponseMessage` on terminal/transformative paths. Pass-through paths still leave disposal to the caller until the chain reaches `ReadJson*`.
+Behavioral semantics, registration helpers, and the validation-aggregation rule are documented in [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md).
 
-There are no shims or compatibility redirects: this is a clean, pre-GA cut.
+## Package map (legacy → current)
+
+| Legacy package | Current package | Notes |
+|---|---|---|
+| `Trellis.Results` | `Trellis.Core` | CLR namespace stays `Trellis` — no `using` changes. Legacy package is unlisted; no metapackage shim. |
+| `Trellis.DomainDrivenDesign` | _(removed — merged into `Trellis.Core`)_ | DDD types (`Aggregate<T>`, `Entity<T>`, `ValueObject`, `Specification<T>`) moved into `Trellis.Core`. Namespace `Trellis` unchanged. |
+| `Trellis.Primitives.Generator` | _(removed — bundled in `Trellis.Core.nupkg`)_ | Source generator now ships at `analyzers/dotnet/cs/Trellis.Core.Generator.dll`. |
+| `Trellis.AspSourceGenerator` | _(removed — bundled in `Trellis.Asp.nupkg`)_ | Generator ships at `analyzers/dotnet/cs/Trellis.AspSourceGenerator.dll`. |
+| `Trellis.EntityFrameworkCore.Generator` | _(removed — bundled in `Trellis.EntityFrameworkCore.nupkg`)_ | Generator ships at `analyzers/dotnet/cs/Trellis.EntityFrameworkCore.Generator.dll`. |
+| `Trellis.Asp.Authorization` | _(removed — folded into `Trellis.Asp.nupkg`)_ | Namespace `Trellis.Asp.Authorization` unchanged; actor providers and `AddTrellisAspAuthorization()` are unchanged. |
+| `Trellis.Stateless` | `Trellis.StateMachine` | Namespace also renamed; public surface unchanged. |
+
+Authoritative diff (with `<PackageReference>` snippets): [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1).
+
+> [!NOTE]
+> Earlier predecessors (`FunctionalDdd.RailwayOrientedProgramming`, `FunctionalDdd.DomainDrivenDesign`, `FunctionalDdd.PrimitiveValueObjects`, `FunctionalDdd.Asp`, `FunctionalDdd.Http`, `FunctionalDdd.FluentValidation`, `FunctionalDdd.PrimitiveValueObjectGenerator`) are not part of the v1 → v2 cut and are not documented in the api_reference breaking-changes sections. Treat them as out of scope; rename to the matching v2 package and then apply this guide.
+
+## Observability
+
+Update OpenTelemetry subscriptions when you upgrade:
+
+```csharp
+// v1
+builder.AddSource("Trellis.Results");
+
+// v2
+builder.AddSource("Trellis.Core");
+// or, programmatically:
+builder.AddSource(RopTrace.ActivitySourceName);
+```
+
+The OTel extension method names (`AddResultsInstrumentation()`, `AddPrimitiveValueObjectInstrumentation()`) are unchanged. See [`integration-observability.md`](integration-observability.md) for tracing setup and [`debugging.md`](debugging.md) for ROP-trace forensics.
+
+## Analyzer ID renames
+
+The Primitives and EF Core source-generator diagnostics were renumbered into the main `TRLS` range:
+
+| v1 ID | v2 ID |
+|---|---|
+| `TRLSGEN001` | `TRLS031` |
+| `TRLSGEN002` | `TRLS032` |
+| `TRLSGEN003` | `TRLS033` |
+| `TRLSGEN004` | `TRLS034` |
+| `TRLSGEN100` | `TRLS035` |
+| `TRLSGEN101` | `TRLS036` |
+| `TRLSGEN102` | `TRLS037` |
+| `TRLSGEN103` | `TRLS038` |
+
+Update any `<NoWarn>` / `#pragma warning disable` / editorconfig severity overrides accordingly. Full diagnostic catalog: [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md).
+
+## Practical guidance
+
+Recommended order — each step is small enough that the build should succeed before the next:
+
+1. **Pin a green baseline.** Tag the v1 commit and confirm `dotnet build` and `dotnet test` are clean.
+2. **Update `PackageReference` / `Directory.Packages.props`.** Apply the [Package map](#package-map-legacy--current). Drop generator packages that are now bundled. Add `Trellis.StateMachine` if you used `Trellis.Stateless`.
+3. **Mechanical rename of factories.** `Result.Success` → `Result.Ok`; `Result.Failure` → `Result.Fail`. Find-and-replace is safe because `IsSuccess` / `IsFailure` are unchanged and not affected.
+4. **Replace `Result` returns and parameters with `Result<Unit>` (ADR-005).** Including `Task<Result>` → `Task<Result<Unit>>`. Add `_ =>` or `(Unit _) =>` to lambdas after `.Bind`/`.BindAsync`/`.Tap`/etc.
+5. **Convert `Error.X("msg")` factory calls to constructor + `with` syntax.** `new Error.X(payload) { Detail = "msg" }`. Replace concrete subclass type names (`ValidationError`, `NotFoundError`) with the closed cases (`Error.UnprocessableContent`, `Error.NotFound`).
+6. **Replace `result.Value` reads.** Use `TryGetValue`, `Match`, or deconstruction. Replace `result.Error` reads with `if (result.Error is { } e)` or `result.TryGetError(out var e)`.
+7. **Remove `MatchError` / `FlattenValidationErrors` calls.** `MatchError` → `Match` + `switch`. `FlattenValidationErrors` is no-op — `Combine` already merges field/rule violations.
+8. **Audit HTTP call sites.** Replace `EnsureSuccess*` / `HandleClientError*` / `HandleServerError*` / `HandleForbidden*` / `HandleFailureAsync<TContext>` with `ToResultAsync(statusMap)` or body-aware `ToResultAsync(mapper, ct)`. Rename `ReadResultFromJsonAsync` / `ReadResultMaybeFromJsonAsync` to `ReadJsonAsync` / `ReadJsonMaybeAsync`. Stop disposing `HttpResponseMessage` after the chain reaches `ReadJson*` — `Trellis.Http` owns it.
+9. **Update OTel sources.** `"Trellis.Results"` → `"Trellis.Core"` (or `RopTrace.ActivitySourceName`).
+10. **Update analyzer suppressions.** Apply the `TRLSGEN*` → `TRLS0xx` map.
+11. **Build, run tests, and iterate.** The compiler errors (`CS0029`, `CS0117`, `CS1061`, `CS1593`) are deliberately the migration map — work through them top-down.
+12. **Add `Trellis.Analyzers`** if you want the compiler to enforce current patterns (notably `TRLS003` on `Maybe<T>.Value` and `TRLS019` on `default(Result<T>)`).
+
+> [!TIP]
+> There are no shims or compatibility redirects — this is a clean pre-GA cut. The compiler is the migration script.
+
+## Cross-references
+
+- Result / Error / `Unit` semantics: [`trellis-api-core.md`](../api_reference/trellis-api-core.md), [ADR-005](../adr/ADR-005-reintroduce-unit.md)
+- HTTP migration table (full): [`trellis-api-http.md` → Breaking changes from v1](../api_reference/trellis-api-http.md#breaking-changes-from-v1)
+- HTTP usage recipes: [`integration-http.md`](integration-http.md)
+- State machine package/namespace rename: [`trellis-api-statemachine.md` → Breaking changes from v1](../api_reference/trellis-api-statemachine.md#breaking-changes-from-v1)
+- ASP.NET Core surface (post-merge): [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- Mediator pipeline behaviors: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
+- Analyzer catalog: [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md)
+- OTel wiring: [`integration-observability.md`](integration-observability.md)
+- Recipe lookup table: [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md)

--- a/docs/docfx_project/articles/performance.md
+++ b/docs/docfx_project/articles/performance.md
@@ -1,4 +1,12 @@
-﻿# Performance
+﻿---
+title: Performance
+package: Trellis (multiple)
+topics: [performance, benchmarks, allocations, rop, overhead, optimization]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# Performance
 
 If you're deciding whether Trellis is "too expensive," the short answer is usually **no**.
 

--- a/docs/docfx_project/articles/primitives.md
+++ b/docs/docfx_project/articles/primitives.md
@@ -1,20 +1,74 @@
+﻿---
+title: Primitive Value Objects
+package: Trellis.Primitives
+topics: [primitive-obsession, value-object, validation, json, ef-core, type-converter]
+related_api_reference: [trellis-api-primitives.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Primitive Value Objects
 
-Primitive obsession makes code look simple right up until `"USD"`, `"Pending"`, `"john@example.com"`, `42`, and `true` all start carrying business meaning the compiler cannot see.
+`Trellis.Primitives` turns raw CLR values into small, validated domain types so `"USD"`, `"john@example.com"`, `42`, and `true` stop carrying business meaning the compiler cannot see.
 
-Trellis primitives solve that by turning raw values into **small, validated domain types**.
+## Patterns Index
 
-## Start with a practical example
+| Goal | Use | See |
+|---|---|---|
+| Use a ready-made validated email / URL / phone / ISO code | Built-in concrete VOs in `Trellis.Primitives` (`EmailAddress`, `Url`, `PhoneNumber`, `CountryCode`, ...) | [Built-in primitives](#built-in-primitives) |
+| Wrap an ID, name, count, flag, or timestamp from your own domain | `partial class X : Required*<X>` from `Trellis.Core` | [Defining custom primitives](#defining-custom-primitives) |
+| Constrain a custom string length or numeric range | `[Trellis.StringLength(...)]` / `[Trellis.Range(...)]` on the partial class | [Validation](#validation) |
+| Add a regex / pattern check | Override `static partial void ValidateAdditional(...)` | [Validation](#validation) |
+| Construct from untrusted input on the railway | `TSelf.TryCreate(value, "field")` returning `Result<TSelf>` | [Factory methods](#factory-methods) |
+| Construct in tests / from trusted constants | `TSelf.Create(value)` (throws on invalid input) | [Factory methods](#factory-methods) |
+| Generate a new ID | `TId.NewUniqueV4()` / `TId.NewUniqueV7()` | [Defining custom primitives](#defining-custom-primitives) |
+| Serialize a scalar primitive to/from JSON | `ParsableJsonConverter<T>` (auto-applied by the generator) | [JSON binding](#json-binding) |
+| Serialize a multi-field value object (e.g., `Money`-shaped) | `[JsonConverter(typeof(CompositeValueObjectJsonConverter<MyVo>))]` | [JSON binding](#json-binding) |
+| Translate `StartsWith` / `Contains` / `Length` in EF Core LINQ | Register `AddTrellisInterceptors()` on the `DbContextOptionsBuilder` | [EF Core interop](#ef-core-interop) |
+| Combine several `TryCreate` calls into one validated command | `Result.Combine(...)` (see `Trellis.Core`) | [Composition](#composition) |
+
+## Use this guide when
+
+- You want a typed domain instead of `string` / `int` / `Guid` parameters with implicit validation rules.
+- You need JSON, model-binding, and EF Core to flow through a single `TryCreate(...)` so validation is enforced at every seam.
+- You are deciding between a built-in primitive (`EmailAddress`, `Money`, ...) and a custom `Required*<TSelf>` for your own SKU, order id, or display name.
+
+## Surface at a glance
+
+`Trellis.Primitives` ships 13 ready-made concrete value objects plus the JSON / tracing infrastructure that backs them. The `Required*<TSelf>` base classes, validation attributes, and source generator that you use to define **your own** primitives all live in `Trellis.Core` and are pulled in transitively.
+
+| Area | Key APIs | Lives in |
+|---|---|---|
+| Built-in scalar VOs | `Age`, `CountryCode`, `CurrencyCode`, `EmailAddress`, `Hostname`, `IpAddress`, `LanguageCode`, `MonetaryAmount`, `Percentage`, `PhoneNumber`, `Slug`, `Url` | `Trellis.Primitives` |
+| Built-in structured VO | `Money` (`amount` + `currency`) | `Trellis.Primitives` |
+| Custom-primitive bases | `RequiredString<TSelf>`, `RequiredGuid<TSelf>`, `RequiredInt<TSelf>`, `RequiredLong<TSelf>`, `RequiredDecimal<TSelf>`, `RequiredBool<TSelf>`, `RequiredDateTime<TSelf>`, `RequiredEnum<TSelf>` | `Trellis.Core` |
+| Validation attributes | `[Trellis.StringLength]`, `[Trellis.Range]`, `[Trellis.EnumValue]` | `Trellis.Core` |
+| Pattern / cross-field hook | `static partial void ValidateAdditional(value, fieldName, ref string? errorMessage)` | generator-emitted |
+| JSON converters | `ParsableJsonConverter<T>` (scalars), `CompositeValueObjectJsonConverter<T>` (composites), `RequiredEnumJsonConverter<TRequiredEnum>` | `Trellis.Primitives` / `Trellis.Core` |
+| Tracing | `PrimitiveValueObjectTrace.ActivitySource`, `AddPrimitiveValueObjectInstrumentation(this TracerProviderBuilder)` | `Trellis.Primitives` |
+
+Full signatures: [trellis-api-primitives.md](../api_reference/trellis-api-primitives.md).
+
+## Installation
+
+```bash
+dotnet add package Trellis.Primitives
+```
+
+`Trellis.Primitives` depends on `Trellis.Core`, which carries the `Required*<TSelf>` base classes, the validation attributes, and the source generator (bundled at `analyzers/dotnet/cs/Trellis.Core.Generator.dll`). Installing `Trellis.Primitives` is enough — you do not need a separate generator package.
+
+## Quick start
+
+Define a few primitives, then build an entity that cannot be constructed from invalid input.
 
 ```csharp
 using Trellis;
 using Trellis.Primitives;
 
-namespace PrimitiveExamples;
+namespace QuickStart;
 
 public partial class CustomerId : RequiredGuid<CustomerId> { }
 
-[Trellis.StringLength(200)]
+[Trellis.StringLength(200, MinimumLength = 1)]
 public partial class DisplayName : RequiredString<DisplayName> { }
 
 [Trellis.Range(0, 150)]
@@ -47,46 +101,39 @@ public sealed class Customer : Entity<CustomerId>
     public IsVipCustomer IsVipCustomer { get; }
     public LastPurchaseAt LastPurchaseAt { get; }
 }
+
+public static class Construction
+{
+    public static Result<Customer> Build(string displayName, string email, int loyaltyScore, bool isVip, DateTime lastPurchase) =>
+        DisplayName.TryCreate(displayName, "displayName")
+            .Combine(EmailAddress.TryCreate(email, "email"))
+            .Combine(LoyaltyScore.TryCreate(loyaltyScore, "loyaltyScore"))
+            .Combine(IsVipCustomer.TryCreate(isVip, "isVip"))
+            .Combine(LastPurchaseAt.TryCreate(lastPurchase, "lastPurchaseAt"))
+            .Map(((((DisplayName n, EmailAddress e), LoyaltyScore s), IsVipCustomer v), LastPurchaseAt t) =>
+                new Customer(CustomerId.NewUniqueV7(), n, e, s, v, t));
+}
 ```
 
-Now your model says what the values **mean**, not just what CLR type they happen to use.
+Every primitive enforces its rule on the way in, so the entity body has nothing to validate.
 
-## Why primitives help
+## Defining custom primitives
 
-They give you:
+A custom primitive is a `partial class` that inherits the appropriate `Required*<TSelf>` base. `partial` is required — the source generator emits the factory methods, parser, JSON converter, and the optional `ValidateAdditional` hook into the partial half.
 
-- **type safety** — `DisplayName` and `EmailAddress` cannot be mixed up
-- **centralized validation** — every creation path enforces the same rules
-- **better APIs** — invalid input fails early through `Result<T>`
-- **clearer domain language** — code reads like the business language
-
-## The core base classes
-
-All custom primitives are declared with the generic self type:
-
-- `RequiredString<EmailAddress>`
-- `RequiredGuid<OrderId>`
-- `RequiredInt<Quantity>`
-
-Not just `RequiredString` or `RequiredGuid`.
-
-| Base class | Use for | Notes |
-| --- | --- | --- |
-| `RequiredString<TSelf>` | names, codes, titles | exposes `Length`, `StartsWith`, `Contains`, `EndsWith` |
-| `RequiredGuid<TSelf>` | IDs | source generator adds `NewUniqueV4()` and `NewUniqueV7()` |
-| `RequiredInt<TSelf>` | counts, quantities | supports range validation |
-| `RequiredDecimal<TSelf>` | scalar decimals | supports range validation |
-| `RequiredLong<TSelf>` | large integer values | available for high-range counters/identifiers |
-| `RequiredBool<TSelf>` | explicit domain flags | useful when `bool` has real business meaning |
-| `RequiredDateTime<TSelf>` | required timestamps | invariant round-trip formatting |
-| `RequiredEnum<TSelf>` | symbolic finite sets | separate symbolic type family |
+| Base class | Underlying type | Built-in validation | Notable extras |
+|---|---|---|---|
+| `RequiredString<TSelf>` | `string` | null / empty / whitespace rejected, value trimmed; `[StringLength]` enforced | `Length`, `StartsWith(string)`, `Contains(string)`, `EndsWith(string)` |
+| `RequiredGuid<TSelf>` | `Guid` | `Guid.Empty` rejected | `NewUniqueV4()`, `NewUniqueV7()` |
+| `RequiredInt<TSelf>` | `int` | `null` rejected for nullable inputs; `[Range(int, int)]` enforced | invariant + culture-aware string parsing |
+| `RequiredLong<TSelf>` | `long` | `null` rejected for nullable inputs; `[Range(long, long)]` enforced | invariant + culture-aware string parsing |
+| `RequiredDecimal<TSelf>` | `decimal` | `null` rejected for nullable inputs; `[Range(int, int)]` or `[Range(double, double)]` enforced | invariant + culture-aware string parsing |
+| `RequiredBool<TSelf>` | `bool` | `null` rejected for nullable inputs; `false` is valid | string parsing of `"true"`/`"false"` |
+| `RequiredDateTime<TSelf>` | `DateTime` | `DateTime.MinValue` rejected | invariant round-trip `"O"` formatting |
+| `RequiredEnum<TSelf>` | `string` | `TryFromName` lookup against `public static readonly TSelf` fields | `[EnumValue("...")]` on each field overrides the wire name |
 
 > [!NOTE]
-> `ScalarValueObject<TSelf, T>` implements both `IConvertible` and `IFormattable`. That is why Trellis scalar primitives behave naturally in formatting and conversion scenarios.
-
-## Creating your own primitive
-
-Most custom primitives are tiny:
+> The base contracts (`IScalarValue<TSelf, TPrimitive>`, `IFormattableScalarValue<TSelf, TPrimitive>`) and shared bases (`ValueObject`, `ScalarValueObject<TSelf, T>`) live in `Trellis.Core`. `ScalarValueObject<TSelf, T>` implements `IConvertible` and `IFormattable` so scalar primitives behave naturally in formatting and conversion scenarios.
 
 ```csharp
 using Trellis;
@@ -106,30 +153,24 @@ public partial class PublishedAt : RequiredDateTime<PublishedAt> { }
 public partial class ExternalSequence : RequiredLong<ExternalSequence> { }
 ```
 
-That `partial` keyword matters. It allows the generator to add factory methods, parsing, JSON support, and model-binding helpers.
+### Factory methods
 
-## Factory methods: use the right one
+The generator emits the same factory shape on every `Required*<TSelf>` derivation:
 
-Every primitive follows the same creation story:
+| Method | Returns | Use it for |
+|---|---|---|
+| `TryCreate(value, fieldName?)` | `Result<TSelf>` | User input, file input, HTTP / JSON input — anything that may fail. Also accepts the nullable underlying type and the string form. |
+| `Create(value)` (and `Create(string)`) | `TSelf` | Trusted test data and hard-coded constants. Throws on invalid input. |
+| `Parse(s, provider)` | `TSelf` | `IParsable<TSelf>` integration. Throws `FormatException` on failure. |
+| `TryParse(s, provider, out result)` | `bool` | `IParsable<TSelf>` integration. Non-throwing. |
+| `(TSelf)value` (explicit cast) | `TSelf` | Conversion via `Create(...)` — same throwing semantics. |
+| `NewUniqueV4()` / `NewUniqueV7()` | `TSelf` | `RequiredGuid<TSelf>` only. Time-ordered v7 GUIDs are recommended for new IDs. |
 
-- `TryCreate(...)` for user input, file input, API input, or anything that may fail
-- `Create(...)` for trusted test data or hard-coded values
+Stay on the railway at boundaries:
 
 ```csharp
 using Trellis;
 using Trellis.Primitives;
-
-public partial class OrderId : RequiredGuid<OrderId> { }
-
-var emailResult = EmailAddress.TryCreate("alice@example.com");
-var orderId = OrderId.NewUniqueV7();
-var amount = MonetaryAmount.Create(49.95m);
-```
-
-In a request workflow, stay on the railway:
-
-```csharp
-using Trellis;
 
 [Trellis.StringLength(100)]
 public partial class ProductName : RequiredString<ProductName> { }
@@ -137,127 +178,193 @@ public partial class ProductName : RequiredString<ProductName> { }
 [Trellis.Range(1, 1000)]
 public partial class Quantity : RequiredInt<Quantity> { }
 
-var command = EmailAddress.TryCreate("alice@example.com", "email")
-    .Combine(ProductName.TryCreate("Trellis Mug", "name"))
-    .Combine(Quantity.TryCreate(2, "quantity"));
+public sealed record AddToCart(string Email, string Product, int Qty);
+
+public static Result<(EmailAddress, ProductName, Quantity)> Parse(AddToCart input) =>
+    EmailAddress.TryCreate(input.Email, "email")
+        .Combine(ProductName.TryCreate(input.Product, "name"))
+        .Combine(Quantity.TryCreate(input.Qty, "quantity"))
+        .Map(((EmailAddress e, ProductName p) ep, Quantity q) => (ep.e, ep.p, q));
 ```
 
-## `RequiredString<TSelf>` feels like a string on purpose
+### `RequiredEnum<TSelf>` shape
 
-`RequiredString<TSelf>` exposes the string members you need most:
-
-- `Length`
-- `StartsWith(string)`
-- `Contains(string)`
-- `EndsWith(string)`
+Use `RequiredEnum<TSelf>` when you need a finite, symbolic, extensible set with a stable wire name per member.
 
 ```csharp
 using Trellis;
 
-[Trellis.StringLength(100)]
-public partial class ProductName : RequiredString<ProductName> { }
+public partial class OrderState : RequiredEnum<OrderState>
+{
+    public static readonly OrderState Draft = new();
 
-var name = ProductName.Create("Trellis Mug");
-
-_ = name.Length;
-_ = name.StartsWith("Trellis");
-_ = name.Contains("Mug");
-_ = name.EndsWith("Mug");
+    [EnumValue("submitted")]
+    public static readonly OrderState Submitted = new();
+}
 ```
 
-That makes your code more natural and helps EF Core queries read cleanly.
+`EnumValueAttribute` is the only Trellis primitive attribute that targets a field (each `public static readonly TSelf`). Without it, the wire name is the field identifier. See [trellis-api-core.md](../api_reference/trellis-api-core.md#requiredenumtself) for `GetAll`, `TryFromName`, `Is(...)`, and equality semantics, and the dedicated [required-enum.md](required-enum.md) article for usage patterns.
 
-## Built-in primitives you can use immediately
+## Validation
 
-Trellis also ships ready-made types in `Trellis.Primitives`.
+Trellis primitives enforce their rules in the generated `TryCreate`. There are three layers, in order of precedence:
 
-| Type | Category | Good for |
-| --- | --- | --- |
-| `EmailAddress` | scalar string | validated email input |
-| `PhoneNumber` | scalar string | E.164 phone values |
-| `Url` | scalar string | absolute HTTP/HTTPS URLs |
-| `Hostname` | scalar string | host names |
-| `IpAddress` | scalar string | IPv4/IPv6 values |
-| `Slug` | scalar string | URL-friendly identifiers |
-| `CountryCode` | scalar string | ISO alpha-2 country codes |
-| `CurrencyCode` | scalar string | ISO 4217 codes |
-| `LanguageCode` | scalar string | ISO language codes |
-| `Age` | scalar int | bounded age values |
-| `Percentage` | scalar decimal | percentages and fraction helpers |
-| `MonetaryAmount` | scalar decimal | **single-currency** amounts |
-| `Money` | structured value object | amount + currency together |
+1. **Built-in checks** (per base class — see the table above).
+2. **Class-targeted attributes** declared on the partial class.
+3. **`ValidateAdditional`** — your own pattern / cross-field rule, called last.
+
+### Class-targeted attributes
+
+| Attribute | Target | Constructors | Notes |
+|---|---|---|---|
+| `Trellis.StringLengthAttribute` | `partial class X : RequiredString<X>` | `StringLength(int maximumLength)`; set `MinimumLength = N` via property initializer | `maximumLength` must be `>= 1`. Enforced after the null/empty/whitespace check. |
+| `Trellis.RangeAttribute` | `partial class X : RequiredInt<X>` / `RequiredLong<X>` / `RequiredDecimal<X>` | `(int, int)`, `(long, long)`, `(double, double)` | The constructor selected determines which generator template fires. There is **no** `RangeAttribute(typeof(decimal), "0.01", "999999.99")` overload — use `(double, double)` for fractional ranges. |
+
+> [!WARNING]
+> The `System.ComponentModel.DataAnnotations` attributes of the same name **do not work**. `[DataAnnotations.StringLength]` on the class fails to compile (`CS0592`); on a property of a `Required*<TSelf>` it compiles but is **silently ignored** by the generator. The analyzer rule `TRLS017` flags the class-placement case. Always import from `namespace Trellis`.
+
+### Patterns and regex
+
+There is no `[RegularExpression]` analog. Override the generated `ValidateAdditional` partial:
+
+```csharp
+using System.Text.RegularExpressions;
+using Trellis;
+
+[Trellis.StringLength(8)]
+public partial class Sku : RequiredString<Sku>
+{
+    private static readonly Regex Pattern = new(@"^[A-Z]{3}\d{4}$", RegexOptions.Compiled);
+
+    static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage)
+    {
+        if (!Pattern.IsMatch(value))
+            errorMessage = $"{fieldName} must match XXX9999.";
+    }
+}
+```
+
+The signature varies by base class — `string` for `RequiredString`, `Guid` for `RequiredGuid`, `int`/`long`/`decimal`/`bool`/`DateTime` for the others. See the source-generated members table in [trellis-api-core.md](../api_reference/trellis-api-core.md#source-generated-members).
+
+### Culture-aware parsing
+
+Numeric and date primitives expose both invariant and culture-aware string overloads through `IFormattableScalarValue<TSelf, TPrimitive>`.
+
+```csharp
+using System.Globalization;
+using Trellis.Primitives;
+
+var invariant = MonetaryAmount.TryCreate("12.34");
+var french    = MonetaryAmount.TryCreate("12,34", CultureInfo.GetCultureInfo("fr-FR"));
+```
+
+## JSON binding
+
+### Scalar primitives — automatic
+
+Every `Required*<TSelf>` partial gets `[JsonConverter(typeof(ParsableJsonConverter<TSelf>))]` from the generator. Each built-in scalar VO in `Trellis.Primitives` (`EmailAddress`, `Url`, `MonetaryAmount`, ...) follows the same pattern. There is **nothing to register** — the converter:
+
+- Accepts JSON `string`, `number`, `true`, `false`; converts to text and calls `TSelf.Parse(...)`.
+- Writes JSON numbers for numeric scalars and JSON strings for everything else.
+- Throws on JSON `null` because Trellis scalars are non-nullable.
+
+`RequiredEnum<TSelf>` uses `RequiredEnumJsonConverter<TSelf>` (string in, string out via `TryFromName`).
+
+### Composite value objects — opt in
+
+Multi-field value objects (the `Money` shape) need `CompositeValueObjectJsonConverter<T>` applied **per type**:
+
+```csharp
+using System.Text.Json.Serialization;
+using Trellis;
+using Trellis.Primitives;
+
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<ShippingAddress>))]
+public sealed class ShippingAddress : ValueObject
+{
+    public ShippingAddress(CountryCode country, string line1, string postcode)
+    {
+        Country = country;
+        Line1 = line1;
+        Postcode = postcode;
+    }
+
+    public CountryCode Country { get; }
+    public string Line1 { get; }
+    public string Postcode { get; }
+
+    public static Result<ShippingAddress> TryCreate(string country, string line1, string postcode, string? fieldName = null) =>
+        CountryCode.TryCreate(country, $"{fieldName}.country")
+            .Map(c => new ShippingAddress(c, line1, postcode));
+}
+```
+
+The converter discovers properties in declaration order, populates a matching `static Result<T> TryCreate(p1, ..., pN[, string? fieldName])`, and throws `TrellisJsonValidationException` on missing properties or `TryCreate` failure. Reflection runs once per generic instantiation and is cached. Native AOT scenarios should hand-write a `JsonConverter<T>`.
+
+> [!WARNING]
+> Without `[JsonConverter(typeof(CompositeValueObjectJsonConverter<MyVo>))]` on a composite VO used in a request DTO, model binding falls back to default construction and **silently bypasses `TryCreate`** — inner-field validation never runs. See [Cookbook Recipe 13](../api_reference/trellis-api-cookbook.md#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership) for the full Domain + API + EF walkthrough.
+
+## Built-in primitives
+
+`Trellis.Primitives` ships 13 concrete value objects so you do not re-derive `Email`, `Money`, or `Slug` in every project.
+
+| Type | Category | Wire shape | Notes |
+|---|---|---|---|
+| `Age` | scalar `int` | JSON number / numeric string | Range `0..150`. |
+| `CountryCode` | scalar `string` | JSON string | Uppercase ISO 3166-1 alpha-2 (exactly two letters). |
+| `CurrencyCode` | scalar `string` | JSON string | Uppercase ISO 4217 (exactly three letters). |
+| `EmailAddress` | scalar `string` | JSON string | Trimmed, regex-validated. |
+| `Hostname` | scalar `string` | JSON string | RFC 1123 hostname. |
+| `IpAddress` | scalar `string` | JSON string | IPv4/IPv6 via `IPAddress.TryParse`; `ToIPAddress()` returns the cached parse. |
+| `LanguageCode` | scalar `string` | JSON string | Lowercase ISO 639-1 alpha-2. |
+| `MonetaryAmount` | scalar `decimal` | JSON number / numeric string | Non-negative; rounds to two decimals (`MidpointRounding.AwayFromZero`). Single-currency. `Add` / `Subtract` / `Multiply` / `Sum` return `Result`. |
+| `Money` | structured `ValueObject` | JSON object `{ "amount": number, "currency": string }` | Amount + `CurrencyCode`. `Add` / `Subtract` / `Sum` require matching currencies. `Allocate(int[] ratios)` distributes remainders. |
+| `Percentage` | scalar `decimal` | JSON number / numeric string | Range `0..100`; `ToString()` appends `%`; `FromFraction(0..1)` and `Of(amount)` helpers. |
+| `PhoneNumber` | scalar `string` | JSON string | Strips spaces / dashes / parentheses then validates E.164; `GetCountryCode()` extracts the calling code. |
+| `Slug` | scalar `string` | JSON string | Lowercase letters, digits, single-hyphen separators. |
+| `Url` | scalar `string` | JSON string | Absolute HTTP/HTTPS only; exposes `Scheme`, `Host`, `Port`, `Path`, `Query`, `IsSecure`, `ToUri()`. |
 
 ### `MonetaryAmount` vs `Money`
 
-This distinction matters:
-
 | Type | Use it when | Shape |
-| --- | --- | --- |
-| `MonetaryAmount` | the whole bounded context uses one currency policy | scalar |
-| `Money` | currency is part of the value's identity | structured |
-
-`MonetaryAmount` is a scalar primitive. `Money` is not.
+|---|---|---|
+| `MonetaryAmount` | The whole bounded context uses one currency policy. | scalar `decimal` |
+| `Money` | Currency is part of the value's identity. | structured (`amount` + `currency`) |
 
 ```csharp
 using Trellis.Primitives;
 
 var subtotal = MonetaryAmount.Create(120.00m);
-var tax = subtotal.Multiply(0.08m).Value;
-var total = subtotal.Add(tax).Value;
+var tax      = subtotal.Multiply(0.08m).TryGetValue(out var t) ? t : MonetaryAmount.Zero;
+var total    = subtotal.Add(tax).TryGetValue(out var s) ? s : subtotal;
 
-var usdPrice = Money.Create(120.00m, "USD");
+var price    = Money.Create(120.00m, "USD");
 var shipping = Money.Create(10.00m, "USD");
-var grandTotal = usdPrice.Add(shipping).Value;
+var grand    = price.Add(shipping).TryGetValue(out var g) ? g : price;
 ```
 
-## Built-in examples
+For full signatures of every built-in (`Add`, `Multiply`, `Allocate`, `Sum`, `FromFraction`, ...), see [trellis-api-primitives.md](../api_reference/trellis-api-primitives.md).
 
-```csharp
-using System;
-using Trellis.Primitives;
+## ASP.NET integration
 
-var email = EmailAddress.Create("alice@example.com");
-var url = Url.Create("https://example.com/orders/42");
-var percent = Percentage.Create(12.5m);
+Scalar primitives bind from route / query / body once you call `AddTrellisAsp()` or `AddScalarValueValidation()` from `Trellis.Asp`:
 
-Console.WriteLine(url.Host);
-Console.WriteLine(percent.AsFraction());
-Console.WriteLine(percent.Of(80m));
-```
+- Model binders read the raw value, call `TValue.TryCreate`, and add validation errors to `ModelState` on failure.
+- JSON converters write the underlying primitive on `Write`, read with `TryCreate` on `Read`, and route failures into the `Error.UnprocessableContent` aggregator.
+- `Maybe<TValue>` wrappers pass `null` through as `Maybe.None`.
 
-## Culture-aware parsing
+Composite VOs need the explicit `[JsonConverter(typeof(CompositeValueObjectJsonConverter<...>))]` shown above — `AddScalarValueValidation` only wires scalar converters.
 
-Numeric and date primitives support culture-aware parsing through `IFormattableScalarValue<TSelf, TPrimitive>`.
+See [integration-aspnet.md](integration-aspnet.md) for the request pipeline and [trellis-api-asp.md](../api_reference/trellis-api-asp.md#namespace-trellisaspvalidation) for the validation surface.
 
-Use the invariant overload by default:
+## EF Core interop
 
-```csharp
-var amount = MonetaryAmount.TryCreate("12.34");
-```
-
-Use the culture-aware overload when the locale is known:
-
-```csharp
-using System.Globalization;
-using Trellis;
-using Trellis.Primitives;
-
-public partial class LastPurchaseAt : RequiredDateTime<LastPurchaseAt> { }
-
-var amount = MonetaryAmount.TryCreate("12,34", CultureInfo.GetCultureInfo("fr-FR"));
-var timestamp = LastPurchaseAt.TryCreate("2024-12-31T18:30:00", CultureInfo.InvariantCulture);
-```
-
-## EF Core queries stay readable
-
-Trellis primitives are designed to work cleanly in LINQ. In many cases you do **not** need to reach into `.Value`.
+Trellis primitives are designed to read naturally in LINQ; you usually do not reach into `.Value`.
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using Trellis;
-
-namespace EfCoreQueryExample;
 
 [Trellis.StringLength(200)]
 public partial class DisplayName : RequiredString<DisplayName> { }
@@ -271,51 +378,60 @@ public sealed class Customer
     public IsVipCustomer IsVipCustomer { get; set; } = null!;
 }
 
-public sealed class AppDbContext : DbContext
-{
-    public DbSet<Customer> Customers => Set<Customer>();
-}
-
-public static IQueryable<Customer> BuildQuery(AppDbContext dbContext) =>
-    dbContext.Customers
-        .Where(customer => customer.DisplayName.StartsWith("Tre"))
-        .Where(customer => customer.DisplayName.Length > 3)
-        .Where(customer => customer.IsVipCustomer == IsVipCustomer.Create(true));
+public static IQueryable<Customer> Vips(DbContext db) =>
+    db.Set<Customer>()
+        .Where(c => c.DisplayName.StartsWith("Tre"))
+        .Where(c => c.DisplayName.Length > 3)
+        .Where(c => c.IsVipCustomer == IsVipCustomer.Create(true));
 ```
 
 > [!NOTE]
-> String helper translation such as `StartsWith`, `Contains`, `EndsWith`, and `Length` requires `AddTrellisInterceptors()` in your EF Core configuration.
+> Translation of `RequiredString<TSelf>` helpers (`StartsWith`, `Contains`, `EndsWith`, `Length`) requires `optionsBuilder.AddTrellisInterceptors()` from `Trellis.EntityFrameworkCore`. The same call wires `MaybeQueryInterceptor`, the ETag interceptor, and the entity-timestamp interceptor. See [integration-ef.md](integration-ef.md).
 
-## When to use built-in types vs custom types
+For composite VOs (e.g., `Money`), `ApplyTrellisConventions` registers `CompositeValueObjectConvention`, which maps owned types via table-splitting where valid and falls back to `{Owner}_{Property}` tables when nested owned navigations exist. See [trellis-api-efcore.md](../api_reference/trellis-api-efcore.md).
 
-Choose a built-in primitive when the validation rules already match your domain.
+## Composition
 
-Create a custom primitive when:
-
-- the name needs domain meaning
-- the validation rules differ
-- the type should carry behavior specific to your domain
-
-For example, you might still create your own email type:
+`TryCreate` returns `Result<T>`, so primitives compose with the rest of Trellis (`Combine`, `Map`, `Bind`, `Ensure`).
 
 ```csharp
 using Trellis;
+using Trellis.Primitives;
 
 [Trellis.StringLength(100)]
-public partial class CompanyEmailAddress : RequiredString<CompanyEmailAddress> { }
+public partial class ProductName : RequiredString<ProductName> { }
+
+[Trellis.Range(1, 1000)]
+public partial class Quantity : RequiredInt<Quantity> { }
+
+public sealed record PlaceOrderCommand(EmailAddress Email, ProductName Product, Quantity Qty);
+
+public static Result<PlaceOrderCommand> ParseCommand(string email, string product, int qty) =>
+    EmailAddress.TryCreate(email, "email")
+        .Combine(ProductName.TryCreate(product, "product"))
+        .Combine(Quantity.TryCreate(qty, "qty"))
+        .Map(((EmailAddress e, ProductName p) ep, Quantity q) => new PlaceOrderCommand(ep.e, ep.p, q));
 ```
+
+`Combine` aggregates field-level failures into one `Error.UnprocessableContent` so every invalid field is reported in a single response. See [trellis-api-core.md](../api_reference/trellis-api-core.md) for the full ROP surface.
 
 ## Practical guidance
 
-1. Wrap IDs immediately
-2. Prefer domain names over technical names
-3. Use `TryCreate(...)` at boundaries
-4. Reach for built-ins first, custom types second
-5. Use `MonetaryAmount` only when currency is truly external policy
+- **Wrap IDs immediately.** Every entity gets a `RequiredGuid<TSelf>` id; never let a raw `Guid` cross the application boundary.
+- **Reach for the built-ins first.** Use `EmailAddress`, `Url`, `Money`, `CountryCode`, ... before declaring your own. Define a custom primitive only when the name needs domain meaning, the validation rules differ, or the type should carry domain-specific behavior.
+- **Use `TryCreate(...)` at boundaries** (HTTP, file, queue, CLI). Reserve `Create(...)` for trusted constants and tests.
+- **Always use `Trellis.*` attributes**, never `System.ComponentModel.DataAnnotations.*`. The DataAnnotations attributes of the same name compile in some positions but are silently ignored by the generator.
+- **Keep parsing out of handlers.** Convert transport primitives to value objects at the DTO / controller / application seam, then pass shaped commands inward.
+- **Pick `MonetaryAmount` over `Money` only when currency is external policy** for the whole bounded context.
+- **Prefer v7 GUIDs** (`NewUniqueV7()`) over v4 for new IDs — they are time-ordered and storage-friendly.
 
-## See also
+## Cross-references
 
-- [RequiredEnum](required-enum.md)
-- [Specifications](specifications.md)
-- [Trellis primitive taxonomy](../api_reference/trellis-value-object-taxonomy.md)
-- [Trellis primitives API reference](../api_reference/trellis-api-primitives.md)
+- API surface — built-in VOs and JSON converters: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- API surface — `Required*<TSelf>` bases, attributes, generated members, `Result<T>` / `Maybe<T>`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Symbolic enums in depth: [required-enum.md](required-enum.md)
+- Specifications over primitives: [specifications.md](specifications.md)
+- HTTP request pipeline + scalar binders: [integration-aspnet.md](integration-aspnet.md), [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md)
+- EF Core mapping + LINQ translation: [integration-ef.md](integration-ef.md), [`trellis-api-efcore.md`](../api_reference/trellis-api-efcore.md)
+- Composite VO end-to-end recipe: [Cookbook Recipe 13](../api_reference/trellis-api-cookbook.md#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership)
+- Value-object taxonomy: [`trellis-value-object-taxonomy.md`](../api_reference/trellis-value-object-taxonomy.md)

--- a/docs/docfx_project/articles/required-enum.md
+++ b/docs/docfx_project/articles/required-enum.md
@@ -1,19 +1,74 @@
+﻿---
+title: RequiredEnum
+package: Trellis.Core
+topics: [required-enum, primitive-obsession, validation, source-generator, analyzer, json, ddd]
+related_api_reference: [trellis-api-primitives.md, trellis-api-analyzers.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # RequiredEnum
 
-Regular C# enums are fast and familiar, but they are weak at domain modeling:
+`RequiredEnum<TSelf>` is the Trellis primitive base for finite, behavior-rich symbolic value sets — a typed replacement for `enum` that round-trips through JSON, model binding, and EF Core via the bundled source generator.
 
-- invalid casts are possible
-- behavior has to live somewhere else
-- wire names and display names get bolted on afterward
+## Patterns Index
 
-`RequiredEnum<TSelf>` solves that by giving you a **finite symbolic set with behavior**.
+| Goal | Use | See |
+|---|---|---|
+| Declare a symbolic set with optional behavior | `partial class : RequiredEnum<TSelf>` + `public static readonly TSelf` fields | [Defining members](#defining-members) |
+| Override the wire / serialized name for one member | `[EnumValue("...")]` on the field | [Symbolic value names](#symbolic-value-names) |
+| Parse user input safely (nullable, with field name) | `TryCreate(string?, fieldName?)` → `Result<TSelf>` | [Parsing and creation](#parsing-and-creation) |
+| Throwing factory for trusted input | `Create(string)` | [Parsing and creation](#parsing-and-creation) |
+| Look up by symbolic name (case-insensitive) | `TryFromName(string?, fieldName?)` | [Parsing and creation](#parsing-and-creation) |
+| `IParsable<TSelf>` for ASP.NET binding pipelines | `Parse(s, provider)` / `TryParse(s, provider, out)` | [Parsing and creation](#parsing-and-creation) |
+| JSON round-trip in `System.Text.Json` | Auto-applied `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` | [JSON serialization](#json-serialization) |
+| Membership and negated membership | `Is(params TSelf[])` / `IsNot(params TSelf[])` | [Equality and membership](#equality-and-membership) |
+| Persist symbolic values in EF Core | `HasConversion(status => status.Value, value => Status.Create(value))` | [Composition](#composition) |
 
-## Start with a working example
+## Use this guide when
+
+- You want a closed set of named domain values that carry data or behavior, not just an `int`.
+- You need stable string identities for JSON, model binding, and EF Core columns.
+- You want invalid values to be unrepresentable — no `(OrderStatus)999` cast hole.
+- You need a Result-returning factory and case-insensitive symbolic lookup baked into the type.
+
+## Surface at a glance
+
+`RequiredEnum<TSelf>` lives in `Trellis.Core`, namespace `Trellis`. The base type is hand-written; the per-derived members are emitted by the bundled `Trellis.Core.Generator` (attached automatically via `analyzers/dotnet/cs/`).
+
+| Member | Source | Purpose |
+|---|---|---|
+| `Value` (`string`) | base | Canonical symbolic identity. Defaults to the field name unless `[EnumValue]` overrides it. |
+| `Ordinal` (`int`) | base | Declaration-order metadata. Not a wire / storage identity. |
+| `static GetAll()` | base | All discovered `public static readonly TSelf` members, in declaration order. |
+| `static TryFromName(string? name, string? fieldName = null)` | base | Case-insensitive lookup → `Result<TSelf>`. |
+| `Is(params TSelf[])` / `IsNot(params TSelf[])` | base | Membership / negated membership. |
+| `Equals` / `==` / `!=` / `GetHashCode` | base | Case-insensitive symbolic equality on `Value`. |
+| `static TryCreate(string)` and `static TryCreate(string?, string? fieldName = null)` | generated | Result-returning factories; both delegate to `TryFromName`. |
+| `static Create(string)` | generated | Throwing factory. |
+| `static Parse(string, IFormatProvider?)` / `TryParse(...)` | generated | `IParsable<TSelf>` implementation for binding pipelines. |
+| `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` | generated | Applied to the derived class — no manual registration needed. |
+
+Full signatures: [`trellis-api-core.md` → `RequiredEnum<TSelf>`](../api_reference/trellis-api-core.md#requiredenumtself) and the [source-generated members section](../api_reference/trellis-api-core.md#requiredenumtself-1). Package scope: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md).
+
+> [!NOTE]
+> Generated `TryCreate` delegates only to `TryFromName`. There is no `TryFromValue` API path; the JSON converter and parser also resolve through `TryFromName`.
+
+## Installation
+
+```bash
+dotnet add package Trellis.Core
+```
+
+`Trellis.Primitives` transitively depends on `Trellis.Core`, so projects that already use the primitive value-object library do not need a separate install.
+
+## Quick start
+
+A `partial class` derivation, behavior-carrying members, and a Result-returning lookup — no other plumbing required.
 
 ```csharp
 using Trellis;
 
-namespace RequiredEnumExamples;
+namespace QuickStart;
 
 public partial class OrderStatus : RequiredEnum<OrderStatus>
 {
@@ -35,157 +90,144 @@ public partial class OrderStatus : RequiredEnum<OrderStatus>
     public bool CanShip { get; }
     public bool IsTerminal { get; }
 }
-```
 
-Usage stays simple:
-
-```csharp
-using RequiredEnumExamples;
-
-var paid = OrderStatus.Paid;
-var parsed = OrderStatus.TryCreate("awaiting-payment");
-var shipped = OrderStatus.TryFromName("Shipped");
-var all = OrderStatus.GetAll();
-
-bool readyToShip = paid.CanShip;
-bool isOpenState = paid.Is(OrderStatus.Draft, OrderStatus.AwaitingPayment, OrderStatus.Paid);
-bool isNotTerminal = paid.IsNot(OrderStatus.Cancelled);
-```
-
-## Why teams reach for `RequiredEnum<TSelf>`
-
-It helps when your “enum” has to do more than hold an integer:
-
-- state transitions
-- policy flags
-- wire-name overrides
-- JSON/model binding
-- richer equality semantics
-
-## What the API actually gives you
-
-`RequiredEnum<TSelf>` exposes these important members:
-
-| Member | Purpose |
-| --- | --- |
-| `Value` | symbolic identity |
-| `Ordinal` | declaration-order metadata only |
-| `GetAll()` | returns every declared member |
-| `TryFromName(...)` | case-insensitive symbolic lookup |
-| `Is(params TSelf[])` | membership check |
-| `IsNot(params TSelf[])` | negated membership check |
-
-The source generator also adds:
-
-- `TryCreate(string value)`
-- `TryCreate(string? value, string? fieldName = null)`
-- `Create(string value)`
-- parsing and JSON support
-
-> [!NOTE]
-> Generated `TryCreate(...)` delegates to `TryFromName(...)`. There is **no separate `TryFromValue(...)` API path** in the current Trellis implementation.
-
-## `Value` and `Ordinal` mean different things
-
-This distinction is easy to miss:
-
-- **`Value`** is the semantic identity
-- **`Ordinal`** is just declaration-order metadata
-
-`Ordinal` is useful for diagnostics or display ordering, but it should not be treated as a stable wire contract.
-
-## Default names vs `[EnumValue]`
-
-By default, the symbolic value is the field name:
-
-```csharp
-using RequiredEnumExamples;
-
-bool usesFieldName = OrderStatus.Paid.Value == "Paid";
-```
-
-Use `[EnumValue(...)]` only when the external symbolic name must differ:
-
-```csharp
-using RequiredEnumExamples;
-
-bool usesOverride = OrderStatus.AwaitingPayment.Value == "awaiting-payment";
-```
-
-That keeps one source of truth most of the time.
-
-## Adding behavior is the real win
-
-This is where `RequiredEnum<TSelf>` beats a raw enum.
-
-```csharp
-public partial class InvoiceStatus : RequiredEnum<InvoiceStatus>
+public static class Demo
 {
-    public static readonly InvoiceStatus Draft = new(canPost: false);
-    public static readonly InvoiceStatus Approved = new(canPost: true);
-    public static readonly InvoiceStatus Posted = new(canPost: false);
-
-    private InvoiceStatus(bool canPost) => CanPost = canPost;
-
-    public bool CanPost { get; }
+    public static void Run()
+    {
+        Result<OrderStatus> parsed = OrderStatus.TryCreate("awaiting-payment");
+        OrderStatus paid = OrderStatus.Create("Paid");
+        bool isOpen = paid.Is(OrderStatus.Draft, OrderStatus.AwaitingPayment, OrderStatus.Paid);
+        bool notDone = paid.IsNot(OrderStatus.Cancelled);
+        IReadOnlyCollection<OrderStatus> all = OrderStatus.GetAll();
+    }
 }
 ```
 
-Now the behavior travels with the symbolic value instead of being scattered through `switch` statements.
+## Defining members
 
-## State-machine style modeling
+Members are `public static readonly` fields of type `TSelf`. The base type discovers them by reflection on first access (then caches). The discovery contract:
 
-`RequiredEnum<TSelf>` works especially well for workflows:
+| Requirement | Why |
+|---|---|
+| Class must be `partial` | The generator augments it with `IScalarValue<TSelf, string>`, the factories, and the `[JsonConverter]` attribute. |
+| Fields must be `public static readonly TSelf` | Reflection inspects only `Public \| Static \| DeclaredOnly` init-only fields whose type equals `TSelf`. |
+| Constructors should be `private` (or `protected`) | Prevents external instantiation outside the declared set. |
+| Each `Value` must be unique (case-insensitive) | Duplicate detection runs the first time `GetAll` / `TryFromName` / `Value` is touched and throws `InvalidOperationException` naming the duplicate. |
+
+`Ordinal` is assigned during discovery in declaration order (0, 1, 2, …). Reordering fields changes ordinals — do not persist or transmit them.
+
+## Symbolic value names
+
+By default, `Value` equals the C# field name:
 
 ```csharp
-using Trellis;
-
-namespace WorkflowExample;
-
-public partial class ShipmentStatus : RequiredEnum<ShipmentStatus>
-{
-    public static readonly ShipmentStatus Draft = new();
-    public static readonly ShipmentStatus Ready = new();
-    public static readonly ShipmentStatus Sent = new();
-    public static readonly ShipmentStatus Delivered = new();
-
-    private ShipmentStatus() { }
-
-    public bool CanTransitionTo(ShipmentStatus next) =>
-        this switch
-        {
-            _ when this == Draft => next.Is(Ready),
-            _ when this == Ready => next.Is(Sent),
-            _ when this == Sent => next.Is(Delivered),
-            _ => false
-        };
-}
+OrderStatus.Paid.Value == "Paid"; // true
 ```
 
-## Serialization and web input
+Apply `[EnumValue("...")]` only when the external symbolic name must differ from the identifier (kebab-case wire formats, legacy compatibility, etc.):
 
-When you declare a concrete type as `partial`, the generator provides the plumbing for:
+```csharp
+[EnumValue("awaiting-payment")]
+public static readonly OrderStatus AwaitingPayment = new(canShip: false, isTerminal: false);
 
-- JSON conversion
-- ASP.NET Core model binding
-- parsing helpers
+OrderStatus.AwaitingPayment.Value == "awaiting-payment"; // true
+```
 
-That means `"Paid"` or `"awaiting-payment"` can flow naturally through APIs without hand-written converters.
+`EnumValueAttribute` is field-targeted and lives in `Trellis.Core`, namespace `Trellis`. See [`trellis-api-core.md` → `EnumValueAttribute`](../api_reference/trellis-api-core.md#enumvalueattribute) for the full signature. Keep the field name equal to `Value` whenever possible — one source of truth is easier to read and to grep for.
 
-## EF Core persistence
+## Parsing and creation
 
-Persist the symbolic `Value`, not `Ordinal`.
+The generator emits five entry points; all of them resolve through the base-type `TryFromName`.
+
+| API | Returns | Failure mode |
+|---|---|---|
+| `TryCreate(string value)` | `Result<TSelf>` | `Fail` with `Error.UnprocessableContent` for null, empty, whitespace, or unknown name. |
+| `TryCreate(string? value, string? fieldName = null)` | `Result<TSelf>` | Same; `fieldName` is included in the field violation. |
+| `TryFromName(string? name, string? fieldName = null)` | `Result<TSelf>` | Base-type lookup that all generated factories delegate to. |
+| `Create(string value)` | `TSelf` | Throws on failure. Use only for trusted, internally-known names. |
+| `Parse(string s, IFormatProvider? provider)` / `TryParse(...)` | `TSelf` / `bool` | `IParsable<TSelf>` for ASP.NET model binding pipelines. |
+
+```csharp
+Result<OrderStatus> ok   = OrderStatus.TryCreate("Paid");          // Ok(Paid)
+Result<OrderStatus> fail = OrderStatus.TryCreate("paid-in-full");  // Fail(UnprocessableContent)
+Result<OrderStatus> none = OrderStatus.TryCreate(null, "status");  // Fail("status cannot be empty.")
+
+OrderStatus paid = OrderStatus.Create("Paid");                     // throws on unknown
+```
+
+Lookup is case-insensitive (`OrdinalIgnoreCase`). The error message on an unknown value lists every valid name, alphabetised — convenient for API responses but verbose; trim before exposing externally if needed.
+
+## JSON serialization
+
+The generator emits `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` on the derived class, so `System.Text.Json` round-trips with no extra registration.
+
+| Direction | Behavior |
+|---|---|
+| Read | Accepts JSON `string` and `null`; resolves the string through `TryFromName`. Other token types (number, object, array, bool) throw `JsonException`. |
+| Write | Emits `value.Value` as a JSON string. |
+
+```csharp
+using System.Text.Json;
+
+string json = JsonSerializer.Serialize(OrderStatus.AwaitingPayment); // "\"awaiting-payment\""
+OrderStatus back = JsonSerializer.Deserialize<OrderStatus>(json)!;   // OrderStatus.AwaitingPayment
+```
+
+Converter signature: [`trellis-api-core.md` → `RequiredEnumJsonConverter<TRequiredEnum>`](../api_reference/trellis-api-core.md#requiredenumjsonconvertertrequiredenum).
+
+## Equality and membership
+
+`RequiredEnum<TSelf>` produces reference-stable singletons but uses **case-insensitive symbolic equality** on `Value`. All four — `Equals(object?)`, `Equals(RequiredEnum<TSelf>?)`, `==`, and `!=` — agree, and `GetHashCode` matches.
+
+```csharp
+OrderStatus.Paid == OrderStatus.Paid;      // true (also reference-equal)
+OrderStatus.Paid.Equals(OrderStatus.Paid); // true
+
+OrderStatus paid = OrderStatus.Create("PAID"); // resolves to OrderStatus.Paid
+ReferenceEquals(paid, OrderStatus.Paid);       // true — Create returns the singleton
+
+bool isOpen  = paid.Is(OrderStatus.Draft, OrderStatus.AwaitingPayment, OrderStatus.Paid);
+bool notDone = paid.IsNot(OrderStatus.Cancelled);
+```
+
+`Is` and `IsNot` accept `params TSelf[]` and call `Contains` on the array — fine for short lists; for hot paths with large sets, pre-build a `HashSet<TSelf>` once and check membership against that.
+
+## Validation rules
+
+| Input or condition | Outcome |
+|---|---|
+| `null` or whitespace name passed to `TryCreate` / `TryFromName` | `Fail` with `Error.UnprocessableContent.ForField(field, "validation.error", "{Type} cannot be empty.")` |
+| Unknown name | `Fail` with message `'{name}' is not a valid {Type}. Valid values: {alphabetised list}` |
+| Two members declared with the same `Value` (case-insensitive) | `InvalidOperationException` thrown by the base class on first cache build, naming the duplicate symbol |
+| `[EnumValue]` on a non-`TSelf` field, an instance member, or a non-`readonly` field | Silently ignored — only `public static readonly TSelf` init-only fields are discovered |
+
+`fieldName` defaults to the camelCased type name (e.g., `orderStatus`) when omitted. Pass it explicitly to align field-violation paths with the calling DTO property.
+
+## Analyzer warnings
+
+Two analyzer / generator diagnostics commonly affect `RequiredEnum<TSelf>`-derived types. Full reference: [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md).
+
+| ID | Severity | Trigger | Fix |
+|---|---|---|---|
+| `TRLS017` | Warning | `[StringLength]` / `[Range]` from `System.ComponentModel.DataAnnotations` applied to a Trellis primitive class. The Trellis generator only inspects attributes from `namespace Trellis`. | Switch the `using` to `using Trellis;` or fully-qualify (`[Trellis.StringLength(...)]`). |
+| `TRLS031` | Warning | Source generator detected a `Required*`-derived class whose base is not in the supported set (`RequiredString`, `RequiredGuid`, `RequiredInt`, `RequiredLong`, `RequiredDecimal`, `RequiredBool`, `RequiredDateTime`, `RequiredEnum`). | Inherit directly from `RequiredEnum<TSelf>`; do not insert intermediate base classes. |
+
+There is no analyzer that flags a `RequiredEnum<TSelf>` declared without `partial`. The build will simply fail to find the generated `IScalarValue<TSelf, string>` implementation — if `TryCreate` / `Parse` look missing on the derived class, the class is almost always missing the `partial` keyword.
+
+## Composition
+
+`RequiredEnum<TSelf>` round-trips cleanly through every Trellis surface that consumes `IScalarValue<TSelf, string>` — ASP.NET model binding, FluentValidation rules, and EF Core via a value converter on `Value`.
 
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-
-namespace RequiredEnumEfExample;
+using QuickStart;
 
 public sealed class Order
 {
-    public int Id { get; set; }
-    public RequiredEnumExamples.OrderStatus Status { get; set; } = null!;
+    public Guid Id { get; set; }
+    public OrderStatus Status { get; set; } = null!;
 }
 
 public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
@@ -195,37 +237,37 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.Property(order => order.Status)
             .HasConversion(
                 status => status.Value,
-                value => RequiredEnumExamples.OrderStatus.Create(value))
+                value  => OrderStatus.Create(value))
             .IsRequired();
     }
 }
 ```
 
+Because `TryCreate` returns `Result<TSelf>`, member parsing also composes inside ROP pipelines:
+
+```csharp
+public static Result<Order> Submit(Guid id, string statusName) =>
+    OrderStatus.TryCreate(statusName, fieldName: "status")
+        .Map(status => new Order { Id = id, Status = status });
+```
+
 > [!WARNING]
-> Persisting `Ordinal` turns declaration order into a storage contract. That is usually a mistake.
+> Persist `Value`, never `Ordinal`. `Ordinal` is reflection-derived from declaration order and silently changes when fields are reordered.
 
-## Best practices
+## Practical guidance
 
-1. Declare members as `public static readonly`
-2. Keep constructors private
-3. Prefer field names as the default symbolic value
-4. Use `[EnumValue(...)]` only for true wire-name overrides
-5. Put state behavior on the type itself
-6. Use `Is(...)` and `IsNot(...)` for readable membership checks
+- **Default to field names; reach for `[EnumValue]` only when the wire name must differ.** Two names per member is one too many to keep in sync.
+- **Keep constructors `private`.** The point of `RequiredEnum<TSelf>` is that the declared set is the entire set.
+- **Use `TryCreate` at boundaries, `Create` for trusted constants.** `Create` throws — pair it with literal strings, not user input.
+- **Prefer `Is` / `IsNot` over `switch` chains for membership checks.** They read like the domain language.
+- **Model state-transition rules on the type itself**, not in the caller — that is the point of moving from `enum` to value object.
+- **Persist `Value`. Index `Value`. Never persist `Ordinal`.**
+- **For hot membership checks against large sets, cache a `HashSet<TSelf>` once** instead of re-allocating a `params` array on every call.
 
-## Summary
+## Cross-references
 
-Use `RequiredEnum<TSelf>` when you need a finite set of domain values that:
-
-- must be valid
-- may carry behavior
-- need stable symbolic names
-- should work cleanly with JSON and model binding
-
-If you just need an integer-backed constant, a regular enum is fine. If the values are part of your domain language, `RequiredEnum<TSelf>` is usually the better fit.
-
-## See also
-
-- [Primitive Value Objects](primitives.md)
-- [Clean Architecture](clean-architecture.md)
-- [Trellis primitives API reference](../api_reference/trellis-api-primitives.md)
+- API surface and source-generated members: [`trellis-api-core.md` → `RequiredEnum<TSelf>`](../api_reference/trellis-api-core.md#requiredenumtself)
+- Concrete primitives derived from `Required*<TSelf>` bases: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- Analyzer / generator diagnostics: [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md) (in particular `TRLS017`, `TRLS031`)
+- JSON converter: [`trellis-api-core.md` → `RequiredEnumJsonConverter<TRequiredEnum>`](../api_reference/trellis-api-core.md#requiredenumjsonconvertertrequiredenum)
+- Companion article on scalar primitives: [`primitives.md`](primitives.md)

--- a/docs/docfx_project/articles/specifications.md
+++ b/docs/docfx_project/articles/specifications.md
@@ -1,22 +1,66 @@
+﻿---
+title: Specifications
+package: Trellis.Core
+topics: [specifications, ddd, query, predicate, composition, expression-tree, ef-core]
+related_api_reference: [trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
 # Specifications
 
-The same business rule often shows up in three places:
+`Specification<T>` encapsulates a named business rule as a composable, storage-agnostic `Expression<Func<T, bool>>` that runs identically in memory (`IsSatisfiedBy`) and against `IQueryable<T>` providers such as EF Core.
 
-- query filters
-- validation logic
-- reporting or batch jobs
+## Patterns Index
 
-Without a specification, that rule gets copied, renamed, and slowly drifts apart.
+| Goal | Use | See |
+|---|---|---|
+| Name a single business rule that can be reused across services and repositories | Subclass `Specification<T>` and override `ToExpression()` | [Defining a specification](#defining-a-specification) |
+| Combine two rules with logical AND / OR | `spec.And(other)` / `spec.Or(other)` | [Composing rules](#composing-rules) |
+| Invert a rule | `spec.Not()` | [Composing rules](#composing-rules) |
+| Evaluate against an in-memory object | `spec.IsSatisfiedBy(entity)` | [In-memory evaluation](#in-memory-evaluation) |
+| Filter an `IQueryable<T>` (LINQ-to-Objects, EF Core, ...) | Pass the spec where an `Expression<Func<T, bool>>` is expected (implicit conversion) | [Applying to IQueryable](#applying-to-iqueryable) |
+| Reference `Maybe<T>` members from a spec used by EF Core | Register `AddTrellisInterceptors()` on the `DbContextOptionsBuilder` | [EF Core integration](#ef-core-integration) |
+| Force recompilation on each `IsSatisfiedBy` call | Override `CacheCompilation` to return `false` | [Caching the compiled delegate](#caching-the-compiled-delegate) |
 
-`Specification<T>` gives you one reusable home for that rule.
+## Use this guide when
 
-## Start with a practical example
+- The same predicate appears in more than one repository method, validator, or batch job.
+- You need a single source of truth for a rule that runs both in memory and as a translated SQL `WHERE`.
+- A repository should accept a domain-named filter (`OverdueOrderSpec`) instead of raw `Expression<Func<T, bool>>` arguments.
+
+## Surface at a glance
+
+`Trellis.Core` exposes one abstract class, `Specification<T>` (namespace `Trellis`).
+
+| Member | Kind | Purpose |
+|---|---|---|
+| `ToExpression()` | `abstract Expression<Func<T, bool>>` | The canonical expression tree for the rule. The only member subclasses must implement. |
+| `IsSatisfiedBy(T entity)` | `bool` | In-memory evaluation. Uses a lazily compiled, cached delegate by default. |
+| `And(Specification<T> other)` | `Specification<T>` | Logical AND combinator. Throws `ArgumentNullException` if `other` is `null`. |
+| `Or(Specification<T> other)` | `Specification<T>` | Logical OR combinator. Throws `ArgumentNullException` if `other` is `null`. |
+| `Not()` | `Specification<T>` | Logical negation. |
+| `implicit operator Expression<Func<T, bool>>` | conversion | Lets the spec be passed directly to `Where`, `Any`, `Count`, ... |
+| `CacheCompilation` | `protected virtual bool` (default `true`) | Override to `false` when the expression depends on mutable closure state. |
+
+`AndSpecification<T>`, `OrSpecification<T>`, and `NotSpecification<T>` are internal implementation types — they are not part of the public surface.
+
+Full signatures: [trellis-api-core.md](../api_reference/trellis-api-core.md).
+
+## Installation
+
+```bash
+dotnet add package Trellis.Core
+```
+
+## Quick start
+
+Define one rule, compose with another, and run it both in memory and against a queryable.
 
 ```csharp
+using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Trellis;
-
-namespace SpecificationExamples;
 
 public sealed class Order
 {
@@ -26,52 +70,76 @@ public sealed class Order
     public string Region { get; init; } = string.Empty;
 }
 
-public sealed class OverdueOrderSpecification(DateTimeOffset now) : Specification<Order>
+public sealed class OverdueOrderSpec(DateTimeOffset now) : Specification<Order>
 {
     public override Expression<Func<Order, bool>> ToExpression() =>
         order => !order.IsPaid && order.DueAt < now;
 }
 
-public sealed class HighValueOrderSpecification(decimal threshold) : Specification<Order>
+public sealed class HighValueOrderSpec(decimal threshold) : Specification<Order>
 {
     public override Expression<Func<Order, bool>> ToExpression() =>
         order => order.TotalAmount >= threshold;
 }
 
-public sealed class RegionSpecification(string region) : Specification<Order>
+var spec = new OverdueOrderSpec(DateTimeOffset.UtcNow)
+    .And(new HighValueOrderSpec(500m));
+
+bool match = spec.IsSatisfiedBy(new Order { TotalAmount = 750m, DueAt = DateTimeOffset.UtcNow.AddDays(-1) });
+
+IQueryable<Order> filtered = new[] { /* ... */ }.AsQueryable().Where(spec);
+```
+
+## Defining a specification
+
+Subclass `Specification<T>` and implement `ToExpression()`. Constructor parameters become closure values inside the expression — keep them immutable.
+
+```csharp
+using System;
+using System.Linq.Expressions;
+using Trellis;
+
+public sealed class RegionSpec(string region) : Specification<Order>
 {
     public override Expression<Func<Order, bool>> ToExpression() =>
         order => order.Region == region;
 }
 ```
 
-Now the business rule reads clearly:
+Rules of thumb:
+
+- One specification = one named rule. Don't pack unrelated conditions into a single class.
+- Keep the expression body translation-friendly (member access, arithmetic, comparisons). Method calls only translate if the LINQ provider supports them.
+- Capture only immutable state in the constructor. See [Caching the compiled delegate](#caching-the-compiled-delegate) if you must capture mutable state.
+
+## Composing rules
+
+| Combinator | Result |
+|---|---|
+| `a.And(b)` | Satisfied when both `a` and `b` are. |
+| `a.Or(b)` | Satisfied when either `a` or `b` is. |
+| `a.Not()` | Satisfied when `a` is not. |
 
 ```csharp
-var spec = new OverdueOrderSpecification(DateTimeOffset.UtcNow)
-    .And(new HighValueOrderSpecification(500m))
-    .And(new RegionSpecification("West"));
+var overdue   = new OverdueOrderSpec(DateTimeOffset.UtcNow);
+var highValue = new HighValueOrderSpec(500m);
+var west      = new RegionSpec("West");
+
+var urgent        = overdue.And(highValue);
+var westOrUrgent  = west.Or(urgent);
+var notOverdue    = overdue.Not();
 ```
 
-## Why this is better than inline predicates
-
-Inline LINQ predicates are fine for one-off queries. Specifications help when the rule has a name and a life of its own.
-
-They give you:
-
-- **reuse** across repository methods and services
-- **composability** through `And`, `Or`, and `Not`
-- **storage-agnostic expressions** for LINQ providers
-- **testability** through `IsSatisfiedBy(...)`
+`And`/`Or`/`Not` return a new `Specification<T>` — original instances are never mutated, so combinators are safe to share.
 
 ## In-memory evaluation
 
-Use `IsSatisfiedBy(...)` when you already have objects in memory:
+`IsSatisfiedBy(entity)` evaluates the rule against an object you already hold in memory.
 
 ```csharp
-var spec = new HighValueOrderSpecification(500m);
+var spec = new HighValueOrderSpec(500m);
 
-bool isMatch = spec.IsSatisfiedBy(new Order
+bool match = spec.IsSatisfiedBy(new Order
 {
     TotalAmount = 750m,
     DueAt = DateTimeOffset.UtcNow.AddDays(2),
@@ -80,88 +148,68 @@ bool isMatch = spec.IsSatisfiedBy(new Order
 });
 ```
 
-`Specification<T>` caches the compiled delegate by default, so repeated in-memory checks stay cheap.
+By default the delegate compiled from `ToExpression()` is cached behind a `Lazy<Func<T, bool>>`, so repeated calls do not recompile.
 
-## Composing rules
+## Applying to IQueryable
 
-Composition is where specifications become really useful:
-
-```csharp
-var overdue = new OverdueOrderSpecification(DateTimeOffset.UtcNow);
-var highValue = new HighValueOrderSpecification(500m);
-var westRegion = new RegionSpecification("West");
-
-var urgent = overdue.And(highValue);
-var westOrUrgent = westRegion.Or(urgent);
-var notOverdue = overdue.Not();
-```
-
-## Querying with `IQueryable`
-
-`Specification<T>` has an implicit conversion to `Expression<Func<T, bool>>`, so it plugs directly into LINQ:
+Because `Specification<T>` defines an implicit conversion to `Expression<Func<T, bool>>`, you can pass it directly to any LINQ operator that takes a predicate expression.
 
 ```csharp
-using System;
-using System.Collections.Generic;
 using System.Linq;
 
-List<Order> orders =
-[
-    new() { TotalAmount = 250m, DueAt = DateTimeOffset.UtcNow.AddDays(1), IsPaid = false, Region = "West" },
-    new() { TotalAmount = 750m, DueAt = DateTimeOffset.UtcNow.AddDays(-2), IsPaid = false, Region = "West" }
-];
+IQueryable<Order> query = /* AsQueryable() / DbSet<Order> / ... */;
 
-IQueryable<Order> query = orders.AsQueryable();
-
-var spec = new OverdueOrderSpecification(DateTimeOffset.UtcNow)
-    .And(new HighValueOrderSpecification(500m));
+var spec = new OverdueOrderSpec(DateTimeOffset.UtcNow)
+    .And(new HighValueOrderSpec(500m));
 
 var filtered = query.Where(spec);
+int count    = query.Count(spec);
+bool any     = query.Any(spec);
 ```
 
-That same pattern works with EF Core and other LINQ providers.
-
-> [!NOTE]
-> Composed specifications use `Expression.Invoke` internally. For EF Core translation, use **EF Core 8+**.
-
-## Repository-friendly design
-
-A repository can accept a specification without learning any business details:
+A repository can therefore accept the named rule without learning the rule itself:
 
 ```csharp
 using System.Threading;
 using System.Threading.Tasks;
 using Trellis;
 
-namespace RepositoryExample;
-
-public sealed class Order
-{
-    public decimal TotalAmount { get; init; }
-}
-
 public interface IOrderRepository
 {
-    Task<IReadOnlyList<Order>> ListAsync(Specification<Order> specification, CancellationToken ct);
-    Task<bool> AnyAsync(Specification<Order> specification, CancellationToken ct);
+    Task<IReadOnlyList<Order>> ListAsync(Specification<Order> spec, CancellationToken ct);
+    Task<bool>                 AnyAsync(Specification<Order> spec, CancellationToken ct);
 }
 ```
 
-That keeps the repository generic and the business rules named.
+## EF Core integration
 
-## When to disable cached compilation
+Composed specifications combine sub-expressions using `Expression.Invoke`. EF Core 8+ translates these reliably; older versions may not.
 
-Most specifications are created with immutable constructor values and should keep the default behavior.
-
-If your expression depends on mutable state, override `CacheCompilation`:
+If your specification reads `Maybe<T>` members (`HasValue`, `Value`, `GetValueOrDefault(d)`, `== Maybe<T>.None`), register the Trellis interceptors so the `MaybeQueryInterceptor` rewrites the access into the underlying storage member:
 
 ```csharp
+using Microsoft.EntityFrameworkCore;
+using Trellis.EntityFrameworkCore;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
+        optionsBuilder.AddTrellisInterceptors();
+}
+```
+
+Without `AddTrellisInterceptors()`, `Maybe<T>` access inside a spec either fails to translate or silently drops the predicate — a "fake says yes, production says no" failure mode. See the EF Core guide for details.
+
+## Caching the compiled delegate
+
+`CacheCompilation` (protected, virtual, default `true`) controls whether `IsSatisfiedBy` reuses a single `Lazy<Func<T, bool>>`. Override it to `false` only when `ToExpression()` returns a different tree on different invocations of the same instance — for example, when the predicate captures a mutable callback.
+
+```csharp
+using System;
 using System.Linq.Expressions;
 using Trellis;
 
-namespace CacheControlExample;
-
-public sealed class ThresholdSpecification(Func<int> getThreshold) : Specification<int>
+public sealed class ThresholdSpec(Func<int> getThreshold) : Specification<int>
 {
     protected override bool CacheCompilation => false;
 
@@ -170,59 +218,47 @@ public sealed class ThresholdSpecification(Func<int> getThreshold) : Specificati
 }
 ```
 
-## Specifications and Trellis value objects
+The override only affects in-memory evaluation. LINQ providers always read the current `ToExpression()` result.
 
-Specifications work well with Trellis primitives because the domain types can stay in the predicate instead of being peeled back to raw values everywhere.
+## Composition
 
-For example, you can use specifications over aggregates or entities that expose:
-
-- `EmailAddress`
-- `RequiredEnum<TSelf>` members
-- `MonetaryAmount`
-- `Money`
-
-That keeps your query language aligned with the domain language.
-
-## `Maybe<T>` support in EF Core queries
-
-If your specification references `Maybe<T>` members in EF Core, register the Trellis interceptors so the query can be rewritten correctly.
+Specifications compose with the rest of Trellis through the data they filter, not through `Result<T>`. A typical flow loads via spec, validates, and continues in a result pipeline:
 
 ```csharp
-using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
 
-public sealed class AppDbContext : DbContext
+public sealed class FulfilOverdueOrders(IOrderRepository repository)
 {
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
-        optionsBuilder.AddTrellisInterceptors();
+    public Task<Result<int>> RunAsync(CancellationToken ct) =>
+        FetchAsync(ct)
+            .EnsureAsync(orders => orders.Count > 0, new Error.NotFound(ResourceRef.For<Order>("overdue")))
+            .MapAsync(orders => orders.Count);
+
+    private async Task<Result<IReadOnlyList<Order>>> FetchAsync(CancellationToken ct)
+    {
+        var spec = new OverdueOrderSpec(DateTimeOffset.UtcNow)
+            .And(new HighValueOrderSpec(500m));
+
+        var orders = await repository.ListAsync(spec, ct).ConfigureAwait(false);
+        return Result.Ok(orders);
+    }
 }
 ```
 
-Then expressions like `HasValue` and `Value` can translate cleanly in supported scenarios.
+## Practical guidance
 
-## When specifications are a good fit
+- **One rule, one name.** A spec earns its keep when the rule has a domain name and shows up in more than one place. Inline `Where(o => ...)` is fine for one-off queries.
+- **Prefer combinators over re-implementing.** If `OverdueOrderSpec.And(HighValueOrderSpec)` already says it, don't write `OverdueHighValueOrderSpec`.
+- **Keep expressions translatable.** Stick to property access, comparisons, arithmetic, and provider-supported helpers. Avoid invoking arbitrary instance methods inside `ToExpression()`.
+- **Treat constructor args as immutable.** They get baked into the expression tree closure; mutating a captured field after composition produces surprising results.
+- **EF Core 8+.** Composed specs use `Expression.Invoke`; older EF Core versions cannot translate that pattern.
+- **Test specs directly.** `IsSatisfiedBy` against representative objects is the cheapest way to lock the rule down before exercising it through a repository.
 
-Use them when the rule:
+## Cross-references
 
-- has a clear business name
-- appears in more than one place
-- should run both in memory and in queries
-- is worth testing independently
-
-Skip them when a predicate is truly one-off and unlikely to matter again.
-
-## Summary
-
-Specifications help you keep business rules:
-
-- named
-- reusable
-- composable
-- testable
-
-That is the main win. They are less about pattern purity and more about preventing rule duplication.
-
-## See also
-
-- [Clean Architecture](clean-architecture.md)
-- [Primitive Value Objects](primitives.md)
-- [Trellis DDD API reference](../api_reference/trellis-api-core.md)
+- API surface: [`trellis-api-core.md` → `Specification<T>`](../api_reference/trellis-api-core.md#specificationt)
+- `Maybe<T>` query rewriting and the `AddTrellisInterceptors()` registration: [`integration-ef.md`](integration-ef.md)
+- Spec / `Maybe<T>` / fake-vs-real divergence walkthrough: [`trellis-api-cookbook.md` → Recipe 15](../api_reference/trellis-api-cookbook.md)
+- Domain primitives that read well inside specifications: [`primitives.md`](primitives.md)

--- a/docs/docfx_project/articles/state-machines.md
+++ b/docs/docfx_project/articles/state-machines.md
@@ -1,54 +1,44 @@
-﻿# State Machines
+﻿---
+title: State Machines
+package: Trellis.StateMachine
+topics: [state-machine, transition, guard, result, aggregate, ddd, stateless, lazy]
+related_api_reference: [trellis-api-statemachine.md, trellis-api-core.md]
+last_verified: 2026-05-01
+audience: [developer]
+---
+# State Machines
 
-State machines matter when the order of operations is part of the business rule.
+`Trellis.StateMachine` wraps the [Stateless](https://github.com/dotnet-state-machine/stateless) library so invalid transitions become typed `Result<TState>` failures instead of `InvalidOperationException`s — keeping workflow logic inside the same railway as the rest of your domain code.
 
-If an order must go `Draft -> Submitted -> Approved -> Shipped`, you do not want that logic scattered across `if` statements and exception handling. You want one explicit model of the workflow.
+## Patterns Index
 
-Trellis integrates with [Stateless](https://github.com/dotnet-state-machine/stateless) so invalid transitions can participate in result-based flows instead of blowing up ordinary pipelines.
+| Goal | Use | See |
+|---|---|---|
+| Fire a Stateless trigger and get a `Result<TState>` | `stateMachine.FireResult(trigger)` | [Quick start](#quick-start) |
+| Treat invalid transitions as 422 rule violations | Default `FireResult` behavior — match on reason code `state.machine.invalid.transition` | [What `FireResult` guarantees](#what-fireresult-guarantees) |
+| Defer machine construction until entity state is populated (ORM materialization) | `LazyStateMachine<TState, TTrigger>` | [Lazy construction for aggregates](#lazy-construction-for-aggregates) |
+| Compose a transition with domain side effects and events | `FireResult(...).Tap(...).Map(...)` | [Composition](#composition) |
+| Block transitions on dynamic conditions | Stateless `PermitIf` / `IgnoreIf` (honored by `CanFire`) | [Guards](#guards) |
 
-## Why use Trellis here?
+## Use this guide when
 
-Plain Stateless throws `InvalidOperationException` when a trigger is not valid in the current state.
+- The order of operations is part of the business rule (orders, approvals, publishing, fulfillment).
+- You want invalid transitions to flow through the same `Result<T>` pipeline as validation errors and HTTP failures.
+- An ORM (e.g., EF Core) materializes your aggregate before populating its state property, and an eagerly-constructed Stateless machine would read the wrong initial state.
+- You need invalid-transition detection that survives Stateless library upgrades (no exception-message parsing).
 
-That is fine for exception-based code, but awkward in a result-based application flow.
+## Surface at a glance
 
-```csharp
-using System;
-using Stateless;
+`Trellis.StateMachine` exposes one static class and one sealed wrapper. The `StateMachine<TState, TTrigger>` type itself comes from the upstream `Stateless` namespace and remains visible in user code.
 
-public enum OrderState { Draft, Submitted, Approved, Shipped, Cancelled }
-public enum OrderTrigger { Submit, Approve, Ship, Cancel }
+| Type | Kind | Purpose |
+|---|---|---|
+| `StateMachineExtensions` | `static class` | Adds `FireResult<TState, TTrigger>(this StateMachine<TState, TTrigger>, TTrigger)` returning `Result<TState>`. |
+| `LazyStateMachine<TState, TTrigger>` | `sealed class` | Defers machine creation and configuration until first access via `Machine` or `FireResult`. |
 
-var machine = new StateMachine<OrderState, OrderTrigger>(OrderState.Draft);
-machine.Configure(OrderState.Draft)
-    .Permit(OrderTrigger.Submit, OrderState.Submitted);
+Both generics carry `where TState : notnull` and `where TTrigger : notnull` constraints.
 
-try
-{
-    machine.Fire(OrderTrigger.Ship);
-}
-catch (InvalidOperationException ex)
-{
-    Console.WriteLine(ex.Message);
-}
-```
-
-With Trellis, the same invalid transition can stay inside the railway:
-
-```csharp
-using Stateless;
-using Trellis;
-using Trellis.StateMachine;
-
-public enum OrderState { Draft, Submitted, Approved, Shipped, Cancelled }
-public enum OrderTrigger { Submit, Approve, Ship, Cancel }
-
-var machine = new StateMachine<OrderState, OrderTrigger>(OrderState.Draft);
-machine.Configure(OrderState.Draft)
-    .Permit(OrderTrigger.Submit, OrderState.Submitted);
-
-Result<OrderState> result = machine.FireResult(OrderTrigger.Ship);
-```
+Full signatures: [`trellis-api-statemachine.md`](../api_reference/trellis-api-statemachine.md).
 
 ## Installation
 
@@ -56,7 +46,9 @@ Result<OrderState> result = machine.FireResult(OrderTrigger.Ship);
 dotnet add package Trellis.StateMachine
 ```
 
-## A simple working example
+## Quick start
+
+Configure a Stateless machine, then call `FireResult` instead of `Fire`. Invalid transitions become a typed `Result` failure.
 
 ```csharp
 using Stateless;
@@ -78,163 +70,172 @@ machine.Configure(OrderState.Submitted)
     .Permit(OrderTrigger.Cancel, OrderState.Cancelled);
 
 machine.Configure(OrderState.Approved)
-    .Permit(OrderTrigger.Ship, OrderState.Shipped)
-    .Permit(OrderTrigger.Cancel, OrderState.Cancelled);
+    .Permit(OrderTrigger.Ship, OrderState.Shipped);
 
-Result<OrderState> submit = machine.FireResult(OrderTrigger.Submit);
-Result<OrderState> approve = machine.FireResult(OrderTrigger.Approve);
-Result<OrderState> invalidCancel = machine.FireResult(OrderTrigger.Cancel);
+Result<OrderState> submit  = machine.FireResult(OrderTrigger.Submit);  // Ok(Submitted)
+Result<OrderState> approve = machine.FireResult(OrderTrigger.Approve); // Ok(Approved)
+Result<OrderState> invalid = machine.FireResult(OrderTrigger.Submit);  // Fail (UnprocessableContent)
 ```
 
-## Visualizing the workflow
+## What `FireResult` guarantees
 
-```mermaid
-stateDiagram-v2
-    [*] --> Draft
-    Draft --> Submitted: Submit
-    Draft --> Cancelled: Cancel
-    Submitted --> Approved: Approve
-    Submitted --> Cancelled: Cancel
-    Approved --> Shipped: Ship
-    Approved --> Cancelled: Cancel
-```
+`FireResult` is intentionally narrow — see [`trellis-api-statemachine.md`](../api_reference/trellis-api-statemachine.md#statemachineextensions) for the exact signature and translation rules.
 
-## What `FireResult` actually guarantees
+| Outcome | Result |
+|---|---|
+| `CanFire(trigger)` is `true` | Calls `Fire(trigger)`, returns `Result.Ok(stateMachine.State)`. |
+| `CanFire(trigger)` is `false`, default unhandled-trigger handler throws | Returns `Error.UnprocessableContent` (HTTP 422) carrying a `RuleViolation` with reason code `state.machine.invalid.transition`. |
+| `CanFire(trigger)` is `false`, custom `OnUnhandledTrigger` swallows the trigger | Returns `Result.Ok(stateMachine.State)` — state unchanged. |
+| User entry/exit/transition/guard/accessor/mutator code throws | Exception propagates untouched. |
 
-`FireResult` is intentionally narrow and predictable.
-
-### On success
-
-- it pre-checks the trigger with `CanFire(trigger)` (which honors `PermitIf`/`IgnoreIf` guards)
-- it fires the trigger once
-- it returns `Result<TState>` containing the new state
-
-### On failure
-
-- if `CanFire(trigger)` returns false, it returns `Error.UnprocessableContent` (HTTP 422) carrying a single `RuleViolation` with reason code `state.machine.invalid.transition` and a Trellis-owned `Detail` string — no Stateless exception is involved. Invalid transitions are semantic rule violations, not concurrent-modification conflicts.
-- the failure shape is therefore independent of the Stateless library version and its exception message text
-
-### What it does **not** do
-
-- it does **not** make Stateless thread-safe — Stateless is single-threaded by contract; callers must externally synchronize concurrent calls
-- it does **not** swallow arbitrary exceptions from your own entry, exit, guard, accessor, mutator, or configuration code — those propagate to the caller
-- it does **not** depend on the textual content of any Stateless exception, so library upgrades that reword internal messages will not break it
+Invalid-transition detection uses `CanFire` (which honors `PermitIf` / `IgnoreIf` guards) — there is no Stateless message-string parsing, so the failure shape is independent of Stateless's exception text.
 
 > [!NOTE]
-> Because `FireResult` evaluates the guard once via `CanFire` and again via `Fire`, transition guards must be **idempotent and side-effect-free** — which is already a Stateless requirement. The guard is evaluated at most twice per `FireResult` call.
+> Because `FireResult` evaluates the guard once via `CanFire` and (when permitted) again via `Fire`, transition guards must be **idempotent and side-effect-free** — already a Stateless requirement. Guards run at most twice per call.
 
 > [!WARNING]
-> `FireResult<TState, TTrigger>` has `where TState : notnull` and `where TTrigger : notnull` constraints. `LazyStateMachine<TState, TTrigger>` has the same constraints.
+> Neither `FireResult` nor `LazyStateMachine` makes Stateless thread-safe. Stateless is single-threaded by contract; concurrent callers on the same machine instance must synchronize externally.
 
-## Composing transitions with Trellis pipelines
+## Guards
 
-The main benefit is not just avoiding exceptions. It is that state changes now compose naturally with other result-based work.
+Guards are plain Stateless `PermitIf` / `IgnoreIf` predicates. `FireResult` honors them through `CanFire`, so a guard that returns `false` produces the same `Error.UnprocessableContent` as a missing transition.
 
 ```csharp
 using Stateless;
 using Trellis;
 using Trellis.StateMachine;
 
-public sealed class OrderWorkflow
+public enum InvoiceState { Draft, Approved }
+public enum InvoiceTrigger { Approve }
+
+bool hasLineItems = false;
+
+var state = InvoiceState.Draft;
+var machine = new StateMachine<InvoiceState, InvoiceTrigger>(() => state, s => state = s);
+
+machine.Configure(InvoiceState.Draft)
+    .PermitIf(InvoiceTrigger.Approve, InvoiceState.Approved, () => hasLineItems);
+
+Result<InvoiceState> blocked = machine.FireResult(InvoiceTrigger.Approve); // Fail (guard false)
+hasLineItems = true;
+Result<InvoiceState> ok = machine.FireResult(InvoiceTrigger.Approve);      // Ok(Approved)
+```
+
+Because guards may run twice per `FireResult` call, do not mutate state inside them — read flags or value-object snapshots only.
+
+## Lazy construction for aggregates
+
+ORMs typically construct an entity instance, then populate its properties. A state machine wired up in the constructor with `() => Status` will read whatever the property holds at construction time, not the materialized value. `LazyStateMachine<TState, TTrigger>` defers the accessor call, the mutator wiring, and the `configure` callback until first use.
+
+```csharp
+using Stateless;
+using Trellis;
+using Trellis.StateMachine;
+
+public enum DocumentStatus { Draft, Published, Archived }
+public enum DocumentTrigger { Publish, Archive }
+
+public sealed class Document
 {
-    private OrderState _state = OrderState.Draft;
-    private readonly StateMachine<OrderState, OrderTrigger> _machine;
+    private readonly LazyStateMachine<DocumentStatus, DocumentTrigger> _machine;
 
-    public List<string> Events { get; } = [];
+    public DocumentStatus Status { get; private set; } = DocumentStatus.Draft;
 
-    public OrderWorkflow()
+    public Document()
     {
-        _machine = new StateMachine<OrderState, OrderTrigger>(() => _state, s => _state = s);
-
-        _machine.Configure(OrderState.Draft)
-            .Permit(OrderTrigger.Submit, OrderState.Submitted);
-
-        _machine.Configure(OrderState.Submitted)
-            .Permit(OrderTrigger.Approve, OrderState.Approved);
+        _machine = new LazyStateMachine<DocumentStatus, DocumentTrigger>(
+            () => Status,
+            s => Status = s,
+            Configure);
     }
 
-    public Result<OrderWorkflow> Submit() =>
+    public Result<DocumentStatus> Publish() => _machine.FireResult(DocumentTrigger.Publish);
+    public Result<DocumentStatus> Archive() => _machine.FireResult(DocumentTrigger.Archive);
+
+    private static void Configure(StateMachine<DocumentStatus, DocumentTrigger> machine)
+    {
+        machine.Configure(DocumentStatus.Draft)
+            .Permit(DocumentTrigger.Publish, DocumentStatus.Published);
+
+        machine.Configure(DocumentStatus.Published)
+            .Permit(DocumentTrigger.Archive, DocumentStatus.Archived);
+    }
+}
+```
+
+Key facts:
+
+| Aspect | Value |
+|---|---|
+| Class modifier | `sealed` |
+| Thread-safety | Not thread-safe; `_machine ??= CreateMachine()` has no locking. |
+| Configuration timing | Once, on first access to `Machine` (or first `FireResult`). |
+| Direct Stateless access | Available via the `Machine` property when you need raw Stateless APIs. |
+| Constructor null checks | Throws `ArgumentNullException` for any `null` delegate. |
+
+## Composition
+
+The point of returning `Result<TState>` is that a transition composes with the rest of Trellis (`Tap`, `Map`, `Bind`, `Ensure`) — domain mutations, events, and validation chain off the same railway.
+
+```csharp
+using Stateless;
+using Trellis;
+using Trellis.StateMachine;
+
+public enum OrderStatus { Draft, Submitted, Approved }
+public enum OrderTrigger { Submit, Approve }
+
+public sealed class Order
+{
+    private readonly LazyStateMachine<OrderStatus, OrderTrigger> _machine;
+    private readonly List<string> _events = [];
+
+    public OrderStatus Status { get; private set; } = OrderStatus.Draft;
+    public IReadOnlyList<string> Events => _events;
+
+    public Order()
+    {
+        _machine = new LazyStateMachine<OrderStatus, OrderTrigger>(
+            () => Status,
+            s => Status = s,
+            machine =>
+            {
+                machine.Configure(OrderStatus.Draft)
+                    .Permit(OrderTrigger.Submit, OrderStatus.Submitted);
+                machine.Configure(OrderStatus.Submitted)
+                    .Permit(OrderTrigger.Approve, OrderStatus.Approved);
+            });
+    }
+
+    public Result<Order> Submit() =>
         _machine.FireResult(OrderTrigger.Submit)
-            .Tap(_ => Events.Add("OrderSubmitted"))
+            .Tap(_ => _events.Add("OrderSubmitted"))
+            .Map(_ => this);
+
+    public Result<Order> Approve() =>
+        _machine.FireResult(OrderTrigger.Approve)
+            .Tap(_ => _events.Add("OrderApproved"))
             .Map(_ => this);
 }
 ```
 
-That is the Trellis-friendly pattern:
+The pattern is consistent: `FireResult(...)` for the transition, `Tap(...)` for domain side effects (events, audit), `Map(_ => this)` to return the richer aggregate.
 
-1. transition with `FireResult(...)`
-2. do side effects with `Tap(...)`
-3. return the richer domain object with `Map(_ => this)` when needed
+Keep business mutations **after** `FireResult` succeeds. Do not place domain side effects inside Stateless `OnEntry`/`OnExit` callbacks — those are for transition mechanics only.
 
-## `LazyStateMachine<TState, TTrigger>`: for ORM materialization scenarios
+## Practical guidance
 
-A common problem with ORMs is timing.
+- **Use `FireResult`, not `Fire`.** The whole reason to take this dependency is to keep invalid transitions inside the result pipeline.
+- **Distinguish state-machine 422s.** All `FireResult` failures share the reason code `state.machine.invalid.transition` — match on it when callers need to react specifically to workflow rejections.
+- **422, not 409.** Invalid transitions are semantic rule violations, not concurrent-modification conflicts; retrying will not help. That is why the failure is `Error.UnprocessableContent`.
+- **One state machine per aggregate instance.** They are not thread-safe; do not share across requests or threads.
+- **Keep guards pure.** They run via `CanFire` and again via `Fire`, so any side effect would execute twice on the success path.
+- **Use `LazyStateMachine` for ORM-materialized aggregates.** It removes the manual `_machine ??= Configure()` boilerplate and ensures the accessor reads the populated value.
+- **Reach for state machines when the workflow is the rule.** Orders, approvals, publishing, onboarding — yes. Cosmetic UI flags or trivial CRUD lifecycles — no.
 
-The object is constructed first, and only then are its properties populated. If your state machine reads the state too early, it can start from the wrong value.
+## Cross-references
 
-`LazyStateMachine<TState, TTrigger>` solves that by deferring machine creation until first use.
-
-```csharp
-using Stateless;
-using Trellis;
-using Trellis.StateMachine;
-
-public enum DocumentState { Draft, Published }
-public enum DocumentTrigger { Publish }
-
-public sealed class DocumentWorkflow
-{
-    private readonly LazyStateMachine<DocumentState, DocumentTrigger> _machine;
-
-    public DocumentState State { get; private set; } = DocumentState.Draft;
-
-    public DocumentWorkflow()
-    {
-        _machine = new LazyStateMachine<DocumentState, DocumentTrigger>(
-            () => State,
-            state => State = state,
-            machine => machine.Configure(DocumentState.Draft)
-                .Permit(DocumentTrigger.Publish, DocumentState.Published));
-    }
-
-    public Result<DocumentState> Publish() =>
-        _machine.FireResult(DocumentTrigger.Publish);
-}
-```
-
-## Important `LazyStateMachine` facts
-
-- it is **sealed**
-- it is **not thread-safe**
-- initialization uses lazy creation with no locking
-- configuration runs once, on first use
-- the underlying machine is available through `.Machine` when you need direct Stateless access
-
-> [!WARNING]
-> Do not share one `LazyStateMachine` instance across concurrent callers without external synchronization.
-
-## When to use a state machine at all
-
-Use one when the workflow is part of the domain, not just UI flow.
-
-Good candidates:
-
-- orders
-- approvals
-- fulfillment
-- publishing
-- onboarding workflows
-- long-running business processes with explicit transitions
-
-Probably overkill:
-
-- one-off CRUD entities with no meaningful lifecycle
-- state that is purely cosmetic or presentation-specific
-
-## Bottom line
-
-Use state machines when the workflow itself is business logic.
-
-Use `FireResult(...)` when you want that workflow to stay inside Trellis pipelines.
-
-Use `LazyStateMachine<TState, TTrigger>` when object materialization timing would otherwise make machine setup fragile.
+- API surface: [`trellis-api-statemachine.md`](../api_reference/trellis-api-statemachine.md)
+- `Result<T>`, `Error.UnprocessableContent`, `RuleViolation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- Cookbook recipe (CanFire + Fire pattern with `FireResult`): [`trellis-api-cookbook.md`](../api_reference/trellis-api-cookbook.md#recipe-9--state-machine-canfire--fire-pattern-with-fireresult)
+- Upstream library: [Stateless on GitHub](https://github.com/dotnet-state-machine/stateless)

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -92,5 +92,5 @@
     href: performance.md
   - name: Benchmarks Data
     href: BENCHMARKS.md
-  - name: Migration from FunctionalDDD
+  - name: Migrating from v1 to v2
     href: migration.md

--- a/docs/docfx_project/articles/with-vs-without-trellis.md
+++ b/docs/docfx_project/articles/with-vs-without-trellis.md
@@ -1,3 +1,11 @@
+﻿---
+title: With Trellis vs Without Trellis
+package: Trellis (multiple)
+topics: [ai, comparison, study, scaffolding, security, review]
+related_api_reference: []
+last_verified: 2026-05-01
+audience: [developer]
+---
 # With Trellis vs Without Trellis
 
 If you are using AI to build production software, the real question is not "Can it generate code?"

--- a/docs/docfx_project/audit-llm-doc-quality.ps1
+++ b/docs/docfx_project/audit-llm-doc-quality.ps1
@@ -1,0 +1,421 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+  LLM-doc-quality smoke test for the Trellis docfx project.
+
+.DESCRIPTION
+  Runs four static probes against `docs/docfx_project/articles/*.md`,
+  `docs/docfx_project/api_reference/*.md`, and the Trellis package source
+  trees. Designed to catch regressions in LLM-targeted documentation
+  quality without invoking a model. Runs in seconds and exits non-zero
+  on any probe failure so it can gate a CI workflow.
+
+  Probe 1 — Anti-pattern absence
+    Searches current-facing documentation for v1 surfaces and other
+    patterns the new (v2/v3) surface has obsoleted. A hit indicates a
+    user/AI could be misled into copying broken code.
+
+  Probe 2 — Canonical-form presence
+    Confirms each v2 canonical pattern is documented in articles/.
+    A missing pattern means an LLM has no positive example to imitate.
+
+  Probe 3 — Public-surface coverage
+    For every public type defined in `Trellis.*/src/**.cs`, checks that
+    its simple name appears at least once across articles/ or
+    api_reference/. Reports coverage % and lists uncovered types.
+    Threshold is configurable via -SurfaceCoverageThreshold.
+
+  Probe 4 — Frontmatter completeness
+    Every .md in articles/ and api_reference/ (excluding the
+    auto-generated completeness-report.md) must declare the required
+    YAML keys for its collection.
+
+.PARAMETER RepositoryRoot
+  Path to the repository root. Defaults to the resolved
+  `docs/docfx_project/..` from this script's location.
+
+.PARAMETER SurfaceCoverageThreshold
+  Minimum acceptable surface-coverage percentage (Probe 3). Default 70.
+
+.PARAMETER FailOnWarnings
+  Treat WARN findings as failures (raises exit code).
+
+.EXAMPLE
+  pwsh -NoProfile -File audit-llm-doc-quality.ps1
+
+.EXAMPLE
+  pwsh -NoProfile -File audit-llm-doc-quality.ps1 -SurfaceCoverageThreshold 80
+#>
+
+param(
+    [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path,
+    [int]    $SurfaceCoverageThreshold = 70,
+    [switch] $FailOnWarnings
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ----------------------------------------------------------------------------
+# Configuration
+# ----------------------------------------------------------------------------
+
+$ArticlesDir     = Join-Path $RepositoryRoot 'docs/docfx_project/articles'
+$ApiReferenceDir = Join-Path $RepositoryRoot 'docs/docfx_project/api_reference'
+
+# Probe 1 file allowlist — files that legitimately document v1 surfaces
+# (migration guides) should NOT trigger anti-pattern findings, matching
+# the convention used by audit-stale-docs.ps1.
+$Probe1FileAllowlist = @(
+    'docs/docfx_project/articles/migration.md'
+)
+
+# Probe 1: anti-patterns. Each entry: literal-or-regex pattern + reason.
+# Patterns scan articles/*.md + api_reference/*.md (current-facing docs only).
+# Per-line `v1-stale-ok` marker exempts a single line (matches the existing
+# audit-stale-docs.ps1 convention).
+$AntiPatterns = @(
+    @{ Pattern = '\bError\.(Validation|Domain|Failure)\(';          Reason = 'v1 Error static factory (use new Error.X(...))' },
+    @{ Pattern = '\bPage\.Create\(';                                Reason = 'Nonexistent factory (use new Page<T>(...) / Page.Empty<T>())' },
+    @{ Pattern = '\bInputPointer\.Append\(';                        Reason = 'Nonexistent method' },
+    @{ Pattern = '\bHonorPreconditions\b';                          Reason = 'v1 method name (use EvaluatePreconditions)' },
+    @{ Pattern = '\bToActionResultAsync\s*\(\s*this\b';             Reason = 'v1 ASP bridge (use ToHttpResponseAsync(...).AsActionResultAsync<T>())' },
+    @{ Pattern = '\b18\s+nested\b';                                 Reason = 'Stale Error ADT count (now 20 nested)' },
+    @{ Pattern = '\bResult\.Failure<';                              Reason = 'v1 Result factory (use Result.Fail<T>(...))' }
+)
+
+# Probe 2: canonical-form presence. Each pattern must appear ≥ MinHits times
+# across articles/*.md (developer-facing). Most need only 1; widely-used
+# patterns can demand more.
+$CanonicalPatterns = @(
+    @{ Pattern = 'Error\.UnprocessableContent\.ForField\(';                              MinHits = 2; Description = 'Field-level validation factory' },
+    @{ Pattern = 'Error\.UnprocessableContent\.ForRule\(';                               MinHits = 1; Description = 'Rule-level validation factory' },
+    @{ Pattern = 'new\s+Error\.NotFound\(';                                              MinHits = 2; Description = 'Closed-ADT NotFound construction' },
+    @{ Pattern = 'new\s+Error\.Conflict\(';                                              MinHits = 1; Description = 'Closed-ADT Conflict construction' },
+    @{ Pattern = 'new\s+Error\.Forbidden\(';                                             MinHits = 1; Description = 'Closed-ADT Forbidden construction' },
+    @{ Pattern = 'new\s+ResourceRef\(';                                                  MinHits = 1; Description = 'ResourceRef construction for NotFound payloads' },
+    @{ Pattern = 'RetryAfterValue\.From(Seconds|Date)\(';                                MinHits = 1; Description = 'RetryAfterValue static factories' },
+    @{ Pattern = '\bEvaluatePreconditions\b';                                            MinHits = 1; Description = 'Precondition evaluation API' },
+    @{ Pattern = '\.AsActionResultAsync<';                                               MinHits = 1; Description = 'MVC bridge from ToHttpResponseAsync' },
+    @{ Pattern = '\bIActorProvider\b';                                                   MinHits = 2; Description = 'Actor provider abstraction' },
+    @{ Pattern = '\bIAuthorizeResource<';                                                MinHits = 1; Description = 'Resource-based authorization marker' },
+    @{ Pattern = '\bIIdentifyResource<';                                                 MinHits = 1; Description = 'Resource identifier abstraction' },
+    @{ Pattern = '\bSaveChangesResultAsync\b';                                           MinHits = 1; Description = 'Result-returning EF SaveChanges' },
+    @{ Pattern = '\bApplyTrellisConventions\b';                                          MinHits = 1; Description = 'EF Core convention bundle' },
+    @{ Pattern = '\bAddTrellisInterceptors\b';                                           MinHits = 1; Description = 'EF Core natural-VO LINQ interceptors' },
+    @{ Pattern = 'CreatedAtRoute\(';                                                     MinHits = 1; Description = 'AOT-safe Created response (with named route)' },
+    @{ Pattern = 'Result<Unit>';                                                         MinHits = 5; Description = 'Canonical command response type' },
+    @{ Pattern = 'AddCachingActorProvider<';                                             MinHits = 1; Description = 'Per-request actor caching decorator' }
+)
+
+# Probe 3: surface-coverage exclusions.
+# Public types whose simple name we would NOT expect to find in user-facing
+# docs (internal-feeling helpers, generator artifacts, attribute markers,
+# private-implementation interfaces, test infrastructure).
+$SurfaceCoverageExcludedNames = @(
+    # Generator-emitted / attribute-only types
+    'GeneratedCodeAttribute', 'CompilerGeneratedAttribute',
+    # AssemblyInfo / build-time artifacts
+    'AssemblyAttributes', 'ThisAssembly',
+    # Source-generated test scaffolding
+    'StringSyntaxAttribute',
+    # Names too generic to grep meaningfully
+    'IExtension', 'IBuilder', 'IConfig', 'IOptions', 'IAdapter',
+    'Builder', 'Options', 'Configuration', 'Extensions',
+    'Helpers', 'Constants', 'Defaults'
+)
+
+# Probe 4: required frontmatter keys per collection.
+$RequiredFrontmatterKeys = @{
+    'articles'      = @('title', 'package', 'audience', 'last_verified')
+    'api_reference' = @('package', 'audience', 'last_verified')
+}
+
+$FrontmatterExcludedFiles = @(
+    'completeness-report.md',  # auto-generated
+    'toc.yml'                  # not markdown
+)
+
+# ----------------------------------------------------------------------------
+# Result accumulator
+# ----------------------------------------------------------------------------
+
+$script:Findings = @()
+
+function Add-Finding {
+    param(
+        [Parameter(Mandatory)] [string] $Probe,
+        [Parameter(Mandatory)] [ValidateSet('FAIL','WARN','INFO')] [string] $Severity,
+        [Parameter(Mandatory)] [string] $Message,
+        [string] $File,
+        [int]    $Line
+    )
+    $script:Findings += [pscustomobject]@{
+        Probe    = $Probe
+        Severity = $Severity
+        Message  = $Message
+        File     = $File
+        Line     = $Line
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+function Get-DocFiles {
+    param([string] $Directory)
+    if (-not (Test-Path $Directory)) { return @() }
+    Get-ChildItem -Path $Directory -Filter '*.md' -File |
+        Where-Object { $FrontmatterExcludedFiles -notcontains $_.Name }
+}
+
+function Read-Frontmatter {
+    param([string] $Path)
+    $lines = Get-Content -Path $Path -Encoding UTF8
+    if ($lines.Count -lt 3) { return $null }
+    # Accept BOM-prefixed first line.
+    $first = $lines[0] -replace '^\uFEFF', ''
+    if ($first -ne '---') { return $null }
+    $end = -1
+    for ($i = 1; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -eq '---') { $end = $i; break }
+    }
+    if ($end -lt 0) { return $null }
+    $keys = @{}
+    for ($i = 1; $i -lt $end; $i++) {
+        if ($lines[$i] -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:') {
+            $keys[$Matches[1]] = $lines[$i].Substring($Matches[1].Length + 1).Trim().TrimStart(':').Trim()
+        }
+    }
+    return $keys
+}
+
+# ----------------------------------------------------------------------------
+# Probe 1: anti-pattern absence
+# ----------------------------------------------------------------------------
+
+function Invoke-Probe1 {
+    Write-Host ""
+    Write-Host "=== Probe 1: anti-pattern absence ===" -ForegroundColor Cyan
+    $docFiles = @()
+    $docFiles += Get-DocFiles -Directory $ArticlesDir
+    $docFiles += Get-DocFiles -Directory $ApiReferenceDir
+
+    $hits = 0
+    foreach ($file in $docFiles) {
+        $relPath = $file.FullName.Substring($RepositoryRoot.Length).TrimStart('\','/').Replace('\','/')
+        if ($Probe1FileAllowlist -contains $relPath) { continue }
+        $lineNo = 0
+        foreach ($line in (Get-Content -Path $file.FullName -Encoding UTF8)) {
+            $lineNo++
+            if ($line -match 'v1-stale-ok|stale-doc-ok') { continue }
+            foreach ($ap in $AntiPatterns) {
+                if ($line -match $ap.Pattern) {
+                    Add-Finding -Probe 'P1.AntiPattern' -Severity 'FAIL' `
+                        -Message ("{0}: {1}" -f $ap.Reason, $line.Trim()) `
+                        -File $relPath -Line $lineNo
+                    $hits++
+                }
+            }
+        }
+    }
+    if ($hits -eq 0) {
+        Write-Host "  PASS — no anti-patterns found in $($docFiles.Count) docs"
+    } else {
+        Write-Host "  FAIL — $hits anti-pattern hits across $($docFiles.Count) docs" -ForegroundColor Red
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Probe 2: canonical-form presence
+# ----------------------------------------------------------------------------
+
+function Invoke-Probe2 {
+    Write-Host ""
+    Write-Host "=== Probe 2: canonical-form presence ===" -ForegroundColor Cyan
+    $articleFiles = Get-DocFiles -Directory $ArticlesDir
+    $allText = ($articleFiles | ForEach-Object { Get-Content -Path $_.FullName -Encoding UTF8 -Raw }) -join "`n"
+
+    $missing = 0
+    foreach ($cp in $CanonicalPatterns) {
+        $matches = [regex]::Matches($allText, $cp.Pattern)
+        $count = $matches.Count
+        if ($count -lt $cp.MinHits) {
+            Add-Finding -Probe 'P2.Canonical' -Severity 'FAIL' `
+                -Message ("'{0}' ({1}): found {2} occurrence(s), need {3}" -f $cp.Pattern, $cp.Description, $count, $cp.MinHits)
+            $missing++
+        }
+    }
+    if ($missing -eq 0) {
+        Write-Host "  PASS — all $($CanonicalPatterns.Count) canonical patterns present at expected frequency"
+    } else {
+        Write-Host "  FAIL — $missing of $($CanonicalPatterns.Count) canonical patterns under-represented" -ForegroundColor Red
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Probe 3: public-surface coverage
+# ----------------------------------------------------------------------------
+
+function Get-PublicTypeNames {
+    $packageDirs = Get-ChildItem -Path $RepositoryRoot -Directory -Filter 'Trellis.*' |
+        Where-Object { Test-Path (Join-Path $_.FullName 'src') }
+
+    $typeRegex = [regex] ('(?m)^\s*public\s+(?:(?:static|sealed|abstract|partial|readonly|ref)\s+)*' +
+                          '(?:class|record|interface|struct|enum|delegate)\s+' +
+                          '(?:[A-Za-z_]\w*\s+)?([A-Za-z_]\w*)')
+
+    $names = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($pkg in $packageDirs) {
+        $srcDir = Join-Path $pkg.FullName 'src'
+        if (-not (Test-Path $srcDir)) { continue }
+        Get-ChildItem -Path $srcDir -Filter '*.cs' -File -Recurse |
+            ForEach-Object {
+                $content = Get-Content -Path $_.FullName -Raw
+                foreach ($m in $typeRegex.Matches($content)) {
+                    $name = $m.Groups[1].Value
+                    if ($name -and -not ($SurfaceCoverageExcludedNames -contains $name)) {
+                        [void] $names.Add($name)
+                    }
+                }
+            }
+    }
+    return $names
+}
+
+function Invoke-Probe3 {
+    Write-Host ""
+    Write-Host "=== Probe 3: public-surface coverage ===" -ForegroundColor Cyan
+    $publicTypes = Get-PublicTypeNames
+    if ($publicTypes.Count -eq 0) {
+        Add-Finding -Probe 'P3.SurfaceCoverage' -Severity 'WARN' `
+            -Message 'No public types discovered. Probe configuration may be wrong.'
+        Write-Host "  WARN — no public types discovered" -ForegroundColor Yellow
+        return
+    }
+
+    $docFiles = @()
+    $docFiles += Get-DocFiles -Directory $ArticlesDir
+    $docFiles += Get-DocFiles -Directory $ApiReferenceDir
+    $docText = ($docFiles | ForEach-Object { Get-Content -Path $_.FullName -Encoding UTF8 -Raw }) -join "`n"
+
+    $covered = 0
+    $uncovered = @()
+    foreach ($name in ($publicTypes | Sort-Object)) {
+        # Word-boundary match using the simple type name.
+        if ($docText -match ('\b{0}\b' -f [regex]::Escape($name))) {
+            $covered++
+        } else {
+            $uncovered += $name
+        }
+    }
+    $total = $publicTypes.Count
+    $pct = [math]::Round(100.0 * $covered / $total, 1)
+    Write-Host ("  Coverage: {0}/{1} ({2}%) — threshold {3}%" -f $covered, $total, $pct, $SurfaceCoverageThreshold)
+
+    if ($pct -lt $SurfaceCoverageThreshold) {
+        Add-Finding -Probe 'P3.SurfaceCoverage' -Severity 'FAIL' `
+            -Message ("Coverage {0}% below threshold {1}%. {2} types uncovered." -f $pct, $SurfaceCoverageThreshold, $uncovered.Count)
+        Write-Host "  FAIL" -ForegroundColor Red
+    } else {
+        Write-Host "  PASS"
+    }
+
+    # Always emit per-type WARN findings for the uncovered set so reviewers
+    # can see what's missing without having to re-run with verbose output.
+    foreach ($name in $uncovered) {
+        Add-Finding -Probe 'P3.SurfaceCoverage' -Severity 'WARN' `
+            -Message ("Public type not mentioned in any doc: {0}" -f $name)
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Probe 4: frontmatter completeness
+# ----------------------------------------------------------------------------
+
+function Invoke-Probe4 {
+    Write-Host ""
+    Write-Host "=== Probe 4: frontmatter completeness ===" -ForegroundColor Cyan
+    $bad = 0
+    $checked = 0
+    foreach ($collection in $RequiredFrontmatterKeys.Keys) {
+        $dir = Join-Path $RepositoryRoot ("docs/docfx_project/{0}" -f $collection)
+        $required = $RequiredFrontmatterKeys[$collection]
+        foreach ($file in (Get-DocFiles -Directory $dir)) {
+            $checked++
+            $relPath = $file.FullName.Substring($RepositoryRoot.Length).TrimStart('\','/').Replace('\','/')
+            $fm = Read-Frontmatter -Path $file.FullName
+            if ($null -eq $fm) {
+                Add-Finding -Probe 'P4.Frontmatter' -Severity 'FAIL' `
+                    -Message 'Missing or malformed YAML frontmatter (no `--- ... ---` block)' `
+                    -File $relPath
+                $bad++
+                continue
+            }
+            $missing = @($required | Where-Object { -not $fm.ContainsKey($_) })
+            if ($missing.Count -gt 0) {
+                Add-Finding -Probe 'P4.Frontmatter' -Severity 'FAIL' `
+                    -Message ("Missing required key(s): {0}" -f ($missing -join ', ')) `
+                    -File $relPath
+                $bad++
+                continue
+            }
+            if ($fm['last_verified'] -notmatch '^\d{4}-\d{2}-\d{2}$') {
+                Add-Finding -Probe 'P4.Frontmatter' -Severity 'FAIL' `
+                    -Message ("Invalid last_verified format (expected YYYY-MM-DD): {0}" -f $fm['last_verified']) `
+                    -File $relPath
+                $bad++
+            }
+        }
+    }
+    if ($bad -eq 0) {
+        Write-Host "  PASS — all $checked docs have valid frontmatter"
+    } else {
+        Write-Host "  FAIL — $bad of $checked docs have frontmatter issues" -ForegroundColor Red
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Run
+# ----------------------------------------------------------------------------
+
+Push-Location $RepositoryRoot
+try {
+    Invoke-Probe1
+    Invoke-Probe2
+    Invoke-Probe3
+    Invoke-Probe4
+
+    Write-Host ""
+    Write-Host "=== Summary ===" -ForegroundColor Cyan
+    $byProbe = $script:Findings | Group-Object Probe, Severity | Sort-Object Name
+    foreach ($g in $byProbe) {
+        $color = if ($g.Name -match 'FAIL') { 'Red' } elseif ($g.Name -match 'WARN') { 'Yellow' } else { 'Gray' }
+        Write-Host ("  {0}: {1}" -f $g.Name, $g.Count) -ForegroundColor $color
+    }
+    if ($script:Findings.Count -eq 0) {
+        Write-Host "  (no findings)" -ForegroundColor Green
+    }
+
+    # Detailed findings (FAIL + optionally WARN).
+    $detailed = $script:Findings | Where-Object {
+        $_.Severity -eq 'FAIL' -or ($FailOnWarnings -and $_.Severity -eq 'WARN')
+    }
+    if ($detailed.Count -gt 0) {
+        Write-Host ""
+        Write-Host "=== Findings (detail) ===" -ForegroundColor Cyan
+        foreach ($f in $detailed) {
+            $loc = if ($f.File) { "  $($f.File)$(if ($f.Line) { ":$($f.Line)" })" } else { '' }
+            Write-Host ("  [{0}] [{1}] {2}{3}" -f $f.Severity, $f.Probe, $f.Message, $loc)
+        }
+    }
+
+    $hasFail = $script:Findings | Where-Object { $_.Severity -eq 'FAIL' }
+    $hasWarn = $script:Findings | Where-Object { $_.Severity -eq 'WARN' }
+
+    if ($hasFail.Count -gt 0)                            { exit 1 }
+    if ($FailOnWarnings -and $hasWarn.Count -gt 0)       { exit 1 }
+    exit 0
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
LLM-targeted restructuring of the docfx documentation. Two commits:

1. **`839d659` — Phase 0**: additive foundation on `api_reference/*.md` (frontmatter + audit fixes).
2. **`affae99` — Article restructure**: rewrites all 31 `articles/*.md` against a locked LLM-optimized template, flips `api_reference` audience to `[llm]`-only, and tightens the audit tooling.

---

## Commit 1 — `839d659`: api_reference Phase 0

### 1a. YAML frontmatter on 16 api_reference docs

Added a `---`-delimited block at the top of every `api_reference/*.md`:

```yaml
---
package: Trellis.Core
namespaces: [Trellis]
types: [Result, Result<T>, Maybe<T>, Error, Unit, Page<T>, Cursor, ...]
version: v3
last_verified: 2026-05-01
audience: [llm, developer]
---
```

Frontmatter lets readers (and `grep -A 8 '^package: Trellis.Core'`) filter docs by package / type without scanning prose. DocFX (Markdig) ignores unknown frontmatter fields, so this is purely additive. (Audience is later narrowed to `[llm]` in commit 2.)

### 1b. Patterns Index added to `trellis-value-object-taxonomy.md`

The taxonomy doc was the only api_reference page (other than the auto-generated `completeness-report.md`) without a `## Patterns Index`. Added a Goal / Canonical-base / See table mirroring the convention used in the other 13 docs.

### 1c. Eleven audit findings fixed in `trellis-api-core.md`

From a prior read-only subagent audit of `Trellis.Core/src/**` against the doc:

| ID | Severity | Fix |
|---|---|---|
| F-01 | HIGH | Dropped stale `partial` modifier from `Result<TValue>` heading + Patterns Index anchor |
| F-02 | HIGH | Replaced nonexistent `Page.Create(...)` with `new Page<T>(...)` / `Page.Empty<T>(...)` |
| F-04 | MED | Corrected "18" → "20" `Error` closed-ADT cases (2 sites) |
| F-05 | MED | Removed reference to nonexistent `InputPointer.Append(...)` |
| F-06 | MED | Reordered `PreconditionKind` enum members to match source (2 sites): `IfMatch, IfNoneMatch, IfModifiedSince, IfUnmodifiedSince` |
| F-07 | MED | Added `Where` to `ResultLinqExtensions` catalog |
| F-08 | MED | Corrected `EnsureExtensionsAsync` overload count from "10" to "~34" with breakdown across the 6 partial files |
| F-09 | MED | Renamed `Page<T>` ctor parameters PascalCase → camelCase |
| F-10 | LOW | Added required parens to `(await predicate()) ?` migration snippet |
| F-12 | LOW | Added 4 missing rows to `TraverseExtensions` table |
| F-13 | LOW | Clarified `TapOnFailureExtensionsAsync` "12 overloads" with tuple-arity note |

F-03 (aggregate/ETag broken example) and F-11 (cosmetic) **deferred**: re-verification against source showed F-03's claims don't hold (the example does implement both static-abstract `TryCreate` overloads; `Aggregate.ETag` is initialized to `string.Empty`, not `null`).

---

## Commit 2 — `affae99`: LLM article restructure (48 files, +5,037 / −3,732)

Restructures all 31 `articles/*.md` against a locked LLM-optimized template, narrows `api_reference` audience, and removes design-process noise from current-facing docs.

### 2a. 21 articles fully rewritten to LLM template

Locked 11-section template (proven via `integration-http.md` pilot then applied by sub-agents):

1. YAML frontmatter (`title`, `package`, `topics`, `related_api_reference`, `last_verified`, `audience: [developer]`)
2. H1 + 1-line intent
3. `## Patterns Index` (Goal | Use | See)
4. `## Use this guide when` (bullets)
5. `## Surface at a glance` (table xref'ing into `api_reference`)
6. `## Installation`
7. `## Quick start` (self-contained C# with full `using` directives)
8. Per-feature sections with signature/outcome tables + self-contained examples
9. `## Composition`
10. `## Practical guidance`
11. `## Cross-references`

Articles rewritten:

| Article | Notes |
|---|---|
| `integration-http.md` | Pilot — canonical template example |
| `integration-mediator.md` | |
| `integration-asp-authorization.md` | Reflects absorption into `Trellis.Asp` package |
| `integration-aspnet.md` | Largest (~30 KB): result mapping, MVC, Problem Details, ETag, Prefer, pagination, Range, scalar validation, route constraints |
| `integration-ef.md` | |
| `integration-fluentvalidation.md` | |
| `integration-sso.md` | Providers, claim mapping, scope/permission extraction, multi-tenant, JWT options |
| `integration-testing.md` | |
| `integration-entra-testing.md` | |
| `integration-db-permissions.md` | |
| `integration-observability.md` | |
| `error-handling.md` | Reflects 20-case (was 18) `Error` closed-ADT |
| `maybe-type.md` | |
| `primitives.md` | Defining, validation, JSON, ASP, EF interop |
| `specifications.md` | |
| `state-machines.md` | Notes `Trellis.StateMachine` is a separate package |
| `aggregate-factory-pattern.md` | |
| `asp-tohttpresponse.md` | Corrected `RetryAfterValue.FromSeconds` / `FromDate`; removed invented `WithBody` |
| `required-enum.md` | |
| `migration.md` | Renamed in TOC: "Migrating from v1 to v2"; allowlisted in `audit-stale-docs.ps1` |
| `integration.md` | Hub article (light-touch rewrite) |

Stale facts caught and corrected during rewrites:

- `Error.Validation(...)` → `Error.UnprocessableContent` with `FieldViolation` / `RuleViolation`
- `RetryAfter` ctor → `RetryAfterValue.FromSeconds(int)` / `FromDate(DateTimeOffset)`
- `HonorPreconditions` → `EvaluatePreconditions`
- Pagination: `nextUrlBuilder` is `Func<Cursor,int,string>`; `body` is per-item `Func<T,TBody>`
- `Trellis.Asp.Authorization` package absorbed into `Trellis.Asp` (namespace persists; `dotnet add package Trellis.Asp`)

### 2b. 10 articles light-passed

Frontmatter + HTML-entity strip + `**Level:**` header drop, narrative preserved:

`basics.md`, `intro.md`, `examples.md`, `clean-architecture.md`, `debugging.md`, `advanced-features.md`, `with-vs-without-trellis.md`, `performance.md`, `BENCHMARKS.md`, `ai-code-generation.md`.

### 2c. api_reference audience narrowed

All 16 `api_reference/*.md` had `audience: [llm, developer]` → `audience: [llm]`. Articles are now the developer surface; api_reference is the LLM-targeted source-of-truth.

### 2d. Cross-doc anchor fixes

Four broken anchors caught by `docfx --warningsAsErrors`:

- `#writeoutcomet-variants`
- `#result-pipeline-extension-families`
- `#per-call-error-mapping`
- `#mediator-integration`

### 2e. Audit-tooling tightening

- `audit-stale-docs.ps1`: allowlisted `articles/migration.md` (legitimately documents v1 surfaces in "from" columns of breaking-change tables).
- Stripped `(per ADR-005)` / `(ADR-005)` parentheticals from 9 current-facing articles (audit rule: ADR refs are design-process, not current behavior).

---

## Out of scope

- **File splits (Phase 1)**: still planned for the 4 oversized api_reference docs; articles are all under 30 KB and don't need splitting yet.
- Per-doc signatures-over-prose pass (Phase 2)
- Cross-doc fact deduplication (Phase 3)
- Dedicated anchor-validator script (Phase 4 — covered by `docfx --warningsAsErrors` for now)

## Verification

- `dotnet build -c Release` → 0 warnings, 0 errors
- `docfx docfx.json --warningsAsErrors` → 0 errors, 2 pre-existing FailedToLoadAnalyzer warnings (unchanged, unrelated source-generator compiler-version skew)
- `audit-stale-docs.ps1` → "No stale current-facing documentation references found."
- Global scan: 0 HTML entities, 0 `**Level:**` headers, 0 stale "18 nested" strings, all 31 article BOMs intact

## Notes for reviewers

- Frontmatter is added **before** the existing `# Title` line; raw markdown carries it but DocFX strips it from rendered HTML.
- All articles preserve UTF-8 BOM (written via `b"\xef\xbb\xbf" + content.encode("utf-8")`).
- `completeness-report.md` is gitignored (auto-regenerated by an audit script) so it's not in this PR; its frontmatter will be applied on next regeneration.
- **Anchor-syntax spike result:** docfx (Markdig) does NOT support `{#stable-id}` syntax. Phase 1 splits will preserve heading text byte-for-byte to keep auto-generated anchors stable.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
