### PR TITLE
Sweep typeof-name CLR mangling out of resource refs and wire-facing error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Trellis.Core — `ResourceRef.FormatTypeName(Type)` public helper
+
+`ResourceRef.FormatTypeName(Type)` is a new public static helper that returns the simple CLR name of a type with backtick arity-mangling stripped (`List`1` → `"List"`, `Dictionary`2` → `"Dictionary"`). It is used internally by `ResourceRef.For<TResource>()` and exposed publicly so other Trellis components — and consumer code — can sanitize type-derived identifiers without duplicating the algorithm. Non-generic types pass through unchanged.
+
+`ResourceRef.For<TResource>(id)` additionally peels `Maybe<T>` wrappers (recursively) before formatting, so `For<Maybe<Order>>()` produces `"Order"` instead of the previously-mangled `"Maybe`1"`. This mirrors the documented use case where a result type happens to wrap its domain in `Maybe<>` (e.g. `Result<Maybe<Order>>.ToHttpResponse(...)` for the precondition-fail branch). Non-`Maybe` generics collapse to the outer simple name (e.g. `List<Order>` → `"List"`); when the inner type argument is the meaningful resource identifier, callers should continue to use `ResourceRef.For(string, object?)` with an explicit name. The xmldoc carries the full contract.
+
 #### Trellis.Asp — `WWW-Authenticate` emission for `Error.Unauthorized`
 
 `ResponseFailureWriter` now emits a `WWW-Authenticate` header for every `AuthChallenge` carried on `Error.Unauthorized.Challenges`, completing the round-trip that `AuthChallenge` already documented. Format follows RFC 9110 §11.6.1: scheme alone for parameterless challenges (e.g. `Bearer`), or `<scheme> key1="value1", key2="value2"` for parameterized ones; values are always emitted as quoted-strings with `"` and `\` backslash-escaped per §5.6.4. Multiple challenges produce one `WWW-Authenticate` header per challenge (matching ASP.NET Core authentication handler convention). Emission is gated on the resolved status code being `401` — if `WithErrorMapping` promotes `Error.Unauthorized` to a non-401 status, the header is suppressed, mirroring the m-13 status-aware design used by ValidationProblem detail scrubbing. When `Challenges` is empty (the default `Error.Unauthorized()`), no header is written — the configured authentication handler retains full ownership of that flow.
@@ -18,6 +24,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `ValidationErrorsContext.AddError(string fieldName, string errorMessage)`, `ValidationErrorsContext.AddError(Error.UnprocessableContent unprocessableContent)`, and `ValidationErrorsContext.CurrentPropertyName` (get/set) are now `public` (previously `internal`). Promoting these formalizes the contract that AOT-generated `JsonConverter<TValue>`s in consumer assemblies depend on. The reflection-mode `ScalarValueJsonConverterBase<,,>` continues to use the same APIs unchanged. No behavioral change for any existing caller.
 
 ### Changed
+
+#### Trellis.Core / Trellis.Asp / Trellis.EntityFrameworkCore / Trellis.Testing — sweep CLR-mangled type names out of resource refs and wire-facing error messages
+
+Across the framework, several wire-facing error messages and `ResourceRef` constructions used `typeof(T).Name` directly. For closed-generic Ts this leaks the CLR-mangled form (`List`1`, `Maybe`1`) onto the wire — an inspection finding (ASP m-4 / m-7 / m-10, Core 2.4-4) flagged this as both ugly and a "one programming model" violation between modes (the AOT generator already emits friendly names at generation time; only the runtime/reflection paths mangled).
+
+This release routes every such site through one of two new Trellis.Core helpers:
+
+- `ResourceRef.For<TResource>(id)` — peels `Maybe<T>` wrappers (recursively, so `Result<Maybe<Order>>`-backed precondition fails report `"Order"` not `"Maybe`1"`), then strips backtick mangling.
+- `ResourceRef.FormatTypeName(Type)` — strips backtick mangling only (no `Maybe<>` peeling, since that is intentionally scoped to the resource-naming contract on `For<T>`).
+
+Sites updated:
+
+- `Trellis.Asp/src/Response/TrellisHttpResult.cs:105` — `PreconditionFailed` resource ref in the conditional-evaluator path.
+- `Trellis.Asp/src/IfNoneMatchExtensions.cs:22` — `EnforceIfNoneMatchPrecondition<T>` resource ref.
+- `Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs:56,70,104,115,124,129,173` — six fallback message templates plus `GetDefaultFieldName()` (the camel-cased-type-name fallback used when no `CurrentPropertyName` is set).
+- `Trellis.Asp/src/Validation/ValidatingJsonConverter.cs:41` — `OnNullToken` "TValue cannot be null." message.
+- `Trellis.Asp/src/Validation/PrimitiveJsonReader.cs:31,37` — `FormatException`/`InvalidOperationException` catch and unsupported-primitive fallbacks (the reflection-mode counterparts of the AOT generator's `__TryReadPrimitive` helper, restoring wire-shape parity between modes).
+- `Trellis.Core/src/DomainDrivenDesign/AggregateETagExtensions.cs:66,75,80` — three `Error.PreconditionFailed` resource refs.
+- `Trellis.EntityFrameworkCore/src/RepositoryBase.cs:223` — `RemoveByIdAsync` not-found resource ref + Detail.
+- `Trellis.Testing/src/FakeRepository.cs:82,189,210` — `GetByIdAsync` not-found, `SaveAsync` conflict, `DeleteAsync` not-found resource refs + Details. Also the `Add()` unique-constraint exception message at line 136.
+
+For non-generic CLR types (the typical case) all sweeps are no-ops; no existing test asserted on the mangled form. The fix is materially observable only when a wrapping generic appears in the type position — most commonly `Maybe<T>` for the m-4 path.
+
+#### Trellis.Asp — `ScalarValueModelBinderBase` removes dead `InvalidOperationException` (i-8)
+
+`ScalarValueModelBinderBase.BindModelAsync` previously called `parseResult.TryGetError(...)` followed by an unconditional `parseResult.TryGetValue(out var value)`, with a defensive `throw new InvalidOperationException("Result is in an unexpected state.")` for the impossible `(success, !TryGetValue)` branch. Replaced both calls with the combined `Result<T>.TryGetValue(out value, out error)` overload, which is mutually exclusive on the two outputs and removes the dead branch entirely. No behavior change for any path callers can actually reach.
 
 #### Trellis.Core — null-check consistency, default-uninit defensiveness, tracing perf docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Trellis.Core — `ResourceRef.FormatTypeName(Type)` public helper
 
-`ResourceRef.FormatTypeName(Type)` is a new public static helper that returns the simple CLR name of a type with backtick arity-mangling stripped (`List`1` → `"List"`, `Dictionary`2` → `"Dictionary"`). It is used internally by `ResourceRef.For<TResource>()` and exposed publicly so other Trellis components — and consumer code — can sanitize type-derived identifiers without duplicating the algorithm. Non-generic types pass through unchanged.
+`ResourceRef.FormatTypeName(Type)` is a new public static helper that returns the simple CLR name of a type with backtick arity-mangling stripped (``List`1`` → `"List"`, ``Dictionary`2`` → `"Dictionary"`). It is used internally by `ResourceRef.For<TResource>()` and exposed publicly so other Trellis components — and consumer code — can sanitize type-derived identifiers without duplicating the algorithm. Non-generic types pass through unchanged.
 
-`ResourceRef.For<TResource>(id)` additionally peels `Maybe<T>` wrappers (recursively) before formatting, so `For<Maybe<Order>>()` produces `"Order"` instead of the previously-mangled `"Maybe`1"`. This mirrors the documented use case where a result type happens to wrap its domain in `Maybe<>` (e.g. `Result<Maybe<Order>>.ToHttpResponse(...)` for the precondition-fail branch). Non-`Maybe` generics collapse to the outer simple name (e.g. `List<Order>` → `"List"`); when the inner type argument is the meaningful resource identifier, callers should continue to use `ResourceRef.For(string, object?)` with an explicit name. The xmldoc carries the full contract.
+`ResourceRef.For<TResource>(id)` additionally peels `Maybe<T>` wrappers (recursively) before formatting, so `For<Maybe<Order>>()` produces `"Order"` instead of the previously-mangled ``"Maybe`1"``. This mirrors the documented use case where a result type happens to wrap its domain in `Maybe<>` (e.g. `Result<Maybe<Order>>.ToHttpResponse(...)` for the precondition-fail branch). Non-`Maybe` generics collapse to the outer simple name (e.g. `List<Order>` → `"List"`); when the inner type argument is the meaningful resource identifier, callers should continue to use `ResourceRef.For(string, object?)` with an explicit name. The xmldoc carries the full contract.
 
 #### Trellis.Asp — `WWW-Authenticate` emission for `Error.Unauthorized`
 
@@ -27,11 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Trellis.Core / Trellis.Asp / Trellis.EntityFrameworkCore / Trellis.Testing — sweep CLR-mangled type names out of resource refs and wire-facing error messages
 
-Across the framework, several wire-facing error messages and `ResourceRef` constructions used `typeof(T).Name` directly. For closed-generic Ts this leaks the CLR-mangled form (`List`1`, `Maybe`1`) onto the wire — an inspection finding (ASP m-4 / m-7 / m-10, Core 2.4-4) flagged this as both ugly and a "one programming model" violation between modes (the AOT generator already emits friendly names at generation time; only the runtime/reflection paths mangled).
+Across the framework, several wire-facing error messages and `ResourceRef` constructions used `typeof(T).Name` directly. For closed-generic Ts this leaks the CLR-mangled form (``List`1``, ``Maybe`1``) onto the wire — an inspection finding (ASP m-4 / m-7 / m-10, Core 2.4-4) flagged this as both ugly and a "one programming model" violation between modes (the AOT generator already emits friendly names at generation time; only the runtime/reflection paths mangled).
 
 This release routes every such site through one of two new Trellis.Core helpers:
 
-- `ResourceRef.For<TResource>(id)` — peels `Maybe<T>` wrappers (recursively, so `Result<Maybe<Order>>`-backed precondition fails report `"Order"` not `"Maybe`1"`), then strips backtick mangling.
+- `ResourceRef.For<TResource>(id)` — peels `Maybe<T>` wrappers (recursively, so `Result<Maybe<Order>>`-backed precondition fails report `"Order"` not ``"Maybe`1"``), then strips backtick mangling.
 - `ResourceRef.FormatTypeName(Type)` — strips backtick mangling only (no `Maybe<>` peeling, since that is intentionally scoped to the resource-naming contract on `For<T>`).
 
 Sites updated:

--- a/Trellis.Asp/src/IfNoneMatchExtensions.cs
+++ b/Trellis.Asp/src/IfNoneMatchExtensions.cs
@@ -19,7 +19,7 @@ public static class IfNoneMatchExtensions
         if (result.IsFailure)
             return result;
         if (ifNoneMatchETags.Any(tag => tag.IsWildcard))
-            return Result.Fail<T>(new Error.PreconditionFailed(new ResourceRef(typeof(T).Name, null), PreconditionKind.IfNoneMatch) { Detail = "Resource already exists. If-None-Match: * requires the resource to be absent." });
+            return Result.Fail<T>(new Error.PreconditionFailed(ResourceRef.For<T>(), PreconditionKind.IfNoneMatch) { Detail = "Resource already exists. If-None-Match: * requires the resource to be absent." });
         return result;
     }
 

--- a/Trellis.Asp/src/ModelBinding/ScalarValueModelBinderBase.cs
+++ b/Trellis.Asp/src/ModelBinding/ScalarValueModelBinderBase.cs
@@ -57,16 +57,16 @@ public abstract class ScalarValueModelBinderBase<TResult, TValue, TPrimitive> : 
 
         var parseResult = PrimitiveConverter.ConvertToPrimitive<TPrimitive>(rawValue);
 
-        if (parseResult.TryGetError(out var parseError))
+        // Combined check: TryGetValue(out value, out error) is mutually exclusive on Result<T>,
+        // so a single call replaces the two separate TryGetError/TryGetValue calls (and the
+        // accompanying dead defensive throw the old shape required after them).
+        if (!parseResult.TryGetValue(out var primitiveValue, out var parseError))
         {
             bindingContext.ModelState.AddModelError(modelName, parseError.Detail ?? parseError.Code);
             bindingContext.Result = ModelBindingResult.Failed();
             return Task.CompletedTask;
         }
 
-        // Safe: TryGetError returned false above, so parseResult is success.
-        if (!parseResult.TryGetValue(out var primitiveValue))
-            throw new InvalidOperationException("Result is in an unexpected state.");
         var result = TValue.TryCreate(primitiveValue, modelName);
 
         if (result.TryGetValue(out var typedValue))

--- a/Trellis.Asp/src/Response/TrellisHttpResult.cs
+++ b/Trellis.Asp/src/Response/TrellisHttpResult.cs
@@ -102,7 +102,7 @@ internal sealed class TrellisHttpResult<TDomain, TBody> :
 
                     if (decision == ConditionalDecision.PreconditionFailed)
                     {
-                        var pf = new Error.PreconditionFailed(new ResourceRef(typeof(TDomain).Name, null), failedKind ?? PreconditionKind.IfMatch)
+                        var pf = new Error.PreconditionFailed(ResourceRef.For<TDomain>(), failedKind ?? PreconditionKind.IfMatch)
                         { Detail = "A conditional request header evaluated to false." };
 
                         return ResponseFailureWriter.WriteAsync(httpContext, pf, ResolveErrorStatusCode(httpContext, pf, _options));

--- a/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
+++ b/Trellis.Asp/src/Validation/PrimitiveJsonReader.cs
@@ -28,13 +28,13 @@ internal static class PrimitiveJsonReader
         }
         catch (Exception ex) when (ex is FormatException or InvalidOperationException)
         {
-            ValidationErrorsContext.AddError(fieldName, $"'{fieldName}' is not a valid {typeof(TPrimitive).Name}.");
+            ValidationErrorsContext.AddError(fieldName, $"'{fieldName}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
             return false;
         }
 
         ValidationErrorsContext.AddError(
             fieldName,
-            $"Primitive type '{typeof(TPrimitive).Name}' is not supported by the Trellis validation JSON converter. Provide a custom JsonConverter.");
+            $"Primitive type '{ResourceRef.FormatTypeName(typeof(TPrimitive))}' is not supported by the Trellis validation JSON converter. Provide a custom JsonConverter.");
         return false;
     }
 

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -166,9 +166,6 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
     }
 
     /// <summary>
-    /// Gets the default field name derived from the value object type name.
-    /// </summary>
-    /// <summary>
     /// Returns the default field name used when no <see cref="ValidationErrorsContext.CurrentPropertyName"/>
     /// is set for the current async-local scope (e.g. AOT consumers that haven't wired the
     /// reflection-based <c>PropertyNameAwareConverter&lt;T&gt;</c>). The CLR simple name is

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -53,7 +53,7 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
 
         if (primitiveValue is null)
         {
-            ValidationErrorsContext.AddError(fieldName, $"Cannot deserialize null to {typeof(TValue).Name}");
+            ValidationErrorsContext.AddError(fieldName, $"Cannot deserialize null to {ResourceRef.FormatTypeName(typeof(TValue))}");
             return OnValidationFailure();
         }
 
@@ -67,7 +67,7 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
                     ValidationErrorsContext.AddError(
                         fieldName,
                         string.IsNullOrWhiteSpace(createError.Detail)
-                            ? $"{typeof(TValue).Name} is invalid."
+                            ? $"{ResourceRef.FormatTypeName(typeof(TValue))} is invalid."
                             : createError.Detail);
 
                 return OnValidationFailure();
@@ -101,7 +101,7 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
             if (TryParseEnumValue(rawValue, out primitiveValue))
                 return true;
 
-            ValidationErrorsContext.AddError(fieldName, $"'{rawValue}' is not a valid {typeof(TPrimitive).Name}.");
+            ValidationErrorsContext.AddError(fieldName, $"'{rawValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
             return false;
         }
 
@@ -112,7 +112,7 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
                 var enumValue = ReadNumericEnumValue(ref reader);
                 if (!IsValidEnumValue(enumValue))
                 {
-                    ValidationErrorsContext.AddError(fieldName, $"'{enumValue}' is not a valid {typeof(TPrimitive).Name}.");
+                    ValidationErrorsContext.AddError(fieldName, $"'{enumValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
                     return false;
                 }
 
@@ -121,12 +121,12 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
             }
             catch (Exception ex) when (ex is FormatException or InvalidOperationException)
             {
-                ValidationErrorsContext.AddError(fieldName, $"JSON number is not a valid {typeof(TPrimitive).Name}.");
+                ValidationErrorsContext.AddError(fieldName, $"JSON number is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
                 return false;
             }
         }
 
-        ValidationErrorsContext.AddError(fieldName, $"JSON token '{reader.TokenType}' is not a valid {typeof(TPrimitive).Name}.");
+        ValidationErrorsContext.AddError(fieldName, $"JSON token '{reader.TokenType}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
         return false;
     }
 
@@ -168,9 +168,13 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
     /// <summary>
     /// Gets the default field name derived from the value object type name.
     /// </summary>
-    protected static string GetDefaultFieldName()
-    {
-        var name = typeof(TValue).Name;
-        return JsonNamingPolicy.CamelCase.ConvertName(name);
-    }
+    /// <summary>
+    /// Returns the default field name used when no <see cref="ValidationErrorsContext.CurrentPropertyName"/>
+    /// is set for the current async-local scope (e.g. AOT consumers that haven't wired the
+    /// reflection-based <c>PropertyNameAwareConverter&lt;T&gt;</c>). The CLR simple name is
+    /// sanitized via <see cref="ResourceRef.FormatTypeName"/> so closed-generic types such as
+    /// <c>Maybe&lt;EmailAddress&gt;</c> produce <c>"maybe"</c> rather than <c>"maybe`1"</c>.
+    /// </summary>
+    protected static string GetDefaultFieldName() =>
+        JsonNamingPolicy.CamelCase.ConvertName(ResourceRef.FormatTypeName(typeof(TValue)));
 }

--- a/Trellis.Asp/src/Validation/ValidatingJsonConverter.cs
+++ b/Trellis.Asp/src/Validation/ValidatingJsonConverter.cs
@@ -38,7 +38,7 @@ public sealed class ValidatingJsonConverter<TValue, TPrimitive> : ScalarValueJso
     /// <inheritdoc />
     protected override TValue? OnNullToken(string fieldName)
     {
-        ValidationErrorsContext.AddError(fieldName, $"{typeof(TValue).Name} cannot be null.");
+        ValidationErrorsContext.AddError(fieldName, $"{ResourceRef.FormatTypeName(typeof(TValue))} cannot be null.");
         return null;
     }
 

--- a/Trellis.Asp/tests/IfNoneMatchExtensionsTests.cs
+++ b/Trellis.Asp/tests/IfNoneMatchExtensionsTests.cs
@@ -79,4 +79,39 @@ public class IfNoneMatchExtensionsTests
 
         actual.Should().BeFailureOfType<Error.PreconditionFailed>();
     }
+
+    /// <summary>
+    /// Regression for inspection finding m-7: <c>EnforceIfNoneMatchPrecondition&lt;T&gt;</c> previously
+    /// constructed <c>new ResourceRef(typeof(T).Name, null)</c>, which leaks CLR backtick mangling for
+    /// closed-generic Ts and ignores documented wrapper-peeling for <see cref="Maybe{T}"/>. The fix
+    /// routes through <see cref="ResourceRef.For{TResource}(object?)"/> so both concerns are handled
+    /// in one place.
+    /// </summary>
+    [Fact]
+    public void EnforceIfNoneMatchPrecondition_ResourceRef_uses_friendly_type_name_for_closed_generic_T()
+    {
+        var result = Result.Ok(new List<string>());
+
+        var actual = result.EnforceIfNoneMatchPrecondition([EntityTagValue.Wildcard()]);
+
+        actual.Should().BeFailureOfType<Error.PreconditionFailed>();
+        actual.TryGetError(out var error).Should().BeTrue();
+        var pf = (Error.PreconditionFailed)error!;
+        pf.Resource.Type.Should().Be("List",
+            "m-7: backtick-mangled CLR names like 'List`1' must not leak through to the resource ref");
+    }
+
+    [Fact]
+    public void EnforceIfNoneMatchPrecondition_ResourceRef_peels_Maybe_wrapper_to_expose_inner_domain()
+    {
+        var result = Result.Ok(Maybe.From("value"));
+
+        var actual = result.EnforceIfNoneMatchPrecondition([EntityTagValue.Wildcard()]);
+
+        actual.Should().BeFailureOfType<Error.PreconditionFailed>();
+        actual.TryGetError(out var error).Should().BeTrue();
+        var pf = (Error.PreconditionFailed)error!;
+        pf.Resource.Type.Should().Be("String",
+            "m-7: Maybe<T> wrappers must be peeled so the meaningful inner domain name is the resource type");
+    }
 }

--- a/Trellis.Core/src/DomainDrivenDesign/AggregateETagExtensions.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/AggregateETagExtensions.cs
@@ -63,7 +63,7 @@ public static class AggregateETagExtensions
         if (result.IsFailure) return result;
 
         if (expectedETags.Length == 0)
-            return Result.Fail<T>(new Error.PreconditionFailed(new ResourceRef(typeof(T).Name, null), PreconditionKind.IfMatch) { Detail = "If-Match header is empty." });
+            return Result.Fail<T>(new Error.PreconditionFailed(ResourceRef.For<T>(), PreconditionKind.IfMatch) { Detail = "If-Match header is empty." });
 
         // Wildcard check (any wildcard satisfies If-Match)
         if (Array.Exists(expectedETags, tag => tag.IsWildcard))
@@ -72,11 +72,11 @@ public static class AggregateETagExtensions
         // Strong comparison per RFC 9110 §13.1.1: weak tags don't satisfy If-Match.
         var strongTags = Array.FindAll(expectedETags, tag => !tag.IsWeak);
         if (strongTags.Length == 0)
-            return Result.Fail<T>(new Error.PreconditionFailed(new ResourceRef(typeof(T).Name, null), PreconditionKind.IfMatch) { Detail = "If-Match contains only weak ETags. Strong comparison is required." });
+            return Result.Fail<T>(new Error.PreconditionFailed(ResourceRef.For<T>(), PreconditionKind.IfMatch) { Detail = "If-Match contains only weak ETags. Strong comparison is required." });
 
         return result.Ensure(
             aggregate => Array.Exists(strongTags,
                 tag => string.Equals(aggregate.ETag, tag.OpaqueTag, StringComparison.Ordinal)),
-            _ => new Error.PreconditionFailed(new ResourceRef(typeof(T).Name, null), PreconditionKind.IfMatch) { Detail = "Resource has been modified. Please reload and retry." });
+            _ => new Error.PreconditionFailed(ResourceRef.For<T>(), PreconditionKind.IfMatch) { Detail = "Resource has been modified. Please reload and retry." });
     }
 }

--- a/Trellis.Core/src/Errors/ResourceRef.cs
+++ b/Trellis.Core/src/Errors/ResourceRef.cs
@@ -31,19 +31,73 @@ public readonly record struct ResourceRef(string Type, string? Id = null)
     }
 
     /// <summary>
-    /// Creates a resource reference whose resource type is <c>typeof(TResource).Name</c>.
+    /// Creates a resource reference whose resource type name is derived from
+    /// <typeparamref name="TResource"/>.
     /// </summary>
     /// <typeparam name="TResource">The resource type.</typeparam>
     /// <param name="id">Optional resource identifier.</param>
     /// <returns>A resource reference.</returns>
     /// <remarks>
-    /// For closed generic resource types (e.g. <c>List&lt;User&gt;</c>) <see cref="System.Reflection.MemberInfo.Name">Type.Name</see>
-    /// produces the CLR mangled form <c>"List`1"</c>, which is rarely the desired user-visible
-    /// name. Prefer <see cref="For(string, object?)"/> with an explicit, stable resource name
-    /// when the resource is parameterized.
+    /// <para>
+    /// The resource type name is the simple CLR name with two normalisations applied:
+    /// </para>
+    /// <list type="number">
+    /// <item>
+    /// <description>
+    /// <b>Backtick mangling stripped.</b> A closed generic such as <c>List&lt;User&gt;</c>
+    /// reports a CLR <see cref="System.Reflection.MemberInfo.Name">Name</see> of
+    /// <c>"List`1"</c>; the backtick suffix is removed so the resource type is <c>"List"</c>.
+    /// Closed generics with multiple type arguments collapse to the outer simple name
+    /// (e.g. <c>Dictionary&lt;string,int&gt;</c> → <c>"Dictionary"</c>). When the inner type
+    /// argument is the meaningful resource identifier, prefer <see cref="For(string, object?)"/>
+    /// with an explicit name.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <b><see cref="Maybe{T}"/> wrappers are peeled.</b> <c>Maybe&lt;Order&gt;</c> reports
+    /// <c>"Order"</c>, and the peeling is recursive (<c>Maybe&lt;Maybe&lt;Order&gt;&gt;</c>
+    /// also reports <c>"Order"</c>). This avoids the CLR-mangled <c>"Maybe`1"</c> from
+    /// leaking onto the wire when a result type happens to wrap its domain in
+    /// <see cref="Maybe{T}"/> (e.g. <c>Result&lt;Maybe&lt;Order&gt;&gt;.ToHttpResponse(...)</c>).
+    /// Other generic wrappers are not peeled — see <see cref="FormatTypeName"/> if you need
+    /// the formatting without the Maybe-peeling step.
+    /// </description>
+    /// </item>
+    /// </list>
     /// </remarks>
     public static ResourceRef For<TResource>(object? id = null) =>
-        new(typeof(TResource).Name, FormatId(id));
+        new(FormatTypeName(PeelMaybe(typeof(TResource))), FormatId(id));
+
+    /// <summary>
+    /// Returns the simple CLR name for <paramref name="type"/> with backtick-mangling
+    /// stripped. Used by Trellis components that surface a type-derived identifier on the
+    /// wire (e.g. AOT-generated JSON converter fallback messages).
+    /// </summary>
+    /// <param name="type">The type whose name should be formatted.</param>
+    /// <returns>
+    /// The simple name with any <c>`N</c> arity suffix removed. For example,
+    /// <c>typeof(List&lt;int&gt;)</c> returns <c>"List"</c>; <c>typeof(Order)</c> returns
+    /// <c>"Order"</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="type"/> is null.</exception>
+    /// <remarks>
+    /// This helper does <b>not</b> peel <see cref="Maybe{T}"/> wrappers — that is intentionally
+    /// scoped to <see cref="For{TResource}(object?)"/>, which owns the resource-naming contract.
+    /// </remarks>
+    public static string FormatTypeName(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        var name = type.Name;
+        var tickIndex = name.IndexOf('`');
+        return tickIndex < 0 ? name : name.Substring(0, tickIndex);
+    }
+
+    private static Type PeelMaybe(Type type) =>
+        type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Maybe<>)
+            ? PeelMaybe(type.GetGenericArguments()[0])
+            : type;
 
     private static string? FormatId(object? id) =>
         id switch

--- a/Trellis.Core/tests/Errors/ResourceRefTests.cs
+++ b/Trellis.Core/tests/Errors/ResourceRefTests.cs
@@ -83,6 +83,102 @@ public class ResourceRefTests
         resource.Id.Should().Be("custom:abc");
     }
 
+    /// <summary>
+    /// Regression for inspection finding 2.4-4: <c>typeof(T).Name</c> for closed generics
+    /// produces the CLR mangled form <c>"Name`N"</c>. <see cref="ResourceRef.For{TResource}"/>
+    /// must strip the backtick mangling so a closed generic resource type is emitted as
+    /// <c>"List"</c> on the wire instead of <c>"List`1"</c>.
+    /// </summary>
+    [Fact]
+    public void For_generic_strips_backtick_mangling_from_closed_generic_simple_name()
+    {
+        var resource = ResourceRef.For<List<string>>("42");
+
+        resource.Type.Should().Be("List",
+            "the CLR-mangled simple name 'List`1' is not a useful resource identifier and must not leak through to the wire");
+        resource.Id.Should().Be("42");
+    }
+
+    /// <summary>
+    /// Regression for inspection finding 2.4-4 (multi-arg): same mangling-strip for
+    /// closed generics with multiple type arguments.
+    /// </summary>
+    [Fact]
+    public void For_generic_strips_backtick_mangling_from_multi_arg_closed_generic()
+    {
+        var resource = ResourceRef.For<Dictionary<string, int>>();
+
+        resource.Type.Should().Be("Dictionary");
+    }
+
+    /// <summary>
+    /// Regression for inspection finding ASP m-4: the <c>PreconditionFailed</c> resource ref
+    /// in <c>TrellisHttpResult&lt;TDomain, TBody&gt;</c> uses <c>typeof(TDomain).Name</c> for the
+    /// resource type. When TDomain is <c>Maybe&lt;Order&gt;</c> the wire detail becomes
+    /// <c>"Maybe`1"</c>. <see cref="ResourceRef.For{TResource}"/> must peel the
+    /// <see cref="Maybe{T}"/> wrapper so the meaningful inner domain name is exposed.
+    /// </summary>
+    [Fact]
+    public void For_generic_peels_Maybe_wrapper_to_expose_inner_domain_name()
+    {
+        var resource = ResourceRef.For<Maybe<CustomerAccount>>("abc");
+
+        resource.Type.Should().Be(nameof(CustomerAccount),
+            "Maybe<T> is a documented wrapping case for resource references; the inner domain " +
+            "name (CustomerAccount) is the meaningful resource identifier");
+        resource.Id.Should().Be("abc");
+    }
+
+    /// <summary>
+    /// Maybe-peeling is recursive so even pathological double-wrappings collapse to the
+    /// underlying domain type name.
+    /// </summary>
+    [Fact]
+    public void For_generic_peels_nested_Maybe_wrappers_recursively()
+    {
+        var resource = ResourceRef.For<Maybe<Maybe<CustomerAccount>>>();
+
+        resource.Type.Should().Be(nameof(CustomerAccount));
+    }
+
+    /// <summary>
+    /// The public <see cref="ResourceRef.FormatTypeName"/> helper exposes the friendly-name
+    /// formatting so other Trellis components (e.g. AOT-generated JSON converter fallback
+    /// messages) can sanitize CLR mangling without duplicating the algorithm. It strips
+    /// backtick mangling but does NOT peel <see cref="Maybe{T}"/> (that is intentionally
+    /// scoped to <see cref="ResourceRef.For{TResource}"/>, which owns the resource-naming
+    /// contract).
+    /// </summary>
+    [Fact]
+    public void FormatTypeName_strips_backtick_mangling_for_closed_generics()
+    {
+        ResourceRef.FormatTypeName(typeof(List<string>)).Should().Be("List");
+        ResourceRef.FormatTypeName(typeof(Dictionary<string, int>)).Should().Be("Dictionary");
+    }
+
+    [Fact]
+    public void FormatTypeName_returns_simple_name_unchanged_for_non_generic_types()
+    {
+        ResourceRef.FormatTypeName(typeof(CustomerAccount)).Should().Be(nameof(CustomerAccount));
+        ResourceRef.FormatTypeName(typeof(string)).Should().Be("String");
+        ResourceRef.FormatTypeName(typeof(int)).Should().Be("Int32");
+    }
+
+    [Fact]
+    public void FormatTypeName_does_not_peel_Maybe_wrapper() =>
+        ResourceRef.FormatTypeName(typeof(Maybe<CustomerAccount>)).Should().Be("Maybe",
+            "Maybe-peeling is part of the For<T>() resource-naming contract, not a property " +
+            "of the general-purpose type-name formatter; callers needing peeling should use For<T>");
+
+    [Fact]
+    public void FormatTypeName_throws_for_null_type()
+    {
+        var act = () => ResourceRef.FormatTypeName(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .Where(exception => exception.ParamName == "type");
+    }
+
     private sealed record CustomerAccount;
 
     private sealed class CustomId(string value)

--- a/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
+++ b/Trellis.EntityFrameworkCore/src/RepositoryBase.cs
@@ -220,7 +220,7 @@ public abstract class RepositoryBase<TAggregate, TId>
     {
         var entity = await DbSet.FindAsync([id], cancellationToken).ConfigureAwait(false);
         if (entity is null)
-            return Result.Fail(new Error.NotFound(new ResourceRef(typeof(TAggregate).Name, id?.ToString())) { Detail = $"{typeof(TAggregate).Name} with ID '{id}' not found." });
+            return Result.Fail(new Error.NotFound(ResourceRef.For<TAggregate>(id)) { Detail = $"{ResourceRef.FormatTypeName(typeof(TAggregate))} with ID '{id}' not found." });
 
         DbSet.Remove(entity);
         return Result.Ok();

--- a/Trellis.Testing/src/FakeRepository.cs
+++ b/Trellis.Testing/src/FakeRepository.cs
@@ -79,7 +79,7 @@ public class FakeRepository<TAggregate, TId>
             return Task.FromResult(Result.Ok(aggregate));
 
         return Task.FromResult(Result.Fail<TAggregate>(
-            new Error.NotFound(new ResourceRef(typeof(TAggregate).Name, id?.ToString())) { Detail = $"{typeof(TAggregate).Name} with ID {id} not found" }));
+            new Error.NotFound(ResourceRef.For<TAggregate>(id)) { Detail = $"{ResourceRef.FormatTypeName(typeof(TAggregate))} with ID {id} not found" }));
     }
 
     /// <summary>
@@ -133,7 +133,7 @@ public class FakeRepository<TAggregate, TId>
 
             if (conflict is not null)
                 throw new InvalidOperationException(
-                    $"Cannot Add {typeof(TAggregate).Name} with ID '{id}': would violate unique constraint " +
+                    $"Cannot Add {ResourceRef.FormatTypeName(typeof(TAggregate))} with ID '{id}': would violate unique constraint " +
                     $"(another aggregate with the same constrained value already exists). " +
                     $"If you are testing conflict handling, call SaveAsync and assert on the Result instead.");
         }
@@ -186,7 +186,7 @@ public class FakeRepository<TAggregate, TId>
 
             if (conflict is not null)
                 return Task.FromResult(Result.Fail(
-                    new Error.Conflict(Resource: new ResourceRef(typeof(TAggregate).Name, id?.ToString()), ReasonCode: "duplicate.unique.constraint") { Detail = $"A {typeof(TAggregate).Name} with the same value already exists." }));
+                    new Error.Conflict(Resource: ResourceRef.For<TAggregate>(id), ReasonCode: "duplicate.unique.constraint") { Detail = $"A {ResourceRef.FormatTypeName(typeof(TAggregate))} with the same value already exists." }));
         }
 
         _store[id] = aggregate;
@@ -207,7 +207,7 @@ public class FakeRepository<TAggregate, TId>
             return Task.FromResult(Result.Ok());
 
         return Task.FromResult(Result.Fail(
-            new Error.NotFound(new ResourceRef(typeof(TAggregate).Name, id?.ToString())) { Detail = $"{typeof(TAggregate).Name} with ID {id} not found" }));
+            new Error.NotFound(ResourceRef.For<TAggregate>(id)) { Detail = $"{ResourceRef.FormatTypeName(typeof(TAggregate))} with ID {id} not found" }));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Sweep CLR-mangled type names (`List`1`, `Maybe`1`) out of every wire-facing error message and `ResourceRef` construction in the framework. Closes inspection findings **ASP m-4 / m-7 / m-10 / i-8** + **Core 2.4-4** in a single PR.

The AOT generator already emitted friendly type names at generation time (M-2 fix in #456). This PR restores parity for the runtime/reflection paths that used `typeof(T).Name` directly.

## Approach

TDD: 8 RED-then-GREEN unit tests on the new `ResourceRef` helper + 2 ASP regression tests + mechanical sweep of every cited site.

## What changed

### Trellis.Core — new public helper, centralised contract

- **`ResourceRef.FormatTypeName(Type)`** — public static helper that returns the simple CLR name with backtick arity-mangling stripped (`List`1` → `"List"`, `Dictionary`2` → `"Dictionary"`). Non-generic types pass through unchanged. Documented contract: does **not** peel `Maybe<T>` (that is intentionally scoped to `For<T>`).
- **`ResourceRef.For<TResource>(id)`** — additionally peels `Maybe<T>` wrappers (recursively, so `Result<Maybe<Order>>`-backed precondition fails report `"Order"` not `"Maybe`1"`), then strips backtick mangling. Non-`Maybe` generics collapse to the outer simple name; when the inner type argument is the meaningful resource identifier, callers should continue to use `ResourceRef.For(string, object?)` with an explicit name.

### Trellis.Asp — 4 source files swept

| Site | Finding |
|---|---|
| `Response/TrellisHttpResult.cs:105` (PreconditionFailed in conditional-evaluator path) | m-4 |
| `IfNoneMatchExtensions.cs:22` (EnforceIfNoneMatchPrecondition<T>) | m-7 |
| `Validation/ScalarValueJsonConverterBase.cs:56,70,104,115,124,129,173` (six fallback message templates + `GetDefaultFieldName()`) | m-10 |
| `Validation/ValidatingJsonConverter.cs:41` (`OnNullToken` "TValue cannot be null.") | reflection-mode parity |
| `Validation/PrimitiveJsonReader.cs:31,37` (FormatException catch + unsupported-primitive fallback) | reflection-mode parity (counterparts of the AOT generator's `__TryReadPrimitive`) |
| `ModelBinding/ScalarValueModelBinderBase.cs` (combined `TryGetValue(out v, out e)` overload removes dead defensive throw) | i-8 |

### Trellis.Core / Trellis.EntityFrameworkCore / Trellis.Testing — consistency sweep

| Site | Concern |
|---|---|
| `Trellis.Core/src/DomainDrivenDesign/AggregateETagExtensions.cs:66,75,80` (3 sites) | Same root cause as m-7 |
| `Trellis.EntityFrameworkCore/src/RepositoryBase.cs:223` (`RemoveByIdAsync`) | Same root cause |
| `Trellis.Testing/src/FakeRepository.cs:82,189,210` (`GetByIdAsync` / `SaveAsync` / `DeleteAsync`) + `:136` (`Add()` exception message) | Same root cause |

For non-generic CLR types (the typical case) every sweep is a **no-op**; no existing test asserted on the mangled form. The fix is materially observable only when a wrapping generic appears in the type position — most commonly `Maybe<T>` for the m-4 path.

### Cleanup (i-8)

`ScalarValueModelBinderBase.BindModelAsync` previously called `parseResult.TryGetError(...)` followed by an unconditional `parseResult.TryGetValue(out var value)`, with a defensive `throw new InvalidOperationException("Result is in an unexpected state.")` for the impossible `(success, !TryGetValue)` branch. Replaced both calls with the combined `Result<T>.TryGetValue(out value, out error)` overload, which is mutually exclusive on the two outputs and removes the dead branch entirely. No behavior change for any path callers can actually reach.

## Audit-discovered closures (no work in this PR)

During the audit against current `main`, these inspection findings were verified already closed by prior PRs (#448 / #452 / #453 / #454 / #455 / #456): **ASP m-2, i-1, i-4, i-5, i-7, i-9; Core 2.3-1, 2.3-2, 2.3-3, 2.3-4, 2.3-5, 2.3-11, 2.4-3, 2.4-5, 2.4-6, 2.4-7.**

## Skipped findings (rationale)

- **ASP m-2** (TrellisErrorOnlyResult.ResolveStatusCode duplication) — both methods already delegate to the shared `ErrorStatusCodeResolver.Resolve`. Cosmetic; refactoring would risk regression with no behavior change.
- **Core 2.3-9, 2.4-1, 2.4-2, 2.4-8** — low-ROI perf/style/test-coverage items the inspection report itself flagged as "low priority unless profiled" or similar.

## Tests

- **+8 ResourceRef unit tests** (`Trellis.Core/tests/Errors/ResourceRefTests.cs`) covering: backtick mangling strip (single + multi-arg generic), Maybe<T> peeling (single + nested), public `FormatTypeName` contract (strips mangling but does NOT peel `Maybe`), null-arg guard, no-change case for plain types.
- **+2 IfNoneMatchExtensions regression tests** verifying `List<string>` → `"List"` and `Maybe<string>` → `"String"` through a real `EnforceIfNoneMatchPrecondition` flow.

**Validation:** `dotnet build` clean (0/0); `dotnet test -c Release` → **5,262 passed / 0 failed / 15 skipped / 5,277 total** (+10 over the PR #456 baseline) across all 21 projects.

## Files

- `Trellis.Core/src/Errors/ResourceRef.cs` — new `FormatTypeName` helper + `For<T>` Maybe-peeling.
- `Trellis.Core/tests/Errors/ResourceRefTests.cs` — +8 tests.
- `Trellis.Core/src/DomainDrivenDesign/AggregateETagExtensions.cs` — 3 sites swept.
- `Trellis.Asp/src/Response/TrellisHttpResult.cs` — m-4.
- `Trellis.Asp/src/IfNoneMatchExtensions.cs` — m-7.
- `Trellis.Asp/tests/IfNoneMatchExtensionsTests.cs` — +2 regression tests.
- `Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs` — m-10 (7 sites).
- `Trellis.Asp/src/Validation/ValidatingJsonConverter.cs` — parity sweep.
- `Trellis.Asp/src/Validation/PrimitiveJsonReader.cs` — parity sweep (2 sites).
- `Trellis.Asp/src/ModelBinding/ScalarValueModelBinderBase.cs` — i-8 cleanup.
- `Trellis.EntityFrameworkCore/src/RepositoryBase.cs` — 1 site swept.
- `Trellis.Testing/src/FakeRepository.cs` — 4 sites swept.
- `CHANGELOG.md` — 2 new `[Unreleased]` entries (`Added` `ResourceRef.FormatTypeName` + `Changed` sweep paragraph).