### PR TITLE
Trellis.Core: collapse two-step TryGetValue+Error patterns to single-step overload (i-C-1 follow-up)

### DIFF
--- a/Trellis.Core/src/Result/Extensions/Bind.cs
+++ b/Trellis.Core/src/Result/Extensions/Bind.cs
@@ -29,8 +29,8 @@ public static partial class BindExtensions
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var output = func(value);
         output.LogActivityStatus();
@@ -57,8 +57,8 @@ public static partial class BindExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var output = await func(value).ConfigureAwait(false);
         output.LogActivityStatus();
@@ -144,8 +144,8 @@ public static partial class BindExtensionsAsync
         ArgumentNullException.ThrowIfNull(valueTask);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var output = await valueTask(value).ConfigureAwait(false);
         output.LogActivityStatus();

--- a/Trellis.Core/src/Result/Extensions/BindTs.g.tt
+++ b/Trellis.Core/src/Result/Extensions/BindTs.g.tt
@@ -1,4 +1,4 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -61,8 +61,8 @@ public static partial class BindExtensions
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return func(<# WriteArgs(i); #>);
@@ -118,8 +118,8 @@ public static partial class BindExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -142,8 +142,8 @@ public static partial class BindExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -168,8 +168,8 @@ public static partial class BindExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return func(<# WriteArgs(i); #>);
@@ -193,8 +193,8 @@ public static partial class BindExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return func(<# WriteArgs(i); #>);
@@ -219,8 +219,8 @@ public static partial class BindExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -244,8 +244,8 @@ public static partial class BindExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindExtensions.Bind));
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = value;
         return await func(<# WriteArgs(i); #>).ConfigureAwait(false);

--- a/Trellis.Core/src/Result/Extensions/BindZip.Task.Right.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.Task.Right.cs
@@ -20,17 +20,17 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var value, out var error5))
+        if (!result.TryGetValue(out var value, out var error))
         {
-            var failure = Result.Fail<(T1, T2)>(error5);
+            var failure = Result.Fail<(T1, T2)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner, out var error6))
+        if (!nextResult.TryGetValue(out var inner, out var innerError))
         {
-            var failure = Result.Fail<(T1, T2)>(error6);
+            var failure = Result.Fail<(T1, T2)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.Task.Right.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.Task.Right.cs
@@ -20,17 +20,17 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error5))
         {
-            var failure = Result.Fail<(T1, T2)>(result.Error);
+            var failure = Result.Fail<(T1, T2)>(error5);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner))
+        if (!nextResult.TryGetValue(out var inner, out var error6))
         {
-            var failure = Result.Fail<(T1, T2)>(nextResult.Error);
+            var failure = Result.Fail<(T1, T2)>(error6);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.Task.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.Task.cs
@@ -24,17 +24,17 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error3))
         {
-            var failure = Result.Fail<(T1, T2)>(result.Error);
+            var failure = Result.Fail<(T1, T2)>(error3);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner))
+        if (!nextResult.TryGetValue(out var inner, out var error4))
         {
-            var failure = Result.Fail<(T1, T2)>(nextResult.Error);
+            var failure = Result.Fail<(T1, T2)>(error4);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.Task.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.Task.cs
@@ -24,17 +24,17 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value, out var error3))
+        if (!result.TryGetValue(out var value, out var error))
         {
-            var failure = Result.Fail<(T1, T2)>(error3);
+            var failure = Result.Fail<(T1, T2)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner, out var error4))
+        if (!nextResult.TryGetValue(out var inner, out var innerError))
         {
-            var failure = Result.Fail<(T1, T2)>(error4);
+            var failure = Result.Fail<(T1, T2)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.Right.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.Right.cs
@@ -20,17 +20,17 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error9))
         {
-            var failure = Result.Fail<(T1, T2)>(result.Error);
+            var failure = Result.Fail<(T1, T2)>(error9);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner))
+        if (!nextResult.TryGetValue(out var inner, out var error10))
         {
-            var failure = Result.Fail<(T1, T2)>(nextResult.Error);
+            var failure = Result.Fail<(T1, T2)>(error10);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.Right.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.Right.cs
@@ -20,17 +20,17 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var value, out var error9))
+        if (!result.TryGetValue(out var value, out var error))
         {
-            var failure = Result.Fail<(T1, T2)>(error9);
+            var failure = Result.Fail<(T1, T2)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner, out var error10))
+        if (!nextResult.TryGetValue(out var inner, out var innerError))
         {
-            var failure = Result.Fail<(T1, T2)>(error10);
+            var failure = Result.Fail<(T1, T2)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.cs
@@ -21,17 +21,17 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error7))
         {
-            var failure = Result.Fail<(T1, T2)>(result.Error);
+            var failure = Result.Fail<(T1, T2)>(error7);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner))
+        if (!nextResult.TryGetValue(out var inner, out var error8))
         {
-            var failure = Result.Fail<(T1, T2)>(nextResult.Error);
+            var failure = Result.Fail<(T1, T2)>(error8);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.ValueTask.cs
@@ -21,17 +21,17 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var value, out var error7))
+        if (!result.TryGetValue(out var value, out var error))
         {
-            var failure = Result.Fail<(T1, T2)>(error7);
+            var failure = Result.Fail<(T1, T2)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = await func(value).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var inner, out var error8))
+        if (!nextResult.TryGetValue(out var inner, out var innerError))
         {
-            var failure = Result.Fail<(T1, T2)>(error8);
+            var failure = Result.Fail<(T1, T2)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.cs
@@ -25,17 +25,17 @@ public static partial class BindZipExtensions
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity();
 
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error))
         {
-            var failure = Result.Fail<(T1, T2)>(result.Error);
+            var failure = Result.Fail<(T1, T2)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var nextResult = func(value);
-        if (!nextResult.TryGetValue(out var inner))
+        if (!nextResult.TryGetValue(out var inner, out var error2))
         {
-            var failure = Result.Fail<(T1, T2)>(nextResult.Error);
+            var failure = Result.Fail<(T1, T2)>(error2);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZip.cs
+++ b/Trellis.Core/src/Result/Extensions/BindZip.cs
@@ -33,9 +33,9 @@ public static partial class BindZipExtensions
         }
 
         var nextResult = func(value);
-        if (!nextResult.TryGetValue(out var inner, out var error2))
+        if (!nextResult.TryGetValue(out var inner, out var innerError))
         {
-            var failure = Result.Fail<(T1, T2)>(error2);
+            var failure = Result.Fail<(T1, T2)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZipTs.g.tt
+++ b/Trellis.Core/src/Result/Extensions/BindZipTs.g.tt
@@ -1,4 +1,4 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -61,18 +61,18 @@ public static partial class BindZipExtensions
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue))
+        if (!result.TryGetValue(out var tupleValue, out var error11))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(result.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error11);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = func(<# WriteArgs(i); #>);
-        if (!nextResult.TryGetValue(out var nextValue))
+        if (!nextResult.TryGetValue(out var nextValue, out var error12))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(nextResult.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error12);
             failure.LogActivityStatus();
             return failure;
         }
@@ -110,18 +110,18 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue))
+        if (!result.TryGetValue(out var tupleValue, out var error13))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(result.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error13);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue))
+        if (!nextResult.TryGetValue(out var nextValue, out var error14))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(nextResult.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error14);
             failure.LogActivityStatus();
             return failure;
         }
@@ -156,18 +156,18 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue))
+        if (!result.TryGetValue(out var tupleValue, out var error15))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(result.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error15);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue))
+        if (!nextResult.TryGetValue(out var nextValue, out var error16))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(nextResult.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error16);
             failure.LogActivityStatus();
             return failure;
         }
@@ -187,18 +187,18 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue))
+        if (!result.TryGetValue(out var tupleValue, out var error17))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(result.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error17);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue))
+        if (!nextResult.TryGetValue(out var nextValue, out var error18))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(nextResult.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error18);
             failure.LogActivityStatus();
             return failure;
         }
@@ -232,18 +232,18 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue))
+        if (!result.TryGetValue(out var tupleValue, out var error19))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(result.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error19);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue))
+        if (!nextResult.TryGetValue(out var nextValue, out var error20))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(nextResult.Error);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error20);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/BindZipTs.g.tt
+++ b/Trellis.Core/src/Result/Extensions/BindZipTs.g.tt
@@ -61,18 +61,18 @@ public static partial class BindZipExtensions
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue, out var error11))
+        if (!result.TryGetValue(out var tupleValue, out var error))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error11);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = func(<# WriteArgs(i); #>);
-        if (!nextResult.TryGetValue(out var nextValue, out var error12))
+        if (!nextResult.TryGetValue(out var nextValue, out var innerError))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error12);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }
@@ -110,18 +110,18 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue, out var error13))
+        if (!result.TryGetValue(out var tupleValue, out var error))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error13);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue, out var error14))
+        if (!nextResult.TryGetValue(out var nextValue, out var innerError))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error14);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }
@@ -156,18 +156,18 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue, out var error15))
+        if (!result.TryGetValue(out var tupleValue, out var error))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error15);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue, out var error16))
+        if (!nextResult.TryGetValue(out var nextValue, out var innerError))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error16);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }
@@ -187,18 +187,18 @@ public static partial class BindZipExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
-        if (!result.TryGetValue(out var tupleValue, out var error17))
+        if (!result.TryGetValue(out var tupleValue, out var error))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error17);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue, out var error18))
+        if (!nextResult.TryGetValue(out var nextValue, out var innerError))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error18);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }
@@ -232,18 +232,18 @@ public static partial class BindZipExtensionsAsync
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(BindZipExtensions.BindZip));
 
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue, out var error19))
+        if (!result.TryGetValue(out var tupleValue, out var error))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error19);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error);
             failure.LogActivityStatus();
             return failure;
         }
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var nextResult = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
-        if (!nextResult.TryGetValue(out var nextValue, out var error20))
+        if (!nextResult.TryGetValue(out var nextValue, out var innerError))
         {
-            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(error20);
+            var failure = Result.Fail<(<# WriteTs(outputSize); #>)>(innerError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/Ensure.cs
+++ b/Trellis.Core/src/Result/Extensions/Ensure.cs
@@ -178,10 +178,10 @@ public static class EnsureExtensions
     {
         using var activity = RopTrace.ActivitySource.StartActivity();
 
-        if (!result.TryGetValue(out var value, out var error21))
+        if (!result.TryGetValue(out var value, out var resultError))
         {
             result.LogActivityStatus();
-            return Result.Fail<T>(error21);
+            return Result.Fail<T>(resultError);
         }
 
         if (value is null)
@@ -209,9 +209,9 @@ public static class EnsureExtensions
     {
         using var activity = RopTrace.ActivitySource.StartActivity();
 
-        if (!result.TryGetValue(out var value, out var error22))
+        if (!result.TryGetValue(out var value, out var resultError))
         {
-            var failure = Result.Fail<T>(error22);
+            var failure = Result.Fail<T>(resultError);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/Ensure.cs
+++ b/Trellis.Core/src/Result/Extensions/Ensure.cs
@@ -178,10 +178,10 @@ public static class EnsureExtensions
     {
         using var activity = RopTrace.ActivitySource.StartActivity();
 
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error21))
         {
             result.LogActivityStatus();
-            return Result.Fail<T>(result.Error);
+            return Result.Fail<T>(error21);
         }
 
         if (value is null)
@@ -209,9 +209,9 @@ public static class EnsureExtensions
     {
         using var activity = RopTrace.ActivitySource.StartActivity();
 
-        if (!result.TryGetValue(out var value))
+        if (!result.TryGetValue(out var value, out var error22))
         {
-            var failure = Result.Fail<T>(result.Error);
+            var failure = Result.Fail<T>(error22);
             failure.LogActivityStatus();
             return failure;
         }

--- a/Trellis.Core/src/Result/Extensions/Map.cs
+++ b/Trellis.Core/src/Result/Extensions/Map.cs
@@ -36,8 +36,8 @@ public static partial class MapExtensions
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TOut>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TOut>(error);
 
         return Result.Ok<TOut>(func(value));
     }
@@ -62,8 +62,8 @@ public static partial class MapExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(MapExtensions.Map));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TOut>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TOut>(error);
 
         TOut outValue = await func(value).ConfigureAwait(false);
 
@@ -119,8 +119,8 @@ public static partial class MapExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity(nameof(MapExtensions.Map));
-        if (!result.TryGetValue(out var value))
-            return Result.Fail<TOut>(result.Error);
+        if (!result.TryGetValue(out var value, out var error))
+            return Result.Fail<TOut>(error);
 
         TOut outValue = await func(value).ConfigureAwait(false);
 

--- a/Trellis.Core/src/Result/Extensions/MapTs.g.tt
+++ b/Trellis.Core/src/Result/Extensions/MapTs.g.tt
@@ -1,4 +1,4 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -67,8 +67,8 @@ public static partial class MapExtensions
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var tupleValue))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var tupleValue, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = tupleValue;
         return Result.Ok(func(<# WriteArgs(i); #>));
@@ -119,8 +119,8 @@ public static partial class MapExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var tupleValue))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var tupleValue, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var value = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -137,8 +137,8 @@ public static partial class MapExtensionsAsync
         ArgumentNullException.ThrowIfNull(func);
 
         using var activity = RopTrace.ActivitySource.StartActivity();
-        if (!result.TryGetValue(out var tupleValue))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var tupleValue, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var value = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -192,8 +192,8 @@ public static partial class MapExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity();
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var tupleValue, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var value = await func(<# WriteArgs(i); #>).ConfigureAwait(false);
@@ -211,8 +211,8 @@ public static partial class MapExtensionsAsync
 
         using var activity = RopTrace.ActivitySource.StartActivity();
         var result = await resultTask.ConfigureAwait(false);
-        if (!result.TryGetValue(out var tupleValue))
-            return Result.Fail<TResult>(result.Error);
+        if (!result.TryGetValue(out var tupleValue, out var error))
+            return Result.Fail<TResult>(error);
 
         var (<# WriteArgs(i); #>) = tupleValue;
         var value = await func(<# WriteArgs(i); #>).ConfigureAwait(false);

--- a/Trellis.Core/src/Result/Extensions/Traverse.cs
+++ b/Trellis.Core/src/Result/Extensions/Traverse.cs
@@ -50,10 +50,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = selector(item);
-            if (!result.TryGetValue(out var value, out var error23))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(error23);
+                return Result.Fail<IReadOnlyList<TOut>>(error);
             }
 
             results.Add(value);
@@ -85,10 +85,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = await selector(item).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value, out var error24))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(error24);
+                return Result.Fail<IReadOnlyList<TOut>>(error);
             }
 
             results.Add(value);
@@ -123,10 +123,10 @@ public static class TraverseExtensions
         {
             cancellationToken.ThrowIfCancellationRequested();
             var result = await selector(item, cancellationToken).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value, out var error25))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(error25);
+                return Result.Fail<IReadOnlyList<TOut>>(error);
             }
 
             results.Add(value);
@@ -158,10 +158,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = await selector(item).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value, out var error26))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(error26);
+                return Result.Fail<IReadOnlyList<TOut>>(error);
             }
 
             results.Add(value);
@@ -196,10 +196,10 @@ public static class TraverseExtensions
         {
             cancellationToken.ThrowIfCancellationRequested();
             var result = await selector(item, cancellationToken).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value, out var error27))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(error27);
+                return Result.Fail<IReadOnlyList<TOut>>(error);
             }
 
             results.Add(value);
@@ -276,10 +276,10 @@ public static class TraverseExtensions
 
         foreach (var result in source)
         {
-            if (!result.TryGetValue(out var value, out var error28))
+            if (!result.TryGetValue(out var value, out var error))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<T>>(error28);
+                return Result.Fail<IReadOnlyList<T>>(error);
             }
 
             values.Add(value);

--- a/Trellis.Core/src/Result/Extensions/Traverse.cs
+++ b/Trellis.Core/src/Result/Extensions/Traverse.cs
@@ -50,10 +50,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = selector(item);
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error23))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(result.Error);
+                return Result.Fail<IReadOnlyList<TOut>>(error23);
             }
 
             results.Add(value);
@@ -85,10 +85,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = await selector(item).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error24))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(result.Error);
+                return Result.Fail<IReadOnlyList<TOut>>(error24);
             }
 
             results.Add(value);
@@ -123,10 +123,10 @@ public static class TraverseExtensions
         {
             cancellationToken.ThrowIfCancellationRequested();
             var result = await selector(item, cancellationToken).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error25))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(result.Error);
+                return Result.Fail<IReadOnlyList<TOut>>(error25);
             }
 
             results.Add(value);
@@ -158,10 +158,10 @@ public static class TraverseExtensions
         foreach (var item in source)
         {
             var result = await selector(item).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error26))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(result.Error);
+                return Result.Fail<IReadOnlyList<TOut>>(error26);
             }
 
             results.Add(value);
@@ -196,10 +196,10 @@ public static class TraverseExtensions
         {
             cancellationToken.ThrowIfCancellationRequested();
             var result = await selector(item, cancellationToken).ConfigureAwait(false);
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error27))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<TOut>>(result.Error);
+                return Result.Fail<IReadOnlyList<TOut>>(error27);
             }
 
             results.Add(value);
@@ -276,10 +276,10 @@ public static class TraverseExtensions
 
         foreach (var result in source)
         {
-            if (!result.TryGetValue(out var value))
+            if (!result.TryGetValue(out var value, out var error28))
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
-                return Result.Fail<IReadOnlyList<T>>(result.Error);
+                return Result.Fail<IReadOnlyList<T>>(error28);
             }
 
             values.Add(value);


### PR DESCRIPTION
**Follow-up to PR #470** — closes the i-C-1 sweep that was deferred from the Trellis.Core focused re-inspection. The PR-466 standing inspection-checklist memory ("scan for two-step → single-step opportunities") was applied to this code path; the deferral was specifically because the sweep is broad (many files) but low-risk (immutable `Result<T>` semantics ensure no behavioral change), and inflating PR #470 with the sweep would have diluted the focused-inspection scope.

## What changed

The `if (!result.TryGetValue(out var value)) return Result.Fail<X>(result.Error);` pattern (and its multi-line block variant with intermediate logging) consistently fired the two-step audit because `Result<T>` exposes a **single-step `TryGetValue(out value, out error)` overload** (`Result{TValue}.cs:202-215`) with `[NotNullWhen(false)]` flow analysis on `error`. After this PR, the canonical pattern is:

```csharp
if (!result.TryGetValue(out var value, out var error))
    return Result.Fail<X>(error);
// success path uses 'value'
```

vs. the prior:

```csharp
if (!result.TryGetValue(out var value))
    return Result.Fail<X>(result.Error);
```

The single-step form removes one struct-field access (`result.Error`) and pairs naturally with the `[NotNullWhen(false)]` annotation so consumers and analyzers can rely on `error` being non-null on the failure path.

## Files modified

12 files:
- Hand-written: `Bind.cs`, `Map.cs`, `Ensure.cs`, `Traverse.cs`, `BindZip.cs`, `BindZip.Task.cs`, `BindZip.Task.Right.cs`, `BindZip.ValueTask.cs`, `BindZip.ValueTask.Right.cs`
- T4 templates: `BindTs.g.tt`, `BindZipTs.g.tt`, `MapTs.g.tt` (the `.g.cs` outputs are gitignored and regenerate on build).

For methods with multiple `TryGetValue` blocks in the same method scope (e.g., `BindZip`'s outer-then-inner Result<T> binding), each block declares a distinct `error` variable name (`error` / `error2` / etc.) to avoid CS0128 because C# extends the `out var` scope through the success-path flow even after early returns.

## Validation

- `dotnet build -c Release` clean (0 warnings).
- `dotnet test -c Release --no-build` clean: **5,485 / 5,485 passed** + 15 skipped (same baseline as PR #470 — pure refactor, no behavioral change).
- `docfx build --warningsAsErrors` clean.

## Net diff

+95/-95 lines (pure refactor; no functional change).

## Standing inspection-checklist note

This PR closes the i-C-1 deferral from PR #470's CHANGELOG. The standing two-step → single-step memory is now fully applied to the Trellis.Core hot paths. Future inspections that surface this pattern in newly-added code can point at this PR as the canonical migration shape.