### PR TITLE
Fix orphaned MinLength doc-comment in RequiredPartialClassInfo (Trellis.Core.Generator)

### DIFF
--- a/Trellis.Core/generator/RequiredPartialClassInfo.cs
+++ b/Trellis.Core/generator/RequiredPartialClassInfo.cs
@@ -88,6 +88,7 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// The minimum length (inclusive), or <c>null</c> if no constraint was specified.
     /// Only applicable when <see cref="ClassBase"/> is <c>"RequiredString"</c>.
     /// </value>
+    public readonly int? MinLength;
 
     /// <summary>
     /// Gets the minimum range constraint, if specified via <c>[Range(min, max)]</c>.
@@ -136,7 +137,6 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// Gets a unique type path including namespace and nesting used for hint names.
     /// </summary>
     public readonly string TypePath;
-    public readonly int? MinLength;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequiredPartialClassInfo"/> class.


### PR DESCRIPTION
Trivial doc-organization cleanup spotted while surveying `Trellis.Core/generator/`. The internal `RequiredPartialClassInfo` type had a doc-comment block describing the `MinLength` field at `RequiredPartialClassInfo.cs:84-89`, but the actual field was declared without docs at `RequiredPartialClassInfo.cs:139` (way down the type, between `TypePath` and the constructor). The orphaned doc-comment had no member after it and effectively documented the wrong target.

## What changed

- Moved the `MinLength` field declaration up next to its `<summary>` block.
- Removed the undocumented stray `public readonly int? MinLength;` at line 139.

## Validation

- `dotnet build -c Release` clean (0 warnings).
- `dotnet test -c Release --no-build` clean: **5,485 / 5,485 passed** + 15 skipped (same baseline as PR #471).

## Scope note

Internal type with no public surface change. The generator's emitted code is unaffected; this is purely a source-tree doc-organization fix. Surveyed the rest of `Trellis.Core/generator/` (3 source files, ~2169 lines total) and found no other actionable findings of this nature, so no broader inspection PR is warranted for this generator.