### PR TITLE
Fix Trellis.Asp composition bugs (#42 AddTrellisAsp; #36 actor providers)

### DIFF
--- a/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
@@ -170,7 +170,11 @@ public static class ServiceCollectionExtensions
         where T : class, IActorProvider
     {
         services.AddHttpContextAccessor();
-        services.AddScoped<T>();
+        // TryAddScoped (not AddScoped): repeated AddCachingActorProvider<T>() calls
+        // (e.g. library + application) must not accumulate duplicate scoped descriptors
+        // for the inner provider type. The IActorProvider slot is already idempotent via
+        // the Replace below.
+        services.TryAddScoped<T>();
         services.Replace(ServiceDescriptor.Scoped<IActorProvider>(sp =>
             new CachingActorProvider(
                 sp.GetRequiredService<T>(),

--- a/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
@@ -21,6 +21,11 @@ public static class ServiceCollectionExtensions
     /// <see cref="ClaimsActorOptions.PermissionsClaim"/> to match your token format.
     /// </param>
     /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <b>Replaces</b> any prior <see cref="IActorProvider"/> registration — actor-provider
+    /// helpers do not stack. Pick one provider per environment (or wrap an inner provider
+    /// with <see cref="AddCachingActorProvider{T}"/>); the last <c>AddXxxActorProvider</c> call wins.
+    /// </remarks>
     /// <example>
     /// <code>
     /// // Auth0
@@ -69,6 +74,12 @@ public static class ServiceCollectionExtensions
     /// <see cref="EntraActorOptions.MapAttributes"/> to add custom ABAC attributes.
     /// </param>
     /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <b>Replaces</b> any prior <see cref="IActorProvider"/> registration — actor-provider
+    /// helpers do not stack. Pick one provider per environment (or wrap with
+    /// <see cref="AddCachingActorProvider{T}"/> using <c>EntraActorProvider</c> as the inner type);
+    /// the last <c>AddXxxActorProvider</c> call wins.
+    /// </remarks>
     /// <example>
     /// <code>
     /// builder.Services.AddEntraActorProvider(options =>
@@ -116,6 +127,11 @@ public static class ServiceCollectionExtensions
     /// <c>X-Test-Actor</c> header is present on the request. Use <see cref="AddEntraActorProvider"/>
     /// for production deployments.
     /// </para>
+    /// <para>
+    /// <b>Replaces</b> any prior <see cref="IActorProvider"/> registration — actor-provider
+    /// helpers do not stack. Pick one provider per environment; the last
+    /// <c>AddXxxActorProvider</c> call wins.
+    /// </para>
     /// </remarks>
     /// <example>
     /// <code>
@@ -160,10 +176,37 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="T">The concrete <see cref="IActorProvider"/> implementation to cache.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// <b>Replaces</b> the <see cref="IActorProvider"/> slot with the caching wrapper. The inner
+    /// type <typeparamref name="T"/> is registered via <c>TryAddScoped&lt;T&gt;()</c>, so repeated
+    /// calls do not accumulate inner-provider descriptors.
+    /// </para>
+    /// <para>
+    /// <b>Inner-provider dependencies are NOT auto-registered.</b> This helper only adds
+    /// <typeparamref name="T"/> itself and <c>IHttpContextAccessor</c>. If <typeparamref name="T"/>
+    /// is one of the built-in providers (<see cref="EntraActorProvider"/>,
+    /// <see cref="ClaimsActorProvider"/>) or a subclass thereof, you must first call the matching
+    /// <c>AddXxxActorProvider(...)</c> helper so its <c>IOptions&lt;TOptions&gt;</c> is configured.
+    /// The matching helper's <c>Replace</c> on the <see cref="IActorProvider"/> slot is then
+    /// overwritten by this caching wrap — that is the intended composition order.
+    /// </para>
+    /// </remarks>
     /// <example>
     /// <code>
-    /// // Wrap a DB-backed provider that resolves permissions from a database
+    /// // Pattern B(i): Custom provider with no Trellis-managed options dependencies.
     /// services.AddCachingActorProvider&lt;DatabaseActorProvider&gt;();
+    ///
+    /// // Pattern B(ii): Built-in provider — register the inner provider's options
+    /// // helper FIRST so IOptions&lt;EntraActorOptions&gt; is configured, then wrap.
+    /// services.AddEntraActorProvider(o => o.MapPermissions = ...);
+    /// services.AddCachingActorProvider&lt;EntraActorProvider&gt;();
+    ///
+    /// // Pattern B(iii): Subclass of ClaimsActorProvider (e.g. KeycloakActorProvider).
+    /// // Inner subclass shares ClaimsActorOptions, so AddClaimsActorProvider(...)
+    /// // configures IOptions&lt;ClaimsActorOptions&gt; for the subclass too.
+    /// services.AddClaimsActorProvider(o => o.ActorIdClaim = "sub");
+    /// services.AddCachingActorProvider&lt;KeycloakActorProvider&gt;();
     /// </code>
     /// </example>
     public static IServiceCollection AddCachingActorProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services)

--- a/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Trellis.Authorization;
 
 /// <summary>
@@ -48,7 +49,10 @@ public static class ServiceCollectionExtensions
         else
             services.Configure<ClaimsActorOptions>(_ => { });
 
-        services.AddScoped<IActorProvider, ClaimsActorProvider>();
+        // Replace (not append): each AddXxxActorProvider helper claims the IActorProvider
+        // slot. Without Replace, calling two helpers leaves two descriptors and
+        // GetServices<IActorProvider>() returns both — order-dependent and surprising.
+        services.Replace(ServiceDescriptor.Scoped<IActorProvider, ClaimsActorProvider>());
 
         return services;
     }
@@ -87,7 +91,7 @@ public static class ServiceCollectionExtensions
         else
             services.Configure<EntraActorOptions>(_ => { });
 
-        services.AddScoped<IActorProvider, EntraActorProvider>();
+        services.Replace(ServiceDescriptor.Scoped<IActorProvider, EntraActorProvider>());
 
         return services;
     }
@@ -143,7 +147,7 @@ public static class ServiceCollectionExtensions
         else
             services.Configure<DevelopmentActorOptions>(_ => { });
 
-        services.AddScoped<IActorProvider, DevelopmentActorProvider>();
+        services.Replace(ServiceDescriptor.Scoped<IActorProvider, DevelopmentActorProvider>());
 
         return services;
     }
@@ -167,10 +171,10 @@ public static class ServiceCollectionExtensions
     {
         services.AddHttpContextAccessor();
         services.AddScoped<T>();
-        services.AddScoped<IActorProvider>(sp =>
+        services.Replace(ServiceDescriptor.Scoped<IActorProvider>(sp =>
             new CachingActorProvider(
                 sp.GetRequiredService<T>(),
-                sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>()));
+                sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>())));
 
         return services;
     }

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -500,11 +500,17 @@ public static class ServiceCollectionExtensions
         // Compose configuration via IConfigureOptions<TrellisAspOptions>: multiple
         // AddTrellisAsp(o => ...) calls (e.g. library + application) all run against
         // the same options instance built lazily by OptionsFactory<TrellisAspOptions>.
-        // Resolution remains via GetService<TrellisAspOptions>() through a single
-        // TryAddSingleton that materializes from IOptions<TrellisAspOptions>.Value.
+        // Resolution remains via GetService<TrellisAspOptions>() through a singleton
+        // bridge that materializes from IOptions<TrellisAspOptions>.Value.
+        //
+        // Replace (not TryAdd): AddTrellisAsp claims the TrellisAspOptions slot. Without
+        // Replace, a host's pre-registered TrellisAspOptions instance would silently mask
+        // every Configure delegate registered here, so MapError overrides would never
+        // reach the resolved options. Hosts customize via the configure action, not via
+        // raw AddSingleton(new TrellisAspOptions()).
         services.Configure(configure);
-        services.TryAddSingleton<TrellisAspOptions>(sp =>
-            sp.GetRequiredService<IOptions<TrellisAspOptions>>().Value);
+        services.Replace(ServiceDescriptor.Singleton<TrellisAspOptions>(sp =>
+            sp.GetRequiredService<IOptions<TrellisAspOptions>>().Value));
 
         // auto-register VO binding / JSON converter infrastructure.
         // Idempotent: configures both MVC and Minimal API JSON pipelines for ScalarValue/Maybe support.

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -484,6 +484,21 @@ public static class ServiceCollectionExtensions
     /// Default mappings are applied first. The <paramref name="configure"/> action can override
     /// any mapping using <see cref="TrellisAspOptions.MapError{TError}"/>.
     /// </para>
+    /// <para>
+    /// <b>Composition:</b> multiple <c>AddTrellisAsp(...)</c> calls compose. Each call's
+    /// <paramref name="configure"/> delegate runs (in registration order) against the same
+    /// <see cref="TrellisAspOptions"/> instance materialized by
+    /// <c>OptionsFactory&lt;TrellisAspOptions&gt;</c>, so mappings for distinct
+    /// <c>TError</c> types from earlier calls survive. Mappings for the same
+    /// <c>TError</c> follow last-wins.
+    /// </para>
+    /// <para>
+    /// <b>Slot ownership:</b> <c>AddTrellisAsp</c> owns the <see cref="TrellisAspOptions"/>
+    /// service descriptor and replaces any existing one with a bridge factory that resolves
+    /// from <c>IOptions&lt;TrellisAspOptions&gt;.Value</c>. Hosts must customize via this
+    /// <paramref name="configure"/> action; raw <c>services.AddSingleton(new TrellisAspOptions())</c>
+    /// is unsupported and will be silently overwritten the next time <c>AddTrellisAsp</c> runs.
+    /// </para>
     /// </remarks>
     /// <example>
     /// <code>

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Trellis;
 using Trellis.Asp.ModelBinding;
 using Trellis.Asp.Validation;
@@ -494,9 +496,15 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTrellisAsp(this IServiceCollection services, Action<TrellisAspOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
-        var options = new TrellisAspOptions();
-        configure(options);
-        services.AddSingleton(options);
+
+        // Compose configuration via IConfigureOptions<TrellisAspOptions>: multiple
+        // AddTrellisAsp(o => ...) calls (e.g. library + application) all run against
+        // the same options instance built lazily by OptionsFactory<TrellisAspOptions>.
+        // Resolution remains via GetService<TrellisAspOptions>() through a single
+        // TryAddSingleton that materializes from IOptions<TrellisAspOptions>.Value.
+        services.Configure(configure);
+        services.TryAddSingleton<TrellisAspOptions>(sp =>
+            sp.GetRequiredService<IOptions<TrellisAspOptions>>().Value);
 
         // auto-register VO binding / JSON converter infrastructure.
         // Idempotent: configures both MVC and Minimal API JSON pipelines for ScalarValue/Maybe support.

--- a/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
@@ -208,6 +208,23 @@ public class ServiceCollectionExtensionsTests
         descriptor.ImplementationType.Should().Be<ClaimsActorProvider>();
     }
 
+    [Fact]
+    public void AddCachingActorProvider_called_twice_does_not_accumulate_inner_T_descriptors()
+    {
+        // Composition contract: a library and an app must each be safe to call
+        // AddCachingActorProvider<X>() without accumulating duplicate inner-T scoped
+        // descriptors. Without TryAddScoped, GetServices<X>()/IEnumerable<X> would
+        // expose multiple instances even though IActorProvider (replaced) does not.
+        var services = new ServiceCollection();
+
+        services.AddCachingActorProvider<FakeActorProvider>();
+        services.AddCachingActorProvider<FakeActorProvider>();
+
+        services
+            .Where(d => d.ServiceType == typeof(FakeActorProvider))
+            .Should().HaveCount(1, "AddCachingActorProvider must not accumulate duplicate inner-T descriptors");
+    }
+
     private sealed class FakeActorProvider : IActorProvider
     {
         public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>

--- a/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
@@ -138,6 +138,76 @@ public class ServiceCollectionExtensionsTests
         descriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
     }
 
+    [Fact]
+    public void AddClaimsActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor()
+    {
+        // Composition contract: each AddXxxActorProvider helper REPLACES the IActorProvider
+        // registration rather than appending. Without this, two helpers leave two descriptors:
+        // GetRequiredService<IActorProvider>() silently returns the last-registered one but
+        // GetServices<IActorProvider>() exposes both, and the call ordering is invisible to
+        // consumers reading composition root code. Replace makes intent explicit.
+        var services = new ServiceCollection();
+        services.AddEntraActorProvider();
+        services.AddClaimsActorProvider();
+
+        var actorProviders = services
+            .Where(d => d.ServiceType == typeof(IActorProvider))
+            .ToList();
+        actorProviders.Should().HaveCount(1, "AddXxxActorProvider must Replace, not append");
+    }
+
+    [Fact]
+    public void AddEntraActorProvider_after_AddClaimsActorProvider_leaves_single_IActorProvider_descriptor()
+    {
+        var services = new ServiceCollection();
+        services.AddClaimsActorProvider();
+        services.AddEntraActorProvider();
+
+        services
+            .Where(d => d.ServiceType == typeof(IActorProvider))
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddDevelopmentActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor()
+    {
+        var services = new ServiceCollection();
+        services.AddEntraActorProvider();
+        services.AddDevelopmentActorProvider();
+
+        services
+            .Where(d => d.ServiceType == typeof(IActorProvider))
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddCachingActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor()
+    {
+        var services = new ServiceCollection();
+        services.AddEntraActorProvider();
+        services.AddCachingActorProvider<FakeActorProvider>();
+
+        services
+            .Where(d => d.ServiceType == typeof(IActorProvider))
+            .Should().HaveCount(1, "AddCachingActorProvider must also Replace the IActorProvider registration");
+    }
+
+    [Fact]
+    public void Last_AddXxxActorProvider_wins_after_replacement()
+    {
+        // After Replace, the resolved IActorProvider must be the LAST registered.
+        // (Same observable last-wins outcome, but achieved via explicit replacement
+        // instead of relying on resolution-order semantics over multiple descriptors.)
+        // Asserts via descriptor introspection to keep the test isolated from each
+        // provider's full constructor dependency graph (e.g. IHostEnvironment).
+        var services = new ServiceCollection();
+        services.AddEntraActorProvider();
+        services.AddClaimsActorProvider();
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IActorProvider));
+        descriptor.ImplementationType.Should().Be<ClaimsActorProvider>();
+    }
+
     private sealed class FakeActorProvider : IActorProvider
     {
         public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>

--- a/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
@@ -193,13 +193,13 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void Last_AddXxxActorProvider_wins_after_replacement()
+    public void AddClaimsActorProvider_after_AddEntraActorProvider_leaves_ClaimsActorProvider_as_implementation_type()
     {
-        // After Replace, the resolved IActorProvider must be the LAST registered.
-        // (Same observable last-wins outcome, but achieved via explicit replacement
-        // instead of relying on resolution-order semantics over multiple descriptors.)
-        // Asserts via descriptor introspection to keep the test isolated from each
-        // provider's full constructor dependency graph (e.g. IHostEnvironment).
+        // After Replace, the resolved IActorProvider must be the LAST helper's
+        // concrete type. Same observable last-wins outcome as before, but achieved
+        // via explicit replacement instead of resolution-order semantics over
+        // multiple descriptors. Asserts via descriptor introspection to keep the
+        // test isolated from each provider's full constructor dependency graph.
         var services = new ServiceCollection();
         services.AddEntraActorProvider();
         services.AddClaimsActorProvider();

--- a/Trellis.Asp/tests/TrellisAspOptionsTests.cs
+++ b/Trellis.Asp/tests/TrellisAspOptionsTests.cs
@@ -258,6 +258,60 @@ public class TrellisAspOptionsTests
     }
 
     [Fact]
+    public void AddTrellisAsp_called_twice_composes_configuration_delegates()
+    {
+        // Composition contract: when a library calls AddTrellisAsp(o => ...) and then the
+        // application also calls AddTrellisAsp(o => ...), BOTH MapError overrides must survive
+        // on the resolved instance. Last-wins (AddSingleton(options)) silently dropped the
+        // first call's mappings, surprising hosts that compose Trellis with their own libraries.
+        var services = new ServiceCollection();
+        services.AddTrellisAsp(o => o.MapError<Error.Conflict>(StatusCodes.Status400BadRequest));
+        services.AddTrellisAsp(o => o.MapError<Error.PreconditionFailed>(StatusCodes.Status418ImATeapot));
+
+        var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<TrellisAspOptions>();
+
+        resolved
+            .GetStatusCode(new Error.Conflict(null, "k") { Detail = "x" })
+            .Should().Be(StatusCodes.Status400BadRequest, "first AddTrellisAsp call's MapError must survive composition");
+        resolved
+            .GetStatusCode(new Error.PreconditionFailed(new ResourceRef("R", null), PreconditionKind.IfMatch) { Detail = "x" })
+            .Should().Be(StatusCodes.Status418ImATeapot, "second AddTrellisAsp call's MapError must survive composition");
+    }
+
+    [Fact]
+    public void AddTrellisAsp_called_twice_still_registers_only_one_TrellisAspOptions_descriptor()
+    {
+        // Even when AddTrellisAsp is called multiple times, exactly one descriptor of
+        // ServiceType = typeof(TrellisAspOptions) must exist so the resolved instance is
+        // unambiguous. Composition happens via IConfigureOptions<TrellisAspOptions>, which
+        // is a different ServiceType.
+        var services = new ServiceCollection();
+        services.AddTrellisAsp(o => o.MapError<Error.Conflict>(StatusCodes.Status400BadRequest));
+        services.AddTrellisAsp(o => o.MapError<Error.PreconditionFailed>(StatusCodes.Status418ImATeapot));
+
+        services.Should().ContainSingle(d => d.ServiceType == typeof(TrellisAspOptions));
+    }
+
+    [Fact]
+    public void AddTrellisAsp_called_twice_last_wins_for_same_TError_mapping()
+    {
+        // Composition is order-preserving. When two AddTrellisAsp calls map the SAME error
+        // type to different status codes, the later call wins (standard IConfigureOptions
+        // semantics — delegates run in registration order on the same instance).
+        var services = new ServiceCollection();
+        services.AddTrellisAsp(o => o.MapError<Error.Conflict>(StatusCodes.Status400BadRequest));
+        services.AddTrellisAsp(o => o.MapError<Error.Conflict>(StatusCodes.Status418ImATeapot));
+
+        var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<TrellisAspOptions>();
+
+        resolved
+            .GetStatusCode(new Error.Conflict(null, "k") { Detail = "x" })
+            .Should().Be(StatusCodes.Status418ImATeapot);
+    }
+
+    [Fact]
     public async Task ResultExecuteAsync_uses_TrellisAspOptions_resolved_from_request_services()
     {
         // ga-09 contract: error → status mapping flows through DI, not ambient static state.

--- a/Trellis.Asp/tests/TrellisAspOptionsTests.cs
+++ b/Trellis.Asp/tests/TrellisAspOptionsTests.cs
@@ -312,6 +312,26 @@ public class TrellisAspOptionsTests
     }
 
     [Fact]
+    public void AddTrellisAsp_after_pre_registered_TrellisAspOptions_singleton_applies_configure_delegates()
+    {
+        // PR #453 review (Finding 3): hosts that pre-register their own TrellisAspOptions
+        // (documented as "hosts that want a different default must register their own")
+        // must not silently mask the Configure delegates registered by AddTrellisAsp.
+        // AddTrellisAsp owns the TrellisAspOptions slot — it must Replace, not TryAdd.
+        var services = new ServiceCollection();
+        services.AddSingleton(new TrellisAspOptions());
+
+        services.AddTrellisAsp(o => o.MapError<Error.Conflict>(StatusCodes.Status418ImATeapot));
+
+        var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<TrellisAspOptions>();
+
+        resolved
+            .GetStatusCode(new Error.Conflict(null, "k") { Detail = "x" })
+            .Should().Be(StatusCodes.Status418ImATeapot, "AddTrellisAsp must claim the TrellisAspOptions slot so its Configure delegates run, even when a host pre-registered the type");
+    }
+
+    [Fact]
     public async Task ResultExecuteAsync_uses_TrellisAspOptions_resolved_from_request_services()
     {
         // ga-09 contract: error → status mapping flows through DI, not ambient static state.

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -851,25 +851,15 @@ return result.ToHttpResponse(opts => opts
 
 ### Actor providers
 
+`AddXxxActorProvider` helpers all `Replace` the `IActorProvider` slot — only the **last** call wins. The two clean composition patterns:
+
+**Pattern A — select one provider per environment:**
+
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
 
 var services = new ServiceCollection();
-
-services.AddClaimsActorProvider(opts =>
-{
-    opts.ActorIdClaim = "sub";
-    opts.PermissionsClaim = "permissions";
-});
-
-services.AddEntraActorProvider(opts =>
-{
-    opts.MapPermissions = claims => claims
-        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
-        .Select(c => c.Value)
-        .ToHashSet();
-});
 
 if (env.IsDevelopment())
 {
@@ -879,9 +869,30 @@ if (env.IsDevelopment())
         opts.DefaultPermissions = new HashSet<string> { "orders:read", "orders:create" };
     });
 }
+else
+{
+    services.AddEntraActorProvider(opts =>
+    {
+        opts.MapPermissions = claims => claims
+            .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value)
+            .ToHashSet();
+    });
+}
+```
 
+**Pattern B — wrap the chosen inner provider with caching:**
+
+```csharp
+// First register the inner provider, then wrap with caching.
+// Each AddCachingActorProvider<T>() call replaces the IActorProvider slot
+// with CachingActorProvider over T. The inner T is registered idempotently
+// via TryAddScoped<T>() so library + application calls do not duplicate.
+services.AddEntraActorProvider(opts => { /* ... */ });
 services.AddCachingActorProvider<EntraActorProvider>();
 ```
+
+Do **not** chain multiple `AddXxxActorProvider` calls expecting them to coexist or fall back — the last one always wins. If you need different providers in different environments, branch the registration code as in Pattern A.
 
 ### Route constraints for scalar value objects
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -374,7 +374,7 @@ The main DI surface for `Trellis.Asp` (in folder `Extensions/`).
 | `public static IServiceCollection AddScalarValueValidationForMinimalApi(this IServiceCollection services)` | `IServiceCollection` | Configures only the Minimal API JSON pipeline. |
 | `public static RouteHandlerBuilder WithScalarValueValidation(this RouteHandlerBuilder builder)` | `RouteHandlerBuilder` | Adds `ScalarValueValidationEndpointFilter` to the route handler. |
 | `public static IServiceCollection AddTrellisAsp(this IServiceCollection services)` | `IServiceCollection` | Registers `TrellisAspOptions` with default error mappings, then calls `AddScalarValueValidation()`. |
-| `public static IServiceCollection AddTrellisAsp(this IServiceCollection services, Action<TrellisAspOptions> configure)` | `IServiceCollection` | Same as above, with a `MapError<TError>(...)` callback for overrides. |
+| `public static IServiceCollection AddTrellisAsp(this IServiceCollection services, Action<TrellisAspOptions> configure)` | `IServiceCollection` | Same as above, with a `MapError<TError>(...)` callback for overrides. **Calls compose** — when `AddTrellisAsp(o => ...)` is invoked more than once (e.g. by a library and the application), every `configure` delegate runs in registration order against the same `TrellisAspOptions` instance built lazily by `OptionsFactory<TrellisAspOptions>`. Same-`TError` mappings still follow last-wins, but mappings for different error types from earlier calls are preserved. |
 
 ### Namespace `Trellis.Asp.Authorization`
 
@@ -390,10 +390,18 @@ public static class ServiceCollectionExtensions
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static IServiceCollection AddClaimsActorProvider(this IServiceCollection services, Action<ClaimsActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor`, configures `ClaimsActorOptions`, and registers `IActorProvider` as a scoped `ClaimsActorProvider`. |
-| `public static IServiceCollection AddEntraActorProvider(this IServiceCollection services, Action<EntraActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor`, configures `EntraActorOptions`, and registers `IActorProvider` as a scoped `EntraActorProvider`. |
-| `public static IServiceCollection AddDevelopmentActorProvider(this IServiceCollection services, Action<DevelopmentActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor` + logging, configures `DevelopmentActorOptions`, and registers `IActorProvider` as a scoped `DevelopmentActorProvider`. The provider itself throws outside the Development environment. |
-| `public static IServiceCollection AddCachingActorProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IActorProvider` | `IServiceCollection` | Registers concrete provider `T` as scoped, then wraps it with `CachingActorProvider` as the scoped `IActorProvider`. |
+| `public static IServiceCollection AddClaimsActorProvider(this IServiceCollection services, Action<ClaimsActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor`, configures `ClaimsActorOptions`, and **replaces** the `IActorProvider` registration with a scoped `ClaimsActorProvider`. |
+| `public static IServiceCollection AddEntraActorProvider(this IServiceCollection services, Action<EntraActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor`, configures `EntraActorOptions`, and **replaces** the `IActorProvider` registration with a scoped `EntraActorProvider`. |
+| `public static IServiceCollection AddDevelopmentActorProvider(this IServiceCollection services, Action<DevelopmentActorOptions>? configure = null)` | `IServiceCollection` | Adds `IHttpContextAccessor` + logging, configures `DevelopmentActorOptions`, and **replaces** the `IActorProvider` registration with a scoped `DevelopmentActorProvider`. The provider itself throws outside the Development environment. |
+| `public static IServiceCollection AddCachingActorProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IActorProvider` | `IServiceCollection` | Registers concrete provider `T` as scoped, then **replaces** the `IActorProvider` registration with a scoped `CachingActorProvider` wrapping `T`. |
+
+> **Replacement semantics.** Each `AddXxxActorProvider` helper calls
+> `services.Replace(...)` for the `IActorProvider` slot. Calling more than one
+> helper leaves exactly one `IActorProvider` descriptor — the last one wins —
+> and `GetServices<IActorProvider>()` returns a single provider. Without
+> `Replace`, two helpers would leave two scoped descriptors with surprising
+> resolution semantics (single resolve picks the last; enumeration exposes
+> both).
 
 ### `ClaimsActorOptions`
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -158,7 +158,7 @@ Configuration registered via `AddTrellisAsp(...)` that maps domain `Error` types
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `SystemDefault` | `static TrellisAspOptions` (internal) | Read-only default instance used when DI cannot resolve a configured `TrellisAspOptions` (e.g. the host did not call `AddTrellisAsp`). Internal — not callable from user code; hosts that want a different default must register their own. |
+| `SystemDefault` | `static TrellisAspOptions` (internal) | Read-only default instance used when DI cannot resolve a configured `TrellisAspOptions` (e.g. the host did not call `AddTrellisAsp`). Internal — not callable from user code. Hosts customize the mappings by passing a configure delegate to `AddTrellisAsp(o => o.MapError<...>(...))`; raw `AddSingleton(new TrellisAspOptions())` is unsupported and will be replaced by the bridge factory the next time `AddTrellisAsp` runs. |
 
 | Signature | Returns | Description |
 | --- | --- | --- |

--- a/docs/docfx_project/articles/examples.md
+++ b/docs/docfx_project/articles/examples.md
@@ -33,7 +33,7 @@ The repository includes full examples you can browse after these snippets click:
 
 - [`Showcase`](https://github.com/xavierjohn/Trellis/tree/main/Examples/Showcase) — one banking domain hosted twice (MVC + Minimal API) with full Result/Error walkthrough, `TimeProvider`, lifecycle state machine, and integration tests for both hosting styles.
 - [`ConditionalRequestExample`](https://github.com/xavierjohn/Trellis/tree/main/Examples/ConditionalRequestExample) — RFC 9110 conditional requests (`If-Match` / `If-None-Match`) with strong ETags.
-- [`SsoExample`](https://github.com/xavierjohn/Trellis/tree/main/Examples/SsoExample) — `AddDevelopmentActorProvider()` and `AddClaimsActorProvider()` wired side-by-side.
+- [`SsoExample`](https://github.com/xavierjohn/Trellis/tree/main/Examples/SsoExample) — `AddDevelopmentActorProvider()` in Development, JWT bearer + `AddClaimsActorProvider()` otherwise (single-provider-per-environment pattern; `AddXxxActorProvider` helpers Replace the `IActorProvider` slot and do not stack).
 - [`EfCoreExample`](https://github.com/xavierjohn/Trellis/tree/main/Examples/EfCoreExample) — VO ID conversions, automatic timestamps, value-object composition over `DbContext`.
 - [`TestingPatterns`](https://github.com/xavierjohn/Trellis/tree/main/Examples/TestingPatterns) — async, parallel, `Maybe`, `EquatableArray`, and validating-by-result patterns.
 

--- a/docs/docfx_project/articles/integration-aspnet.md
+++ b/docs/docfx_project/articles/integration-aspnet.md
@@ -482,22 +482,10 @@ app.MapGet("/products/{id:ProductId}", (ProductId id) => Results.Ok(id));
 
 `Trellis.Asp.Authorization` hydrates the current `Actor` from JWT/OIDC claims. The `Actor` and `IActorProvider` types themselves live in `Trellis.Authorization`.
 
+Each `AddXxxActorProvider` helper **replaces** the `IActorProvider` slot — chaining multiple helpers does not stack them. Pick one provider per environment, then optionally wrap with caching:
+
 ```csharp
 using Trellis.Asp.Authorization;
-
-services.AddClaimsActorProvider(opts =>
-{
-    opts.ActorIdClaim = "sub";
-    opts.PermissionsClaim = "permissions";
-});
-
-services.AddEntraActorProvider(opts =>
-{
-    opts.MapPermissions = claims => claims
-        .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
-        .Select(c => c.Value)
-        .ToHashSet();
-});
 
 if (env.IsDevelopment())
 {
@@ -507,9 +495,21 @@ if (env.IsDevelopment())
         opts.DefaultPermissions = new HashSet<string> { "orders:read", "orders:create" };
     });
 }
+else
+{
+    services.AddEntraActorProvider(opts =>
+    {
+        opts.MapPermissions = claims => claims
+            .Where(c => string.Equals(c.Type, "roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value)
+            .ToHashSet();
+    });
 
-// Wraps the previously registered IActorProvider with per-request caching:
-services.AddCachingActorProvider<EntraActorProvider>();
+    // Wraps EntraActorProvider with per-request caching. The inner provider type is
+    // registered idempotently via TryAddScoped<T>(); the outer IActorProvider slot
+    // is replaced with the caching decorator.
+    services.AddCachingActorProvider<EntraActorProvider>();
+}
 ```
 
 `DevelopmentActorProvider` throws `InvalidOperationException` outside the Development environment regardless of header presence; in Development it reads the `X-Test-Actor` header (JSON: `{ "Id", "Permissions", "ForbiddenPermissions", "Attributes" }`, case-insensitive). See [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md) for `WebApplicationFactory.CreateClientWithActor`.

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -16,7 +16,7 @@ audience: [developer]
 |---|---|---|
 | Validate Entra ID v2.0 tokens and project them onto an `Actor` | `AddJwtBearer` + `AddEntraActorProvider(options?)` | [Entra ID provider](#entra-id-provider) |
 | Validate any flat-claim OIDC token (Auth0, Okta, Google) | `AddJwtBearer` + `AddClaimsActorProvider(options?)` | [Generic OIDC provider](#generic-oidc-provider) |
-| Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddCachingActorProvider<T>()` | [Nested-claim providers](#nested-claim-providers) |
+| Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddClaimsActorProvider(opts?)` for options + `AddCachingActorProvider<T>()` for the wrap | [Nested-claim providers](#nested-claim-providers) |
 | Use `roles` for app permissions (Entra app roles) | Default `EntraActorOptions.MapPermissions` | [Claim mapping](#claim-mapping) |
 | Use delegated scopes (`scp`) for permissions | Override `EntraActorOptions.MapPermissions` | [Scope and permission extraction](#scope-and-permission-extraction) |
 | Accept multi-tenant Entra tokens and pin allowed tenants | `JwtBearerOptions.TokenValidationParameters` + read `ActorAttributes.TenantId` | [Multi-tenant Entra](#multi-tenant-entra) |
@@ -238,10 +238,16 @@ public sealed class KeycloakActorProvider(
     }
 }
 
+// Register IOptions<ClaimsActorOptions> first (the subclass shares the base
+// options type), then wrap with the caching helper. AddClaimsActorProvider
+// initially Replaces IActorProvider with ClaimsActorProvider; the subsequent
+// AddCachingActorProvider then Replaces it again with CachingActorProvider
+// wrapping KeycloakActorProvider — that final composition is the one resolved.
+services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
 services.AddCachingActorProvider<KeycloakActorProvider>();
 ```
 
-`AddCachingActorProvider<T>` registers `T` as scoped and wraps it with `CachingActorProvider`, so the JSON parse runs once per request even if multiple handlers ask for the actor.
+`AddClaimsActorProvider(...)` configures `IOptions<ClaimsActorOptions>` (which `KeycloakActorProvider` consumes through its base constructor). `AddCachingActorProvider<T>` then registers `T` as scoped via `TryAddScoped` and wraps it with `CachingActorProvider`, so the JSON parse runs once per request even if multiple handlers ask for the actor. Because every `AddXxxActorProvider` Replaces the `IActorProvider` slot, the order matters: register the inner-provider's options helper first, then wrap.
 
 ## JWT validation options
 


### PR DESCRIPTION
## Summary

Fixes two composition-root bugs in `Trellis.Asp` registration helpers that silently surprise hosts when called more than once.

### #42 — `AddTrellisAsp` configuration calls now compose

**Before:** `AddTrellisAsp(o => ...)` used `services.AddSingleton(options)`. Calling it twice (e.g. a library and the application) made the **second call win entirely**, dropping every `MapError<X>` from the first call.

**After:** Switches to standard .NET options pattern: `services.Configure<TrellisAspOptions>(configure)` plus `services.Replace(ServiceDescriptor.Singleton<TrellisAspOptions>(sp => sp.GetRequiredService<IOptions<TrellisAspOptions>>().Value))`. Multiple calls compose via `OptionsFactory<TrellisAspOptions>`; the existing direct-resolve consumer surface (`ErrorStatusCodeResolver`, tests) is preserved.

`Replace` (instead of `TryAddSingleton`) is required so that any host that previously called `AddSingleton<TrellisAspOptions>(...)` directly does not mask all `Configure` delegates. The trade-off — host-pre-registered `TrellisAspOptions` instances are now silently overwritten by the bridge factory — is acceptable: `AddTrellisAsp` semantically owns the slot, and the documented customization path is the configure delegate, not raw `AddSingleton`. Documented in the `SystemDefault` row of `trellis-api-asp.md`.

Same-`TError` mappings still follow last-wins (standard `IConfigureOptions` semantics — delegates run in registration order on the same instance), but mappings for **different** error types from earlier calls are preserved.

### #36 — actor providers now use `services.Replace`

**Before:** Each `AddClaimsActorProvider` / `AddEntraActorProvider` / `AddDevelopmentActorProvider` / `AddCachingActorProvider<T>` did `services.AddScoped<IActorProvider, X>()`. Calling two helpers left two scoped descriptors — `GetRequiredService<IActorProvider>()` silently returned the last one but `GetServices<IActorProvider>()` exposed both.

**After:** Each helper uses `services.Replace(ServiceDescriptor.Scoped<IActorProvider, X>())`. `AddCachingActorProvider<T>` additionally uses `services.TryAddScoped<T>()` for the inner provider type so repeated calls do not accumulate inner-provider descriptors. Same observable last-wins outcome for `IActorProvider` but explicit and accumulation-free.

## TDD

10 tests added in **red** state first, then production fixes turned them **green**:

- `AddTrellisAsp_called_twice_composes_configuration_delegates`
- `AddTrellisAsp_called_twice_still_registers_only_one_TrellisAspOptions_descriptor`
- `AddTrellisAsp_called_twice_last_wins_for_same_TError_mapping`
- `AddTrellisAsp_after_pre_registered_TrellisAspOptions_singleton_applies_configure_delegates`
- `AddClaimsActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor`
- `AddEntraActorProvider_after_AddClaimsActorProvider_leaves_single_IActorProvider_descriptor`
- `AddDevelopmentActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor`
- `AddCachingActorProvider_after_AddEntraActorProvider_leaves_single_IActorProvider_descriptor`
- `AddClaimsActorProvider_after_AddEntraActorProvider_leaves_ClaimsActorProvider_as_implementation_type`
- `AddCachingActorProvider_called_twice_does_not_accumulate_inner_T_descriptors`

## Validation

- Repo-wide `dotnet build` clean.
- All 13 test projects pass: **4,971 tests, 0 failures**.

## Docs

- `docs/docfx_project/api_reference/trellis-api-asp.md` — composition behavior for `AddTrellisAsp`, `Replace` semantics for `AddXxxActorProvider`, and `SystemDefault` row clarified to point hosts at the configure delegate (not raw `AddSingleton`).
- `docs/docfx_project/articles/integration-aspnet.md` — Actor providers example reworked into Pattern A (env select) + Pattern B (caching wrap) to match Replace semantics.
- `docs/docfx_project/articles/examples.md` — `SsoExample` description corrected to reflect the actual environment-branched pattern (not "side-by-side").

## Inspection trail

Bundle B of the Trellis.Asp follow-up plan from the inspection report. Remaining bundles (A: AOT validation parity #40/#47, C: wire-shape standardization #33/F2, D: `WWW-Authenticate` #20/#45 + `WithResourceName` #24/#30 + #41) will follow as separate PRs.