### PR TITLE
docs(qa-bench): add LLM Q&A bench harness for measuring docfx doc-quality changes

### DIFF
--- a/docs/docfx_project/qa-bench/.gitignore
+++ b/docs/docfx_project/qa-bench/.gitignore
@@ -1,0 +1,3 @@
+results/
+*.local.json
+.env

--- a/docs/docfx_project/qa-bench/BASELINE.md
+++ b/docs/docfx_project/qa-bench/BASELINE.md
@@ -1,0 +1,45 @@
+# Q&A bench score: 20260502T151024Z-gpt-4.1-2025-04-14-baseline.json
+
+- Model: `gpt-4.1-2025-04-14`
+- Tag: `baseline`
+- Timestamp (UTC): 20260502T151024Z
+- Git commit: d8a6f72c0927cbb7a4a48589a7a8ab4a2ebf01e0
+- **Overall: 22 / 23 (95.7%)**
+
+## By category
+
+| Category | Pass | Total | % |
+|---|---|---|---|
+| asp | 4 | 4 | 100% |
+| control | 4 | 4 | 100% |
+| cookbook | 4 | 4 | 100% |
+| core | 7 | 8 | 87.5% |
+| efcore | 3 | 3 | 100% |
+
+## Per-question
+
+| Result | Id | Category | Difficulty | Notes |
+|---|---|---|---|---|
+| ✅ | `core-error-cases-count` | core | medium |  |
+| ✅ | `core-page-items-type` | core | easy |  |
+| ✅ | `core-result-kind` | core | easy |  |
+| ✅ | `core-unit-namespace` | core | medium |  |
+| ✅ | `core-command-return-type` | core | easy |  |
+| ✅ | `core-error-conflict-construction` | core | medium |  |
+| ✅ | `core-error-page-construction` | core | easy |  |
+| ❌ | `core-traverse-overloads` | core | hard | missing: 5 |
+| ✅ | `cookbook-savechanges-return` | cookbook | easy |  |
+| ✅ | `cookbook-actor-provider` | cookbook | medium |  |
+| ✅ | `cookbook-validation-error` | cookbook | medium |  |
+| ✅ | `cookbook-fluentvalidation-package` | cookbook | easy |  |
+| ✅ | `asp-tohttpresponse-name` | asp | easy |  |
+| ✅ | `asp-actionresult-vs-httpresponse` | asp | medium |  |
+| ✅ | `asp-trellishttpresult-visibility` | asp | hard |  |
+| ✅ | `asp-resource-authorization-tparams` | asp | hard |  |
+| ✅ | `efcore-repositorybase` | efcore | easy |  |
+| ✅ | `efcore-uow-interface` | efcore | easy |  |
+| ✅ | `efcore-package-name` | efcore | easy |  |
+| ✅ | `control-mediator-pipeline-behaviors` | control | medium |  |
+| ✅ | `control-statemachine-type` | control | easy |  |
+| ✅ | `control-http-toresult-async` | control | medium |  |
+| ✅ | `control-authorization-interfaces` | control | medium |  |

--- a/docs/docfx_project/qa-bench/README.md
+++ b/docs/docfx_project/qa-bench/README.md
@@ -1,0 +1,128 @@
+# Trellis docfx Q&A bench
+
+A static, scriptable LLM bench that A/B-tests changes to the docfx
+documentation. Runs a fixed question bank against a hosted chat model, scores
+answers against verifier rules, and writes a markdown report.
+
+Goal: produce a quantitative signal — *did this doc PR actually help an LLM
+answer questions?* — before merging structural changes (e.g., splitting an
+oversized doc into multiple files).
+
+## Baseline (frozen reference)
+
+`BASELINE.md` records the most recent committed scorecard against the
+unmodified docfx doc set. As of the initial commit:
+
+- Model: `gpt-4.1-2025-04-14` on Azure AI Foundry
+- Question bank: 23 questions, 5 categories (core, cookbook, asp, efcore, control)
+- **Score: 22 / 23 (95.7%)**, 3-iteration determinism confirmed
+- Single failure: `core-traverse-overloads` (model miscounts overloads documented in a long table — a candidate signal for whether splitting `trellis-api-core.md` improves needle-in-haystack retrieval)
+
+A doc PR is judged "doc-quality positive" when its post-change score *strictly
+improves* on a target category and does not regress any control category.
+
+## What it is, what it isn't
+
+- **It is** a small, hand-curated bench (23 questions) where every ground
+  truth is derived directly from `Trellis.*/src/**.cs`.
+- **It is** a one-shot batched run: the entire docfx doc set (articles +
+  api_reference) is concatenated into a single prompt, so the model has to
+  *navigate* it the same way an unprimed LLM session would.
+- **It is not** a substitute for the full `Trellis-training/` lab (83-criterion
+  rubric, full code-generation evaluation). Use the lab for whole-framework
+  comprehension. Use this bench for fast doc-change A/B.
+- **It is not** wired into CI today. Designed to be runnable manually before
+  and after a doc PR.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `questions.json` | Question bank with verifier rules (`all_of` / `any_of` / `none_of`) |
+| `run-qa-bench.ps1` | Runner: builds prompt, calls Azure AI Foundry, saves result |
+| `score-qa-bench.ps1` | Scorer: applies verifiers, writes `.score.json` + `.score.md` |
+| `BASELINE.md` | Frozen baseline scorecard. Update only when (a) a doc PR demonstrably changes the score, or (b) the question bank itself changes. |
+| `results/` | Run outputs (gitignored) |
+
+## Prerequisites
+
+1. PowerShell 7+
+2. An Azure AI Foundry deployment of a chat model with **≥256K input context**
+   (the doc set is ~250K tokens). GPT-4.1 is the default; o3-mini, Claude
+   Sonnet 4 also work.
+3. Two env vars:
+   - `AZURE_AI_ENDPOINT` — e.g., `https://yourname.services.ai.azure.com`
+   - `AZURE_AI_KEY`      — the api-key (do **not** commit)
+
+Optional:
+- `AZURE_AI_MODEL` — defaults to `gpt-4.1`
+
+## Run
+
+```pwsh
+$env:AZURE_AI_ENDPOINT = 'https://yourname.services.ai.azure.com'
+$env:AZURE_AI_KEY      = '...'
+
+# baseline run, scored
+pwsh ./run-qa-bench.ps1 -Tag baseline -Score
+
+# 5 iterations for variance estimation
+pwsh ./run-qa-bench.ps1 -Tag baseline -Iterations 5 -Score
+
+# preview the prompt without calling the API (free)
+pwsh ./run-qa-bench.ps1 -Tag dryrun -DryRun
+```
+
+## A/B workflow
+
+1. **Before** a doc PR: `pwsh ./run-qa-bench.ps1 -Tag baseline -Iterations 3 -Score`
+2. Apply the doc change on a branch.
+3. **After**: `pwsh ./run-qa-bench.ps1 -Tag <branch-name> -Iterations 3 -Score`
+4. Compare `.score.md` files. Ship the change only if:
+   - **target-category** scores improve, AND
+   - **control-category** scores don't regress.
+
+## Cost estimate
+
+GPT-4.1 at ~$2/M input + $8/M output, ~250K input tokens × 1 call/run:
+- Single run: **≈ $0.50**
+- 3-iteration baseline + 3-iteration post-change: **≈ $3**
+
+## Adding questions
+
+Each entry in `questions.json` needs:
+
+```jsonc
+{
+  "id": "unique-stable-id",
+  "category": "core | cookbook | asp | efcore | control",
+  "target_doc": "trellis-api-core.md",
+  "difficulty": "easy | medium | hard",
+  "question": "...",
+  "verifier": {
+    "all_of":  ["string1", "string2"],          // AND: every keyword must appear (case-insensitive substring)
+    "any_of":  [["alt1a","alt1b"], ["alt2a"]],  // groups: at least one keyword from each group must appear
+    "none_of": ["antipattern1"]                  // NONE may appear (e.g., v1 anti-patterns)
+  },
+  "source_ref": "Trellis.X/src/Y.cs:123 + brief justification"
+}
+```
+
+Rules of thumb:
+- **Ground truth must come from source**, not from another doc. Cite
+  `source_ref` precisely.
+- Prefer questions where the answer is a single token / signature / type name.
+- Use `none_of` to catch v1 anti-patterns (`Error.Validation(`, `Page.Create(`,
+  etc.) the LLM might still suggest.
+- Mix categories so that *control* questions (about un-changed docs) don't
+  vary across runs — they're your noise floor.
+
+## Limitations
+
+- Verifiers use case-insensitive substring matching, not semantic equivalence.
+  Phrase questions to constrain answer shape ("reply with the type signature
+  only") to keep matching reliable.
+- Single model, single run = noisy. Use `-Iterations 3` minimum for any
+  judgment.
+- The bench measures *retrieval-from-context*, not free-recall. It can't tell
+  you the docs are wrong, only that they're hard or easy to navigate.

--- a/docs/docfx_project/qa-bench/questions.json
+++ b/docs/docfx_project/qa-bench/questions.json
@@ -1,0 +1,285 @@
+{
+  "version": "1.0",
+  "description": "Doc-quality Q&A bench for Trellis framework. Each question has a single verifiable ground-truth fact derived from Trellis.*/src/**.cs at the noted source_ref. Used to A/B doc structure changes (e.g., splitting oversized api_reference docs).",
+  "scoring": "all_of: every keyword (case-insensitive substring) must appear in answer. any_of: at least one keyword from each inner array must appear. none_of: no keyword may appear. Answer is PASS iff all three constraints satisfied.",
+  "questions": [
+    {
+      "id": "core-error-cases-count",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "medium",
+      "question": "List every concrete subtype of Trellis Error in the v3 closed-ADT. Reply with a comma-separated list of the simple type names only.",
+      "verifier": {
+        "all_of": ["BadRequest", "Unauthorized", "Forbidden", "NotFound", "MethodNotAllowed", "NotAcceptable", "Conflict", "Gone", "PreconditionFailed", "ContentTooLarge", "UnsupportedMediaType", "RangeNotSatisfiable", "UnprocessableContent", "PreconditionRequired", "TooManyRequests", "InternalServerError", "Unexpected", "NotImplemented", "ServiceUnavailable", "Aggregate"],
+        "none_of": ["Validation(", "Domain(", "Failure("]
+      },
+      "source_ref": "Trellis.Core/src/Errors/Error.cs (20 sealed records)"
+    },
+    {
+      "id": "core-page-items-type",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "easy",
+      "question": "What is the declared property type of `Page<T>.Items`? Reply with just the type name.",
+      "verifier": {
+        "all_of": ["IReadOnlyList<T>"],
+        "none_of": ["IEnumerable<T>", "T[]"]
+      },
+      "source_ref": "Trellis.Core/src/Pagination/Page.cs:57"
+    },
+    {
+      "id": "core-result-kind",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "easy",
+      "question": "Is `Result<TValue>` declared as a class, record, or struct in Trellis v3? Reply with one word.",
+      "verifier": {
+        "all_of": ["struct"],
+        "none_of": ["class", "record"]
+      },
+      "source_ref": "Trellis.Core/src/Result/Result{TValue}.cs:48 (readonly struct)"
+    },
+    {
+      "id": "core-unit-namespace",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "medium",
+      "question": "What is the full namespace of the `Unit` type in Trellis v3? Reply with the namespace only (no type name).",
+      "verifier": {
+        "all_of": ["Trellis"],
+        "none_of": ["Trellis.Core", "Trellis.Results", "Trellis.Result", "Trellis.Primitives"]
+      },
+      "source_ref": "Trellis.Core/src/Trellis/Unit.cs (single-segment namespace 'Trellis')"
+    },
+    {
+      "id": "core-command-return-type",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "easy",
+      "question": "In Trellis v3, what type should a fire-and-forget command (no business payload) return from its handler? Reply with just the type signature.",
+      "verifier": {
+        "all_of": ["Result<Unit>"],
+        "none_of": ["Result.Success()", "Result.Failure(", "Result.Ok();"]
+      },
+      "source_ref": "ADR-005: bare 'Result' removed; commands return Result<Unit>"
+    },
+    {
+      "id": "core-error-conflict-construction",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "medium",
+      "question": "Show the v3 idiomatic C# expression to construct an Error.Conflict for a resource `order` with reason code 'order.already-shipped'. Use the canonical v3 syntax (constructor + object initializer if needed).",
+      "verifier": {
+        "all_of": ["new Error.Conflict", "order", "order.already-shipped"],
+        "none_of": ["Error.Conflict(order, \"order.already-shipped\")", "Error.Validation", "Error.Domain"]
+      },
+      "source_ref": "Error.cs:236; v3 canonical = new Error.Conflict(resource) { ReasonCode = ... }"
+    },
+    {
+      "id": "core-error-page-construction",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "easy",
+      "question": "How do you construct an empty `Page<int>` in Trellis v3? Show the C# expression.",
+      "verifier": {
+        "any_of": [["Page.Empty<int>", "new Page<int>(Array.Empty<int>"]],
+        "none_of": ["Page.Create"]
+      },
+      "source_ref": "Trellis.Core/src/Pagination/Page.cs (Page.Empty<T>() static factory)"
+    },
+    {
+      "id": "core-traverse-overloads",
+      "category": "core",
+      "target_doc": "trellis-api-core.md",
+      "difficulty": "hard",
+      "question": "How many overloads of `Result.TraverseAsync<...>(...)` exist in TraverseExtensions (count every TraverseAsync overload, including any Unit-returning specialization)? Reply with just the count as a digit.",
+      "verifier": {
+        "all_of": ["5"],
+        "none_of": ["4 overloads", "is 4", "are 4", "total of 4", "exactly 4"]
+      },
+      "source_ref": "Trellis.Core/src/Result/Extensions/Traverse.cs (5 TraverseAsync overloads at L75, L111, L148, L184, L215 incl. Unit specialization)"
+    },
+    {
+      "id": "cookbook-savechanges-return",
+      "category": "cookbook",
+      "target_doc": "trellis-api-cookbook.md",
+      "difficulty": "easy",
+      "question": "What is the return type of `DbContext.SaveChangesResultAsync(...)`? Reply with the full type signature.",
+      "verifier": {
+        "all_of": ["Task<Result<int>>"],
+        "none_of": ["Task<int>", "Task<Result>", "ValueTask"]
+      },
+      "source_ref": "Trellis.EntityFrameworkCore/src/DbContextExtensions.cs:20,54"
+    },
+    {
+      "id": "cookbook-actor-provider",
+      "category": "cookbook",
+      "target_doc": "trellis-api-cookbook.md",
+      "difficulty": "medium",
+      "question": "Which Trellis interface should an application implement to supply the current actor (user identity) to the mediator pipeline? Reply with the interface name only.",
+      "verifier": {
+        "all_of": ["IActorProvider"],
+        "none_of": ["IUserProvider", "IIdentityProvider", "ICurrentUser"]
+      },
+      "source_ref": "Trellis.Mediator/src/AuthorizationBehavior.cs:13 (constructor takes IActorProvider)"
+    },
+    {
+      "id": "cookbook-validation-error",
+      "category": "cookbook",
+      "target_doc": "trellis-api-cookbook.md",
+      "difficulty": "medium",
+      "question": "How do you create a single-field validation error for a field named 'email' with reason 'must.be.email' in Trellis v3? Show only the C# expression.",
+      "verifier": {
+        "all_of": ["UnprocessableContent", "email", "must.be.email"],
+        "any_of": [["ForField", "FieldViolation"]],
+        "none_of": ["Error.Validation(", "Validation.For(", "ValidationError("]
+      },
+      "source_ref": "Error.cs:293 + UnprocessableContent.ForField factory"
+    },
+    {
+      "id": "cookbook-fluentvalidation-package",
+      "category": "cookbook",
+      "target_doc": "trellis-api-cookbook.md",
+      "difficulty": "easy",
+      "question": "Which Trellis NuGet package provides FluentValidation integration? Reply with the package name only.",
+      "verifier": {
+        "all_of": ["Trellis.FluentValidation"],
+        "none_of": ["Trellis.Validation", "Trellis.Core.FluentValidation"]
+      },
+      "source_ref": "Trellis.FluentValidation package directory"
+    },
+    {
+      "id": "asp-tohttpresponse-name",
+      "category": "asp",
+      "target_doc": "trellis-api-asp.md",
+      "difficulty": "easy",
+      "question": "Which extension method on `Result<T>` produces a Minimal API `Microsoft.AspNetCore.Http.IResult`? Reply with the method name only (no parens).",
+      "verifier": {
+        "all_of": ["ToHttpResponse"],
+        "none_of": ["ToActionResult", "ToHttpResult", "AsActionResult"]
+      },
+      "source_ref": "Trellis.Asp/src/Response/HttpResponseExtensions.cs:39"
+    },
+    {
+      "id": "asp-actionresult-vs-httpresponse",
+      "category": "asp",
+      "target_doc": "trellis-api-asp.md",
+      "difficulty": "medium",
+      "question": "Complete this sentence using exactly the format shown, naming the controller style each method targets: 'AsActionResult is for ___ controllers; ToHttpResponse is for ___ APIs.' (Fill the two blanks with one word each.)",
+      "verifier": {
+        "all_of": ["AsActionResult is for MVC", "ToHttpResponse is for Minimal"],
+        "none_of": ["AsActionResult is for Minimal", "ToHttpResponse is for MVC"]
+      },
+      "source_ref": "ActionResultAdapter.cs (AsActionResult => ActionResult<T> for MVC controllers); HttpResponseExtensions.cs (ToHttpResponse => IResult for Minimal API)"
+    },
+    {
+      "id": "asp-trellishttpresult-visibility",
+      "category": "asp",
+      "target_doc": "trellis-api-asp.md",
+      "difficulty": "hard",
+      "question": "Is the `TrellisHttpResult<TDomain, TBody>` class public or internal? Reply with one word.",
+      "verifier": {
+        "all_of": ["internal"],
+        "none_of": ["public"]
+      },
+      "source_ref": "Trellis.Asp/src/Response/TrellisHttpResult.cs:18 (internal sealed class)"
+    },
+    {
+      "id": "asp-resource-authorization-tparams",
+      "category": "asp",
+      "target_doc": "trellis-api-asp.md",
+      "difficulty": "hard",
+      "question": "Show the type-parameter list for `services.AddResourceAuthorization<...>()`. Reply with EXACTLY the angle-bracket fragment as it would appear in C# source, including spaces and commas (e.g., `<TFoo, TBar, TBaz>`). The order matters.",
+      "verifier": {
+        "all_of": ["<TMessage, TResource, TResponse>"],
+        "none_of": ["<TResource, TMessage", "<TResponse, ", "<TResource, TResponse"]
+      },
+      "source_ref": "Trellis.Mediator/src/ServiceCollectionExtensions.cs:171 — AddResourceAuthorization<TMessage, TResource, TResponse>"
+    },
+    {
+      "id": "efcore-repositorybase",
+      "category": "efcore",
+      "target_doc": "trellis-api-efcore.md",
+      "difficulty": "easy",
+      "question": "What is the abstract base class to inherit when authoring a Trellis EF Core repository? Reply with just the type name including its type parameters.",
+      "verifier": {
+        "all_of": ["RepositoryBase", "TAggregate", "TId"],
+        "none_of": []
+      },
+      "source_ref": "Trellis.EntityFrameworkCore/src/RepositoryBase.cs:42"
+    },
+    {
+      "id": "efcore-uow-interface",
+      "category": "efcore",
+      "target_doc": "trellis-api-efcore.md",
+      "difficulty": "easy",
+      "question": "Which Trellis interface represents the Unit-of-Work for EF Core? Reply with just the interface name.",
+      "verifier": {
+        "all_of": ["IUnitOfWork"],
+        "none_of": ["IUnitOfWorkAsync", "ITransaction"]
+      },
+      "source_ref": "Trellis.EntityFrameworkCore/src/IUnitOfWork.cs:13"
+    },
+    {
+      "id": "efcore-package-name",
+      "category": "efcore",
+      "target_doc": "trellis-api-efcore.md",
+      "difficulty": "easy",
+      "question": "What is the NuGet package name for Trellis EF Core integration? Reply with the package id only.",
+      "verifier": {
+        "all_of": ["Trellis.EntityFrameworkCore"],
+        "none_of": ["Trellis.EFCore ", "Trellis.EF "]
+      },
+      "source_ref": "Package directory name"
+    },
+    {
+      "id": "control-mediator-pipeline-behaviors",
+      "category": "control",
+      "target_doc": "trellis-api-mediator.md",
+      "difficulty": "medium",
+      "question": "List the names of every pipeline behavior class defined in Trellis.Mediator (include both default-registered behaviors AND any opt-in behaviors). Reply with comma-separated class names.",
+      "verifier": {
+        "all_of": ["AuthorizationBehavior", "ValidationBehavior", "LoggingBehavior", "TracingBehavior", "ExceptionBehavior", "ResourceAuthorizationBehavior"],
+        "none_of": []
+      },
+      "source_ref": "Trellis.Mediator/src/*Behavior.cs (6 *Behavior.cs files)"
+    },
+    {
+      "id": "control-statemachine-type",
+      "category": "control",
+      "target_doc": "trellis-api-statemachine.md",
+      "difficulty": "easy",
+      "question": "What is the main public class in Trellis.StateMachine? Reply with the type name including its type parameters.",
+      "verifier": {
+        "all_of": ["LazyStateMachine", "TState", "TTrigger"],
+        "none_of": []
+      },
+      "source_ref": "Trellis.StateMachine/src/LazyStateMachine.cs:52"
+    },
+    {
+      "id": "control-http-toresult-async",
+      "category": "control",
+      "target_doc": "trellis-api-http.md",
+      "difficulty": "medium",
+      "question": "What is the return type of `HttpResponseExtensions.ToResultAsync(this Task<HttpResponseMessage>, ...)` in Trellis.Http? Reply with just the type signature.",
+      "verifier": {
+        "all_of": ["Task<Result<HttpResponseMessage>>"],
+        "none_of": ["Task<HttpResponseMessage>", "ValueTask", "Task<Result>"]
+      },
+      "source_ref": "Trellis.Http/src/HttpResponseExtensions.cs:72,201"
+    },
+    {
+      "id": "control-authorization-interfaces",
+      "category": "control",
+      "target_doc": "trellis-api-authorization.md",
+      "difficulty": "medium",
+      "question": "Name the marker interface a message implements to opt into per-resource authorization, AND any one of the two collaborator interfaces the application can implement to supply the resource (either the per-command loader interface or the shared-loader identifier interface). Reply with the interface names including type parameters.",
+      "verifier": {
+        "all_of": ["IAuthorizeResource", "TResource"],
+        "any_of": [["IResourceLoader", "IIdentifyResource"]],
+        "none_of": []
+      },
+      "source_ref": "Trellis.Authorization: IAuthorizeResource<TResource> + IResourceLoader<TMessage, TResource> (escape hatch) OR IIdentifyResource<TResource, TId> (preferred + shared loader)"
+    }
+  ]
+}

--- a/docs/docfx_project/qa-bench/run-qa-bench.ps1
+++ b/docs/docfx_project/qa-bench/run-qa-bench.ps1
@@ -1,0 +1,237 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Runs the LLM doc-quality Q&A bench against Azure AI Foundry.
+
+.DESCRIPTION
+  Loads questions.json, concatenates the docfx doc set as context, calls a
+  hosted chat model once with the full bank, parses the JSON answer array,
+  writes results to results/<UTC-timestamp>-<model>-<tag>.json, and
+  optionally invokes score-qa-bench.ps1.
+
+  The bench is designed to A/B-test docfx documentation changes (e.g.,
+  splitting oversized docs). Run baseline before the change; run again
+  after; compare scores.
+
+.PARAMETER Tag
+  Short label for the run (e.g., 'baseline', 'phase1-split'). Goes into the
+  output filename.
+
+.PARAMETER Model
+  Model deployment name in Foundry. Defaults to env:AZURE_AI_MODEL or 'gpt-4.1'.
+
+.PARAMETER ApiVersion
+  Azure API version. Defaults to '2024-05-01-preview'.
+
+.PARAMETER Iterations
+  Number of repeat runs (for variance estimation). Default 1.
+
+.PARAMETER Score
+  After the run, invoke score-qa-bench.ps1 on the result.
+
+.PARAMETER DryRun
+  Build the prompt and write to results/dry-run-<tag>.txt; do NOT call the API.
+
+.PARAMETER Temperature
+  Sampling temperature. Default 0 for reproducibility.
+
+.PARAMETER Seed
+  Sampling seed. Default 42.
+
+.PARAMETER QuestionsPath
+  Override the questions JSON file. Default: ./questions.json next to this script.
+
+.ENVIRONMENT
+  AZURE_AI_ENDPOINT  required, e.g., https://xavaifoundry.services.ai.azure.com
+  AZURE_AI_KEY       required, the api-key value
+  AZURE_AI_MODEL     optional, default 'gpt-4.1'
+
+.EXAMPLE
+  $env:AZURE_AI_ENDPOINT='https://xxx.services.ai.azure.com'
+  $env:AZURE_AI_KEY='...'
+  pwsh ./run-qa-bench.ps1 -Tag baseline -Score
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Tag,
+    [string] $Model,
+    [string] $ApiVersion = '2024-05-01-preview',
+    [int]    $Iterations = 1,
+    [switch] $Score,
+    [switch] $DryRun,
+    [double] $Temperature = 0,
+    [int]    $Seed = 42,
+    [string] $QuestionsPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- locate paths -----------------------------------------------------------
+$benchRoot   = Split-Path -Parent $PSCommandPath
+$repoRoot    = Resolve-Path (Join-Path $benchRoot '../../..')
+$articleDir  = Join-Path $benchRoot '../articles'
+$apiRefDir   = Join-Path $benchRoot '../api_reference'
+$resultsDir  = Join-Path $benchRoot 'results'
+if (-not $QuestionsPath) { $QuestionsPath = Join-Path $benchRoot 'questions.json' }
+if (-not (Test-Path $resultsDir)) { New-Item -ItemType Directory -Path $resultsDir | Out-Null }
+
+# --- env / model ------------------------------------------------------------
+$endpoint = $env:AZURE_AI_ENDPOINT
+$apiKey   = $env:AZURE_AI_KEY
+if (-not $Model) { $Model = if ($env:AZURE_AI_MODEL) { $env:AZURE_AI_MODEL } else { 'gpt-4.1' } }
+
+if (-not $DryRun) {
+    if (-not $endpoint) { throw 'AZURE_AI_ENDPOINT env var is required (or pass -DryRun).' }
+    if (-not $apiKey)   { throw 'AZURE_AI_KEY env var is required (or pass -DryRun).' }
+}
+if ($endpoint) { $endpoint = $endpoint.TrimEnd('/') }
+
+# --- load questions ---------------------------------------------------------
+$questionsRaw = Get-Content -Raw -Path $QuestionsPath
+$questionsObj = $questionsRaw | ConvertFrom-Json
+$questions    = @($questionsObj.questions)
+Write-Host ("Loaded {0} questions from {1}" -f $questions.Count, (Split-Path -Leaf $QuestionsPath))
+
+# --- build doc context ------------------------------------------------------
+$docFiles = @()
+$docFiles += Get-ChildItem -Path $articleDir -Filter '*.md' -File | Sort-Object Name
+$docFiles += Get-ChildItem -Path $apiRefDir  -Filter '*.md' -File | Sort-Object Name
+
+$contextSb = [System.Text.StringBuilder]::new(1MB)
+[void] $contextSb.AppendLine('<BEGIN DOCUMENTATION>')
+foreach ($f in $docFiles) {
+    $rel = $f.FullName.Substring($repoRoot.Path.Length + 1).Replace('\','/')
+    [void] $contextSb.AppendLine("=== FILE: $rel ===")
+    [void] $contextSb.AppendLine((Get-Content -Raw -Path $f.FullName))
+}
+[void] $contextSb.AppendLine('<END DOCUMENTATION>')
+$context = $contextSb.ToString()
+$approxTokens = [math]::Round($context.Length / 4)
+Write-Host ("Doc set: {0} files, {1:N0} chars (~{2:N0} tokens)" -f $docFiles.Count, $context.Length, $approxTokens)
+
+# --- build question block ---------------------------------------------------
+$qSb = [System.Text.StringBuilder]::new()
+[void] $qSb.AppendLine('Answer each of the following questions, using ONLY the documentation above. Do not invent facts. Do not call tools. Use no external knowledge.')
+[void] $qSb.AppendLine('Reply with a single JSON array. Each element MUST have exactly these fields: { "id": string, "answer": string }. Keep each answer brief and directly responsive to the question - no markdown, no commentary, no leading explanation. Do NOT wrap the JSON in code fences.')
+[void] $qSb.AppendLine('')
+[void] $qSb.AppendLine('Questions:')
+foreach ($q in $questions) {
+    [void] $qSb.AppendLine(("[{0}] {1}" -f $q.id, $q.question))
+}
+$questionBlock = $qSb.ToString()
+
+# --- assemble messages ------------------------------------------------------
+$systemMsg = @'
+You are a meticulous Trellis framework expert. You answer questions about the Trellis .NET framework strictly from the provided documentation excerpt. You return responses as a single JSON array per the user's instructions, with no surrounding prose, no code fences, and no commentary.
+'@
+$userMsg = "$context`n`n$questionBlock"
+
+# --- dry run path -----------------------------------------------------------
+if ($DryRun) {
+    $safeTag = ($Tag -replace '[^A-Za-z0-9._-]','_')
+    $dryPath = Join-Path $resultsDir ("dry-run-{0}.txt" -f $safeTag)
+    @(
+        "=== SYSTEM ===",
+        $systemMsg,
+        "",
+        "=== USER (length=$($userMsg.Length) chars, ~$approxTokens tokens) ===",
+        $userMsg
+    ) -join "`n" | Out-File -FilePath $dryPath -Encoding utf8
+    Write-Host "DRY RUN written to $dryPath"
+    return
+}
+
+# --- API call (one or more iterations) --------------------------------------
+$uri = "$endpoint/models/chat/completions?api-version=$ApiVersion"
+$headers = @{ 'api-key' = $apiKey; 'Content-Type' = 'application/json' }
+
+for ($iter = 1; $iter -le $Iterations; $iter++) {
+    $iterTag = if ($Iterations -gt 1) { "$Tag-iter$iter" } else { $Tag }
+    $safeIterTag = ($iterTag -replace '[^A-Za-z0-9._-]','_')
+    Write-Host ("`n=== Run {0}/{1} (tag='{2}', model='{3}') ===" -f $iter, $Iterations, $iterTag, $Model)
+
+    $body = @{
+        model       = $Model
+        temperature = $Temperature
+        seed        = $Seed
+        max_tokens  = 4000
+        messages    = @(
+            @{ role = 'system'; content = $systemMsg },
+            @{ role = 'user';   content = $userMsg }
+        )
+    } | ConvertTo-Json -Depth 6 -Compress
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $resp = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $body -ErrorAction Stop -TimeoutSec 600
+    } catch {
+        Write-Host "API call failed: $($_.Exception.Message)" -ForegroundColor Red
+        if ($_.ErrorDetails.Message) { Write-Host "Body: $($_.ErrorDetails.Message)" -ForegroundColor Red }
+        throw
+    }
+    $sw.Stop()
+
+    $finish    = $resp.choices[0].finish_reason
+    $modelOut  = $resp.model
+    $usage     = $resp.usage
+    $contentRaw= $resp.choices[0].message.content
+
+    Write-Host ("  finish={0}  model={1}  prompt_tokens={2}  completion_tokens={3}  duration={4:N1}s" -f `
+        $finish, $modelOut, $usage.prompt_tokens, $usage.completion_tokens, $sw.Elapsed.TotalSeconds)
+
+    # parse: strip code fences if present, then ConvertFrom-Json
+    $content = $contentRaw.Trim()
+    if ($content.StartsWith('```')) {
+        $content = ($content -replace '^```(json)?\s*\r?\n', '') -replace '\r?\n```\s*$', ''
+    }
+    try {
+        $parsed = $content | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Host "Failed to parse JSON answer; saving raw content for inspection." -ForegroundColor Yellow
+        $parsed = $null
+    }
+
+    $stamp = (Get-Date -AsUTC).ToString('yyyyMMddTHHmmssZ')
+    $safeMod = ($modelOut -replace '[^A-Za-z0-9._-]','_')
+    $outPath = Join-Path $resultsDir ("{0}-{1}-{2}.json" -f $stamp, $safeMod, $safeIterTag)
+
+    $payload = [ordered]@{
+        meta = [ordered]@{
+            timestamp_utc      = $stamp
+            tag                = $iterTag
+            model_param        = $Model
+            model_returned     = $modelOut
+            api_version        = $ApiVersion
+            endpoint_host      = ([Uri]$endpoint).Host
+            temperature        = $Temperature
+            seed               = $Seed
+            iteration          = $iter
+            iterations_total   = $Iterations
+            doc_files          = $docFiles.Count
+            prompt_chars       = $userMsg.Length
+            prompt_tokens      = $usage.prompt_tokens
+            completion_tokens  = $usage.completion_tokens
+            total_tokens       = $usage.total_tokens
+            duration_seconds   = [math]::Round($sw.Elapsed.TotalSeconds, 2)
+            finish_reason      = $finish
+            questions_path     = (Resolve-Path $QuestionsPath).Path
+            git_commit         = (git -C $repoRoot rev-parse HEAD 2>$null)
+            git_branch         = (git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null)
+        }
+        answers     = $parsed
+        raw_content = $contentRaw
+    }
+    $payload | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 -FilePath $outPath
+    Write-Host "  result -> $outPath"
+
+    if ($Score) {
+        $scorer = Join-Path $benchRoot 'score-qa-bench.ps1'
+        if (Test-Path $scorer) {
+            & $scorer -ResultPath $outPath -QuestionsPath $QuestionsPath
+        } else {
+            Write-Host "  (score-qa-bench.ps1 not found; skipping)" -ForegroundColor Yellow
+        }
+    }
+}

--- a/docs/docfx_project/qa-bench/score-qa-bench.ps1
+++ b/docs/docfx_project/qa-bench/score-qa-bench.ps1
@@ -1,0 +1,190 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Scores a Q&A bench result file against the question bank's verifier rules.
+
+.DESCRIPTION
+  Reads a result JSON written by run-qa-bench.ps1, applies each question's
+  verifier (all_of / any_of / none_of), prints a per-question and per-category
+  table, and writes a sibling .score.json + .score.md report.
+
+  Returns exit 0 always (this is a measurement, not a gate).
+
+.PARAMETER ResultPath
+  Path to a result JSON file (relative or absolute).
+
+.PARAMETER QuestionsPath
+  Path to questions.json. Defaults to ./questions.json next to this script.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $ResultPath,
+    [string] $QuestionsPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$benchRoot = Split-Path -Parent $PSCommandPath
+if (-not $QuestionsPath) { $QuestionsPath = Join-Path $benchRoot 'questions.json' }
+
+$result    = Get-Content -Raw -Path $ResultPath    | ConvertFrom-Json
+$qdoc      = Get-Content -Raw -Path $QuestionsPath | ConvertFrom-Json
+$questions = @($qdoc.questions)
+
+# index answers by id (case-sensitive match expected from the model)
+$answersById = @{}
+if ($result.answers) {
+    foreach ($a in $result.answers) {
+        if ($a -and $a.id) { $answersById[$a.id] = $a.answer }
+    }
+}
+
+function Test-Verifier {
+    param([string] $Answer, $Verifier)
+    $a = $Answer
+    if (-not $a) { return @{ pass = $false; missing_all = @(); missing_any = @(); hit_none = @(); reason = 'no answer' } }
+    $aLower = $a.ToLowerInvariant()
+
+    $missingAll = @()
+    if ($Verifier -and $Verifier.PSObject.Properties.Name -contains 'all_of' -and $Verifier.all_of) {
+        foreach ($k in @($Verifier.all_of)) {
+            if (-not $aLower.Contains($k.ToLowerInvariant())) { $missingAll += $k }
+        }
+    }
+    $missingAny = @()
+    if ($Verifier -and $Verifier.PSObject.Properties.Name -contains 'any_of' -and $Verifier.any_of) {
+        foreach ($group in @($Verifier.any_of)) {
+            $hit = $false
+            foreach ($k in @($group)) {
+                if ($aLower.Contains($k.ToLowerInvariant())) { $hit = $true; break }
+            }
+            if (-not $hit) { $missingAny += ,@($group) }
+        }
+    }
+    $hitNone = @()
+    if ($Verifier -and $Verifier.PSObject.Properties.Name -contains 'none_of' -and $Verifier.none_of) {
+        foreach ($k in @($Verifier.none_of)) {
+            if ($aLower.Contains($k.ToLowerInvariant())) { $hitNone += $k }
+        }
+    }
+
+    $pass = ($missingAll.Count -eq 0) -and ($missingAny.Count -eq 0) -and ($hitNone.Count -eq 0)
+    return @{ pass = $pass; missing_all = $missingAll; missing_any = $missingAny; hit_none = $hitNone; reason = '' }
+}
+
+$scored = @()
+foreach ($q in $questions) {
+    $ans = if ($answersById.ContainsKey($q.id)) { $answersById[$q.id] } else { $null }
+    $r   = Test-Verifier -Answer $ans -Verifier $q.verifier
+    $scored += [pscustomobject]@{
+        id           = $q.id
+        category     = $q.category
+        difficulty   = $q.difficulty
+        target_doc   = $q.target_doc
+        question     = $q.question
+        answer       = $ans
+        pass         = $r.pass
+        missing_all  = $r.missing_all
+        missing_any  = $r.missing_any
+        hit_none     = $r.hit_none
+    }
+}
+
+# --- aggregate ---------------------------------------------------------------
+$total       = $scored.Count
+$passCount   = @($scored | Where-Object { $_.pass }).Count
+$overallPct  = if ($total -gt 0) { [math]::Round(100.0 * $passCount / $total, 1) } else { 0 }
+
+$catLines = @()
+$byCat = $scored | Group-Object category | Sort-Object Name
+foreach ($g in $byCat) {
+    $cTotal = $g.Count
+    $cPass  = @($g.Group | Where-Object { $_.pass }).Count
+    $cPct   = if ($cTotal -gt 0) { [math]::Round(100.0 * $cPass / $cTotal, 1) } else { 0 }
+    $catLines += [pscustomobject]@{ category = $g.Name; pass = $cPass; total = $cTotal; pct = $cPct }
+}
+
+# --- console report ---------------------------------------------------------
+Write-Host ""
+Write-Host ("=== Score: {0} (model={1}, tag={2}) ===" -f (Split-Path -Leaf $ResultPath), $result.meta.model_returned, $result.meta.tag)
+Write-Host ("Overall: {0}/{1} ({2}%)`n" -f $passCount, $total, $overallPct)
+Write-Host "By category:"
+$catLines | Format-Table -AutoSize | Out-Host
+
+Write-Host "Per-question:"
+$scored | ForEach-Object {
+    $mark = if ($_.pass) { 'PASS' } else { 'FAIL' }
+    $color = if ($_.pass) { 'Green' } else { 'Red' }
+    Write-Host ("  [{0}] {1} ({2}/{3})" -f $mark, $_.id, $_.category, $_.difficulty) -ForegroundColor $color
+    if (-not $_.pass) {
+        if ($_.missing_all.Count -gt 0) { Write-Host ("       missing all_of: {0}" -f ($_.missing_all -join ', ')) -ForegroundColor DarkYellow }
+        if ($_.missing_any.Count -gt 0) {
+            $groups = ($_.missing_any | ForEach-Object { '[' + ($_ -join '|') + ']' }) -join ', '
+            Write-Host ("       missing any_of: $groups") -ForegroundColor DarkYellow
+        }
+        if ($_.hit_none.Count -gt 0)    { Write-Host ("       contains none_of: {0}" -f ($_.hit_none -join ', ')) -ForegroundColor DarkYellow }
+        $preview = if ($_.answer) { $_.answer } else { '(no answer)' }
+        if ($preview.Length -gt 200) { $preview = $preview.Substring(0,200) + '...' }
+        Write-Host ("       answer: $preview") -ForegroundColor DarkGray
+    }
+}
+
+# --- write report files -----------------------------------------------------
+$baseOut    = $ResultPath -replace '\.json$',''
+$scoreJson  = "$baseOut.score.json"
+$scoreMd    = "$baseOut.score.md"
+
+[ordered]@{
+    source            = (Resolve-Path $ResultPath).Path
+    questions         = (Resolve-Path $QuestionsPath).Path
+    model_returned    = $result.meta.model_returned
+    tag               = $result.meta.tag
+    timestamp_utc     = $result.meta.timestamp_utc
+    overall_pass      = $passCount
+    overall_total     = $total
+    overall_pct       = $overallPct
+    by_category       = $catLines
+    questions_results = $scored
+} | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 -FilePath $scoreJson
+
+$md = @()
+$md += "# Q&A bench score: $(Split-Path -Leaf $ResultPath)"
+$md += ""
+$md += "- Model: ``$($result.meta.model_returned)``"
+$md += "- Tag: ``$($result.meta.tag)``"
+$md += "- Timestamp (UTC): $($result.meta.timestamp_utc)"
+$md += "- Git commit: $($result.meta.git_commit)"
+$md += "- **Overall: $passCount / $total ($overallPct%)**"
+$md += ""
+$md += "## By category"
+$md += ""
+$md += "| Category | Pass | Total | % |"
+$md += "|---|---|---|---|"
+foreach ($c in $catLines) { $md += ("| {0} | {1} | {2} | {3}% |" -f $c.category, $c.pass, $c.total, $c.pct) }
+$md += ""
+$md += "## Per-question"
+$md += ""
+$md += "| Result | Id | Category | Difficulty | Notes |"
+$md += "|---|---|---|---|---|"
+foreach ($r in $scored) {
+    $mark = if ($r.pass) { '✅' } else { '❌' }
+    $notes = @()
+    if (-not $r.pass) {
+        if ($r.missing_all.Count -gt 0) { $notes += "missing: $($r.missing_all -join ', ')" }
+        if ($r.missing_any.Count -gt 0) {
+            $groups = @($r.missing_any | ForEach-Object { '[' + (($_ -join ' OR ')) + ']' }) -join ', '
+            $notes += "any-of unmet: $groups"
+        }
+        if ($r.hit_none.Count -gt 0)    { $notes += "anti-pattern: $($r.hit_none -join ', ')" }
+    }
+    $cell = ($notes -join '; ') -replace '\|','\|'
+    $md += ("| {0} | ``{1}`` | {2} | {3} | {4} |" -f $mark, $r.id, $r.category, $r.difficulty, $cell)
+}
+$md -join "`n" | Out-File -Encoding utf8 -FilePath $scoreMd
+
+Write-Host ""
+Write-Host "Wrote:"
+Write-Host "  $scoreJson"
+Write-Host "  $scoreMd"


### PR DESCRIPTION
## Summary

Adds an LLM-driven Q&A bench harness so doc PRs that aim to improve LLM consumption (e.g., the upcoming Phase-1 split of oversized api_reference docs) can be evaluated quantitatively instead of by feel.

The harness asks an LLM 23 hand-curated questions about Trellis with the **entire docfx article + api_reference set** stuffed into the prompt, then scores each answer with deterministic verifier rules (`all_of` / `any_of` / `none_of` substring matches). The score becomes an A/B signal for "did this doc PR actually help an LLM answer questions?"

This PR adds **only the harness** — no doc content changes. It complements the existing static `audit-llm-doc-quality.ps1` smoke test (4 structural probes) with a real LLM-driven measurement.

## What's in `docs/docfx_project/qa-bench/`

| File | Purpose |
|---|---|
| `README.md` | Usage, A/B workflow, cost/latency, schema for adding questions |
| `questions.json` | 23 questions across 5 categories: core (8), cookbook (4), asp (4), efcore (3), control (4) |
| `run-qa-bench.ps1` | PowerShell 7+ runner. Reads `AZURE_AI_ENDPOINT` + `AZURE_AI_KEY` from env. `-Tag`, `-Iterations N`, `-Score`, `-DryRun`, `-Temperature` (default 0), `-Seed` (default 42) |
| `score-qa-bench.ps1` | Applies verifiers, prints per-question + per-category breakdown, writes `.score.json` + `.score.md` |
| `BASELINE.md` | Frozen scorecard: **22/23 (95.7%)** on `gpt-4.1-2025-04-14` against `d8a6f72` |
| `.gitignore` | excludes `results/`, `*.local.json`, `.env` |

## Validation

- ✅ End-to-end against Azure AI Foundry GPT-4.1
- ✅ **Deterministic**: 3 iterations × identical 22/23 scores at temp=0, seed=42
- ✅ Single persistent failure (`core-traverse-overloads`) is intentional — designed-to-be-hard counting question that gives the bench room to show improvement after the Phase-1 split
- ✅ Tag values are sanitized for filesystem safety (`docs/foo` → `docs_foo.txt`)
- ✅ Verifier edge cases tightened during code-review pass:
  - `asp-actionresult-vs-httpresponse` — now requires exact ordered phrases (anti-reversal `none_of`)
  - `asp-resource-authorization-tparams` — now requires exact `<TMessage, TResource, TResponse>` substring (anti-permutation `none_of`)
  - `score-qa-bench.ps1` — `|` in `any_of` failure messages is escaped so markdown table rendering isn't broken

## Cost / Latency

~245K prompt tokens + ~720 completion tokens per iteration → **~$0.50/run, ~10s/run**. A 3-iteration smoke ≈ $1.50.

## Security

- API key is read from env vars only — never written to any committed file (verified by code-review).
- Output `results/` directory is gitignored.

## How to use

```pwsh
$env:AZURE_AI_ENDPOINT = 'https://<your-foundry>.services.ai.azure.com'
$env:AZURE_AI_KEY      = '<key>'

cd docs/docfx_project/qa-bench
pwsh ./run-qa-bench.ps1 -Tag baseline -Iterations 3 -Score
```

## A/B workflow for future doc PRs

1. Run bench on `main` (or use `BASELINE.md`) → record score
2. Apply doc changes on a branch
3. Re-run bench → compare scorecards
4. Merge only if score holds or improves; do NOT merge regressions

## Out of scope

- CI wiring (needs Azure key configured as a GH secret first)
- Splitting the oversized api_reference docs (this PR only adds the measurement tool — the actual split is the next PR, which this bench will gate)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
