### PR TITLE
Trellis.Testing.AspNetCore inspection findings (Major BOM bug + Minor null-guards + GPT-5.5 N-TA-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Trellis.Testing.AspNetCore — inspection findings (m-TA-1, m-TA-3..m-TA-7, i-TA-1, i-TA-2 + GPT-5.5 N-TA-1)
+
+Closes the formal Trellis.Testing.AspNetCore inspection backlog from `files/testing-aspnetcore-inspection-report.md` after a Phase-2 GPT-5.5 meta-review validated 5 of 6 self-inspection findings, refuted m-TA-2 (the case-insensitive fallback in `ScenarioContext.TryResolve` is required because `Record` accepts public callers' arbitrary `IReadOnlyDictionary<string, string>` headers), promoted my refutation of `MsalTestTokenProvider.AcquireTokenAsync` testUserName null-check to a real Minor (m-TA-7), and surfaced 1 NEW Major (N-TA-1: UTF-8 BOM mishandling in `HttpFileParser`).
+
+- **(Major) N-TA-1 — `HttpFileParser` now strips a leading UTF-8 BOM (U+FEFF) before line dispatch.** Many editors save `.http` files with a UTF-8 BOM by default; without stripping it, the first line of the file failed all dispatch checks (`line.StartsWith("###")` returned false because line[0] was U+FEFF, `line[0] == '@'` returned false for the same reason) and fell into `ParseRequestLine`, producing a bogus request with method `"\uFEFF@HOST"` and URL `"="`. The variable definition was lost; subsequent `{{host}}` substitutions resolved against an empty bag. The repository has a real BOM-prefixed `.http` file at `Examples/ConditionalRequestExample/api.http` that demonstrates the case. Fix: strip a single leading `'\uFEFF'` from `content` at the top of `Parse(...)` before splitting into lines. Added a regression test (`Parse_strips_leading_UTF8_BOM_so_first_line_variable_is_registered`).
+
+- **(Minor) m-TA-1 — api ref frontmatter `types:` corrected.** Previously listed `[WebApplicationFactory<TEntryPoint>, TestClient, FakeTimeProvider, EntraTokenAcquirer, HttpFileReplayer]` — all 5 entries were wrong (some belong to other packages, others don't exist anywhere). Updated to the complete actual public-type list (16 types). The api ref body already documented the real surface; only the frontmatter was broken.
+
+- **(Minor) m-TA-3 — `WithFakeTimeProvider` `out`-overloads now `ArgumentNullException.ThrowIfNull(factory)` at their entry points.** Previously the null-check happened 2 calls deep in the delegated `(FakeTimeProvider)` overload. Per GPT-5.5: not an observable param-name bug (the delegated check produces `paramName: "factory"` correctly), but inconsistent with the public-API entry-point guard pattern used elsewhere in the package. Added entry-point guards + regression tests.
+
+- **(Minor) m-TA-4 — `CreateClientWithEntraTokenAsync` now null-checks `factory` and `testUserName`.** Previously only `tokenProvider` was null-checked. A null `factory` would NRE on `factory.CreateClient()` AFTER paying the cost of a real Entra token acquisition. A null `testUserName` flowed into `MsalTestTokenProvider.AcquireTokenAsync` which threw `ArgumentNullException(paramName: "key")` from `Dictionary.TryGetValue`, confusingly NOT matching the user's parameter name. Both companion `CreateClientWithActor` overloads already null-checked `factory`; this overload was the inconsistent one.
+
+- **(Minor) m-TA-5 — `HttpFileTheoryData.FromFile` now `ArgumentNullException.ThrowIfNull(path)`.** Companion `HttpFileParser.ParseFile` already had the explicit guard. `File.ReadAllText` would also throw on null `path`, but the explicit guard at the public-API entry point keeps the surface uniform.
+
+- **(Minor) m-TA-6 — `ScenarioContext.Record` now `ArgumentNullException.ThrowIfNull(headers)`.** Previously a null `headers` was stored in the `_named` dictionary and only NRE'd later in `TryResolve` (far from the misconfiguration site). Fails fast at `Record`'s entry now.
+
+- **(Minor) m-TA-7 (GPT-5.5 promotion) — `MsalTestTokenProvider.AcquireTokenAsync` now null-checks `testUserName`.** Same shape as m-TA-4 but at the inner `AcquireTokenAsync` public surface. Previously `Dictionary.TryGetValue(null, ...)` threw `ArgumentNullException(paramName: "key")`. Defensive convention: public-API entry points get an explicit guard surfacing the right parameter name.
+
+- **(Info) i-TA-1 — Two-step → single-step audit (per the PR-466 standing inspection-checklist memory).** Audited every two-step API pattern in the package. Result: only `ScenarioContext.TryResolve`'s case-insensitive fallback looked like a two-step that could collapse to a single TryGetValue, but GPT-5.5 correctly refuted that — the fallback IS required because `Record` accepts public callers' arbitrary `IReadOnlyDictionary<string, string>` (which may or may not be case-insensitive). Other audited locations: `HttpFileRunner.cs` content-header replace (no single-op equivalent in `HttpHeaders`); `ServiceCollectionDbProviderExtensions` Where-then-Remove (list-then-remove avoids in-iteration-modification); `IServiceCollection.RemoveAll<T>() + AddXxx` (canonical idiom; framework's `Replace(...)` has different semantics). Net: **0 actionable two-step → single-step opportunities** in this package.
+
+- **(Info) i-TA-2 — `WebApplicationFactoryExtensions.CreateClientWithActor` JSON-building duplication.** The two overloads share ~10 lines of `JsonObject` construction. Refactoring was deferred — the duplication is harmless and the shapes differ slightly (the simpler overload uses empty `JsonArray` / `JsonObject` for forbidden-permissions / attributes rather than copying from an `Actor`).
+
+Refuted findings: m-TA-2 (`ScenarioContext.TryResolve` case-insensitive fallback is NOT dead code; required by public `Record` accepting arbitrary `IReadOnlyDictionary<string, string>` — existing test `ScenarioContextTests.cs:177-181` records via case-sensitive `Dictionary<string, string>` and resolves `etag` against stored `ETag`); `MsalTestOptions` mutable `Dictionary<string, TestUserCredentials> TestUsers` (intentional configuration POCO); `HttpFileParser.SubstituteStaticVars` ordinal `IndexOf` (correct for `.http`-file byte-level parsing); `HttpFileRunner.RunSingleAsync` `client.BaseAddress` null-check (`HttpClient.SendAsync` documented to throw on relative URL with no BaseAddress); `MsalTestOptions.Scopes`/`TestUsers` getter-setter (configuration POCO).
+
+Tests: **+8** new tests in `Trellis.Testing.AspNetCore.Tests`:
+- `Parse_strips_leading_UTF8_BOM_so_first_line_variable_is_registered` (N-TA-1).
+- `WithFakeTimeProvider_OutOverload_NullFactory_Throws_ArgumentNullException`, `WithFakeTimeProvider_OutOverloadWithStartInstant_NullFactory_Throws_ArgumentNullException` (m-TA-3).
+- `CreateClientWithEntraTokenAsync_NullFactory_Throws_ArgumentNullException`, `CreateClientWithEntraTokenAsync_NullTestUserName_Throws_ArgumentNullException` (m-TA-4).
+- `FromFile_NullPath_Throws_ArgumentNullException` (m-TA-5).
+- `Record_NullHeaders_Throws_ArgumentNullException` (m-TA-6).
+- `AcquireTokenAsync_NullTestUserName_Throws_ArgumentNullException` (m-TA-7, in new `MsalTestTokenProviderTests.cs`).
+
+Pre-commit GPT-5.5 review confirmed all 7 fix points (correctness of BOM-strip, null-check ordering, out-overload guards before allocations, IL2026 suppression scope, test string construction, project test-globbing, no-network-trigger from null-tests, CHANGELOG-bullet/test-count alignment) and surfaced **zero** additional findings.
+
 #### Trellis.Testing — inspection findings (m-T-1, m-T-2, m-T-3, i-T-1 + GPT-5.5 N-T-1..N-T-4)
 
 Closes the formal Trellis.Testing inspection backlog from `files/testing-inspection-report.md` after a Phase-2 GPT-5.5 meta-review validated all 4 self-inspection findings and surfaced 4 additional ones (all Minor).

--- a/Trellis.Testing.AspNetCore/src/Http/HttpFileParser.cs
+++ b/Trellis.Testing.AspNetCore/src/Http/HttpFileParser.cs
@@ -47,6 +47,16 @@ public static class HttpFileParser
     {
         ArgumentNullException.ThrowIfNull(content);
 
+        // Strip a single leading UTF-8 BOM (U+FEFF). Many editors save .http files
+        // with a BOM by default; without this, the first line's leading FEFF byte
+        // would defeat the `line.StartsWith("###")` and `line[0] == '@'` dispatch
+        // checks below, so a file beginning with `@host = ...` would be misparsed
+        // as a bogus request with method `\uFEFF@HOST` and URL `=`. (N-TA-1.)
+        if (content.Length > 0 && content[0] == '\uFEFF')
+        {
+            content = content.Substring(1);
+        }
+
         var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         if (vars is not null)
         {

--- a/Trellis.Testing.AspNetCore/src/Http/HttpFileTheoryData.cs
+++ b/Trellis.Testing.AspNetCore/src/Http/HttpFileTheoryData.cs
@@ -23,6 +23,7 @@ public static class HttpFileTheoryData
     /// <returns>An enumerable of single-element <c>object[]</c> rows.</returns>
     public static IEnumerable<object[]> FromFile(string path, IReadOnlyDictionary<string, string>? vars = null)
     {
+        ArgumentNullException.ThrowIfNull(path);
         var content = File.ReadAllText(path);
         return HttpFileParser.Parse(content, vars).Select(r => new object[] { r }).ToArray();
     }

--- a/Trellis.Testing.AspNetCore/src/Http/ScenarioContext.cs
+++ b/Trellis.Testing.AspNetCore/src/Http/ScenarioContext.cs
@@ -22,6 +22,7 @@ public sealed class ScenarioContext
     public void Record(string name, int status, IReadOnlyDictionary<string, string> headers, string? body)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(headers);
         JsonNode? node = null;
         if (!string.IsNullOrWhiteSpace(body))
         {

--- a/Trellis.Testing.AspNetCore/src/MsalTestTokenProvider.cs
+++ b/Trellis.Testing.AspNetCore/src/MsalTestTokenProvider.cs
@@ -77,6 +77,8 @@ public sealed class MsalTestTokenProvider
         string testUserName,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(testUserName);
+
         if (!_options.TestUsers.TryGetValue(testUserName, out var credentials))
             throw new KeyNotFoundException(
                 $"Test user '{testUserName}' not found in MsalTestOptions.TestUsers. " +

--- a/Trellis.Testing.AspNetCore/src/WebApplicationFactoryExtensions.cs
+++ b/Trellis.Testing.AspNetCore/src/WebApplicationFactoryExtensions.cs
@@ -109,7 +109,9 @@ public static class WebApplicationFactoryExtensions
         CancellationToken cancellationToken = default)
         where TEntryPoint : class
     {
+        ArgumentNullException.ThrowIfNull(factory);
         ArgumentNullException.ThrowIfNull(tokenProvider);
+        ArgumentNullException.ThrowIfNull(testUserName);
 
         var token = await tokenProvider.AcquireTokenAsync(testUserName, cancellationToken)
             .ConfigureAwait(false);

--- a/Trellis.Testing.AspNetCore/src/WebApplicationFactoryTimeExtensions.cs
+++ b/Trellis.Testing.AspNetCore/src/WebApplicationFactoryTimeExtensions.cs
@@ -96,7 +96,10 @@ public static class WebApplicationFactoryTimeExtensions
         this WebApplicationFactory<TEntryPoint> factory,
         out FakeTimeProvider fakeTimeProvider)
         where TEntryPoint : class
-        => factory.WithFakeTimeProvider(DefaultTestStartInstant, out fakeTimeProvider);
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        return factory.WithFakeTimeProvider(DefaultTestStartInstant, out fakeTimeProvider);
+    }
 
     /// <summary>
     /// Returns a new <see cref="WebApplicationFactory{TEntryPoint}"/> with a <see cref="FakeTimeProvider"/>
@@ -118,6 +121,7 @@ public static class WebApplicationFactoryTimeExtensions
         out FakeTimeProvider fakeTimeProvider)
         where TEntryPoint : class
     {
+        ArgumentNullException.ThrowIfNull(factory);
         var fake = new FakeTimeProvider(startInstant);
         fakeTimeProvider = fake;
         return factory.WithFakeTimeProvider(fake);

--- a/Trellis.Testing.AspNetCore/tests/Http/HttpFileParserTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/Http/HttpFileParserTests.cs
@@ -166,4 +166,29 @@ public class HttpFileParserTests
         reqs[0].Title.Should().Be("Case");
         reqs[0].ParityMode.Should().Be("status-only");
     }
+
+    [Fact]
+    public void Parse_strips_leading_UTF8_BOM_so_first_line_variable_is_registered()
+    {
+        // Inspection finding N-TA-1: many editors save .http files with a UTF-8 BOM
+        // (U+FEFF prefix). Without BOM stripping, the first line was misclassified —
+        // `line.StartsWith("###")` returned false (line starts with U+FEFF then '#'),
+        // `line[0] == '@'` returned false (line[0] is U+FEFF), so the line fell into
+        // ParseRequestLine and produced a bogus request with method "\uFEFF@HOST" and
+        // URL "=". The variable definition was lost; subsequent {{host}} substitutions
+        // resolved against an empty bag.
+        const char Bom = '\uFEFF';
+        var content = Bom + """
+            @host = http://localhost:62266
+            ### Get root
+            GET {{host}}/
+            """;
+
+        var reqs = HttpFileParser.Parse(content);
+
+        reqs.Should().HaveCount(1, "the BOM-prefixed @host line must be recognized as a variable, not a bogus request");
+        reqs[0].Title.Should().Be("Get root");
+        reqs[0].Method.Should().Be("GET");
+        reqs[0].Url.Should().Be("http://localhost:62266/", "the {{host}} substitution must succeed against the BOM-prefixed @host variable");
+    }
 }

--- a/Trellis.Testing.AspNetCore/tests/Http/HttpFileTheoryDataTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/Http/HttpFileTheoryDataTests.cs
@@ -52,4 +52,17 @@ public class HttpFileTheoryDataTests
             if (File.Exists(path)) File.Delete(path);
         }
     }
+
+    [Fact]
+    public void FromFile_NullPath_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-5: HttpFileParser.ParseFile null-checks `path`
+        // explicitly; HttpFileTheoryData.FromFile delegated to File.ReadAllText which
+        // throws on null but with a different stack trace. Defensive convention:
+        // public-API entry points get an explicit guard.
+        var act = () => HttpFileTheoryData.FromFile(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("path");
+    }
 }

--- a/Trellis.Testing.AspNetCore/tests/Http/ScenarioContextTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/Http/ScenarioContextTests.cs
@@ -223,4 +223,18 @@ public class ScenarioContextTests
         ctx.TryResolve("x.response.body.n", out var v).Should().BeTrue();
         v.Should().Be("999");
     }
+
+    [Fact]
+    public void Record_NullHeaders_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-6: Record stored `headers` without null-check, then
+        // later TryResolve iterated/queried it. A null `headers` would NRE later, far
+        // from the misconfiguration site. Now fails fast at Record's entry.
+        var ctx = new ScenarioContext();
+
+        var act = () => ctx.Record("name", 200, headers: null!, body: "{}");
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("headers");
+    }
 }

--- a/Trellis.Testing.AspNetCore/tests/MsalTestTokenProviderTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/MsalTestTokenProviderTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Trellis.Testing.AspNetCore.Tests;
+
+using System;
+using System.Threading.Tasks;
+using Trellis.Testing.AspNetCore;
+
+/// <summary>
+/// Tests for <see cref="MsalTestTokenProvider"/>. The provider is intentionally not
+/// exercised against a real Entra tenant in these tests — only the public-surface
+/// argument-validation contracts.
+/// </summary>
+public sealed class MsalTestTokenProviderTests
+{
+    [Fact]
+    public async Task AcquireTokenAsync_NullTestUserName_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-7: previously a null `testUserName` flowed through
+        // _options.TestUsers.TryGetValue(null!, ...) which throws
+        // ArgumentNullException(paramName: "key"), confusingly NOT matching the
+        // public parameter name `testUserName`. Defensive null-check at the
+        // public-API entry point surfaces the right name.
+        var options = new MsalTestOptions
+        {
+            TenantId = "fake-tenant",
+            ClientId = Guid.NewGuid().ToString(),
+            Scopes = ["api://fake/.default"],
+        };
+#pragma warning disable IL2026 // RequiresUnreferencedCode propagation — test exercises ArgumentNullException, not the MSAL reflection path.
+        var provider = new MsalTestTokenProvider(options);
+
+        var act = async () => await provider.AcquireTokenAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("testUserName");
+#pragma warning restore IL2026
+    }
+}

--- a/Trellis.Testing.AspNetCore/tests/WebApplicationFactoryExtensionsTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/WebApplicationFactoryExtensionsTests.cs
@@ -143,4 +143,58 @@ public sealed class WebApplicationFactoryExtensionsTests : IDisposable
             return host;
         }
     }
+
+    #region Round-N inspection findings (m-TA-4) — CreateClientWithEntraTokenAsync null-guards
+
+    [Fact]
+    public async Task CreateClientWithEntraTokenAsync_NullFactory_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-4: previously only `tokenProvider` was null-checked.
+        // A null `factory` would NRE on factory.CreateClient() AFTER paying the cost of
+        // a real Entra token acquisition. Companion CreateClientWithActor overloads
+        // both null-check `factory`; this overload was the inconsistent one.
+        WebApplicationFactory<TestFactory> factory = null!;
+        // tokenProvider intentionally null too — but the factory check should fire FIRST,
+        // matching the parameter order. We pass a non-null tokenProvider to ensure the
+        // factory check is what's exercised.
+        var msalOptions = new Trellis.Testing.AspNetCore.MsalTestOptions
+        {
+            TenantId = "fake-tenant",
+            ClientId = Guid.NewGuid().ToString(),
+            Scopes = ["api://fake/.default"],
+        };
+#pragma warning disable IL2026 // RequiresUnreferencedCode propagation — test exercises ArgumentNullException, not the MSAL path.
+        var tokenProvider = new Trellis.Testing.AspNetCore.MsalTestTokenProvider(msalOptions);
+
+        var act = async () => await factory.CreateClientWithEntraTokenAsync(tokenProvider, "salesRep");
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("factory");
+#pragma warning restore IL2026
+    }
+
+    [Fact]
+    public async Task CreateClientWithEntraTokenAsync_NullTestUserName_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-4: a null `testUserName` flowed into
+        // tokenProvider.AcquireTokenAsync where Dictionary.TryGetValue threw with
+        // paramName "key", confusingly NOT matching the user's parameter name.
+        // Defensive null-check at the public entry surfaces the right name.
+        var msalOptions = new Trellis.Testing.AspNetCore.MsalTestOptions
+        {
+            TenantId = "fake-tenant",
+            ClientId = Guid.NewGuid().ToString(),
+            Scopes = ["api://fake/.default"],
+        };
+#pragma warning disable IL2026
+        var tokenProvider = new Trellis.Testing.AspNetCore.MsalTestTokenProvider(msalOptions);
+
+        var act = async () => await _factory.CreateClientWithEntraTokenAsync(tokenProvider, null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("testUserName");
+#pragma warning restore IL2026
+    }
+
+    #endregion
 }

--- a/Trellis.Testing.AspNetCore/tests/WebApplicationFactoryTimeExtensionsTests.cs
+++ b/Trellis.Testing.AspNetCore/tests/WebApplicationFactoryTimeExtensionsTests.cs
@@ -97,4 +97,33 @@ public sealed class WebApplicationFactoryTimeExtensionsTests : IDisposable
             return host;
         }
     }
+
+    [Fact]
+    public void WithFakeTimeProvider_OutOverload_NullFactory_Throws_ArgumentNullException()
+    {
+        // Inspection finding m-TA-3: the 2-arg out-overload didn't null-check `factory`
+        // at its entry; the eventual ArgumentNullException came from the delegated
+        // overload, leaking the implementation chain into the stack trace. Defensive
+        // convention: public-API entry points get an explicit guard.
+        WebApplicationFactory<TestFactory> factory = null!;
+
+        var act = () => factory.WithFakeTimeProvider(out var _);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("factory");
+    }
+
+    [Fact]
+    public void WithFakeTimeProvider_OutOverloadWithStartInstant_NullFactory_Throws_ArgumentNullException()
+    {
+        // Same as above for the 3-arg out-overload taking an explicit DateTimeOffset.
+        WebApplicationFactory<TestFactory> factory = null!;
+
+        var act = () => factory.WithFakeTimeProvider(
+            DateTimeOffset.UtcNow,
+            out var _);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("factory");
+    }
 }

--- a/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md
@@ -1,9 +1,9 @@
 ﻿---
 package: Trellis.Testing.AspNetCore
 namespaces: [Trellis.Testing.AspNetCore, Trellis.Testing.AspNetCore.Http]
-types: [WebApplicationFactory<TEntryPoint>, TestClient, FakeTimeProvider, EntraTokenAcquirer, HttpFileReplayer]
+types: [WebApplicationFactoryExtensions, WebApplicationFactoryTimeExtensions, ServiceCollectionExtensions, ServiceCollectionDbProviderExtensions, MsalTestTokenProvider, MsalTestOptions, TestUserCredentials, HttpFileParser, HttpFileRunner, HttpFileAssertions, HttpFileTheoryData, HttpFileRequest, HttpFileResult, ExpectedOutcome, HttpFileAssertionException, ScenarioContext]
 version: v3
-last_verified: 2026-05-01
+last_verified: 2026-05-06
 audience: [llm]
 ---
 # Trellis.Testing.AspNetCore &mdash; API Reference


### PR DESCRIPTION
Closes the formal Trellis.Testing.AspNetCore inspection backlog using the canonical 5-phase workflow.

## Summary

| Phase | Outcome |
|---|---|
| 1 — Self-inspection | `files/testing-aspnetcore-inspection-report.md` (0 Critical, 0 Major, 6 Minor, 2 Info) |
| 2 — GPT-5.5 meta-review | Validated 5 of 6; refuted m-TA-2 (case-insensitive fallback required by public API contract); promoted my refutation of `MsalTestTokenProvider.AcquireTokenAsync` testUserName null-check to real Minor (m-TA-7); surfaced 1 NEW **Major** (N-TA-1: UTF-8 BOM mishandling in `HttpFileParser`) |
| 3 — User decision | Fix everything in one PR with TDD red-first |
| 4 — TDD impl + GPT-5.5 pre-commit | 5 of 8 new tests confirmed RED before fix (3 are regression-only pinning the contract); pre-commit GPT-5.5 confirmed all 7 fix points + **zero new findings** |
| 5 — PR review | We're here |

## Findings closed

### Major
- **N-TA-1** (GPT-5.5 meta-review) — `HttpFileParser` now strips UTF-8 BOM (U+FEFF) at the top of `Parse(...)`. Real BOM-prefixed file in repo (`Examples/ConditionalRequestExample/api.http`) demonstrates the case. Without the fix, the first line was misclassified and produced a bogus request with method `"\uFEFF@HOST"` and URL `"="`.

### Minor
- **m-TA-1** — api ref frontmatter `types:` corrected (5 wrong entries → 16 actual public types).
- **m-TA-3** — `WithFakeTimeProvider` `out`-overloads null-check `factory` at entry (consistency with public-API guard pattern).
- **m-TA-4** — `CreateClientWithEntraTokenAsync` null-checks `factory` + `testUserName` (paramName drift bug).
- **m-TA-5** — `HttpFileTheoryData.FromFile` null-checks `path` (consistency with `HttpFileParser.ParseFile`).
- **m-TA-6** — `ScenarioContext.Record` null-checks `headers` (was NRE'ing far from misconfiguration site).
- **m-TA-7** (GPT-5.5 promotion) — `MsalTestTokenProvider.AcquireTokenAsync` null-checks `testUserName` (paramName drift via `Dictionary.TryGetValue`).

### Info (already addressed in CHANGELOG narrative; no source changes)
- **i-TA-1** — Two-step → single-step audit (per PR-466 standing checklist memory): **0 actionable opportunities** in this package.
- **i-TA-2** — `CreateClientWithActor` JSON duplication (cosmetic; deferred).

### Refuted
- m-TA-2 (case-insensitive fallback in `ScenarioContext.TryResolve` is required because `Record` is public and accepts arbitrary `IReadOnlyDictionary<string,string>` — existing test `ScenarioContextTests.cs:177-181` records via case-sensitive `Dictionary<string, string>` and resolves `etag` against stored `ETag`).

## Tests

**+8 new tests.** TDD red-first; 5 confirmed RED before fix:
- BOM-strip
- 2× CreateClientWithEntraTokenAsync null-guards
- ScenarioContext.Record null headers
- MsalTestTokenProvider.AcquireTokenAsync null testUserName

3 are regression-only (passing both before and after, pinning the contract):
- WithFakeTimeProvider out-overloads × 2 (delegated null-check already produced correct paramName)
- HttpFileTheoryData.FromFile null path (`File.ReadAllText` already threw ANE("path"))

## Documentation

Per the convention "every API or function change updates the api reference":
- `docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md` — frontmatter `types:` fix.
- `CHANGELOG.md` — full Unreleased entry covering all 8 findings.

The README is accurate as-is; no changes required.

## Validation

- `dotnet build -c Release` clean.
- `dotnet test -c Release --no-build` clean: **5,460 / 5,460 passed** + 15 skipped.
- `publish-docs` `Error.X(...)` lint gate: PASS.
- `docfx build --warningsAsErrors` clean.

## Standing inspection-checklist note

The PR-466 standing memory ("scan for two-step API patterns with single-step equivalents") was applied to this inspection — see i-TA-1 audit table in the inspection report. Net result: 0 actionable opportunities here, but the audit is part of the standard inspection process going forward.