### PR TITLE
Trellis.FluentValidation inspection findings (m-FV-1..m-FV-4, i-FV-2 + GPT-5.5 N-FV-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Trellis.FluentValidation — inspection findings (m-FV-1..m-FV-4, i-FV-2 + GPT-5.5 N-FV-1)
 
-Closes the formal Trellis.FluentValidation inspection backlog from `files/fluentvalidation-inspection-report.md` after a Phase-2 GPT-5.5 meta-review validated 5 of 6 self-inspection findings, refuted i-FV-1 (`/`-prefixed-input pass-through is documented escape-hatch + `InputPointer` validates escape sequences), and surfaced 1 additional Minor (N-FV-1: `ToResult<T>` doc/code drift). Pre-commit GPT-5.5 review TODO.
+Closes the formal Trellis.FluentValidation inspection backlog from `files/fluentvalidation-inspection-report.md` after a Phase-2 GPT-5.5 meta-review validated 5 of 6 self-inspection findings, refuted i-FV-1 (`/`-prefixed-input pass-through is documented escape-hatch + `InputPointer` validates escape sequences), and surfaced 1 additional Minor (N-FV-1: `ToResult<T>` doc/code drift). Pre-commit GPT-5.5 review confirmed all 6 fix points and surfaced 1 stale-wording cleanup (api ref Behavioral notes "Grouping rule" bullet + incomplete `ValidateToResultAsync` cancellation note); both addressed in the same commit. The "stale generated DocFX YAML" finding from the pre-commit review is moot — `*.yml` is gitignored under `docs/docfx_project/api/` and CI regenerates metadata fresh.
 
 - **(Minor) m-FV-1 — api ref frontmatter `types:` corrected.** Previously listed `[TrellisValidator<T>, ValidationResultExtensions]` — neither type exists in source. Updated to `[FluentValidationServiceCollectionExtensions, FluentValidationMessageValidatorAdapter<TMessage>, FluentValidationResultExtensions]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Trellis.FluentValidation — inspection findings (m-FV-1..m-FV-4, i-FV-2 + GPT-5.5 N-FV-1)
+
+Closes the formal Trellis.FluentValidation inspection backlog from `files/fluentvalidation-inspection-report.md` after a Phase-2 GPT-5.5 meta-review validated 5 of 6 self-inspection findings, refuted i-FV-1 (`/`-prefixed-input pass-through is documented escape-hatch + `InputPointer` validates escape sequences), and surfaced 1 additional Minor (N-FV-1: `ToResult<T>` doc/code drift). Pre-commit GPT-5.5 review TODO.
+
+- **(Minor) m-FV-1 — api ref frontmatter `types:` corrected.** Previously listed `[TrellisValidator<T>, ValidationResultExtensions]` — neither type exists in source. Updated to `[FluentValidationServiceCollectionExtensions, FluentValidationMessageValidatorAdapter<TMessage>, FluentValidationResultExtensions]`.
+
+- **(Minor) m-FV-2 — `FluentValidationMessageValidatorAdapter<TMessage>` constructor null-guards `validators`.** Previously the public primary-constructor parameter was captured directly; passing `null!` would defer the failure to a `NullReferenceException` at the first `foreach (var validator in validators)`. Converted to a traditional constructor with `ArgumentNullException.ThrowIfNull(validators)` at the entry point. Direct construction is reachable from tests (e.g. `new FluentValidationMessageValidatorAdapter<CreateUserCommand>([])` in the test suite), so this is a real public-API surface, not just a DI internal.
+
+- **(Minor) m-FV-3 — `FluentValidationExtension.cs` renamed to `FluentValidationResultExtensions.cs`.** Pure file rename to match the framework convention "one type per file with matching name". The other three source files in the package already follow this convention.
+
+- **(Minor) m-FV-4 — `AddTrellisFluentValidation()` idempotency check now uses `TryAddEnumerable`.** Replaced the manual `services.Any(d => ...)` linear scan with `services.TryAddEnumerable(ServiceDescriptor.Scoped(typeof(IMessageValidator<>), typeof(FluentValidationMessageValidatorAdapter<>)))` — the canonical .NET pattern matching `Trellis.Mediator.AddTrellisBehaviors`. Behavior unchanged: deduplicates by `(ServiceType, ImplementationType)` so repeated calls register the open-generic adapter exactly once.
+
+- **(Minor) N-FV-1 — `ToResult<T>` documentation corrected.** The api ref method-table row and the source xmldoc both contained behavior claims that didn't match the implementation:
+  - api ref claimed it "groups `validationResult.Errors` by property name" — implementation does NOT group; emits one `FieldViolation` per `ValidationFailure`. Multiple failures on the same property produce multiple violations (no information loss).
+  - api ref claimed it uses `FieldViolation(InputPointer.ForProperty(propName), ...)` — implementation uses `new InputPointer(JsonPointerNormalizer.ToJsonPointer(rawName))`.
+  - source xmldoc `<returns>` said failure "if validation failed or value is null" — implementation returns `Result.Ok(value)` whenever `validationResult.IsValid`, regardless of `value` being null. The api ref's behavioral notes correctly stated this; only the methods-table row and xmldoc were wrong.
+  All three drifts now corrected; api ref + xmldoc reflect the actual contract.
+
+- **(Info) i-FV-2 — `ValidateToResultAsync` now observes cancellation before the null-value short-circuit.** Previously a caller passing a cancelled `CancellationToken` AND a null `value` received a `Failure` result rather than the `OperationCanceledException` the documented "Cancellation token to observe" contract implies. Added `cancellationToken.ThrowIfCancellationRequested()` at the top of the method (after the `validator` null-check) so cancellation always wins over null-value short-circuit.
+
+Refuted findings: i-FV-1 (`JsonPointerNormalizer` `/`-prefixed pass-through is documented escape-hatch behavior; `InputPointer` rejects malformed `~` sequences anyway, so silent corruption is not possible). Refuted candidate findings: PII leakage via `failure.ErrorMessage` (FluentValidation message templates are consumer-controlled — Trellis must not silently rewrite them); open-generic `IMessageValidator<>` registration AOT compatibility (open-generic DI is AOT-safe; the scanning overload correctly carries `[RequiresUnreferencedCode]`).
+
+Tests: **+2** new tests in `Trellis.FluentValidation.Tests`:
+- `Constructor_throws_ArgumentNullException_when_validators_is_null` (m-FV-2).
+- `ValidateToResultAsync_NullValue_CancelledToken_observes_cancellation` (i-FV-2).
+
 #### Trellis.ServiceDefaults — inspection findings (M-S1, M-S2, m-S1..m-S3, i-S1..i-S4 + GPT-5.5 N-S1..N-S4)
 
 Closes the formal Trellis.ServiceDefaults inspection backlog from `files/servicedefaults-inspection-report.md` after a meta-review by GPT-5.5 validated all 9 self-inspection findings and surfaced 4 additional ones (one Major, two Minor, one Info).

--- a/Trellis.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
+++ b/Trellis.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
@@ -28,11 +28,26 @@ using Trellis.Mediator;
 /// </para>
 /// </remarks>
 /// <typeparam name="TMessage">The message type the contained validators target.</typeparam>
-public sealed class FluentValidationMessageValidatorAdapter<TMessage>(
-    IEnumerable<IValidator<TMessage>> validators)
+public sealed class FluentValidationMessageValidatorAdapter<TMessage>
     : IMessageValidator<TMessage>
     where TMessage : global::Mediator.IMessage
 {
+    private readonly IEnumerable<IValidator<TMessage>> _validators;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FluentValidationMessageValidatorAdapter{TMessage}"/>.
+    /// </summary>
+    /// <param name="validators">
+    /// The injected sequence of <see cref="IValidator{T}"/> implementations to run against each
+    /// message. Typically resolved from DI as <c>IEnumerable&lt;IValidator&lt;TMessage&gt;&gt;</c>.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="validators"/> is null.</exception>
+    public FluentValidationMessageValidatorAdapter(IEnumerable<IValidator<TMessage>> validators)
+    {
+        ArgumentNullException.ThrowIfNull(validators);
+        _validators = validators;
+    }
+
     /// <inheritdoc />
     public async ValueTask<IResult> ValidateAsync(
         TMessage message,
@@ -40,7 +55,7 @@ public sealed class FluentValidationMessageValidatorAdapter<TMessage>(
     {
         List<FieldViolation>? violations = null;
 
-        foreach (var validator in validators)
+        foreach (var validator in _validators)
         {
             var validationResult = await validator
                 .ValidateAsync(message, cancellationToken)

--- a/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
+++ b/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
@@ -136,8 +136,10 @@ public static class FluentValidationResultExtensions
     /// <param name="value">The value that was validated.</param>
     /// <returns>
     /// <list type="bullet">
-    /// <item>Success containing the value if validation passed</item>
-    /// <item>Failure with validation errors if validation failed or value is null</item>
+    /// <item>Success containing the value if <see cref="ValidationResult.IsValid"/> is <see langword="true"/>
+    /// (does <b>not</b> independently reject <see langword="null"/> values — the caller-side
+    /// <c>ValidateToResult</c> / <c>ValidateToResultAsync</c> helpers handle null short-circuiting)</item>
+    /// <item>Failure with validation errors if <see cref="ValidationResult.IsValid"/> is <see langword="false"/></item>
     /// </list>
     /// </returns>
     /// <remarks>
@@ -430,6 +432,12 @@ public static class FluentValidationResultExtensions
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(validator);
+        // Observe cancellation BEFORE the null-value short-circuit so a cancelled token
+        // always wins over the synchronous fallback path. Without this, callers passing a
+        // cancelled token + null value would receive a Failure result rather than the
+        // OperationCanceledException the documented "Cancellation token to observe"
+        // contract implies. (Inspection finding i-FV-2.)
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (value is null)
         {

--- a/Trellis.FluentValidation/src/FluentValidationServiceCollectionExtensions.cs
+++ b/Trellis.FluentValidation/src/FluentValidationServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using global::FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Trellis.Mediator;
 
 /// <summary>
@@ -49,12 +50,10 @@ public static class FluentValidationServiceCollectionExtensions
         // scanning overload) must not register the open-generic adapter more than once. Without
         // this guard, DI would resolve multiple IMessageValidator<TMessage> instances and the
         // adapter would execute every IValidator<TMessage> twice per request.
-        if (!services.Any(d =>
-                d.ServiceType == typeof(IMessageValidator<>)
-                && d.ImplementationType == typeof(FluentValidationMessageValidatorAdapter<>)))
-        {
-            services.AddScoped(typeof(IMessageValidator<>), typeof(FluentValidationMessageValidatorAdapter<>));
-        }
+        // TryAddEnumerable deduplicates by (ServiceType, ImplementationType), matching the
+        // canonical pattern used by Trellis.Mediator.AddTrellisBehaviors.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped(typeof(IMessageValidator<>), typeof(FluentValidationMessageValidatorAdapter<>)));
 
         return services;
     }

--- a/Trellis.FluentValidation/tests/FluentTests.cs
+++ b/Trellis.FluentValidation/tests/FluentTests.cs
@@ -279,5 +279,27 @@ public class FluentTests
         result.Should().BeSuccess();
     }
 
+    [Fact]
+    public async Task ValidateToResultAsync_NullValue_CancelledToken_observes_cancellation()
+    {
+        // Inspection finding i-FV-2: when the caller passes a cancelled token AND a null
+        // value, the previous implementation returned a Failure result without observing
+        // the token (the null short-circuit ran before any cancellation check). The fix
+        // observes the token at the top of the method so cancellation always wins over
+        // null-value short-circuit, matching the documented "Cancellation token to observe"
+        // contract.
+        var validator = new InlineValidator<string?>
+        {
+            v => v.RuleFor(x => x).NotEmpty()
+        };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        string? value = null;
+
+        var act = async () => await validator.ValidateToResultAsync(value, cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     #endregion
 }

--- a/Trellis.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
+++ b/Trellis.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
@@ -28,6 +28,20 @@ public class FluentValidationMessageValidatorAdapterTests
     }
 
     [Fact]
+    public void Constructor_throws_ArgumentNullException_when_validators_is_null()
+    {
+        // Inspection finding m-FV-2: the public constructor is reachable directly
+        // (DI never passes null IEnumerable<T>, but tests + future callers can).
+        // Without a guard the adapter NREs at the first foreach(validators) on
+        // ValidateAsync. Defensive convention from PR #459/#461/#462: every public
+        // constructor null-guards reference parameters.
+        var act = () => new FluentValidationMessageValidatorAdapter<CreateUserCommand>(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("validators");
+    }
+
+    [Fact]
     public async Task ValidateAsync_all_validators_pass_returns_success()
     {
         var adapter = new FluentValidationMessageValidatorAdapter<CreateUserCommand>(

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -1,9 +1,9 @@
 ﻿---
 package: Trellis.FluentValidation
 namespaces: [Trellis.FluentValidation]
-types: [TrellisValidator<T>, ValidationResultExtensions]
+types: [FluentValidationServiceCollectionExtensions, FluentValidationMessageValidatorAdapter<TMessage>, FluentValidationResultExtensions]
 version: v3
-last_verified: 2026-05-01
+last_verified: 2026-05-05
 audience: [llm]
 ---
 # Trellis.FluentValidation — API Reference
@@ -107,9 +107,9 @@ public static class FluentValidationResultExtensions
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<T> ToResult<T>(this ValidationResult validationResult, T value, [CallerArgumentExpression(nameof(value))] string paramName = "value")` | `Result<T>` | Returns `Result.Ok(value)` when `validationResult.IsValid` is `true`; otherwise groups `validationResult.Errors` by property name, substitutes `paramName` for root-level failures, and returns `Result.Fail<T>(new Error.UnprocessableContent(fieldViolations))` where each FluentValidation failure becomes a `FieldViolation(InputPointer.ForProperty(propName), reasonCode) { Detail = fvMessage }`. Throws `ArgumentNullException` when `validationResult` is `null`. |
+| `public static Result<T> ToResult<T>(this ValidationResult validationResult, T value, [CallerArgumentExpression(nameof(value))] string paramName = "value")` | `Result<T>` | Returns `Result.Ok(value)` when `validationResult.IsValid` is `true` (does **not** independently reject `null` values). Otherwise emits one `FieldViolation` per `validationResult.Errors` entry and returns `Result.Fail<T>(new Error.UnprocessableContent(fieldViolations))`. Each FluentValidation failure becomes a `FieldViolation(new InputPointer(JsonPointerNormalizer.ToJsonPointer(rawName)), reasonCode) { Detail = fvMessage }`, where `rawName = string.IsNullOrWhiteSpace(failure.PropertyName) ? paramName : failure.PropertyName` and `reasonCode = string.IsNullOrWhiteSpace(failure.ErrorCode) ? "validation.error" : failure.ErrorCode`. Multiple failures on the same property produce multiple `FieldViolation` entries (no grouping). Throws `ArgumentNullException` when `validationResult` is `null`. |
 | `public static Result<T> ValidateToResult<T>(this IValidator<T> validator, T value, [CallerArgumentExpression(nameof(value))] string paramName = "value", string? message = null)` | `Result<T>` | Throws `ArgumentNullException` when `validator` is `null`. If `value is null`, does **not** call `validator.Validate`; instead returns a validation failure for `paramName` using `message ?? $"'{paramName}' must not be empty."`. Otherwise calls `validator.Validate(value)` and forwards to `ToResult(value, paramName)`. |
-| `public static async Task<Result<T>> ValidateToResultAsync<T>(this IValidator<T> validator, T value, [CallerArgumentExpression(nameof(value))] string paramName = "value", string? message = null, CancellationToken cancellationToken = default)` | `Task<Result<T>>` | Throws `ArgumentNullException` when `validator` is `null`. If `value is null`, does **not** call `validator.ValidateAsync`; instead returns the same validation failure shape as `ValidateToResult`. Otherwise awaits `validator.ValidateAsync(value, cancellationToken).ConfigureAwait(false)` and forwards to `ToResult(value, paramName)`. |
+| `public static async Task<Result<T>> ValidateToResultAsync<T>(this IValidator<T> validator, T value, [CallerArgumentExpression(nameof(value))] string paramName = "value", string? message = null, CancellationToken cancellationToken = default)` | `Task<Result<T>>` | Throws `ArgumentNullException` when `validator` is `null`. Observes `cancellationToken` BEFORE the null-value short-circuit, so a cancelled token always wins over the synchronous fallback path. If `value is null`, does **not** call `validator.ValidateAsync`; instead returns the same validation failure shape as `ValidateToResult`. Otherwise awaits `validator.ValidateAsync(value, cancellationToken).ConfigureAwait(false)` and forwards to `ToResult(value, paramName)`. |
 
 ## Extension methods
 
@@ -153,10 +153,10 @@ public static async Task<Result<T>> ValidateToResultAsync<T>(
 - Shared validator instances are only as concurrency-safe as the underlying `IValidator<T>` implementation; these helpers do not change that.
 - `ToResult<T>` only null-checks `validationResult`; it does not independently reject a `null` `value`.
 - Validation failures are converted into `Error.UnprocessableContent` whose `Fields` collection is built from one `FieldViolation` per FluentValidation failure (no grouping; multiple failures on the same property emit multiple violations).
-- Grouping rule: `string.IsNullOrWhiteSpace(e.PropertyName) ? paramName : e.PropertyName`.
+- Field-name selection rule: `string.IsNullOrWhiteSpace(e.PropertyName) ? paramName : e.PropertyName` (FluentValidation root-level failures fall back to the caller-captured `paramName`).
 - `ValidateToResult<T>` and `ValidateToResultAsync<T>` short-circuit `null` input before invoking FluentValidation.
 - Null-input failures are created as `new ValidationResult([new ValidationFailure(paramName, message ?? $"'{paramName}' must not be empty.")])`.
-- `ValidateToResultAsync<T>` propagates cancellation through `validator.ValidateAsync(value, cancellationToken)`.
+- `ValidateToResultAsync<T>` observes `cancellationToken` BEFORE the null-value short-circuit (so a cancelled token always wins over the synchronous fallback) AND propagates cancellation through `validator.ValidateAsync(value, cancellationToken)`.
 - Exceptions from FluentValidation itself are not caught, except for the explicit `ArgumentNullException.ThrowIfNull(...)` guards on `validationResult` and `validator`.
 
 ## Code examples


### PR DESCRIPTION
Closes the formal Trellis.FluentValidation inspection backlog using the canonical 5-phase workflow.

## Summary

| Phase | Outcome |
|---|---|
| 1 — Self-inspection | `files/fluentvalidation-inspection-report.md` (0 Critical, 0 Major, 4 Minor, 2 Info) |
| 2 — GPT-5.5 meta-review | Validated 5 of 6 findings; refuted i-FV-1 (escape-hatch behavior); surfaced 1 NEW Minor (N-FV-1: `ToResult<T>` doc/code drift) |
| 3 — User decision | Fix everything in one PR with TDD red-first |
| 4 — TDD impl + GPT-5.5 pre-commit | Both new tests confirmed RED before fix, GREEN after; pre-commit GPT-5.5 surfaced 1 stale-wording cleanup (api ref Behavioral notes), addressed in same commit |
| 5 — PR review | We're here |

## Findings closed

### Minor
- **m-FV-1** — api ref frontmatter `types:` corrected (`[TrellisValidator<T>, ValidationResultExtensions]` → actual public types).
- **m-FV-2** — `FluentValidationMessageValidatorAdapter<TMessage>` constructor null-guards `validators`.
- **m-FV-3** — file `FluentValidationExtension.cs` renamed to `FluentValidationResultExtensions.cs` to match contained type name.
- **m-FV-4** — `AddTrellisFluentValidation()` idempotency now uses `TryAddEnumerable` (canonical .NET pattern matching `Trellis.Mediator.AddTrellisBehaviors`).
- **N-FV-1** (GPT-5.5 meta-review) — `ToResult<T>` doc/code drift corrected: no grouping, uses `JsonPointerNormalizer`, returns `Ok` even on null value when valid.

### Info
- **i-FV-2** — `ValidateToResultAsync` now observes cancellation BEFORE the null-value short-circuit.

### Refuted
- i-FV-1 (`JsonPointerNormalizer` `/`-prefixed pass-through is documented escape-hatch behavior; `InputPointer` rejects malformed `~` sequences).

## Tests

**+2 new tests** in `Trellis.FluentValidation.Tests`, TDD red-first:

- `Constructor_throws_ArgumentNullException_when_validators_is_null` (m-FV-2).
- `ValidateToResultAsync_NullValue_CancelledToken_observes_cancellation` (i-FV-2).

## Documentation

Per the convention "every API or function change updates BOTH the api reference AND the article (and the package READMEs when contract behavior changes)":

- `docs/docfx_project/api_reference/trellis-api-fluentvalidation.md` — frontmatter `types:` fix; `ToResult<T>` row updated; Behavioral notes "Grouping rule" → "Field-name selection rule"; `ValidateToResultAsync` cancellation note now mentions pre-null-short-circuit observation.
- `CHANGELOG.md` — full Unreleased entry covering all 6 findings.

The integration article and READMEs were already accurate; no changes required there.

## Validation

- `dotnet build -c Release` clean.
- `dotnet test -c Release --no-build` clean: **5,435 / 5,435 passed** + 15 skipped.
- `publish-docs` `Error.X(...)` lint gate: PASS.
- `docfx build --warningsAsErrors` clean.