### PR TITLE
Trellis.ServiceDefaults inspection findings (M-S1, M-S2, m-S1..m-S3, i-S1..i-S4 + GPT-5.5 N-S1..N-S4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Trellis.ServiceDefaults — inspection findings (M-S1, M-S2, m-S1..m-S3, i-S1..i-S4 + GPT-5.5 N-S1..N-S4)
+
+Closes the formal Trellis.ServiceDefaults inspection backlog from `files/servicedefaults-inspection-report.md` after a meta-review by GPT-5.5 validated all 9 self-inspection findings and surfaced 4 additional ones (one Major, two Minor, one Info).
+
+- **(Major) M-S1 — `UseEntityFrameworkUnitOfWork<TContext>()` now throws on duplicate call.** Previously chaining `.UseEntityFrameworkUnitOfWork<DbContextA>().UseEntityFrameworkUnitOfWork<DbContextB>()` silently overwrote the first registration so only `DbContextB`'s UoW was wired. The actor-provider slot already enforces fail-fast; UoW now matches that policy. Same-`TContext` duplicates also throw — the Trellis pipeline supports exactly one transactional `IUnitOfWork` per composition; chaining is always misconfiguration. Read/write context splits should run as separate composition roots or use a multi-tenant `DbContext`.
+
+- **(Major) M-S2 — AOT/trim incompatibility now documented prominently.** The package opts out of AOT/trim analyzers (`<IsAotCompatible>false</IsAotCompatible>`, `<EnableAotAnalyzer>false</EnableAotAnalyzer>`) and the fluent assembly-scanning methods (`UseFluentValidation(asm)`, `UseResourceAuthorization(asm)`, `UseDomainEvents(asm)`) wrap underlying `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` APIs without propagating the attributes — so downstream AOT consumers do NOT receive IL2026/IL3050 warnings at the wrapper call site. New "AOT compatibility" section in api ref + integration article + NUGET_README documents the limitation and recommends per-package direct APIs (with the AOT-friendly mapping table) for AOT/trim consumers. The parameterless `o.UseFluentValidation()` / `o.UseResourceAuthorization()` / `o.UseDomainEvents()` overloads are AOT-compatible.
+
+- **(Major) N-S1 — explicit `AddResourceAuthorization<TMessage, TResource, TResponse>()` calls made BEFORE `AddTrellis(...)` are now order-independent.** `InsertResourceAuthorizationBehavior` (in `Trellis.Mediator`) inserts before `ValidationBehavior<,>` if it exists; otherwise it appended to the end of the descriptor list. When `AddTrellis(...)` then ran, the standard pipeline was registered AFTER the closed-generic resource-auth behaviors, so they ended up at descriptor slot 0 — outside the canonical Exception/Tracing/Logging/Authorization/Validation envelope. `AddTrellisBehaviors()` now performs a relocation pass after registering the standard pipeline: any pre-existing closed-generic `ResourceAuthorizationBehavior<,,>` descriptors are re-inserted immediately before `ValidationBehavior`, mirroring the `AddTrellisUnitOfWork ↔ AddDomainEventDispatch` symmetry.
+
+- **(Info) N-S4 — new `UseCachingActorProvider<T>()` builder slot.** `Trellis.Asp` exposes `AddCachingActorProvider<T>()` for per-request caching of an inner `IActorProvider`, but the builder didn't expose a slot. Now does, with the same fail-fast duplicate-detection as the other actor-provider slots. Chain after the matching `UseXxxActorProvider(...)` so the inner provider's `IOptions<TOptions>` is configured before the wrap replaces the `IActorProvider` slot.
+
+- **(Minor) m-S1 — api ref frontmatter `types:` corrected.** Previously listed `[AddTrellisServiceDefaults, WebApplicationBuilderExtensions]` — neither type exists in source. Updated to `[TrellisServiceCollectionExtensions, TrellisServiceBuilder]`.
+
+- **(Minor) m-S2 — Behavior section step 6 mentions `IDomainEventPublisher`.** The api ref previously said "registers `DomainEventDispatchBehavior<,>` and any scanned handlers", omitting the default `IDomainEventPublisher` registration that the existing test `UseDomainEvents_WithoutAssemblies_RegistersDispatchBehaviorAndPublisher` confirms. Step 6 now explicitly mentions all three.
+
+- **(Minor) m-S3 — `Apply()` else-if branches are explicit about the flag invariant.** The second branch in each `_useFluentValidation`/`_useDomainEvents` pair previously checked only `_xxxAssemblies.Count > 0`, relying on the implicit invariant that those private lists are only mutated by methods that also set the flag. Now the branches are `else if (_useFluentValidation)` / `else if (_useDomainEvents)` — equivalent today, robust against future refactor.
+
+- **(Minor) N-S2 — new integration article `docs/docfx_project/articles/integration-servicedefaults.md`.** ServiceDefaults previously had only an api ref — convention is every package has both a per-LLM api ref and a per-developer integration article. Article added with quick start, canonical order, mutually-exclusive slots, per-request actor caching example, the order-independence section for explicit resource-auth registrations, AOT compatibility note, and layered-config usage. Also added to `articles/toc.yml` under "Integration Guides".
+
+- **(Minor) N-S3 — `Examples/CookbookSnippets/Recipe12_DiPlaybook.cs` rewritten to use the `AddTrellis(...)` builder.** The cookbook prose for Recipe 12 already taught the builder pattern; the compiled snippet still demonstrated direct package-specific registrations, contradicting the recipe. Snippet now uses the builder consistently.
+
+- **(Info) i-S1 — xmldoc `<remarks>` on `UseAsp` and `UseMediator` document the repeated-call combine semantics** (configure delegates compose in call order rather than overwriting, supporting layered library-then-host configuration).
+
+- **(Info) i-S2 — api ref clarifies `UseResourceAuthorization()` no-assembly mechanism.** New "Order-independence" subsection in the Behavior section explains that `AuthorizationBehavior<,>` (static-permission flavor) is registered unconditionally by `AddTrellisBehaviors()` (called via `UseMediator()`), and that the no-assembly path is for AOT consumers who register each `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` explicitly via `services.AddResourceAuthorization<TMessage, TResource, TResponse>()`.
+
+- **(Info) i-S3 — `TrellisServiceBuilder` class summary now documents the `Apply()` lifecycle.** Callers don't invoke `Apply()` directly; `AddTrellis(services, configure)` constructs the builder, hands it to the configure callback, and invokes `Apply()` after the callback returns. `<remarks>` paragraph now states this explicitly.
+
+Refuted findings (kept current behavior intentional): i-S4 (`UseEntityFrameworkUnitOfWork<TContext>` lacks a configure delegate — forward-looking only; no concrete need today). Multiple `AddTrellis(...)` calls within one composition (`AddDomainEventDispatch` and `AddTrellisUnitOfWork` are aware of each other and re-order regardless of registration order). `Apply()` thread safety (builder is constructed/configured/applied/discarded synchronously inside `AddTrellis(...)`).
+
+Tests: **+5** new tests in `Trellis.ServiceDefaults.Tests` covering UoW duplicate-call throw (same context + different context), explicit resource-auth before `AddTrellis` ordering, `UseCachingActorProvider<T>()` wrap behavior, and caching-slot duplicate throw.
+
 #### Trellis.Http — inspection findings (M-H1, M-H2, M-H3, i-H2, i-H3, N-H1, N-H2)
 
 Closes the formal Trellis.Http inspection backlog from `files/http-inspection-report.md` after a meta-review by GPT-5.5 validated, refuted, or adjusted each finding and surfaced 2 additional ones.

--- a/Examples/CookbookSnippets/CookbookSnippets.csproj
+++ b/Examples/CookbookSnippets/CookbookSnippets.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\src\Trellis.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\generator\Trellis.EntityFrameworkCore.Generator.csproj"
                       OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Trellis.ServiceDefaults\src\Trellis.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\Trellis.StateMachine\src\Trellis.StateMachine.csproj" />
     <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
   </ItemGroup>

--- a/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
+++ b/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
@@ -9,41 +9,39 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis;
 using Trellis.Asp;
-using Trellis.Asp.Authorization;
 using Trellis.Asp.Routing;
 using Trellis.EntityFrameworkCore;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
+using Trellis.ServiceDefaults;
 
 public static class CompositionRoot
 {
     public static IServiceCollection AddApp(this IServiceCollection services, string connectionString)
     {
-        // 1. Mediator pipeline (outermost behaviors first).
-        services.AddTrellisBehaviors();
+        // 1. Trellis composition root: ASP, Mediator behaviors, FluentValidation, claims-based
+        //    actor provider, resource authorization, and EF unit of work in canonical order.
+        //    UseEntityFrameworkUnitOfWork<TContext> is applied last so TransactionalCommandBehavior
+        //    lands innermost in the mediator pipeline.
+        services.AddTrellis(options => options
+            .UseAsp()
+            .UseMediator()
+            .UseFluentValidation(typeof(PlaceOrderValidator).Assembly)
+            .UseClaimsActorProvider()
+            .UseResourceAuthorization(typeof(UpdateOrderCommand).Assembly)
+            .UseEntityFrameworkUnitOfWork<AppDbContext>());
 
-        // 2. FluentValidation plug-in. Idempotent; safe to call after AddTrellisBehaviors.
-        services.AddTrellisFluentValidation(typeof(PlaceOrderValidator).Assembly);
-
-        // 3. ASP layer: Problem Details mapping + scalar-value validation pipeline.
-        services.AddTrellisAsp();
-
-        // 4. ASP authorization actor providers.
-        services.AddClaimsActorProvider();
-        services.AddResourceAuthorization(typeof(UpdateOrderCommand).Assembly);
-
-        // 5. EF Core context with Trellis interceptors + conventions.
+        // 2. EF Core context with Trellis interceptors + conventions.
+        //    DbContext registration is application-owned (provider, connection string, pooling).
         services.AddDbContext<AppDbContext>(opts => opts
             .UseInMemoryDatabase("CookbookSample")
             .AddTrellisInterceptors());
 
-        // 6. EF unit of work LAST so TransactionalCommandBehavior lands innermost.
-        services.AddTrellisUnitOfWork<AppDbContext>();
-
-        // 7. Optional: route constraints for value-object IDs (reflection-based).
+        // 3. Optional: route constraints for value-object IDs (reflection-based; not part of
+        //    AddTrellis because route parameter names are application-owned).
         services.AddTrellisRouteConstraints(typeof(OrderId).Assembly);
 
-        // 8. Application services.
+        // 4. Application services.
         services.AddScoped<IOrderRepository, EfOrderRepository>();
 
         return services;

--- a/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
+++ b/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
@@ -7,12 +7,8 @@ using CookbookSnippets.Recipe07;
 using CookbookSnippets.Stubs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Trellis;
-using Trellis.Asp;
 using Trellis.Asp.Routing;
 using Trellis.EntityFrameworkCore;
-using Trellis.FluentValidation;
-using Trellis.Mediator;
 using Trellis.ServiceDefaults;
 
 public static class CompositionRoot

--- a/Trellis.Mediator/src/ServiceCollectionExtensions.cs
+++ b/Trellis.Mediator/src/ServiceCollectionExtensions.cs
@@ -98,7 +98,84 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Scoped(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehavior<,>)));
         services.TryAddEnumerable(ServiceDescriptor.Scoped(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>)));
 
+        // Order-independence for explicit AddResourceAuthorization<TMessage,TResource,TResponse>()
+        // calls made BEFORE AddTrellisBehaviors(): such calls inserted closed-generic
+        // ResourceAuthorizationBehavior<,,> descriptors at the END of the collection (because
+        // ValidationBehavior wasn't registered yet to anchor the insert). Now that the standard
+        // pipeline is in place, relocate them to sit immediately before ValidationBehavior so
+        // they end up in the canonical envelope. Mirrors the AddTrellisUnitOfWork ↔
+        // AddDomainEventDispatch symmetry: pipeline-position-aware registrations are
+        // order-independent regardless of which one runs first.
+        RelocateResourceAuthorizationBehaviorsBeforeValidation(services);
+
         return services;
+    }
+
+    /// <summary>
+    /// Walks the descriptor list, finds any closed-generic
+    /// <c>IPipelineBehavior&lt;TMessage, TResponse&gt;</c> registrations whose
+    /// implementation type is <see cref="ResourceAuthorizationBehavior{TMessage, TResource, TResponse}"/>,
+    /// and re-inserts each one immediately before <see cref="ValidationBehavior{TMessage, TResponse}"/>
+    /// (preserving relative order among the resource-auth behaviors themselves).
+    /// </summary>
+    private static void RelocateResourceAuthorizationBehaviorsBeforeValidation(IServiceCollection services)
+    {
+        var validationIndex = FindValidationBehaviorIndex(services);
+        if (validationIndex < 0)
+            return;
+
+        // Collect (descriptor, originalIndex) pairs for closed-generic resource-auth behaviors
+        // that are NOT already in the slot directly preceding ValidationBehavior. Walk in
+        // descriptor order so relative ordering is preserved when we re-insert.
+        var relocations = new List<ServiceDescriptor>();
+        for (int i = 0; i < services.Count; i++)
+        {
+            var d = services[i];
+            if (IsClosedResourceAuthorizationBehavior(d))
+                relocations.Add(d);
+        }
+
+        if (relocations.Count == 0)
+            return;
+
+        // Remove first (descending index to avoid shifting), then re-insert before validation.
+        for (int i = services.Count - 1; i >= 0; i--)
+        {
+            if (IsClosedResourceAuthorizationBehavior(services[i]))
+                services.RemoveAt(i);
+        }
+
+        // ValidationBehavior may have moved if it was after any of the relocated entries; relocate
+        // it freshly post-removal.
+        var newValidationIndex = FindValidationBehaviorIndex(services);
+        if (newValidationIndex < 0)
+        {
+            // Defensive: ValidationBehavior should always be present since we just registered it.
+            // Fall back to appending to preserve the resource-auth registrations rather than
+            // dropping them.
+            foreach (var d in relocations)
+                services.Add(d);
+            return;
+        }
+
+        for (int i = 0; i < relocations.Count; i++)
+            services.Insert(newValidationIndex + i, relocations[i]);
+    }
+
+    private static bool IsClosedResourceAuthorizationBehavior(ServiceDescriptor descriptor)
+    {
+        if (descriptor.ServiceType.IsGenericTypeDefinition)
+            return false;
+        if (!descriptor.ServiceType.IsGenericType)
+            return false;
+        if (descriptor.ServiceType.GetGenericTypeDefinition() != typeof(IPipelineBehavior<,>))
+            return false;
+
+        var impl = descriptor.ImplementationType;
+        if (impl is null || !impl.IsGenericType || impl.IsGenericTypeDefinition)
+            return false;
+
+        return impl.GetGenericTypeDefinition() == typeof(ResourceAuthorizationBehavior<,,>);
     }
 
     /// <summary>

--- a/Trellis.Mediator/src/ServiceCollectionExtensions.cs
+++ b/Trellis.Mediator/src/ServiceCollectionExtensions.cs
@@ -124,9 +124,12 @@ public static class ServiceCollectionExtensions
         if (validationIndex < 0)
             return;
 
-        // Collect (descriptor, originalIndex) pairs for closed-generic resource-auth behaviors
-        // that are NOT already in the slot directly preceding ValidationBehavior. Walk in
-        // descriptor order so relative ordering is preserved when we re-insert.
+        // Collect every closed-generic resource-auth descriptor in source-order so relative
+        // ordering among them is preserved when we re-insert. We don't filter out descriptors
+        // that already happen to sit directly before ValidationBehavior — moving such a
+        // descriptor from position N to position N is a no-op effectively (the same instance
+        // is removed and re-inserted at the same slot), and skipping the optimization keeps
+        // the relocation logic uniform.
         var relocations = new List<ServiceDescriptor>();
         for (int i = 0; i < services.Count; i++)
         {

--- a/Trellis.ServiceDefaults/NUGET_README.md
+++ b/Trellis.ServiceDefaults/NUGET_README.md
@@ -26,5 +26,11 @@ builder.Services.AddTrellis(options => options
 
 `UseFluentValidation()` and `UseResourceAuthorization()` both support no-assembly calls for explicit, no-scanning composition; pass assemblies only when you want Trellis to discover validators/resource loaders automatically.
 
+## AOT compatibility
+
+`Trellis.ServiceDefaults` is **not** AOT- or trim-compatible. The fluent assembly-scanning methods (`UseFluentValidation(asm)`, `UseResourceAuthorization(asm)`, `UseDomainEvents(asm)`) wrap underlying `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` APIs without propagating the attributes. For AOT consumers, use the per-package direct APIs (`services.AddTrellisFluentValidation()` + explicit validator registrations, `services.AddResourceAuthorization<TMessage, TResource, TResponse>()`, `services.AddDomainEventDispatch()` + `services.AddDomainEventHandler<TEvent, THandler>()`).
+
+The parameterless `o.UseFluentValidation()` / `o.UseResourceAuthorization()` / `o.UseDomainEvents()` overloads are AOT-compatible — they only register the adapter / pipeline behaviors and rely on the consumer's explicit per-type registrations.
+
 ## Part of Trellis
 This package is part of the [Trellis](https://github.com/xavierjohn/Trellis) framework.

--- a/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
+++ b/Trellis.ServiceDefaults/src/TrellisServiceBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp;
 using Trellis.Asp.Authorization;
+using Trellis.Authorization;
 using Trellis.EntityFrameworkCore;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
@@ -14,6 +15,13 @@ using Trellis.Mediator;
 /// <summary>
 /// Collects requested Trellis integration modules and applies them in canonical order.
 /// </summary>
+/// <remarks>
+/// Callers do not invoke this builder directly. Use
+/// <see cref="TrellisServiceCollectionExtensions.AddTrellis(IServiceCollection, Action{TrellisServiceBuilder})"/>;
+/// it constructs a <see cref="TrellisServiceBuilder"/>, hands it to the configure callback, and
+/// invokes <c>Apply()</c> after the callback returns to register the selected modules in the
+/// canonical pipeline order.
+/// </remarks>
 public sealed class TrellisServiceBuilder
 {
     private readonly IServiceCollection _services;
@@ -23,6 +31,7 @@ public sealed class TrellisServiceBuilder
     private Action<TrellisAspOptions>? _configureAsp;
     private Action<TrellisMediatorTelemetryOptions>? _configureMediatorTelemetry;
     private Action<IServiceCollection>? _actorProviderRegistration;
+    private Action<IServiceCollection>? _cachingActorProviderWrap;
     private Action<IServiceCollection>? _unitOfWorkRegistration;
     private bool _useAsp;
     private bool _useMediator;
@@ -37,6 +46,12 @@ public sealed class TrellisServiceBuilder
     /// <summary>
     /// Registers Trellis ASP.NET Core integration.
     /// </summary>
+    /// <remarks>
+    /// Calling this method more than once is allowed; the configure delegates are composed in
+    /// call order rather than overwriting. Each delegate runs against the same
+    /// <see cref="TrellisAspOptions"/> instance, so layered configuration (e.g. a library
+    /// applies defaults; the host overrides specific properties) is supported.
+    /// </remarks>
     public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)
     {
         _useAsp = true;
@@ -49,6 +64,10 @@ public sealed class TrellisServiceBuilder
     /// <summary>
     /// Registers the Trellis Mediator pipeline behaviors.
     /// </summary>
+    /// <remarks>
+    /// Calling this method more than once is allowed; the configure delegates are composed in
+    /// call order rather than overwriting.
+    /// </remarks>
     public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)
     {
         _useMediator = true;
@@ -123,9 +142,19 @@ public sealed class TrellisServiceBuilder
     /// Registers EF Core Unit of Work and the transactional command behavior.
     /// Implies <see cref="UseMediator"/> and is always applied after all other behavior registrations.
     /// </summary>
+    /// <remarks>
+    /// Calling this method more than once — with the same <typeparamref name="TContext"/> or
+    /// a different one — throws <see cref="InvalidOperationException"/>. The Trellis pipeline
+    /// supports exactly one transactional <see cref="IUnitOfWork"/> per composition; chaining
+    /// two calls (e.g. for a read/write context split) is always misconfiguration.
+    /// </remarks>
     public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>()
         where TContext : DbContext
     {
+        if (_unitOfWorkRegistration is not null)
+            throw new InvalidOperationException(
+                "Only one unit of work can be configured per Trellis composition.");
+
         _useMediator = true;
         _unitOfWorkRegistration = services => services.AddTrellisUnitOfWork<TContext>();
         return this;
@@ -154,6 +183,30 @@ public sealed class TrellisServiceBuilder
         return this;
     }
 
+    /// <summary>
+    /// Registers a caching decorator around the inner <see cref="IActorProvider"/>
+    /// (typically registered by a previous <c>UseXxxActorProvider</c> call).
+    /// Per-request caching ensures multiple actor lookups within one request return the same instance.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="IActorProvider"/> implementation to wrap.</typeparam>
+    /// <remarks>
+    /// For built-in providers (<see cref="EntraActorProvider"/>, <see cref="ClaimsActorProvider"/>),
+    /// chain after the matching <c>UseXxxActorProvider(...)</c> call so its
+    /// <c>IOptions&lt;TOptions&gt;</c> is configured before the caching wrap replaces the
+    /// <see cref="IActorProvider"/> slot. Custom providers without Trellis-managed options can
+    /// be cached without a prior <c>UseXxxActorProvider</c>.
+    /// </remarks>
+    public TrellisServiceBuilder UseCachingActorProvider<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
+        where T : class, IActorProvider
+    {
+        if (_cachingActorProviderWrap is not null)
+            throw new InvalidOperationException(
+                "Only one caching actor provider can be configured. Caching actor provider already configured.");
+
+        _cachingActorProviderWrap = services => services.AddCachingActorProvider<T>();
+        return this;
+    }
+
     internal void Apply()
     {
         if (_useAsp)
@@ -165,6 +218,7 @@ public sealed class TrellisServiceBuilder
         }
 
         _actorProviderRegistration?.Invoke(_services);
+        _cachingActorProviderWrap?.Invoke(_services);
 
         if (_useMediator)
         {
@@ -179,12 +233,12 @@ public sealed class TrellisServiceBuilder
 
         if (_useFluentValidation && _fluentValidationAssemblies.Count == 0)
             _services.AddTrellisFluentValidation();
-        else if (_fluentValidationAssemblies.Count > 0)
+        else if (_useFluentValidation)
             _services.AddTrellisFluentValidation([.. _fluentValidationAssemblies]);
 
         if (_useDomainEvents && _domainEventAssemblies.Count == 0)
             _services.AddDomainEventDispatch();
-        else if (_domainEventAssemblies.Count > 0)
+        else if (_useDomainEvents)
             _services.AddDomainEventDispatch([.. _domainEventAssemblies]);
 
         _unitOfWorkRegistration?.Invoke(_services);

--- a/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
+++ b/Trellis.ServiceDefaults/tests/TrellisServiceBuilderTests.cs
@@ -8,6 +8,7 @@ using global::Mediator;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp;
+using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 using Trellis.EntityFrameworkCore;
 using Trellis.Mediator;
@@ -179,6 +180,14 @@ public class TrellisServiceBuilderTests
         }
     }
 
+    private sealed class SecondaryDbContext : DbContext
+    {
+        public SecondaryDbContext(DbContextOptions<SecondaryDbContext> options)
+            : base(options)
+        {
+        }
+    }
+
     public sealed record ProtectedOrder(string Id, string OwnerId);
 
     public sealed record UpdateProtectedOrderCommand(string ResourceId)
@@ -254,5 +263,121 @@ public class TrellisServiceBuilderTests
         dispatchIndex.Should().BeLessThan(txIndex,
             "domain events must dispatch after the transaction commits");
         pipeline.Should().EndWith(typeof(TransactionalCommandBehavior<,>));
+    }
+
+    // -------- Round-N inspection findings (M-S1, N-S1, N-S4) --------
+
+    [Fact]
+    public void UseEntityFrameworkUnitOfWork_TwiceWithSameContext_Throws()
+    {
+        // Inspection finding M-S1: the actor-provider slot throws on duplicate
+        // configuration to prevent silent misconfiguration. The UoW slot must
+        // follow the same fail-fast policy: a user mistakenly chaining two
+        // UseEntityFrameworkUnitOfWork calls is always misconfigured.
+        var services = new ServiceCollection();
+
+        var act = () => services.AddTrellis(options => options
+            .UseEntityFrameworkUnitOfWork<TestDbContext>()
+            .UseEntityFrameworkUnitOfWork<TestDbContext>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unit of work*");
+    }
+
+    [Fact]
+    public void UseEntityFrameworkUnitOfWork_TwiceWithDifferentContext_Throws()
+    {
+        // Inspection finding M-S1: chaining UseEntityFrameworkUnitOfWork<DbContextA>
+        // then UseEntityFrameworkUnitOfWork<DbContextB> previously silently
+        // overwrote the first registration so only DbContextB's UoW was wired.
+        // That class of mistake (read/write split, multi-tenant) must fail fast.
+        var services = new ServiceCollection();
+
+        var act = () => services.AddTrellis(options => options
+            .UseEntityFrameworkUnitOfWork<TestDbContext>()
+            .UseEntityFrameworkUnitOfWork<SecondaryDbContext>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unit of work*");
+    }
+
+    [Fact]
+    public void ExplicitResourceAuthorization_BeforeAddTrellis_PositionsBehaviorBeforeValidation()
+    {
+        // Inspection finding N-S1: the documented "explicit resource-authorization
+        // registrations without scanning" use case (UseResourceAuthorization() with
+        // no assemblies) requires the user to call AddResourceAuthorization<T,R,Resp>()
+        // explicitly. If they do so BEFORE AddTrellis(...), the closed-generic
+        // ResourceAuthorizationBehavior<,,> previously ended up at descriptor slot 0,
+        // before exception/tracing/logging/static-auth/validation — outside the
+        // canonical Trellis behavior envelope. AddTrellisBehaviors now re-positions
+        // any pre-existing closed-generic resource-auth behaviors to sit just before
+        // ValidationBehavior, mirroring the AddTrellisUnitOfWork ↔ AddDomainEventDispatch
+        // symmetry.
+        var services = new ServiceCollection();
+
+        services.AddResourceAuthorization<UpdateProtectedOrderCommand, ProtectedOrder, Result<string>>();
+        services.AddScoped<IResourceLoader<UpdateProtectedOrderCommand, ProtectedOrder>, UpdateProtectedOrderLoader>();
+        services.AddTrellis(options => options.UseResourceAuthorization());
+
+        var descriptors = services
+            .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>)
+                     || d.ServiceType == typeof(IPipelineBehavior<UpdateProtectedOrderCommand, Result<string>>))
+            .ToList();
+
+        var validationIndex = descriptors.FindIndex(d =>
+            d.ServiceType == typeof(IPipelineBehavior<,>) &&
+            d.ImplementationType == typeof(ValidationBehavior<,>));
+        var resAuthIndex = descriptors.FindIndex(d =>
+            d.ServiceType == typeof(IPipelineBehavior<UpdateProtectedOrderCommand, Result<string>>));
+
+        validationIndex.Should().BeGreaterOrEqualTo(0, "ValidationBehavior must be registered by AddTrellisBehaviors");
+        resAuthIndex.Should().BeGreaterOrEqualTo(0, "explicit AddResourceAuthorization must remain registered");
+        resAuthIndex.Should().Be(validationIndex - 1,
+            "ResourceAuthorizationBehavior<,,> must sit immediately before ValidationBehavior in the canonical pipeline");
+    }
+
+    [Fact]
+    public void UseCachingActorProvider_AfterUseClaimsActorProvider_WrapsInnerProvider()
+    {
+        // Inspection finding N-S4: Trellis.Asp exposes AddCachingActorProvider<T>()
+        // for per-request caching of an inner IActorProvider, but the builder didn't
+        // expose a slot for it. Calling AddCachingActorProvider<ClaimsActorProvider>()
+        // after AddTrellis(...UseClaimsActorProvider()) works but is awkward; making
+        // it a builder slot makes the composition explicit and prevents the user
+        // from forgetting the order constraint.
+        var services = new ServiceCollection();
+
+        services.AddTrellis(options => options
+            .UseClaimsActorProvider()
+            .UseCachingActorProvider<ClaimsActorProvider>());
+
+        // The IActorProvider resolves to a delegate registration (factory-based
+        // CachingActorProvider) — assert by descriptor shape that the slot is
+        // factory-based rather than the bare ClaimsActorProvider implementation
+        // type registered by UseClaimsActorProvider alone.
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(IActorProvider) &&
+            d.ImplementationFactory != null,
+            "UseCachingActorProvider must replace the IActorProvider slot with a CachingActorProvider factory");
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(ClaimsActorProvider),
+            "the inner provider type must be registered as scoped so the caching wrapper can resolve it");
+    }
+
+    [Fact]
+    public void UseCachingActorProvider_TwiceWithDifferentInner_Throws()
+    {
+        // Inspection finding N-S4: the caching slot must follow the same fail-fast
+        // duplicate-detection pattern as the actor-provider slot itself.
+        var services = new ServiceCollection();
+
+        var act = () => services.AddTrellis(options => options
+            .UseClaimsActorProvider()
+            .UseCachingActorProvider<ClaimsActorProvider>()
+            .UseCachingActorProvider<EntraActorProvider>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*caching actor provider*");
     }
 }

--- a/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
+++ b/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
@@ -1,9 +1,9 @@
 ﻿---
 package: Trellis.ServiceDefaults
 namespaces: [Trellis.ServiceDefaults]
-types: [AddTrellisServiceDefaults, WebApplicationBuilderExtensions]
+types: [TrellisServiceCollectionExtensions, TrellisServiceBuilder]
 version: v3
-last_verified: 2026-05-01
+last_verified: 2026-05-05
 audience: [llm]
 ---
 # Trellis.ServiceDefaults API Reference
@@ -36,7 +36,22 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-12--di-wiring
 
 - `AddTrellis(...)` does not register `DbContext`, Mediator handlers, route constraints, or app-specific validators.
 - `UseEntityFrameworkUnitOfWork<TContext>()` is applied last so transaction commit remains innermost in the mediator pipeline.
+- Calling `UseEntityFrameworkUnitOfWork<TContext>()` more than once (with the same or a different `TContext`) throws `InvalidOperationException`. The Trellis pipeline supports exactly one transactional `IUnitOfWork` per composition; chaining two calls (e.g. for a read/write context split) is always misconfiguration. Use a separate composition root or a single multi-tenant `DbContext` instead.
 - If you only need one module, direct package-specific registration remains valid; the builder is for composition-root clarity.
+
+## AOT compatibility
+
+`Trellis.ServiceDefaults` is **not** AOT- or trim-compatible. The package opts out of AOT/trim analyzers (`<IsAotCompatible>false</IsAotCompatible>`, `<IsTrimmable>false</IsTrimmable>`) because the assembly-scanning fluent methods (`UseFluentValidation(params Assembly[])`, `UseResourceAuthorization(params Assembly[])`, `UseDomainEvents(params Assembly[])`) wrap underlying `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` APIs whose attributes are not propagated through the wrapper.
+
+For AOT/trim consumers, use the per-package direct APIs that do propagate the attributes:
+
+| Builder method | AOT-friendly direct call |
+| --- | --- |
+| `o.UseFluentValidation(asm)` | `services.AddTrellisFluentValidation()` plus per-validator `services.AddScoped<IValidator<T>, TValidator>()` |
+| `o.UseResourceAuthorization(asm)` | `services.AddResourceAuthorization<TMessage, TResource, TResponse>()` plus `services.AddScoped<IResourceLoader<TMessage, TResource>, TLoader>()` |
+| `o.UseDomainEvents(asm)` | `services.AddDomainEventDispatch()` plus `services.AddDomainEventHandler<TEvent, THandler>()` |
+
+The parameterless `o.UseFluentValidation()` / `o.UseResourceAuthorization()` / `o.UseDomainEvents()` overloads are AOT-compatible — they only register the adapter / pipeline behaviors and rely on the consumer's explicit per-type registrations.
 
 ## Types
 
@@ -58,29 +73,34 @@ public sealed class TrellisServiceBuilder
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `Trellis.Asp` integration via `AddTrellisAsp(...)`. |
-| `public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)` | `TrellisServiceBuilder` | Registers Trellis Mediator behaviors via `AddTrellisBehaviors(...)`. |
-| `public TrellisServiceBuilder UseFluentValidation(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers the FluentValidation adapter. When assemblies are supplied, also scans them for validators. Implies `UseMediator()`. |
-| `public TrellisServiceBuilder UseResourceAuthorization(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers resource authorization behaviors/loaders discovered in assemblies. With no assemblies, enables the mediator pipeline for explicit resource-authorization registrations without scanning. Implies `UseMediator()`. |
-| `public TrellisServiceBuilder UseClaimsActorProvider(Action<ClaimsActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `ClaimsActorProvider` as `IActorProvider`. |
-| `public TrellisServiceBuilder UseEntraActorProvider(Action<EntraActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `EntraActorProvider` as `IActorProvider`. |
-| `public TrellisServiceBuilder UseDevelopmentActorProvider(Action<DevelopmentActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `DevelopmentActorProvider` as `IActorProvider`. Use only in development/testing hosts. |
-| `public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>() where TContext : DbContext` | `TrellisServiceBuilder` | Registers `EfUnitOfWork<TContext>` and `TransactionalCommandBehavior<,>` via `AddTrellisUnitOfWork<TContext>()`. Implies `UseMediator()` and is applied last. |
-| `public TrellisServiceBuilder UseDomainEvents(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers `DomainEventDispatchBehavior<,>` and the default `IDomainEventPublisher`. With assemblies, scans for `IDomainEventHandler<TEvent>` implementations and registers each as scoped. Implies `UseMediator()`. Applied between FluentValidation and `UseEntityFrameworkUnitOfWork<TContext>()` so events fire after the transaction commits. |
+| `public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `Trellis.Asp` integration via `AddTrellisAsp(...)`. Repeated calls compose the configure delegates rather than overwriting. |
+| `public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)` | `TrellisServiceBuilder` | Registers Trellis Mediator behaviors via `AddTrellisBehaviors(...)`. Repeated calls compose the configure delegates rather than overwriting. |
+| `public TrellisServiceBuilder UseFluentValidation(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers the FluentValidation adapter. When assemblies are supplied, also scans them for validators (non-AOT). Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseResourceAuthorization(params Assembly[] assemblies)` | `TrellisServiceBuilder` | With assemblies: scans for `IAuthorizeResource<TResource>` commands and registers `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` for each (non-AOT). With no assemblies: relies on the static-permission `AuthorizationBehavior<,>` registered unconditionally by `UseMediator()`/`AddTrellisBehaviors()`, and on the consumer's explicit per-message `services.AddResourceAuthorization<TMessage, TResource, TResponse>()` calls. Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseClaimsActorProvider(Action<ClaimsActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `ClaimsActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors. |
+| `public TrellisServiceBuilder UseEntraActorProvider(Action<EntraActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `EntraActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors. |
+| `public TrellisServiceBuilder UseDevelopmentActorProvider(Action<DevelopmentActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `DevelopmentActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors. Use only in development/testing hosts. |
+| `public TrellisServiceBuilder UseCachingActorProvider<T>() where T : class, IActorProvider` | `TrellisServiceBuilder` | Wraps the inner `IActorProvider` registration with a per-request caching decorator via `AddCachingActorProvider<T>()`. Chain after the matching `UseXxxActorProvider(...)` call so the inner provider's `IOptions<TOptions>` is configured first. |
+| `public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>() where TContext : DbContext` | `TrellisServiceBuilder` | Registers `EfUnitOfWork<TContext>` and `TransactionalCommandBehavior<,>` via `AddTrellisUnitOfWork<TContext>()`. Implies `UseMediator()` and is applied last. Throws `InvalidOperationException` on repeated call — see "Common traps". |
+| `public TrellisServiceBuilder UseDomainEvents(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers `DomainEventDispatchBehavior<,>` and the default `IDomainEventPublisher`. With assemblies, scans for `IDomainEventHandler<TEvent>` implementations and registers each as scoped (non-AOT). Implies `UseMediator()`. Applied between FluentValidation and `UseEntityFrameworkUnitOfWork<TContext>()` so events fire after the transaction commits. |
 
 ## Behavior
 
 `AddTrellis(...)` records selected modules first and then applies them in this order:
 
 1. ASP integration.
-2. Actor provider.
+2. Actor provider (and the optional caching wrap that chains after it).
 3. Mediator behaviors.
-4. Resource authorization.
+4. Resource authorization (assembly scanning, when assemblies are supplied).
 5. FluentValidation adapter/scanning when selected.
-6. Domain event dispatch (registers `DomainEventDispatchBehavior<,>` and any scanned handlers).
+6. Domain event dispatch (registers `DomainEventDispatchBehavior<,>`, the default `IDomainEventPublisher`, and any scanned handlers).
 7. EF Core Unit of Work.
 
 That order preserves the important pipeline invariant: `TransactionalCommandBehavior<,>` is the innermost behavior, closest to the handler, so commit failures remain visible to outer logging/tracing/exception behaviors.
+
+### Order-independence for explicit resource-authorization registrations
+
+Explicit `services.AddResourceAuthorization<TMessage, TResource, TResponse>()` calls made BEFORE `AddTrellis(...)` are now order-independent. `AddTrellisBehaviors()` (called by `UseMediator()`) detects any pre-existing closed-generic `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` descriptors and re-positions them to sit immediately before `ValidationBehavior<,>`, so they end up in the canonical pipeline envelope regardless of registration order. This mirrors the symmetry between `AddTrellisUnitOfWork<TContext>` and `AddDomainEventDispatch`.
 
 `AddTrellis(...)` deliberately does **not** register:
 

--- a/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
+++ b/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
@@ -34,7 +34,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-12--di-wiring
 
 ## Common traps
 
-- `AddTrellis(...)` does not register `DbContext`, Mediator handlers, route constraints, or app-specific validators.
+- `AddTrellis(...)` does not register `DbContext`, Mediator handlers, or route constraints — those are always application-owned. Validators (`IValidator<T>`), resource loaders (`IResourceLoader<TMessage, TResource>`), and domain event handlers (`IDomainEventHandler<TEvent>`) are registered ONLY when you opt into assembly scanning via the params-`Assembly[]` overloads (`UseFluentValidation(asm)`, `UseResourceAuthorization(asm)`, `UseDomainEvents(asm)`); the parameterless overloads register only the adapter / pipeline behavior and leave per-type registrations to you.
 - `UseEntityFrameworkUnitOfWork<TContext>()` is applied last so transaction commit remains innermost in the mediator pipeline.
 - Calling `UseEntityFrameworkUnitOfWork<TContext>()` more than once (with the same or a different `TContext`) throws `InvalidOperationException`. The Trellis pipeline supports exactly one transactional `IUnitOfWork` per composition; chaining two calls (e.g. for a read/write context split) is always misconfiguration. Use a separate composition root or a single multi-tenant `DbContext` instead.
 - If you only need one module, direct package-specific registration remains valid; the builder is for composition-root clarity.

--- a/docs/docfx_project/articles/integration-servicedefaults.md
+++ b/docs/docfx_project/articles/integration-servicedefaults.md
@@ -1,0 +1,103 @@
+﻿---
+title: Service Defaults (Composition Root)
+package: Trellis.ServiceDefaults
+topics: [composition-root, service-collection, di-wiring, builder, pipeline-ordering]
+related_api_reference: [trellis-api-servicedefaults.md, trellis-api-mediator.md, trellis-api-asp.md, trellis-api-efcore.md, trellis-api-fluentvalidation.md, trellis-api-cookbook.md]
+last_verified: 2026-05-05
+audience: [developer]
+---
+# Service Defaults (Composition Root)
+
+`Trellis.ServiceDefaults` provides one fluent builder — `services.AddTrellis(o => ...)` — that wires the Trellis integration modules in the canonical order so the mediator pipeline ends up with the right behaviors at the right positions.
+
+It is **not** a mandatory dependency. If you only need one integration package, calling that package's direct registration helper (`AddTrellisAsp`, `AddTrellisBehaviors`, `AddTrellisFluentValidation`, etc.) remains a valid choice. The builder exists to make composition-root code easier to read when several integrations are combined.
+
+## Quick start
+
+```csharp
+builder.Services.AddTrellis(options => options
+    .UseAsp()
+    .UseMediator()
+    .UseFluentValidation(typeof(Program).Assembly)
+    .UseClaimsActorProvider()
+    .UseResourceAuthorization(typeof(Program).Assembly)
+    .UseEntityFrameworkUnitOfWork<AppDbContext>());
+
+builder.Services.AddDbContext<AppDbContext>(o => o.UseSqlServer(connectionString));
+```
+
+`AddTrellis` does NOT register your `DbContext`, your mediator handlers, your route constraints, or your application-specific validators. Those remain explicit registrations.
+
+## Canonical order
+
+`AddTrellis(o => ...)` records the requested modules during the configure callback, then applies them in this order:
+
+1. **ASP integration** (`UseAsp`) — `AddTrellisAsp(...)`.
+2. **Actor provider** (`UseClaimsActorProvider` / `UseEntraActorProvider` / `UseDevelopmentActorProvider`) and the **caching wrap** (`UseCachingActorProvider<T>`).
+3. **Mediator behaviors** (`UseMediator`) — `AddTrellisBehaviors(...)`. Always present when any other Use that implies it is selected (FluentValidation, ResourceAuthorization, DomainEvents, EntityFrameworkUnitOfWork).
+4. **Resource authorization** scanning (`UseResourceAuthorization(asm)`) when assemblies are supplied.
+5. **FluentValidation** adapter and (optionally) scanning (`UseFluentValidation`).
+6. **Domain event dispatch** (`UseDomainEvents`) — `DomainEventDispatchBehavior<,>` + default `IDomainEventPublisher` + scanned handlers.
+7. **EF Core Unit of Work** (`UseEntityFrameworkUnitOfWork<TContext>`) — applied last so `TransactionalCommandBehavior<,>` is the innermost behavior.
+
+This sequence preserves the central pipeline invariant: the transactional behavior is closest to the handler, so commit failures remain visible to outer logging/tracing/exception behaviors. Domain events fire after the transaction commits because dispatch is registered before the unit of work.
+
+## Mutually-exclusive slots
+
+| Slot | Single-selection rule |
+|---|---|
+| Actor provider | At most one of `UseClaimsActorProvider`, `UseEntraActorProvider`, `UseDevelopmentActorProvider`. Throws `InvalidOperationException` on duplicate (same kind or different). |
+| Caching actor wrap | At most one `UseCachingActorProvider<T>()`. Throws `InvalidOperationException` on duplicate. |
+| Unit of work | At most one `UseEntityFrameworkUnitOfWork<TContext>()` per composition. Throws `InvalidOperationException` on duplicate (same `TContext` or different). Read/write context splits should run as separate composition roots or use a multi-tenant `DbContext`. |
+
+## Per-request actor caching
+
+`UseCachingActorProvider<T>()` wraps the inner `IActorProvider` with a per-request caching decorator. Chain it AFTER the matching `UseXxxActorProvider(...)` so the inner provider's `IOptions<TOptions>` is configured before the wrap replaces the `IActorProvider` slot.
+
+```csharp
+builder.Services.AddTrellis(options => options
+    .UseClaimsActorProvider(o => o.ActorIdClaim = "sub")
+    .UseCachingActorProvider<ClaimsActorProvider>());
+```
+
+## Order-independence for explicit resource-authorization registrations
+
+The no-assembly form `UseResourceAuthorization()` is for AOT consumers who register each `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` explicitly via `services.AddResourceAuthorization<TMessage, TResource, TResponse>()`. Those explicit calls can be made **before** `AddTrellis(...)`; `AddTrellisBehaviors()` (called by `UseMediator()`) detects pre-existing closed-generic resource-auth behaviors and re-positions them to sit immediately before `ValidationBehavior<,>` in the canonical pipeline envelope. This mirrors the same symmetry between `AddTrellisUnitOfWork<TContext>` and `AddDomainEventDispatch`: pipeline-position-aware registrations are order-independent regardless of which one runs first.
+
+```csharp
+// Either order works; resource-auth ends up in the canonical position.
+builder.Services.AddResourceAuthorization<UpdateOrderCommand, Order, Result<string>>();
+builder.Services.AddScoped<IResourceLoader<UpdateOrderCommand, Order>, OrderLoader>();
+builder.Services.AddTrellis(options => options.UseResourceAuthorization());
+```
+
+## AOT compatibility
+
+`Trellis.ServiceDefaults` itself is **not** AOT- or trim-compatible. The fluent assembly-scanning methods wrap underlying `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` APIs without propagating the attributes, and the package opts out of AOT/trim analyzers (`<IsAotCompatible>false</IsAotCompatible>`).
+
+For AOT/trim consumers, use the per-package direct APIs that DO propagate the attributes:
+
+| Builder method | AOT-friendly direct call |
+|---|---|
+| `o.UseFluentValidation(asm)` | `services.AddTrellisFluentValidation()` plus per-validator `services.AddScoped<IValidator<T>, TValidator>()` |
+| `o.UseResourceAuthorization(asm)` | `services.AddResourceAuthorization<TMessage, TResource, TResponse>()` plus `services.AddScoped<IResourceLoader<TMessage, TResource>, TLoader>()` |
+| `o.UseDomainEvents(asm)` | `services.AddDomainEventDispatch()` plus `services.AddDomainEventHandler<TEvent, THandler>()` |
+
+The parameterless `o.UseFluentValidation()` / `o.UseResourceAuthorization()` / `o.UseDomainEvents()` overloads are AOT-compatible — they only register the adapter / pipeline behaviors and rely on the consumer's explicit per-type registrations, which is the same pattern AOT consumers already use directly.
+
+## Layered configuration via repeated calls
+
+`UseAsp(configure)` and `UseMediator(configureTelemetry)` allow repeated calls; the configure delegates compose in call order rather than overwriting. This supports library-then-host configuration patterns:
+
+```csharp
+// Library defaults applied first…
+builder.Services.AddTrellis(o => o
+    .UseAsp(opts => opts.MapError<MyDomainError>(StatusCodes.Status409Conflict))
+    .UseAsp(opts => opts.HonorPrefer())); // host adds prefer handling on top
+```
+
+## See also
+
+- [API reference](../api_reference/trellis-api-servicedefaults.md) — type tables and method signatures.
+- [Cookbook Recipe 12: DI wiring playbook](../api_reference/trellis-api-cookbook.md#recipe-12--di-wiring-playbook-addtrellis-composition-builder).
+- Per-package articles: [`integration-aspnet.md`](integration-aspnet.md), [`integration-mediator.md`](integration-mediator.md), [`integration-fluentvalidation.md`](integration-fluentvalidation.md), [`integration-ef.md`](integration-ef.md), [`integration-asp-authorization.md`](integration-asp-authorization.md).

--- a/docs/docfx_project/articles/integration-servicedefaults.md
+++ b/docs/docfx_project/articles/integration-servicedefaults.md
@@ -26,7 +26,7 @@ builder.Services.AddTrellis(options => options
 builder.Services.AddDbContext<AppDbContext>(o => o.UseSqlServer(connectionString));
 ```
 
-`AddTrellis` does NOT register your `DbContext`, your mediator handlers, your route constraints, or your application-specific validators. Those remain explicit registrations.
+`AddTrellis` does NOT register your `DbContext`, your mediator handlers, or your route constraints — those are always application-owned. Validators, resource loaders, and domain event handlers are registered only when you opt into assembly scanning via the params-`Assembly[]` overloads (`UseFluentValidation(asm)`, `UseResourceAuthorization(asm)`, `UseDomainEvents(asm)`); the parameterless overloads register only the adapter / pipeline behavior and leave per-type registrations to you.
 
 ## Canonical order
 

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -68,6 +68,8 @@
     href: integration-ef.md
   - name: Mediator Pipeline
     href: integration-mediator.md
+  - name: Service Defaults (Composition Root)
+    href: integration-servicedefaults.md
   - name: Testing
     href: integration-testing.md
   - name: Observability & Monitoring


### PR DESCRIPTION
Closes the formal Trellis.ServiceDefaults inspection backlog using the canonical 5-phase workflow.

## Summary

| Phase | Outcome |
|---|---|
| 1 — Self-inspection | `files/servicedefaults-inspection-report.md` (0 Critical, 2 Major, 3 Minor, 4 Info) |
| 2 — GPT-5.5 meta-review of report | Validated all 9 findings; surfaced 4 new (1 Major, 2 Minor, 1 Info) including the cross-package N-S1 ordering bug |
| 3 — User decision | Fix everything in one PR with TDD red-first |
| 4 — TDD impl + GPT-5.5 pre-commit | All 5 new tests confirmed RED before fix, GREEN after; pre-commit GPT-5.5 review found zero additional issues across 12 targeted points + broad pass |
| 5 — PR review | We're here |

## Findings closed

### Major

- **M-S1 — `UseEntityFrameworkUnitOfWork<TContext>()` now throws on duplicate call.** Previously chaining `.UseEntityFrameworkUnitOfWork<DbContextA>().UseEntityFrameworkUnitOfWork<DbContextB>()` silently overwrote the first registration. Mirrors the actor-provider strict policy.
- **M-S2 — AOT/trim incompatibility documented prominently.** Package opts out of AOT/trim analyzers, and fluent assembly-scanning methods don't propagate `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` from underlying APIs. New "AOT compatibility" sections in api ref + integration article + NUGET_README with AOT-friendly direct-call mapping.
- **N-S1 — explicit `AddResourceAuthorization<TMessage,TResource,TResponse>()` calls before `AddTrellis(...)` are now order-independent.** Cross-package fix in `Trellis.Mediator.AddTrellisBehaviors`: relocates pre-existing closed-generic `ResourceAuthorizationBehavior<,,>` descriptors to sit immediately before `ValidationBehavior<,>`. Mirrors the `AddTrellisUnitOfWork ↔ AddDomainEventDispatch` symmetry.

### Minor

- **m-S1** — api ref frontmatter `types:` corrected.
- **m-S2** — Behavior section step 6 mentions `IDomainEventPublisher`.
- **m-S3** — `Apply()` else-if branches now check `_useXxx` flag explicitly.
- **N-S2** — new `integration-servicedefaults.md` integration article + toc entry.
- **N-S3** — `Examples/CookbookSnippets/Recipe12_DiPlaybook.cs` rewritten to use the `AddTrellis(...)` builder.

### Info

- **i-S1** — xmldoc `<remarks>` on `UseAsp` / `UseMediator` document repeated-call combine semantics.
- **i-S2** — api ref Order-independence subsection explains the no-assembly `UseResourceAuthorization()` mechanism.
- **i-S3** — `TrellisServiceBuilder` summary documents `Apply()` lifecycle.
- **N-S4** — new `UseCachingActorProvider<T>()` builder slot with same fail-fast duplicate detection.

### Refuted

- i-S4 (no configure delegate on `UseEntityFrameworkUnitOfWork<TContext>` — forward-looking only).
- Multiple `AddTrellis(...)` calls breaking pipeline order (`AddDomainEventDispatch` and `AddTrellisUnitOfWork` are aware of each other and re-order regardless of registration order).
- `Apply()` thread safety (builder is constructed/configured/applied/discarded synchronously).

## Tests

**+5 new tests** in `Trellis.ServiceDefaults.Tests`, all TDD red-first:

- `UseEntityFrameworkUnitOfWork_TwiceWithSameContext_Throws`
- `UseEntityFrameworkUnitOfWork_TwiceWithDifferentContext_Throws` (uses new `SecondaryDbContext` test class)
- `ExplicitResourceAuthorization_BeforeAddTrellis_PositionsBehaviorBeforeValidation`
- `UseCachingActorProvider_AfterUseClaimsActorProvider_WrapsInnerProvider`
- `UseCachingActorProvider_TwiceWithDifferentInner_Throws`

## Documentation

Per the rule "every API or function change updates BOTH the api reference AND the article AND the package READMEs":

- `docs/docfx_project/api_reference/trellis-api-servicedefaults.md` — frontmatter, AOT section, Common Traps update, behavior step 6 fix, new method rows, order-independence subsection.
- `docs/docfx_project/articles/integration-servicedefaults.md` — NEW (was missing).
- `docs/docfx_project/articles/toc.yml` — added entry under "Integration Guides".
- `Trellis.ServiceDefaults/NUGET_README.md` — AOT compatibility section.
- `CHANGELOG.md` — full Unreleased entry covering all 13 findings.

## Validation

- `dotnet build -c Release` clean.
- `dotnet test -c Release --no-build` clean: **5,433 / 5,433 passed** + 15 skipped.
- `publish-docs` `Error.X(...)` lint gate: PASS.
- `docfx build --warningsAsErrors` clean.

## Cross-package note

The N-S1 fix lives in `Trellis.Mediator/src/ServiceCollectionExtensions.cs` (the `AddTrellisBehaviors()` relocation pass), not in `Trellis.ServiceDefaults` — that's where the bug lived. All 142 existing `Trellis.Mediator.Tests` continue to pass.