### PR TITLE
ci(codeql): drop per-PR runs, keep main + weekly schedule + workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,13 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+  # CodeQL is intentionally NOT run on every pull_request. Empirically the
+  # repository has produced zero CodeQL findings to date — the framework's
+  # security signal comes from Roslyn analyzers, the custom Trellis.Analyzers
+  # set (TRLS001-022), and the test suite. Per-PR CodeQL runs cost ~9 minutes
+  # of CI compute with no measured value for a library codebase. Drift
+  # detection is preserved by the push-to-main run and the weekly schedule
+  # below; ad-hoc runs remain available via workflow_dispatch.
   schedule:
     - cron: '43 23 * * 4'
 


### PR DESCRIPTION
## Summary

Removes the per-PR CodeQL trigger from `.github/workflows/codeql.yml`. Keeps the push-to-main, weekly cron, and `workflow_dispatch` triggers.

## Why

CodeQL has produced **zero findings** on this repository to date. Verified empirically:

```bash
$ gh api repos/xavierjohn/Trellis/code-scanning/alerts
[]
```

For a library codebase like Trellis, this is the expected outcome: CodeQL's strongest queries (SQL/command/path injection, XSS/CSRF, insecure deserialization, hardcoded credentials, crypto misuse) target code that processes untrusted input directly. Trellis is a framework — it doesn't build SQL, render HTML, deserialize untrusted payloads, or handle authentication flows. Those concerns live in the consumer's application, where CodeQL is genuinely valuable.

The framework's actual security signal comes from a stack that **does** catch real issues:

- Roslyn analyzers (`NetAnalyzers`, `IL2026`/`IL3050` trim/AOT diagnostics)
- The custom `Trellis.Analyzers` set (`TRLS001–022`) that codify Result/Maybe/DDD idiom violations
- The test suite (5,091 tests covering algebraic correctness)
- `Microsoft.VisualStudio.Threading.Analyzers` for async correctness

Per-PR CodeQL has been costing ~9 minutes of CI compute per run with a measured finding rate of 0/all-time. That's pure overhead on the PR critical path.

## What's preserved

- **`push: branches: [main]`** — drift detection at merge-time. If a future contributor introduces SQL string concatenation, a `Process.Start` from user input, or a hardcoded credential, CodeQL still catches it on the next push to `main`.
- **`schedule: cron '43 23 * * 4'`** — weekly Thursday-night sweep against `main`.
- **`workflow_dispatch`** — ad-hoc runs available for any branch on demand (Actions UI → CodeQL → "Run workflow" → pick branch).

## What's removed

Just the `pull_request: branches: [main]` trigger.

## Net impact

| Property | Before | After |
|---|---|---|
| Drift regression detection | per-PR + on-merge + weekly | on-merge + weekly |
| CI minutes per PR | +~9 min | 0 (CodeQL skipped) |
| Finding rate (empirical) | 0/all-time | 0/all-time |
| Ad-hoc scan available | yes (workflow_dispatch) | yes (workflow_dispatch) |

## Validation

YAML parses cleanly via `ConvertFrom-Yaml` — confirmed remaining triggers are exactly `[push, schedule, workflow_dispatch]`.

## Reversibility

If this change turns out to mis-incentivize PR security review or causes a regression that gets caught only at merge-time (when it's harder to fix), reverting is a one-line restore of the `pull_request:` block.
