### PR TITLE
TRLS003: recognise HasValue guard in multi-clause && chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### `TRLS003` no longer flags multi-clause guarded `Maybe<T>.Value` access
+
+The `UnsafeMaybeValueAccess` analyzer recognised the short-circuit guard `m.HasValue && m.Value` only when the two clauses were the only operands of the `&&` expression. The natural multi-clause shape
+
+```csharp
+order => order.Status == Submitted && order.SubmittedAt.HasValue && order.SubmittedAt.Value < cutoff
+```
+
+raised a false `TRLS003` because C# left-associates `a && b && c` as `(a && b) && c`, making the immediate left operand of the outermost `&&` a binary expression rather than the `HasValue` member access.
+
+The analyzer now recognises a `HasValue` guard anywhere in the connected `&&` subtree to the left of the `.Value` access, with parentheses transparent. Recursion stops at non-`&&` boundaries (`||`, `!`, ternary), so genuinely unguarded access — `m.Value < x && m.HasValue`, `m.HasValue || m.Value`, `!m.HasValue && m.Value` — still reports.
+
 ### Changed
 
 #### Trellis.Core — focused re-inspection findings (m-C-1, m-C-2, i-C-1, i-C-2 + GPT-5.5 N-C-1..N-C-7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### `TRLS003` no longer flags multi-clause guarded `Maybe<T>.Value` access
 
-The `UnsafeMaybeValueAccess` analyzer recognised the short-circuit guard `m.HasValue && m.Value` only when the two clauses were the only operands of the `&&` expression. The natural multi-clause shape
+The `UnsafeMaybeValueAccess` analyzer recognized the short-circuit guard `m.HasValue && m.Value` only when the two clauses were the only operands of the `&&` expression. The natural multi-clause shape
 
 ```csharp
 order => order.Status == Submitted && order.SubmittedAt.HasValue && order.SubmittedAt.Value < cutoff
@@ -19,7 +19,7 @@ order => order.Status == Submitted && order.SubmittedAt.HasValue && order.Submit
 
 raised a false `TRLS003` because C# left-associates `a && b && c` as `(a && b) && c`, making the immediate left operand of the outermost `&&` a binary expression rather than the `HasValue` member access.
 
-The analyzer now recognises a `HasValue` guard anywhere in the connected `&&` subtree to the left of the `.Value` access, with parentheses transparent. Recursion stops at non-`&&` boundaries (`||`, `!`, ternary), so genuinely unguarded access — `m.Value < x && m.HasValue`, `m.HasValue || m.Value`, `!m.HasValue && m.Value` — still reports.
+The analyzer now recognizes a `HasValue` guard anywhere in the connected `&&` subtree to the left of the `.Value` access, with parentheses transparent. Recursion stops at non-`&&` boundaries (`||`, `!`, ternary), so genuinely unguarded access — `m.Value < x && m.HasValue`, `m.HasValue || m.Value`, `!m.HasValue && m.Value` — still reports.
 
 ### Changed
 

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -189,8 +189,39 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> if two syntax expressions refer to the same logical
+    /// receiver. For member-access chains (<c>e.Customer.Phone</c>), comparison is structural:
+    /// each chain segment must match in both the terminal symbol and the recursive receiver.
+    /// This prevents false positives where two distinct instances of the same type (e.g.,
+    /// <c>e.Primary.Phone</c> and <c>e.Secondary.Phone</c>) share the same terminal member
+    /// symbol but address different objects.
+    /// </summary>
     private static bool AreSameVariable(ExpressionSyntax expr1, ExpressionSyntax expr2, SemanticModel semanticModel)
     {
+        // Strip parentheses on either side — parens don't change identity.
+        while (expr1 is ParenthesizedExpressionSyntax p1)
+            expr1 = p1.Expression;
+        while (expr2 is ParenthesizedExpressionSyntax p2)
+            expr2 = p2.Expression;
+
+        // Member-access chain: compare terminal member symbols AND recursively compare receivers.
+        if (expr1 is MemberAccessExpressionSyntax ma1 && expr2 is MemberAccessExpressionSyntax ma2)
+        {
+            var name1 = semanticModel.GetSymbolInfo(ma1).Symbol;
+            var name2 = semanticModel.GetSymbolInfo(ma2).Symbol;
+            if (name1 == null || name2 == null)
+                return false;
+
+            return SymbolEqualityComparer.Default.Equals(name1, name2)
+                && AreSameVariable(ma1.Expression, ma2.Expression, semanticModel);
+        }
+
+        // Mixed shapes (one member access, one identifier) — not the same variable.
+        if (expr1 is MemberAccessExpressionSyntax || expr2 is MemberAccessExpressionSyntax)
+            return false;
+
+        // Plain identifier or `this` — fall back to symbol equality on the whole expression.
         var symbol1 = semanticModel.GetSymbolInfo(expr1).Symbol;
         var symbol2 = semanticModel.GetSymbolInfo(expr2).Symbol;
 
@@ -360,9 +391,18 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Recognizes: x.HasValue &amp;&amp; x.Value in binary AND expressions (short-circuit).
-    /// Common in expression trees (Specifications).
+    /// Recognizes <c>x.HasValue &amp;&amp; ... &amp;&amp; x.Value</c> in a left-to-right
+    /// short-circuit chain. Common in expression trees (specifications) and any multi-clause
+    /// boolean filter.
     /// </summary>
+    /// <remarks>
+    /// C# left-associates <c>a &amp;&amp; b &amp;&amp; c</c> as <c>(a &amp;&amp; b) &amp;&amp; c</c>,
+    /// so the immediate left operand of the outermost <c>&amp;&amp;</c> is itself a binary
+    /// expression for any 3+ clause shape. To recognize the guard, recurse through nested
+    /// <c>&amp;&amp;</c> operators on the left side looking for a matching <c>HasValue</c>
+    /// access on the same receiver. <c>||</c>, <c>!</c>, ternary, and other operators stop the
+    /// recursion because they break the short-circuit guarantee.
+    /// </remarks>
     private static bool IsGuardedByShortCircuitAnd(
         MemberAccessExpressionSyntax memberAccess,
         SemanticModel semanticModel)
@@ -371,16 +411,47 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
         while (current != null)
         {
             if (current is BinaryExpressionSyntax binaryExpression &&
-                binaryExpression.IsKind(SyntaxKind.LogicalAndExpression))
+                binaryExpression.IsKind(SyntaxKind.LogicalAndExpression) &&
+                binaryExpression.Right.Contains(memberAccess) &&
+                ContainsHasValueGuard(binaryExpression.Left, memberAccess.Expression, semanticModel))
             {
-                if (binaryExpression.Right.Contains(memberAccess) &&
-                    binaryExpression.Left is MemberAccessExpressionSyntax leftMember &&
-                    leftMember.Name.Identifier.Text == "HasValue" &&
-                    AreSameVariable(leftMember.Expression, memberAccess.Expression, semanticModel))
-                    return true;
+                return true;
             }
 
             current = current.Parent;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="expr"/> is, or contains within a
+    /// connected <c>&amp;&amp;</c> subtree (with parentheses transparent), a <c>HasValue</c>
+    /// member access on the same receiver as <paramref name="targetReceiver"/>. Recursion stops
+    /// at non-<c>&amp;&amp;</c> boundaries so <c>||</c>, <c>!</c>, ternary, and other operators
+    /// do not falsely satisfy the guard.
+    /// </summary>
+    private static bool ContainsHasValueGuard(
+        ExpressionSyntax expr,
+        ExpressionSyntax targetReceiver,
+        SemanticModel semanticModel)
+    {
+        // Parentheses are transparent for short-circuit semantics.
+        while (expr is ParenthesizedExpressionSyntax paren)
+            expr = paren.Expression;
+
+        if (expr is MemberAccessExpressionSyntax member &&
+            member.Name.Identifier.Text == "HasValue" &&
+            AreSameVariable(member.Expression, targetReceiver, semanticModel))
+        {
+            return true;
+        }
+
+        if (expr is BinaryExpressionSyntax binExpr &&
+            binExpr.IsKind(SyntaxKind.LogicalAndExpression))
+        {
+            return ContainsHasValueGuard(binExpr.Left, targetReceiver, semanticModel)
+                || ContainsHasValueGuard(binExpr.Right, targetReceiver, semanticModel);
         }
 
         return false;

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -191,11 +191,15 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// Returns <see langword="true"/> if two syntax expressions refer to the same logical
-    /// receiver. For instance members accessed through a chain of receivers, comparison is
-    /// structural: each chain segment must match in both the terminal symbol and the recursive
-    /// receiver. Implicit and explicit <c>this</c> are treated as equivalent (an unqualified
-    /// instance-member access and the same member explicitly qualified with <c>this.</c> name
-    /// the same thing). Static members and locals/parameters compare by symbol identity alone.
+    /// receiver. Only stable receiver forms are considered comparable: identifiers,
+    /// member-access chains, <c>this</c>, and <c>base</c>. For instance members accessed
+    /// through a chain of receivers, comparison is structural — each chain segment must match
+    /// in both the terminal symbol and the recursive receiver. Implicit and explicit
+    /// <c>this</c> are treated as equivalent (an unqualified instance-member access and the
+    /// same member explicitly qualified with <c>this.</c> name the same thing). Static
+    /// members and locals/parameters compare by symbol identity alone. Any other receiver
+    /// shape (invocation, element access, conditional access, cast, etc.) is conservatively
+    /// rejected because it cannot be structurally compared without evaluating runtime state.
     /// </summary>
     private static bool AreSameVariable(ExpressionSyntax expr1, ExpressionSyntax expr2, SemanticModel semanticModel)
     {
@@ -203,6 +207,10 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
             expr1 = p1.Expression;
         while (expr2 is ParenthesizedExpressionSyntax p2)
             expr2 = p2.Expression;
+
+        // Reject any receiver shape we cannot structurally compare.
+        if (!IsStableReceiverShape(expr1) || !IsStableReceiverShape(expr2))
+            return false;
 
         var symbol1 = semanticModel.GetSymbolInfo(expr1).Symbol;
         var symbol2 = semanticModel.GetSymbolInfo(expr2).Symbol;
@@ -223,12 +231,12 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
 
         // Instance member: the same symbol on different receivers refers to different state.
         // Walk the receiver chains, treating implicit `this` (no receiver) and explicit
-        // `ThisExpressionSyntax` as equivalent.
+        // `this`/`base` as equivalent.
         var receiver1 = expr1 is MemberAccessExpressionSyntax m1 ? m1.Expression : null;
         var receiver2 = expr2 is MemberAccessExpressionSyntax m2 ? m2.Expression : null;
 
-        var isThis1 = receiver1 is null or ThisExpressionSyntax;
-        var isThis2 = receiver2 is null or ThisExpressionSyntax;
+        var isThis1 = receiver1 is null or ThisExpressionSyntax or BaseExpressionSyntax;
+        var isThis2 = receiver2 is null or ThisExpressionSyntax or BaseExpressionSyntax;
 
         if (isThis1 && isThis2)
             return true;
@@ -238,6 +246,12 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
 
         return AreSameVariable(receiver1!, receiver2!, semanticModel);
     }
+
+    private static bool IsStableReceiverShape(ExpressionSyntax expr) =>
+        expr is IdentifierNameSyntax
+            or MemberAccessExpressionSyntax
+            or ThisExpressionSyntax
+            or BaseExpressionSyntax;
 
     private static bool IsInThenBranch(SyntaxNode node, IfStatementSyntax ifStatement) =>
         ifStatement.Statement.Contains(node);

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -191,44 +191,52 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// Returns <see langword="true"/> if two syntax expressions refer to the same logical
-    /// receiver. For member-access chains (<c>e.Customer.Phone</c>), comparison is structural:
-    /// each chain segment must match in both the terminal symbol and the recursive receiver.
-    /// This prevents false positives where two distinct instances of the same type (e.g.,
-    /// <c>e.Primary.Phone</c> and <c>e.Secondary.Phone</c>) share the same terminal member
-    /// symbol but address different objects.
+    /// receiver. For instance members accessed through a chain of receivers, comparison is
+    /// structural: each chain segment must match in both the terminal symbol and the recursive
+    /// receiver. Implicit and explicit <c>this</c> are treated as equivalent (an unqualified
+    /// instance-member access and the same member explicitly qualified with <c>this.</c> name
+    /// the same thing). Static members and locals/parameters compare by symbol identity alone.
     /// </summary>
     private static bool AreSameVariable(ExpressionSyntax expr1, ExpressionSyntax expr2, SemanticModel semanticModel)
     {
-        // Strip parentheses on either side — parens don't change identity.
         while (expr1 is ParenthesizedExpressionSyntax p1)
             expr1 = p1.Expression;
         while (expr2 is ParenthesizedExpressionSyntax p2)
             expr2 = p2.Expression;
 
-        // Member-access chain: compare terminal member symbols AND recursively compare receivers.
-        if (expr1 is MemberAccessExpressionSyntax ma1 && expr2 is MemberAccessExpressionSyntax ma2)
-        {
-            var name1 = semanticModel.GetSymbolInfo(ma1).Symbol;
-            var name2 = semanticModel.GetSymbolInfo(ma2).Symbol;
-            if (name1 == null || name2 == null)
-                return false;
-
-            return SymbolEqualityComparer.Default.Equals(name1, name2)
-                && AreSameVariable(ma1.Expression, ma2.Expression, semanticModel);
-        }
-
-        // Mixed shapes (one member access, one identifier) — not the same variable.
-        if (expr1 is MemberAccessExpressionSyntax || expr2 is MemberAccessExpressionSyntax)
-            return false;
-
-        // Plain identifier or `this` — fall back to symbol equality on the whole expression.
         var symbol1 = semanticModel.GetSymbolInfo(expr1).Symbol;
         var symbol2 = semanticModel.GetSymbolInfo(expr2).Symbol;
 
         if (symbol1 == null || symbol2 == null)
             return false;
 
-        return SymbolEqualityComparer.Default.Equals(symbol1, symbol2);
+        if (!SymbolEqualityComparer.Default.Equals(symbol1, symbol2))
+            return false;
+
+        // Static members, locals, parameters, type names — symbol identity is sufficient.
+        // The receivers (if any) cannot disambiguate them further.
+        if (symbol1.IsStatic ||
+            symbol1 is ILocalSymbol or IParameterSymbol or ITypeSymbol or INamespaceSymbol)
+        {
+            return true;
+        }
+
+        // Instance member: the same symbol on different receivers refers to different state.
+        // Walk the receiver chains, treating implicit `this` (no receiver) and explicit
+        // `ThisExpressionSyntax` as equivalent.
+        var receiver1 = expr1 is MemberAccessExpressionSyntax m1 ? m1.Expression : null;
+        var receiver2 = expr2 is MemberAccessExpressionSyntax m2 ? m2.Expression : null;
+
+        var isThis1 = receiver1 is null or ThisExpressionSyntax;
+        var isThis2 = receiver2 is null or ThisExpressionSyntax;
+
+        if (isThis1 && isThis2)
+            return true;
+
+        if (isThis1 != isThis2)
+            return false;
+
+        return AreSameVariable(receiver1!, receiver2!, semanticModel);
     }
 
     private static bool IsInThenBranch(SyntaxNode node, IfStatementSyntax ifStatement) =>

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -527,7 +527,7 @@ public class UnsafeValueAccessAnalyzerTests
     public async Task InstanceMember_MixedImplicitAndExplicitThis_NoDiagnostic()
     {
         // Mixing `this.X.HasValue && X.Value` (or any combination of implicit/explicit `this`)
-        // refers to the same instance member, so the guard must be recognised. The analyzer
+        // refers to the same instance member, so the guard must be recognized. The analyzer
         // must not falsely reject equivalent receivers when one side qualifies the member with
         // `this.` and the other does not.
         const string source = """
@@ -545,6 +545,45 @@ public class UnsafeValueAccessAnalyzerTests
             """;
 
         var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_DifferentInvocationReceivers_StillReportsDiagnostic()
+    {
+        // Negative case: invocation receivers (`primary.GetPhone()` vs `secondary.GetPhone()`)
+        // resolve to the same `GetPhone` method symbol but address different objects. The
+        // analyzer cannot structurally compare invocation receivers — it must reject this
+        // shape rather than treat them as the same variable.
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter()
+                {
+                    return e => e.Primary.GetPhone().HasValue && e.Secondary.GetPhone().Value.Length > 0;
+                }
+            }
+
+            public class Address
+            {
+                public Maybe<string> GetPhone() => Maybe<string>.None;
+            }
+
+            public class TestEntity
+            {
+                public Address Primary { get; set; } = new();
+                public Address Secondary { get; set; } = new();
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess)
+                .WithLocation(14, 77));
+
         await test.RunAsync();
     }
 

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -328,6 +328,200 @@ public class UnsafeValueAccessAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_HasValueAndValue_WithLeadingClause_NoDiagnostic()
+    {
+        // The natural multi-clause specification shape:
+        //     status == X && maybe.HasValue && maybe.Value < cutoff
+        // C# left-associates this as ((status == X) && maybe.HasValue) && (maybe.Value < cutoff).
+        // The .Value access is short-circuit-guarded by HasValue regardless — the analyzer must
+        // recognize this, not just the two-clause shape.
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter(string status, DateTime cutoff)
+                {
+                    return e => e.Status == status && e.SubmittedAt.HasValue && e.SubmittedAt.Value < cutoff;
+                }
+            }
+
+            public class TestEntity
+            {
+                public string Status { get; set; } = "";
+                public Maybe<DateTime> SubmittedAt { get; set; }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_HasValueAndValue_WithMiddleClause_NoDiagnostic()
+    {
+        // HasValue first, an unrelated middle clause, Value last:
+        //     maybe.HasValue && other && maybe.Value < cutoff
+        // C# left-associates as ((maybe.HasValue && other) && (maybe.Value < cutoff));
+        // because && short-circuits left-to-right, .Value is still guarded by HasValue.
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter(string status, DateTime cutoff)
+                {
+                    return e => e.SubmittedAt.HasValue && e.Status == status && e.SubmittedAt.Value < cutoff;
+                }
+            }
+
+            public class TestEntity
+            {
+                public string Status { get; set; } = "";
+                public Maybe<DateTime> SubmittedAt { get; set; }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_HasValueAndValue_WithFourClauses_NoDiagnostic()
+    {
+        // Four-clause chain — verifies recursion through nested && operators.
+        //     a && b && maybe.HasValue && maybe.Value < cutoff
+        // C# left-associates as (((a && b) && maybe.HasValue) && (maybe.Value < cutoff)).
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter(string status, int min, DateTime cutoff)
+                {
+                    return e => e.Status == status && e.Count > min && e.SubmittedAt.HasValue && e.SubmittedAt.Value < cutoff;
+                }
+            }
+
+            public class TestEntity
+            {
+                public string Status { get; set; } = "";
+                public int Count { get; set; }
+                public Maybe<DateTime> SubmittedAt { get; set; }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_ValueBeforeHasValueGuard_StillReportsDiagnostic()
+    {
+        // Negative case: when .Value appears LEFT of .HasValue in the && chain, the guard is
+        // useless (.Value evaluates first). The analyzer must still report.
+        //     maybe.Value < cutoff && maybe.HasValue
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter(DateTime cutoff)
+                {
+                    return e => e.SubmittedAt.Value < cutoff && e.SubmittedAt.HasValue;
+                }
+            }
+
+            public class TestEntity
+            {
+                public Maybe<DateTime> SubmittedAt { get; set; }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess)
+                .WithLocation(14, 35));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_HasValueOrValue_StillReportsDiagnostic()
+    {
+        // Negative case: || does NOT short-circuit guard. If HasValue is false, the right side
+        // of || still evaluates and m.Value would throw.
+        //     maybe.HasValue || maybe.Value < cutoff
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter(DateTime cutoff)
+                {
+                    return e => e.SubmittedAt.HasValue || e.SubmittedAt.Value < cutoff;
+                }
+            }
+
+            public class TestEntity
+            {
+                public Maybe<DateTime> SubmittedAt { get; set; }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess)
+                .WithLocation(14, 61));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExpressionTreeShortCircuit_DifferentReceiverChainsWithSameMember_StillReportsDiagnostic()
+    {
+        // Negative case: two same-typed properties on the same parent (Primary, Secondary —
+        // both Address). e.Primary.Phone.HasValue does NOT guard e.Secondary.Phone.Value,
+        // even though both terminal members resolve to the same `Phone` symbol. The analyzer
+        // must compare the full receiver chain structurally.
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            public class TestClass
+            {
+                public Expression<Func<TestEntity, bool>> GetFilter()
+                {
+                    return e => e.Primary.Phone.HasValue && e.Secondary.Phone.Value.Length > 0;
+                }
+            }
+
+            public class Address
+            {
+                public Maybe<string> Phone { get; set; }
+            }
+
+            public class TestEntity
+            {
+                public Address Primary { get; set; } = new();
+                public Address Secondary { get; set; } = new();
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess)
+                .WithLocation(14, 67));
+
+        await test.RunAsync();
+    }
+
     #endregion
 
     #region Reassignment invalidates guards

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -454,8 +454,9 @@ public class UnsafeValueAccessAnalyzerTests
     [Fact]
     public async Task ExpressionTreeShortCircuit_HasValueOrValue_StillReportsDiagnostic()
     {
-        // Negative case: || does NOT short-circuit guard. If HasValue is false, the right side
-        // of || still evaluates and m.Value would throw.
+        // Negative case: `||` short-circuits when its left side is true, but a true `HasValue`
+        // does not prevent the right side from being evaluated when `HasValue` is false —
+        // exactly the case where `.Value` would throw. So `||` cannot be a guard.
         //     maybe.HasValue || maybe.Value < cutoff
         const string source = """
             using System;
@@ -519,6 +520,31 @@ public class UnsafeValueAccessAnalyzerTests
             AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess)
                 .WithLocation(14, 67));
 
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task InstanceMember_MixedImplicitAndExplicitThis_NoDiagnostic()
+    {
+        // Mixing `this.X.HasValue && X.Value` (or any combination of implicit/explicit `this`)
+        // refers to the same instance member, so the guard must be recognised. The analyzer
+        // must not falsely reject equivalent receivers when one side qualifies the member with
+        // `this.` and the other does not.
+        const string source = """
+            using System;
+
+            public class TestClass
+            {
+                public Maybe<int> Timestamp { get; set; }
+
+                public bool IsPositive()
+                {
+                    return this.Timestamp.HasValue && Timestamp.Value > 0;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
         await test.RunAsync();
     }
 


### PR DESCRIPTION
## Issue

The natural specification shape

```csharp
order => order.Status == Submitted
      && order.SubmittedAt.HasValue
      && order.SubmittedAt.Value < cutoff
```

raised a false `TRLS003` because the analyzer recognised the short-circuit guard only when `HasValue` and `.Value` were the only operands of the `&&` expression. C# left-associates `a && b && c` as `(a && b) && c`, so for any 3+ clause shape the immediate left operand of the outermost `&&` is itself a binary expression rather than the `HasValue` member access the analyzer was looking for.

A separate weakness in the receiver comparison meant that two distinct instances of the same type with the same terminal property name — e.g.\ `e.Primary.Phone.HasValue && e.Secondary.Phone.Value` — could be treated as referring to the same variable, suppressing a real unsafe access.

## Fix

The analyzer now recognises a `HasValue` guard anywhere in the connected `&&` subtree to the left of the `.Value` access, with parentheses transparent. Recursion stops at non-`&&` boundaries (`||`, `!`, ternary), so genuinely unguarded access continues to report:

```csharp
e.M.Value < cutoff && e.M.HasValue        // Value left of guard
e.M.HasValue || e.M.Value                 // || does not short-circuit
!e.M.HasValue && e.M.Value                // negation breaks the chain
```

Receiver comparison is now structural over member-access chains, so the example above (`e.Primary.Phone` vs `e.Secondary.Phone`) reports correctly even though both terminal members share the same `Phone` symbol.