### PR TITLE
feat(Trellis.Core)!: change IDomainEvent.OccurredAt from DateTime to DateTimeOffset

### DIFF
--- a/Examples/Showcase/src/Showcase.Domain/Aggregates/BankAccount.cs
+++ b/Examples/Showcase/src/Showcase.Domain/Aggregates/BankAccount.cs
@@ -119,7 +119,7 @@ public class BankAccount : Aggregate<AccountId>
             customerId,
             accountType,
             initialDeposit,
-            timeProvider.GetUtcNow().UtcDateTime));
+            timeProvider.GetUtcNow()));
 
         return Result.Ok(account);
     }
@@ -137,8 +137,8 @@ public class BankAccount : Aggregate<AccountId>
             .Tap(newBalance =>
             {
                 Balance = newBalance;
-                var now = _timeProvider.GetUtcNow().UtcDateTime;
-                _transactions.Add(Transaction.CreateDeposit(TransactionId.NewUniqueV4(), amount, Balance, description, now));
+                var now = _timeProvider.GetUtcNow();
+                _transactions.Add(Transaction.CreateDeposit(TransactionId.NewUniqueV4(), amount, Balance, description, now.UtcDateTime));
                 DomainEvents.Add(new MoneyDeposited(Id, amount, Balance, description, now));
             })
             .Map(_ => this);
@@ -162,8 +162,8 @@ public class BankAccount : Aggregate<AccountId>
             .Tap(newBalance =>
             {
                 Balance = newBalance;
-                var now = _timeProvider.GetUtcNow().UtcDateTime;
-                _transactions.Add(Transaction.CreateWithdrawal(TransactionId.NewUniqueV4(), amount, Balance, description, now));
+                var now = _timeProvider.GetUtcNow();
+                _transactions.Add(Transaction.CreateWithdrawal(TransactionId.NewUniqueV4(), amount, Balance, description, now.UtcDateTime));
                 DomainEvents.Add(new MoneyWithdrawn(Id, amount, Balance, description, now));
             })
             .Map(_ => this);
@@ -192,9 +192,9 @@ public class BankAccount : Aggregate<AccountId>
             .Tap(newBalance =>
             {
                 Balance = newBalance;
-                var now = _timeProvider.GetUtcNow().UtcDateTime;
+                var now = _timeProvider.GetUtcNow();
                 var description = $"Interest at {annualRate:P2} APR";
-                _transactions.Add(Transaction.CreateInterest(TransactionId.NewUniqueV4(), interestAmount, Balance, description, now));
+                _transactions.Add(Transaction.CreateInterest(TransactionId.NewUniqueV4(), interestAmount, Balance, description, now.UtcDateTime));
                 DomainEvents.Add(new InterestPaid(Id, interestAmount, Balance, annualRate, now));
             })
             .Map(_ => this);
@@ -226,7 +226,7 @@ public class BankAccount : Aggregate<AccountId>
 
         return Withdraw(amount, $"{description} to {toAccount.Id}")
             .Bind(_ => toAccount.Deposit(amount, $"{description} from {Id}"))
-            .Tap(_ => DomainEvents.Add(new TransferCompleted(Id, toAccount.Id, amount, description, _timeProvider.GetUtcNow().UtcDateTime)))
+            .Tap(_ => DomainEvents.Add(new TransferCompleted(Id, toAccount.Id, amount, description, _timeProvider.GetUtcNow())))
             .Map(_ => (this, toAccount));
     }
 
@@ -239,13 +239,13 @@ public class BankAccount : Aggregate<AccountId>
         }
 
         return _lifecycle.FireResult(AccountTrigger.Freeze)
-            .Tap(_ => DomainEvents.Add(new AccountFrozen(Id, reason, _timeProvider.GetUtcNow().UtcDateTime)))
+            .Tap(_ => DomainEvents.Add(new AccountFrozen(Id, reason, _timeProvider.GetUtcNow())))
             .Map(_ => this);
     }
 
     public Result<BankAccount> Unfreeze() =>
         _lifecycle.FireResult(AccountTrigger.Unfreeze)
-            .Tap(_ => DomainEvents.Add(new AccountUnfrozen(Id, _timeProvider.GetUtcNow().UtcDateTime)))
+            .Tap(_ => DomainEvents.Add(new AccountUnfrozen(Id, _timeProvider.GetUtcNow())))
             .Map(_ => this);
 
     public Result<BankAccount> Close()
@@ -257,7 +257,7 @@ public class BankAccount : Aggregate<AccountId>
         }
 
         return _lifecycle.FireResult(AccountTrigger.Close)
-            .Tap(_ => DomainEvents.Add(new AccountClosed(Id, _timeProvider.GetUtcNow().UtcDateTime)))
+            .Tap(_ => DomainEvents.Add(new AccountClosed(Id, _timeProvider.GetUtcNow())))
             .Map(_ => this);
     }
 

--- a/Examples/Showcase/src/Showcase.Domain/Events/BankingEvents.cs
+++ b/Examples/Showcase/src/Showcase.Domain/Events/BankingEvents.cs
@@ -10,45 +10,45 @@ public record AccountOpened(
     CustomerId CustomerId,
     AccountType AccountType,
     Money InitialBalance,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record MoneyDeposited(
     AccountId AccountId,
     Money Amount,
     Money NewBalance,
     string Description,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record MoneyWithdrawn(
     AccountId AccountId,
     Money Amount,
     Money NewBalance,
     string Description,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record TransferCompleted(
     AccountId FromAccountId,
     AccountId ToAccountId,
     Money Amount,
     string Description,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record AccountFrozen(
     AccountId AccountId,
     string Reason,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record AccountUnfrozen(
     AccountId AccountId,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record AccountClosed(
     AccountId AccountId,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;
 
 public record InterestPaid(
     AccountId AccountId,
     Money InterestAmount,
     Money NewBalance,
     decimal AnnualRate,
-    DateTime OccurredAt) : IDomainEvent;
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/Examples/TestingPatterns/DomainDrivenDesignSamplesTests.cs
+++ b/Examples/TestingPatterns/DomainDrivenDesignSamplesTests.cs
@@ -581,12 +581,12 @@ public class DomainDrivenDesignSamplesTests
     #region Aggregate Examples Tests
 
     // Domain Events
-    public record OrderCreated(OrderId OrderId, CustomerId CustomerId, DateTime OccurredAt) : IDomainEvent;
-    public record OrderLineAdded(OrderId OrderId, ProductId ProductId, int Quantity, DateTime OccurredAt) : IDomainEvent;
-    public record OrderLineRemoved(OrderId OrderId, ProductId ProductId, DateTime OccurredAt) : IDomainEvent;
-    public record OrderSubmitted(OrderId OrderId, Money Total, DateTime OccurredAt) : IDomainEvent;
-    public record OrderCancelled(OrderId OrderId, string Reason, DateTime OccurredAt) : IDomainEvent;
-    public record OrderShipped(OrderId OrderId, DateTime OccurredAt) : IDomainEvent;
+    public record OrderCreated(OrderId OrderId, CustomerId CustomerId, DateTimeOffset OccurredAt) : IDomainEvent;
+    public record OrderLineAdded(OrderId OrderId, ProductId ProductId, int Quantity, DateTimeOffset OccurredAt) : IDomainEvent;
+    public record OrderLineRemoved(OrderId OrderId, ProductId ProductId, DateTimeOffset OccurredAt) : IDomainEvent;
+    public record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset OccurredAt) : IDomainEvent;
+    public record OrderCancelled(OrderId OrderId, string Reason, DateTimeOffset OccurredAt) : IDomainEvent;
+    public record OrderShipped(OrderId OrderId, DateTimeOffset OccurredAt) : IDomainEvent;
 
     public enum OrderStatus
     {
@@ -641,7 +641,7 @@ public class DomainDrivenDesignSamplesTests
             Status = OrderStatus.Draft;
             Total = Money.Create(0m, "USD");
 
-            DomainEvents.Add(new OrderCreated(id, customerId, DateTime.UtcNow));
+            DomainEvents.Add(new OrderCreated(id, customerId, DateTimeOffset.UtcNow));
         }
 
         public static Result<Order> TryCreate(CustomerId customerId) =>
@@ -679,7 +679,7 @@ public class DomainDrivenDesignSamplesTests
                     }
 
                     RecalculateTotal();
-                    DomainEvents.Add(new OrderLineAdded(Id, productId, quantity, DateTime.UtcNow));
+                    DomainEvents.Add(new OrderLineAdded(Id, productId, quantity, DateTimeOffset.UtcNow));
                 });
 
         public Result<Order> RemoveLine(ProductId productId) =>
@@ -693,7 +693,7 @@ public class DomainDrivenDesignSamplesTests
                     var line = _lines.First(l => l.ProductId == productId);
                     _lines.Remove(line);
                     RecalculateTotal();
-                    DomainEvents.Add(new OrderLineRemoved(Id, productId, DateTime.UtcNow));
+                    DomainEvents.Add(new OrderLineRemoved(Id, productId, DateTimeOffset.UtcNow));
                 });
 
         public Result<Order> Submit() =>
@@ -708,7 +708,7 @@ public class DomainDrivenDesignSamplesTests
                 {
                     Status = OrderStatus.Submitted;
                     SubmittedAt = DateTime.UtcNow;
-                    DomainEvents.Add(new OrderSubmitted(Id, Total, DateTime.UtcNow));
+                    DomainEvents.Add(new OrderSubmitted(Id, Total, DateTimeOffset.UtcNow));
                 });
 
         public Result<Order> Ship() =>
@@ -719,7 +719,7 @@ public class DomainDrivenDesignSamplesTests
                 {
                     Status = OrderStatus.Shipped;
                     ShippedAt = DateTime.UtcNow;
-                    DomainEvents.Add(new OrderShipped(Id, DateTime.UtcNow));
+                    DomainEvents.Add(new OrderShipped(Id, DateTimeOffset.UtcNow));
                 });
 
         public Result<Order> Cancel(string reason) =>
@@ -732,7 +732,7 @@ public class DomainDrivenDesignSamplesTests
                 {
                     Status = OrderStatus.Cancelled;
                     CancelledAt = DateTime.UtcNow;
-                    DomainEvents.Add(new OrderCancelled(Id, reason, DateTime.UtcNow));
+                    DomainEvents.Add(new OrderCancelled(Id, reason, DateTimeOffset.UtcNow));
                 });
 
         private void RecalculateTotal()

--- a/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
@@ -35,17 +35,23 @@
 /// </remarks>
 /// <example>
 /// <code>
-/// // Define domain events as immutable records with OccurredAt as the timestamp
-/// public record OrderCreated(OrderId OrderId, CustomerId CustomerId, DateTime OccurredAt) : IDomainEvent;
-/// public record OrderSubmitted(OrderId OrderId, Money Total, DateTime OccurredAt) : IDomainEvent;
+/// // Define domain events as immutable records with OccurredAt as the timestamp.
+/// // OccurredAt is DateTimeOffset so the authored instant is preserved unambiguously
+/// // through serialization (e.g., outbox tables, integration buses, audit projections).
+/// public record OrderCreated(OrderId OrderId, CustomerId CustomerId, DateTimeOffset OccurredAt) : IDomainEvent;
+/// public record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset OccurredAt) : IDomainEvent;
 /// 
-/// // Raise events from an aggregate
+/// // Raise events from an aggregate. Use TimeProvider.GetUtcNow() (typically injected)
+/// // so tests can pin time deterministically with a fake clock.
 /// public class Order : Aggregate&lt;OrderId&gt;
 /// {
-///     private Order(OrderId id, CustomerId customerId) : base(id)
+///     private readonly TimeProvider _clock;
+/// 
+///     private Order(OrderId id, CustomerId customerId, TimeProvider clock) : base(id)
 ///     {
+///         _clock = clock;
 ///         CustomerId = customerId;
-///         DomainEvents.Add(new OrderCreated(id, customerId, DateTime.UtcNow));
+///         DomainEvents.Add(new OrderCreated(id, customerId, _clock.GetUtcNow()));
 ///     }
 ///     
 ///     public Result&lt;Order&gt; Submit()
@@ -55,8 +61,7 @@
 ///             .Tap(_ =>
 ///             {
 ///                 Status = OrderStatus.Submitted;
-///                 SubmittedAt = DateTime.UtcNow;
-///                 DomainEvents.Add(new OrderSubmitted(Id, Total, DateTime.UtcNow));
+///                 DomainEvents.Add(new OrderSubmitted(Id, Total, _clock.GetUtcNow()));
 ///             });
 ///     }
 /// }
@@ -76,27 +81,33 @@
 public interface IDomainEvent
 {
     /// <summary>
-    /// Gets the UTC timestamp when this domain event occurred.
+    /// Gets the timestamp when this domain event occurred.
     /// </summary>
     /// <value>
-    /// The date and time in UTC when the event was raised.
+    /// The instant in time when the event was raised, as a <see cref="DateTimeOffset"/> with explicit UTC offset.
     /// </value>
     /// <remarks>
     /// <para>
     /// This timestamp represents when the business action occurred, not when the event was persisted or published.
-    /// Always use UTC to ensure consistency across distributed systems and time zones.
+    /// Author events using <see cref="TimeProvider.GetUtcNow"/> (typically injected) so the canonical UTC offset
+    /// (<c>+00:00</c>) is recorded and tests can pin time deterministically with a fake clock.
+    /// </para>
+    /// <para>
+    /// <see cref="DateTimeOffset"/> is preferred over <see cref="DateTime"/> because the offset is an explicit
+    /// part of the value and round-trips unambiguously through serialization. Events stored in outbox tables,
+    /// integration buses, and audit projections retain their authored instant without timezone-loss bugs.
     /// </para>
     /// <para>
     /// Use <c>OccurredAt</c> as the single timestamp for your events - avoid adding redundant fields like 
     /// <c>CreatedAt</c>, <c>SubmittedAt</c>, etc. that duplicate this information:
     /// <code>
     /// // Good - OccurredAt captures when the event happened
-    /// public record OrderSubmitted(OrderId OrderId, Money Total, DateTime OccurredAt) : IDomainEvent;
+    /// public record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset OccurredAt) : IDomainEvent;
     /// 
     /// // Avoid - redundant SubmittedAt duplicates OccurredAt
-    /// public record OrderSubmitted(OrderId OrderId, Money Total, DateTime SubmittedAt, DateTime OccurredAt) : IDomainEvent;
+    /// public record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset SubmittedAt, DateTimeOffset OccurredAt) : IDomainEvent;
     /// </code>
     /// </para>
     /// </remarks>
-    DateTime OccurredAt { get; }
+    DateTimeOffset OccurredAt { get; }
 }

--- a/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs
@@ -98,6 +98,14 @@ public interface IDomainEvent
     /// integration buses, and audit projections retain their authored instant without timezone-loss bugs.
     /// </para>
     /// <para>
+    /// <strong>Caveat:</strong> C# implicitly converts <see cref="DateTime"/> to <see cref="DateTimeOffset"/>,
+    /// so a caller that passes <c>DateTime.Now</c> (Local) or <c>new DateTime(...)</c> (Unspecified, treated as Local)
+    /// will silently produce an event timestamped with the machine's local offset rather than UTC. The contract
+    /// does not block this at the type level. Always author events from <see cref="TimeProvider.GetUtcNow"/> or
+    /// <see cref="DateTimeOffset.UtcNow"/> to avoid local-time stamping on non-UTC machines. A static analyzer to
+    /// flag <see cref="DateTime"/> sources flowing into <c>OccurredAt</c> may follow in a future release.
+    /// </para>
+    /// <para>
     /// Use <c>OccurredAt</c> as the single timestamp for your events - avoid adding redundant fields like 
     /// <c>CreatedAt</c>, <c>SubmittedAt</c>, etc. that duplicate this information:
     /// <code>

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateJsonSerializationTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateJsonSerializationTests.cs
@@ -45,7 +45,7 @@ public class AggregateJsonSerializationTests
 
 #region Test Aggregate and Events
 
-internal record JsonTestEvent(string AggregateId, DateTime OccurredAt) : IDomainEvent;
+internal record JsonTestEvent(string AggregateId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 internal class JsonTestAggregate : Aggregate<string>
 {
@@ -58,7 +58,7 @@ internal class JsonTestAggregate : Aggregate<string>
     public void DoSomething()
     {
         Name = $"{Name}_modified";
-        DomainEvents.Add(new JsonTestEvent(Id, DateTime.UtcNow));
+        DomainEvents.Add(new JsonTestEvent(Id, DateTimeOffset.UtcNow));
     }
 }
 

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
@@ -356,7 +356,7 @@ public class AggregateTests
 
 #region Test Aggregate and Events
 
-internal record TestEvent(string AggregateId, DateTime OccurredAt) : IDomainEvent;
+internal record TestEvent(string AggregateId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 internal class TestAggregate : Aggregate<string>
 {
@@ -369,7 +369,7 @@ internal class TestAggregate : Aggregate<string>
     public void DoSomething()
     {
         Name = $"{Name}_modified";
-        DomainEvents.Add(new TestEvent(Id, DateTime.UtcNow));
+        DomainEvents.Add(new TestEvent(Id, DateTimeOffset.UtcNow));
     }
 
     /// <summary>Test-only helper to simulate a persisted ETag.</summary>

--- a/Trellis.Core/tests/DomainDrivenDesign/DomainEvents/DomainEventOccurredAtTypeTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/DomainEvents/DomainEventOccurredAtTypeTests.cs
@@ -1,0 +1,54 @@
+﻿namespace Trellis.Core.Tests.DomainDrivenDesign.DomainEvents;
+
+using System.Text.Json;
+
+/// <summary>
+/// Locks in that <see cref="IDomainEvent.OccurredAt"/> is <see cref="DateTimeOffset"/>, not <see cref="DateTime"/>.
+/// The offset must round-trip through <see cref="JsonSerializer"/> so that events whose origin clock is non-UTC
+/// (or events that flow through a system with a clock-skew tolerant store) preserve their authored instant.
+/// </summary>
+public class DomainEventOccurredAtTypeTests
+{
+    [Fact]
+    public void OccurredAt_TypeIsDateTimeOffset_AtCompileTime()
+    {
+        var moment = new DateTimeOffset(2026, 5, 2, 17, 30, 0, TimeSpan.FromHours(5));
+        var evt = new TimestampedEvent("agg-1", moment);
+
+        // Compile-time check via the interface — this assignment only compiles
+        // if IDomainEvent.OccurredAt is DateTimeOffset (not DateTime).
+        DateTimeOffset captured = ((IDomainEvent)evt).OccurredAt;
+
+        captured.Should().Be(moment);
+    }
+
+    [Fact]
+    public void OccurredAt_PreservesOffsetThroughJsonRoundTrip()
+    {
+        var moment = new DateTimeOffset(2026, 5, 2, 17, 30, 0, TimeSpan.FromHours(5));
+        var evt = new TimestampedEvent("agg-1", moment);
+
+        var json = JsonSerializer.Serialize(evt);
+        json.Should().Contain("+05:00");
+
+        var roundTrip = JsonSerializer.Deserialize<TimestampedEvent>(json)!;
+        roundTrip.OccurredAt.Should().Be(moment);
+        roundTrip.OccurredAt.Offset.Should().Be(TimeSpan.FromHours(5));
+    }
+
+    [Fact]
+    public void OccurredAt_AcceptsTimeProviderGetUtcNowDirectly()
+    {
+        // Regression guard: TimeProvider.GetUtcNow() returns DateTimeOffset.
+        // Authoring an event from it must compile without .UtcDateTime conversion.
+        TimeProvider clock = TimeProvider.System;
+        DateTimeOffset now = clock.GetUtcNow();
+
+        var evt = new TimestampedEvent("agg-1", now);
+
+        ((IDomainEvent)evt).OccurredAt.Should().Be(now);
+        ((IDomainEvent)evt).OccurredAt.Offset.Should().Be(TimeSpan.Zero);
+    }
+}
+
+internal record TimestampedEvent(string AggregateId, DateTimeOffset OccurredAt) : IDomainEvent;

--- a/Trellis.Testing/tests/Fakes/FakeRepositoryTests.cs
+++ b/Trellis.Testing/tests/Fakes/FakeRepositoryTests.cs
@@ -4,9 +4,9 @@ public class FakeRepositoryTests
 {
     #region Test Aggregate
 
-    private record TestEvent(string AggregateId, DateTime OccurredAt) : IDomainEvent
+    private record TestEvent(string AggregateId, DateTimeOffset OccurredAt) : IDomainEvent
     {
-        public TestEvent(string aggregateId) : this(aggregateId, DateTime.UtcNow) { }
+        public TestEvent(string aggregateId) : this(aggregateId, DateTimeOffset.UtcNow) { }
     }
 
     private class TestAggregate : Aggregate<string>

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1325,26 +1325,26 @@ Without `AddTrellisUnitOfWork<TContext>()`, `repo.Add(order)` stages the entity 
 
 ```csharp
 // ❌ Wrong — CS0535 'OrderSubmitted does not implement IDomainEvent.OccurredAt'
-public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTime SubmittedAt) : IDomainEvent;
+public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset SubmittedAt) : IDomainEvent;
 ```
 
 The compile error is unambiguous, but the obvious "fix" — adding `OccurredAt` *alongside* `SubmittedAt` — is the wrong shape:
 
 ```csharp
 // ❌ Wrong — duplicate timestamps. SubmittedAt and OccurredAt always carry the same value.
-public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTime SubmittedAt, DateTime OccurredAt) : IDomainEvent;
+public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset SubmittedAt, DateTimeOffset OccurredAt) : IDomainEvent;
 ```
 
 **Fix.** `OccurredAt` is the canonical, only timestamp on every domain event. The semantic meaning ("when the order was submitted") is carried by the *event type name* (`OrderSubmitted`), not by a parallel timestamp field. Drop the semantic alias:
 
 ```csharp
 // ✅ Correct — OccurredAt is the timestamp; the event name carries the semantic.
-public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTime OccurredAt) : IDomainEvent;
-public sealed record OrderApproved(OrderId OrderId, ActorId ApprovedBy, DateTime OccurredAt) : IDomainEvent;
-public sealed record OrderShipped(OrderId OrderId, TrackingNumber Tracking, DateTime OccurredAt) : IDomainEvent;
+public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset OccurredAt) : IDomainEvent;
+public sealed record OrderApproved(OrderId OrderId, ActorId ApprovedBy, DateTimeOffset OccurredAt) : IDomainEvent;
+public sealed record OrderShipped(OrderId OrderId, TrackingNumber Tracking, DateTimeOffset OccurredAt) : IDomainEvent;
 ```
 
-**Raising the event.** Always pass `DateTime.UtcNow` (or an injected `TimeProvider.GetUtcNow().UtcDateTime` for testability). The aggregate's domain method, not the event constructor, is where time enters the system:
+**Raising the event.** Always pass `TimeProvider.GetUtcNow()` (the .NET 8 testable-clock primitive returns `DateTimeOffset` directly — no conversion needed). The aggregate's domain method, not the event constructor, is where time enters the system:
 
 ```csharp
 public Result<Order> Submit(TimeProvider clock)
@@ -1354,7 +1354,7 @@ public Result<Order> Submit(TimeProvider clock)
         .Tap(_ =>
         {
             Status = OrderStatus.Submitted;
-            DomainEvents.Add(new OrderSubmitted(Id, Total, clock.GetUtcNow().UtcDateTime));
+            DomainEvents.Add(new OrderSubmitted(Id, Total, clock.GetUtcNow()));
         });
 }
 ```
@@ -1362,11 +1362,11 @@ public Result<Order> Submit(TimeProvider clock)
 **On the aggregate.** If your aggregate also exposes a public `SubmittedAt` property (e.g., to drive UI sort order or read-model projections), source it from the event timestamp at write time — don't track it independently:
 
 ```csharp
-public DateTime? SubmittedAt { get; private set; }
+public DateTimeOffset? SubmittedAt { get; private set; }
 
 public Result<Order> Submit(TimeProvider clock)
 {
-    var occurredAt = clock.GetUtcNow().UtcDateTime;
+    var occurredAt = clock.GetUtcNow();
     // ... ensure rules ...
     Status = OrderStatus.Submitted;
     SubmittedAt = occurredAt;
@@ -1375,7 +1375,9 @@ public Result<Order> Submit(TimeProvider clock)
 }
 ```
 
-**Why a single timestamp.** Domain events flow into outbox tables, integration buses, audit projections, and event-sourced read models. Every consumer assumes `OccurredAt` is *the* occurrence time. Adding `SubmittedAt`/`ApprovedAt`/`ShippedAt` to individual events forces every consumer to know which field to project per event type — and the two fields can drift if the aggregate's setter and the event constructor are passed different `DateTime.UtcNow` calls.
+**Why a single timestamp.** Domain events flow into outbox tables, integration buses, audit projections, and event-sourced read models. Every consumer assumes `OccurredAt` is *the* occurrence time. Adding `SubmittedAt`/`ApprovedAt`/`ShippedAt` to individual events forces every consumer to know which field to project per event type — and the two fields can drift if the aggregate's setter and the event constructor are passed different `clock.GetUtcNow()` calls.
+
+**Why `DateTimeOffset`.** `OccurredAt` is `DateTimeOffset` (not `DateTime`) so the explicit offset is a part of the value and round-trips unambiguously through serialization. `TimeProvider.GetUtcNow()` returns `DateTimeOffset` directly — events stored in outbox tables, integration buses, and audit projections retain their authored instant without timezone-loss bugs.
 
 **See also.** The XML doc on `IDomainEvent.OccurredAt` (in `Trellis.Core`) calls this out explicitly. If your IDE shows the doc on hover, the rule is right there before you hit the compile error.
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1458,7 +1458,7 @@ public interface IDomainEvent
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `OccurredAt` | `DateTime` | UTC timestamp for when the domain event occurred. |
+| `OccurredAt` | `DateTimeOffset` | Timestamp (with explicit UTC offset) for when the domain event occurred. |
 
 | Signature | Returns | Description |
 | --- | --- | --- |
@@ -2031,7 +2031,7 @@ public sealed class OrderId : ScalarValueObject<OrderId, Guid>, IScalarValue<Ord
             : Result.Fail<OrderId>(Error.UnprocessableContent.ForField(fieldName ?? "orderId", "must_be_guid", "Order ID must be a GUID."));
 }
 
-public sealed record OrderPlaced(OrderId OrderId, DateTime OccurredAt) : IDomainEvent;
+public sealed record OrderPlaced(OrderId OrderId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 public sealed class Order : Aggregate<OrderId>
 {
@@ -2042,7 +2042,7 @@ public sealed class Order : Aggregate<OrderId>
     public static Result<Order> Create(string description)
     {
         var order = new Order(OrderId.Create(Guid.NewGuid()), description);
-        order.DomainEvents.Add(new OrderPlaced(order.Id, DateTime.UtcNow));
+        order.DomainEvents.Add(new OrderPlaced(order.Id, DateTimeOffset.UtcNow));
         return Result.Ok(order);
     }
 }

--- a/docs/docfx_project/articles/aggregate-factory-pattern.md
+++ b/docs/docfx_project/articles/aggregate-factory-pattern.md
@@ -89,7 +89,7 @@ public sealed class Product : Aggregate<ProductId>
     public static Result<Product> TryCreate(ProductName name, Sku sku)
     {
         var product = new Product(ProductId.NewUniqueV7(), name, sku);
-        product.DomainEvents.Add(new ProductCreated(product.Id, DateTime.UtcNow));
+        product.DomainEvents.Add(new ProductCreated(product.Id, DateTimeOffset.UtcNow));
         return Result.Ok(product);
     }
 
@@ -177,7 +177,7 @@ public static Result<Product> TryCreate(ProductName name, Sku sku)
         return Result.Fail<Product>(validation.Error!);
 
     var product = new Product(ProductId.NewUniqueV7(), name, sku);
-    product.DomainEvents.Add(new ProductCreated(product.Id, DateTime.UtcNow));
+    product.DomainEvents.Add(new ProductCreated(product.Id, DateTimeOffset.UtcNow));
     return Result.Ok(product);
 }
 

--- a/docs/docfx_project/articles/aggregate-factory-pattern.md
+++ b/docs/docfx_project/articles/aggregate-factory-pattern.md
@@ -65,7 +65,7 @@ public partial class Sku : RequiredString<Sku> { }
 
 public partial class ProductId : RequiredGuid<ProductId> { }
 
-public sealed record ProductCreated(ProductId ProductId, DateTime OccurredAt) : IDomainEvent;
+public sealed record ProductCreated(ProductId ProductId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 public sealed class Product : Aggregate<ProductId>
 {

--- a/docs/docfx_project/articles/clean-architecture.md
+++ b/docs/docfx_project/articles/clean-architecture.md
@@ -120,7 +120,7 @@ public sealed class User : Aggregate<UserId>
         LastName lastName)
     {
         var user = new User(UserId.NewUniqueV7(), email, firstName, lastName);
-        user.DomainEvents.Add(new UserRegistered(user.Id, DateTime.UtcNow));
+        user.DomainEvents.Add(new UserRegistered(user.Id, DateTimeOffset.UtcNow));
         return Result.Ok(user);
     }
 }
@@ -278,7 +278,7 @@ public sealed class User : Aggregate<UserId>
         LastName lastName)
     {
         var user = new User(UserId.NewUniqueV7(), email, firstName, lastName);
-        user.DomainEvents.Add(new UserRegistered(user.Id, DateTime.UtcNow));
+        user.DomainEvents.Add(new UserRegistered(user.Id, DateTimeOffset.UtcNow));
         return Result.Ok(user);
     }
 

--- a/docs/docfx_project/articles/clean-architecture.md
+++ b/docs/docfx_project/articles/clean-architecture.md
@@ -91,7 +91,7 @@ public partial class LastName : RequiredString<LastName> { }
 
 public sealed record RegisterUserRequest(string Email, string FirstName, string LastName);
 
-public sealed record UserRegistered(UserId UserId, DateTime OccurredAt) : IDomainEvent;
+public sealed record UserRegistered(UserId UserId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 public sealed class User : Aggregate<UserId>
 {
@@ -247,7 +247,7 @@ public sealed record RegisterUserCommand(
                 new RegisterUserCommand(validEmail, validFirstName, validLastName));
 }
 
-public sealed record UserRegistered(UserId UserId, DateTime OccurredAt) : IDomainEvent;
+public sealed record UserRegistered(UserId UserId, DateTimeOffset OccurredAt) : IDomainEvent;
 
 public sealed class User : Aggregate<UserId>
 {


### PR DESCRIPTION
## Summary

**BREAKING:** `IDomainEvent.OccurredAt` is now `DateTimeOffset`, not `DateTime`.

The previous `DateTime` contract relied on convention ('Always use UTC') that the type system could not enforce. `DateTimeOffset` makes the offset an explicit part of the value, round-trips unambiguously through serialization, and pairs cleanly with `TimeProvider.GetUtcNow()`.

This is a v3 redesign clean break — backward compatibility is not required.

## Why

- **JSON round-trip correctness.** `DateTimeOffset` round-trips unambiguously through `System.Text.Json` (`+00:00` form preserved); no `Kind`-loss bugs in outbox tables, integration buses, or audit projections.
- **TimeProvider alignment.** The .NET 8 testable-clock primitive `TimeProvider.GetUtcNow()` returns `DateTimeOffset` directly. Events can now be authored from it without a lossy `.UtcDateTime` conversion.
- **Removes existing friction.** `Examples/Showcase/.../BankAccount.cs` was already using `TimeProvider.GetUtcNow()` and being forced to call `.UtcDateTime` 9 times to satisfy the old contract. All 9 sites now pass the `DateTimeOffset` directly — net diff is **less code** at every event construction site.
- **Honest xmldoc.** The previous xmldoc said 'Always use UTC' — a contract the type couldn't enforce. The new type matches what the doc could only suggest before.

## What this PR does NOT do (honest scope)

C# implicitly converts `DateTime` to `DateTimeOffset`, and a `DateTime` with `Kind=Unspecified` is treated as Local during the conversion. So a caller passing `DateTime.Now` or `new DateTime(...)` will silently produce an event timestamped with the machine's local offset instead of UTC. **The contract does not block this at the type level.**

The xmldoc remarks now explicitly document this caveat and recommend `TimeProvider.GetUtcNow()` / `DateTimeOffset.UtcNow`. A static analyzer to flag `DateTime` sources flowing into `OccurredAt` may follow in a separate PR; it is **not in scope here**.

## TDD evidence

The regression-guard test `DomainEventOccurredAtTypeTests.cs` was authored first and compiled red against the original `DateTime OccurredAt`:

`error CS0738: 'TimestampedEvent.OccurredAt' cannot implement 'IDomainEvent.OccurredAt' because it does not have the matching return type of 'DateTime'`

After the type change: 3/3 lock-in tests pass.

## What changed

| Surface | Change |
|---|---|
| `Trellis.Core/src/DomainDrivenDesign/IDomainEvent.cs` | Type changed; xmldoc rewritten to recommend `TimeProvider.GetUtcNow()` and document the `DateTime`-coercion caveat |
| `Examples/Showcase/.../BankingEvents.cs` | All 8 records: `DateTime` -> `DateTimeOffset` |
| `Examples/Showcase/.../BankAccount.cs` | 9 sites: drop `.UtcDateTime` conversion (Transaction entity calls keep their `DateTime` arg via `.UtcDateTime` since Transaction is not an `IDomainEvent`) |
| `Examples/TestingPatterns/DomainDrivenDesignSamplesTests.cs` | 6 events + 5 construction sites |
| `Trellis.Core/tests/.../AggregateTests.cs` | `TestEvent` record + 1 site |
| `Trellis.Core/tests/.../AggregateJsonSerializationTests.cs` | `JsonTestEvent` record + 1 site |
| `Trellis.Testing/tests/.../FakeRepositoryTests.cs` | `TestEvent` record + 1 site |
| `docs/.../trellis-api-core.md` | IDomainEvent table + `OrderPlaced` sample |
| `docs/.../trellis-api-cookbook.md` | Recipe 17 rewritten end-to-end |
| `docs/.../articles/clean-architecture.md` | `UserRegistered` sample (record signature + 2 construction sites) |
| `docs/.../articles/aggregate-factory-pattern.md` | `ProductCreated` sample (record signature + 2 construction sites) |
| `Trellis.Core/tests/.../DomainEventOccurredAtTypeTests.cs` | **NEW.** 3 regression-guard tests (compile-time type check, JSON offset round-trip, `TimeProvider.GetUtcNow()` direct authoring) |

## Migration

`csharp
// Before
public record OrderShipped(OrderId Id, DateTime OccurredAt) : IDomainEvent;
DomainEvents.Add(new OrderShipped(Id, DateTime.UtcNow));

// After (preferred — testable clock)
public record OrderShipped(OrderId Id, DateTimeOffset OccurredAt) : IDomainEvent;
DomainEvents.Add(new OrderShipped(Id, _clock.GetUtcNow()));

// After (ad-hoc)
DomainEvents.Add(new OrderShipped(Id, DateTimeOffset.UtcNow));

// AVOID — compiles but silently uses the machine's local offset
DomainEvents.Add(new OrderShipped(Id, DateTime.Now));
DomainEvents.Add(new OrderShipped(Id, new DateTime(2026, 1, 1)));
`

## Verification

- **Trellis.Core**: 1784/1784 passing (was 1781 on main; +3 new lock-in tests)
- **Solution-wide** (excluding `Category=Integration`): 4965 passing, 0 failed, 15 skipped
- **Full solution build**: 0 warnings, 0 errors

## Scope of Top-9 #8 (Aggregate mechanics) audit

This PR is the **only** sub-finding from Top-9 #8 that survived the design audit. The other proposals were dropped:

| Sub-finding | Audit verdict |
|---|---|
| `OccurredAt: DateTime -> DateTimeOffset` | ✅ This PR |
| `Aggregate.Version` (CORE-DDD-002) | ❌ Dropped — `ETag` already handles per-aggregate concurrency for HTTP and EF Core; `OccurredAt` handles ordering and audit. `Version` belongs on a future `EventSourcedAggregate<TId>` if/when Trellis ships event sourcing as a separate package — not on the base CRUD-DDD aggregate |
| `RaiseEvent(@event)` affordance (CORE-DDD-001) | ❌ Dropped — the C# language already binds the verb 'raise' to a specific behavior (`event` keyword + `Raise()` pattern means *invoke subscribed handlers synchronously*). A method named `RaiseEvent` that just appends to a list would lie about what it does — a unit test calling it would expect side effects that don't happen. `DomainEvents.Add(...)` is honest about being a list append. If/when Trellis ships a real synchronous event dispatcher, `RaiseEvent` becomes truthful and we add it then |
| `Guid EventId` on `IDomainEvent` (CORE-DDD-003) | ❌ Dropped — every claimed use case (handler idempotency, outbox PK, replay debugging) requires a consumer that Trellis doesn't ship today. Adding it speculatively means every event-definition site pays boilerplate cost forever for a feature that may never be used. The right place is in the future event-dispatcher / outbox / event-store feature itself, where the actual consumer can drive the design |