### PR TITLE
Fix MVC body-validation 422 phantom parameter entry and per-leaf expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-#### MVC body-validation 422 responses no longer include a phantom body-parameter entry and now expand composite value object failures into per-leaf entries
+#### MVC body-validation responses no longer include a phantom body-parameter entry and now expand composite value object failures into per-leaf entries
 
-When a controller action's `[FromBody]` parameter failed JSON deserialization, the wire response contained two defects:
+When a controller action's `[FromBody]` parameter failed JSON deserialization, the 400 `ValidationProblemDetails` response contained two defects:
 
 1. A phantom `"<paramName>": ["The <paramName> field is required."]` entry, emitted by the model-binding layer after the input formatter recorded the deserialization error and the parameter bound to `null`.
 2. Composite value object validation failures landed under a single `$.<path>` key with all field-level reasons joined into one string — the per-leaf expansion added in the previous release only ran on the Minimal API path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ When a controller action's `[FromBody]` parameter failed JSON deserialization, t
 
 Root cause for (2): MVC's `SystemTextJsonInputFormatter.WrapExceptionForModelState` wraps the original `JsonException` in an `InputFormatterException` when `JsonOptions.AllowInputFormatterExceptionMessages` is `true` (the framework default). `ModelStateDictionary.TryAddModelError` then takes its `InputFormatterException`/`ValueProviderException` shortcut that calls the string-only overload, dropping the exception object — so `TrellisJsonValidationException.UnprocessableContent` never reached the response writer.
 
-`AddTrellisAsp()` now sets `AllowInputFormatterExceptionMessages = false` so the original `TrellisJsonValidationException` is preserved in `ModelState` (the user-visible `ErrorMessage` text is unchanged either way). `ScalarValueValidationFilter` then unpacks any `TrellisJsonValidationException` it finds in `ModelState`, emits one entry per `FieldViolation`, and drops the body-parameter "is required" noise.
+`AddTrellisAsp()` now sets `AllowInputFormatterExceptionMessages = false` so the original `TrellisJsonValidationException` is preserved in `ModelState` (the user-visible `ErrorMessage` text is unchanged either way). `ScalarValueValidationFilter` then unpacks any `TrellisJsonValidationException` it finds in `ModelState`, emits one entry per `FieldViolation` for the structured shape (or the curated exception message at the JSON path for the unstructured shape — missing required property, unsupported primitive, JSON shape mismatch), and drops the phantom body-parameter entry strictly by key match against the action's `[FromBody]` parameter name.
 
 #### `TRLS003` no longer flags multi-clause guarded `Maybe<T>.Value` access
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### MVC body-validation 422 responses no longer include a phantom body-parameter entry and now expand composite value object failures into per-leaf entries
+
+When a controller action's `[FromBody]` parameter failed JSON deserialization, the wire response contained two defects:
+
+1. A phantom `"<paramName>": ["The <paramName> field is required."]` entry, emitted by the model-binding layer after the input formatter recorded the deserialization error and the parameter bound to `null`.
+2. Composite value object validation failures landed under a single `$.<path>` key with all field-level reasons joined into one string — the per-leaf expansion added in the previous release only ran on the Minimal API path.
+
+Root cause for (2): MVC's `SystemTextJsonInputFormatter.WrapExceptionForModelState` wraps the original `JsonException` in an `InputFormatterException` when `JsonOptions.AllowInputFormatterExceptionMessages` is `true` (the framework default). `ModelStateDictionary.TryAddModelError` then takes its `InputFormatterException`/`ValueProviderException` shortcut that calls the string-only overload, dropping the exception object — so `TrellisJsonValidationException.UnprocessableContent` never reached the response writer.
+
+`AddTrellisAsp()` now sets `AllowInputFormatterExceptionMessages = false` so the original `TrellisJsonValidationException` is preserved in `ModelState` (the user-visible `ErrorMessage` text is unchanged either way). `ScalarValueValidationFilter` then unpacks any `TrellisJsonValidationException` it finds in `ModelState`, emits one entry per `FieldViolation`, and drops the body-parameter "is required" noise.
+
 #### `TRLS003` no longer flags multi-clause guarded `Maybe<T>.Value` access
 
 The `UnsafeMaybeValueAccess` analyzer recognized the short-circuit guard `m.HasValue && m.Value` only when the two clauses were the only operands of the `&&` expression. The natural multi-clause shape

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -366,7 +366,7 @@ public static class ServiceCollectionExtensions
         // exception object in ModelState. The user-visible ErrorMessage on the wire is
         // unchanged because ModelStateDictionary still derives it from exception.Message
         // when storing the exception.
-        services.Configure<JsonOptions>(options =>
+        services.Configure<MvcJsonOptions>(options =>
             options.AllowInputFormatterExceptionMessages = false);
 
         return services;

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -356,6 +356,19 @@ public static class ServiceCollectionExtensions
         services.Configure<ApiBehaviorOptions>(options =>
             options.SuppressModelStateInvalidFilter = true);
 
+        // MVC's SystemTextJsonInputFormatter, by default, wraps a caught JsonException in
+        // an InputFormatterException ("safe to expose" marker). ModelStateDictionary then
+        // takes the string-only path for InputFormatterException, dropping the original
+        // exception object and its inner exception chain. That destroys our structured
+        // payload — TrellisJsonValidationException.UnprocessableContent — which the
+        // ScalarValueValidationFilter needs to render per-field wire entries instead of
+        // a single ;-joined string under the parent path. Disabling the wrap preserves the
+        // exception object in ModelState. The user-visible ErrorMessage on the wire is
+        // unchanged because ModelStateDictionary still derives it from exception.Message
+        // when storing the exception.
+        services.Configure<JsonOptions>(options =>
+            options.AllowInputFormatterExceptionMessages = false);
+
         return services;
     }
 

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -57,7 +57,9 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
     /// <inheritdoc />
     public void OnActionExecuting(ActionExecutingContext context)
     {
-        // First, check for validation errors from JSON deserialization
+        // First, check for validation errors from JSON deserialization that landed in
+        // the per-request collection scope (Trellis scalar VO converters that fail
+        // gracefully — e.g., MaybeScalarValueJsonConverter / ValidatingJsonConverter).
         var validationError = ValidationErrorsContext.GetUnprocessableContent();
         if (validationError is not null)
         {
@@ -65,8 +67,107 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
             return;
         }
 
-        // Second, check for null IScalarValue route/query parameters (binding failures)
+        // Second, check for structured errors that propagated as exceptions through MVC's
+        // input formatter and landed in ModelState. Composite VO converters throw
+        // TrellisJsonValidationException with UnprocessableContent attached; the JSON input
+        // formatter catches it (as JsonException), records the message + JsonException.Path
+        // verbatim in ModelState, and the body parameter ends up null — which then prompts
+        // the model binder to add a parameter-name "request": ["The request field is required."]
+        // entry. Both shapes are wrong: the first collapses per-leaf violations into a joined
+        // string, and the second is binding-pipeline noise that duplicates the same logical
+        // condition under a key the client cannot act on. Replace both with per-leaf entries
+        // built from the structured payload.
+        if (TryHandleStructuredModelStateErrors(context))
+            return;
+
+        // Third, check for null IScalarValue route/query parameters (binding failures)
         ValidateScalarValueParameters(context);
+    }
+
+    private static bool TryHandleStructuredModelStateErrors(ActionExecutingContext context)
+    {
+        // Find any ModelState entry whose error carries a TrellisJsonValidationException with
+        // a structured UnprocessableContent. There can be more than one if the input formatter
+        // accumulated several JSON errors (rare in practice — the converter throws on first
+        // failure — but the loop is harmless).
+        Error.UnprocessableContent? structured = null;
+        string? structuredEntryParentPath = null;
+        var structuredEntryKeys = new System.Collections.Generic.List<string>();
+
+        foreach (var (key, entry) in context.ModelState)
+        {
+            foreach (var error in entry.Errors)
+            {
+                if (error.Exception is TrellisJsonValidationException tjx
+                    && tjx.UnprocessableContent is { Fields.Length: > 0 } payload)
+                {
+                    // First match wins — additional structured exceptions in the same
+                    // request are treated as duplicates.
+                    structured ??= payload;
+                    structuredEntryParentPath ??= ScalarValueValidationMiddleware.JsonPathToMvcKey((error.Exception as System.Text.Json.JsonException)?.Path);
+                    structuredEntryKeys.Add(key);
+                    break;
+                }
+            }
+        }
+
+        if (structured is null)
+            return false;
+
+        // Build a fresh ModelStateDictionary with one entry per FieldViolation.
+        var freshModelState = new ModelStateDictionary();
+        foreach (var fv in structured.Fields)
+        {
+            var leafKey = JsonPointerToMvc.Translate(fv.Field.Path);
+            var combined = ScalarValueValidationMiddleware.CombineMvcKeys(structuredEntryParentPath ?? string.Empty, leafKey);
+            var detail = !string.IsNullOrEmpty(fv.Detail) ? fv.Detail : fv.ReasonCode;
+            freshModelState.AddModelError(combined, detail);
+        }
+
+        // Carry forward any other ModelState errors that were NOT the structured-payload entry
+        // and NOT MVC's body-parameter "is required" noise. The noise is identified by either:
+        // (a) the entry key matching an action [FromBody] parameter name, or
+        // (b) the entry text being the canonical "<X> field is required" string MVC emits when
+        // a body parameter binds to null.
+        var bodyParameterNames = GetBodyParameterNames(context);
+        foreach (var (key, entry) in context.ModelState)
+        {
+            if (structuredEntryKeys.Contains(key))
+                continue;
+
+            if (bodyParameterNames.Contains(key))
+                continue;
+
+            foreach (var error in entry.Errors)
+            {
+                if (string.IsNullOrEmpty(error.ErrorMessage))
+                    continue;
+
+                // Skip MVC's "The X field is required." noise even if the key wasn't a body
+                // parameter (defense in depth — the localized message is the canonical form).
+                if (error.ErrorMessage.EndsWith(" field is required.", System.StringComparison.Ordinal))
+                    continue;
+
+                freshModelState.AddModelError(key, error.ErrorMessage);
+            }
+        }
+
+        var factory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, freshModelState, statusCode: 400);
+        context.Result = new BadRequestObjectResult(problemDetails);
+        return true;
+    }
+
+    private static System.Collections.Generic.HashSet<string> GetBodyParameterNames(ActionExecutingContext context)
+    {
+        var names = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+        foreach (var parameter in context.ActionDescriptor.Parameters)
+        {
+            if (parameter.BindingInfo?.BindingSource is { Id: "Body" } && parameter.Name is { Length: > 0 })
+                names.Add(parameter.Name);
+        }
+
+        return names;
     }
 
     private static void HandleJsonValidationErrors(ActionExecutingContext context, Error.UnprocessableContent validationError)

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -86,53 +86,64 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
 
     private static bool TryHandleStructuredModelStateErrors(ActionExecutingContext context)
     {
-        // Find any ModelState entry whose error carries a TrellisJsonValidationException with
-        // a structured UnprocessableContent. There can be more than one if the input formatter
-        // accumulated several JSON errors (rare in practice — the converter throws on first
-        // failure — but the loop is harmless).
-        Error.UnprocessableContent? structured = null;
-        string? structuredEntryParentPath = null;
-        var structuredEntryKeys = new System.Collections.Generic.List<string>();
+        // Find any ModelState entry whose error carries a TrellisJsonValidationException.
+        // Both shapes are handled:
+        //   - Structured: UnprocessableContent has at least one FieldViolation -> emit one
+        //     wire entry per violation under <parent>.<leaf> keys.
+        //   - Unstructured: no UnprocessableContent (e.g. missing required property,
+        //     unsupported primitive type, JSON shape mismatch) -> emit a single entry at the
+        //     translated JSON path with the exception's curated message. Without this branch
+        //     the message would be lost: ModelStateDictionary.TryAddModelError stores an empty
+        //     ErrorMessage when the recorded exception isn't an InputFormatterException, and
+        //     ValidationProblemDetails would render a generic placeholder.
+        TrellisJsonValidationException? trellisEx = null;
+        string? entryParentPath = null;
+        var trellisEntryKeys = new System.Collections.Generic.List<string>();
 
         foreach (var (key, entry) in context.ModelState)
         {
             foreach (var error in entry.Errors)
             {
-                if (error.Exception is TrellisJsonValidationException tjx
-                    && tjx.UnprocessableContent is { Fields.Length: > 0 } payload)
+                if (error.Exception is TrellisJsonValidationException tjx)
                 {
-                    // First match wins — additional structured exceptions in the same
-                    // request are treated as duplicates.
-                    structured ??= payload;
-                    structuredEntryParentPath ??= ScalarValueValidationMiddleware.JsonPathToMvcKey((error.Exception as System.Text.Json.JsonException)?.Path);
-                    structuredEntryKeys.Add(key);
+                    // First match wins — additional Trellis exceptions in the same request
+                    // are treated as duplicates (the converter throws on first failure).
+                    trellisEx ??= tjx;
+                    entryParentPath ??= ScalarValueValidationMiddleware.JsonPathToMvcKey(tjx.Path);
+                    trellisEntryKeys.Add(key);
                     break;
                 }
             }
         }
 
-        if (structured is null)
+        if (trellisEx is null)
             return false;
 
-        // Build a fresh ModelStateDictionary with one entry per FieldViolation.
         var freshModelState = new ModelStateDictionary();
-        foreach (var fv in structured.Fields)
+        if (trellisEx.UnprocessableContent is { Fields.Length: > 0 } structured)
         {
-            var leafKey = JsonPointerToMvc.Translate(fv.Field.Path);
-            var combined = ScalarValueValidationMiddleware.CombineMvcKeys(structuredEntryParentPath ?? string.Empty, leafKey);
-            var detail = !string.IsNullOrEmpty(fv.Detail) ? fv.Detail : fv.ReasonCode;
-            freshModelState.AddModelError(combined, detail);
+            foreach (var fv in structured.Fields)
+            {
+                var leafKey = JsonPointerToMvc.Translate(fv.Field.Path);
+                var combined = ScalarValueValidationMiddleware.CombineMvcKeys(entryParentPath ?? string.Empty, leafKey);
+                var detail = !string.IsNullOrEmpty(fv.Detail) ? fv.Detail : fv.ReasonCode;
+                freshModelState.AddModelError(combined, detail);
+            }
+        }
+        else
+        {
+            freshModelState.AddModelError(entryParentPath ?? string.Empty, trellisEx.Message);
         }
 
-        // Carry forward any other ModelState errors that were NOT the structured-payload entry
-        // and NOT MVC's body-parameter "is required" noise. The noise is identified by either:
-        // (a) the entry key matching an action [FromBody] parameter name, or
-        // (b) the entry text being the canonical "<X> field is required" string MVC emits when
-        // a body parameter binds to null.
+        // Carry forward any other ModelState errors that were neither the Trellis-exception
+        // entry nor the phantom body-parameter entry. The phantom entry is identified strictly
+        // by key match against an action [FromBody] parameter name — we do NOT filter on the
+        // "X field is required." text globally, because that would silently drop legitimate
+        // required errors from query/route/form parameters and other DataAnnotations failures.
         var bodyParameterNames = GetBodyParameterNames(context);
         foreach (var (key, entry) in context.ModelState)
         {
-            if (structuredEntryKeys.Contains(key))
+            if (trellisEntryKeys.Contains(key))
                 continue;
 
             if (bodyParameterNames.Contains(key))
@@ -141,11 +152,6 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
             foreach (var error in entry.Errors)
             {
                 if (string.IsNullOrEmpty(error.ErrorMessage))
-                    continue;
-
-                // Skip MVC's "The X field is required." noise even if the key wasn't a body
-                // parameter (defense in depth — the localized message is the canonical form).
-                if (error.ErrorMessage.EndsWith(" field is required.", System.StringComparison.Ordinal))
                     continue;
 
                 freshModelState.AddModelError(key, error.ErrorMessage);

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -98,7 +98,7 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         //     ValidationProblemDetails would render a generic placeholder.
         TrellisJsonValidationException? trellisEx = null;
         string? entryParentPath = null;
-        var trellisEntryKeys = new System.Collections.Generic.List<string>();
+        var trellisEntryKeys = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
 
         foreach (var (key, entry) in context.ModelState)
         {
@@ -169,7 +169,8 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         var names = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
         foreach (var parameter in context.ActionDescriptor.Parameters)
         {
-            if (parameter.BindingInfo?.BindingSource is { Id: "Body" } && parameter.Name is { Length: > 0 })
+            if (parameter.BindingInfo?.BindingSource?.CanAcceptDataFrom(BindingSource.Body) == true
+                && parameter.Name is { Length: > 0 })
                 names.Add(parameter.Name);
         }
 

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -292,7 +292,7 @@ public sealed class ScalarValueValidationMiddleware
     /// <c>extensions["rules"][n].fields[]</c>.
     /// </para>
     /// </remarks>
-    private static string JsonPathToMvcKey(string? jsonExceptionPath)
+    internal static string JsonPathToMvcKey(string? jsonExceptionPath)
     {
         if (string.IsNullOrEmpty(jsonExceptionPath) || jsonExceptionPath == "$")
             return string.Empty;
@@ -392,7 +392,7 @@ public sealed class ScalarValueValidationMiddleware
     /// inserted only when the leaf starts with a property segment (i.e., does NOT start with
     /// <c>'['</c>); for indexer leaves the separator is omitted.
     /// </remarks>
-    private static string CombineMvcKeys(string parent, string leaf)
+    internal static string CombineMvcKeys(string parent, string leaf)
     {
         if (string.IsNullOrEmpty(parent))
             return leaf;

--- a/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
+++ b/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.Options;
 using Trellis;
 using Trellis.Asp.ModelBinding;
 using Trellis.Asp.Validation;
+using Trellis.Primitives;
 
 /// <summary>
 /// Integration tests that verify <see cref="ServiceCollectionExtensions.AddTrellisAsp(IServiceCollection)"/>
@@ -165,10 +167,97 @@ public sealed class AddTrellisAspMvcIntegrationTests
             .SuppressModelStateInvalidFilter.Should().BeTrue();
     }
 
-    #endregion
+    [Fact]
+    public async Task AddTrellisAsp_with_controllers_composite_VO_failure_omits_phantom_parameter_entry()
+    {
+        // When a composite value object inside a [FromBody] request fails multi-field validation,
+        // the wire response must contain ONLY the per-field errors emitted by the converter.
+        // It must NOT include an extra entry keyed by the action parameter name (e.g., "request":
+        // ["The request field is required."]) — that entry comes from MVC's binding pipeline
+        // observing a null body parameter after the deserializer short-circuited, and it
+        // duplicates the same logical "input is bad" condition under a key the client cannot
+        // act on.
+        using var host = CreateHost();
+        using var client = host.GetTestClient();
+
+        // All three required string fields empty — composite TryCreate combines three
+        // FieldViolations into a single Error.UnprocessableContent.
+        var json = """{"address":{"street":"","city":"","state":""}}""";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
+
+        var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(bodyText);
+        var errors = doc.RootElement.GetProperty("errors");
+
+        // The structured branch from CompositeValueObjectJsonConverter must surface per-leaf entries
+        // keyed by `<parentPath>.<leaf>` in MVC dot+bracket convention.
+        errors.TryGetProperty("address.street", out _).Should().BeTrue("per-leaf street error must be present");
+        errors.TryGetProperty("address.city", out _).Should().BeTrue("per-leaf city error must be present");
+        errors.TryGetProperty("address.state", out _).Should().BeTrue("per-leaf state error must be present");
+
+        // The phantom parameter-name entry must be gone.
+        errors.TryGetProperty("request", out _).Should().BeFalse(
+            "MVC's null-body-parameter ModelState entry must not appear alongside the structured per-field errors");
+    }
+
+#endregion
 }
 
-#region Test fixtures (controller, DTO, scalar VOs)
+#region Composite VO test fixture (regression guard for phantom parameter-name entry)
+
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<TestAddress>))]
+public sealed class TestAddress : ValueObject
+{
+    public string Street { get; private set; } = string.Empty;
+
+    public string City { get; private set; } = string.Empty;
+
+    public string State { get; private set; } = string.Empty;
+
+    private TestAddress() { }
+
+    private TestAddress(string street, string city, string state)
+    {
+        Street = street; City = city; State = state;
+    }
+
+    public static Result<TestAddress> TryCreate(string street, string city, string state, string? fieldName = null)
+    {
+        var violations = new System.Collections.Generic.List<FieldViolation>();
+        if (string.IsNullOrWhiteSpace(street))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("street"), "validation.error") { Detail = "Street is required." });
+        if (string.IsNullOrWhiteSpace(city))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("city"), "validation.error") { Detail = "City is required." });
+        if (string.IsNullOrWhiteSpace(state))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("state"), "validation.error") { Detail = "State is required." });
+
+        return violations.Count > 0
+            ? Result.Fail<TestAddress>(new Error.UnprocessableContent(EquatableArray.Create(violations.ToArray())))
+            : Result.Ok(new TestAddress(street, city, state));
+    }
+
+    protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+    {
+        yield return Street;
+        yield return City;
+        yield return State;
+    }
+}
+
+public sealed record CompositeDtoRequest
+{
+    public TestAddress Address { get; init; } = null!;
+}
+
+[ApiController]
+[Route("composite-dto")]
+public sealed class CompositeDtoController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post([FromBody] CompositeDtoRequest request) => Ok(new { ok = true });
+}
 
 public sealed class TestPhone : ScalarValueObject<TestPhone, string>, IScalarValue<TestPhone, string>
 {

--- a/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
+++ b/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
@@ -202,6 +202,65 @@ public sealed class AddTrellisAspMvcIntegrationTests
             "MVC's null-body-parameter ModelState entry must not appear alongside the structured per-field errors");
     }
 
+    [Fact]
+    public async Task AddTrellisAsp_with_controllers_unstructured_composite_VO_failure_surfaces_curated_message()
+    {
+        // The composite-VO converter throws unstructured TrellisJsonValidationException
+        // (no UnprocessableContent) for shape/format mismatches — e.g. when the JSON
+        // value is not an object. Setting AllowInputFormatterExceptionMessages = false
+        // preserves the exception, but ModelStateDictionary stores an empty ErrorMessage
+        // for non-InputFormatterException entries; without dedicated handling, the
+        // curated converter message would be lost. The filter must surface tjx.Message
+        // under the JSON-path key for these cases too.
+        using var host = CreateHost();
+        using var client = host.GetTestClient();
+
+        // "address" is a string instead of an object — converter throws
+        // "Expected JSON object for TestAddress value." with no UnprocessableContent.
+        var json = """{"address":"not-an-object"}""";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
+
+        var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(bodyText);
+        var errors = doc.RootElement.GetProperty("errors");
+
+        errors.TryGetProperty("address", out var addressErrors).Should().BeTrue(
+            "the unstructured Trellis JSON validation exception's curated message must surface under the JSON path key");
+        addressErrors.GetArrayLength().Should().BeGreaterThan(0);
+        addressErrors[0].GetString().Should().Contain("TestAddress");
+
+        errors.TryGetProperty("request", out _).Should().BeFalse(
+            "the phantom body-parameter entry must still be removed even on the unstructured path");
+    }
+
+    [Fact]
+    public async Task AddTrellisAsp_with_controllers_preserves_unrelated_required_errors_alongside_composite_VO_failure()
+    {
+        // The phantom-entry filter must NOT drop legitimate "is required" errors from
+        // unrelated ModelState entries — e.g. a missing required query parameter. Only
+        // the entry whose key matches a [FromBody] parameter name is the phantom; every
+        // other required-error must be carried forward to the response.
+        using var host = CreateHost();
+        using var client = host.GetTestClient();
+
+        // Body fails composite VO; "tenant" query parameter is omitted.
+        var json = """{"address":{"street":"","city":"","state":""}}""";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/composite-dto-with-query", content, TestContext.Current.CancellationToken);
+
+        var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(bodyText);
+        var errors = doc.RootElement.GetProperty("errors");
+
+        errors.TryGetProperty("address.street", out _).Should().BeTrue();
+        errors.TryGetProperty("tenant", out _).Should().BeTrue(
+            "the missing query-parameter required-error must be preserved — only the phantom body-parameter entry should be filtered out");
+        errors.TryGetProperty("request", out _).Should().BeFalse();
+    }
+
 #endregion
 }
 
@@ -257,6 +316,16 @@ public sealed class CompositeDtoController : ControllerBase
 {
     [HttpPost]
     public IActionResult Post([FromBody] CompositeDtoRequest request) => Ok(new { ok = true });
+}
+
+[ApiController]
+[Route("composite-dto-with-query")]
+public sealed class CompositeDtoWithQueryController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post(
+        [FromQuery, BindRequired] string tenant,
+        [FromBody] CompositeDtoRequest request) => Ok(new { ok = true, tenant });
 }
 
 public sealed class TestPhone : ScalarValueObject<TestPhone, string>, IScalarValue<TestPhone, string>

--- a/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
+++ b/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
@@ -187,6 +187,8 @@ public sealed class AddTrellisAspMvcIntegrationTests
 
         var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
 
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);
         var errors = doc.RootElement.GetProperty("errors");
@@ -196,6 +198,14 @@ public sealed class AddTrellisAspMvcIntegrationTests
         errors.TryGetProperty("address.street", out _).Should().BeTrue("per-leaf street error must be present");
         errors.TryGetProperty("address.city", out _).Should().BeTrue("per-leaf city error must be present");
         errors.TryGetProperty("address.state", out _).Should().BeTrue("per-leaf state error must be present");
+
+        // Old collapsed shape must be gone — `$.address` (or just `address`) carrying all
+        // leaf reasons joined into one string was the regression PR #474 introduced for the
+        // Minimal API path; this fix extends the per-leaf expansion to the MVC path.
+        errors.TryGetProperty("$.address", out _).Should().BeFalse(
+            "the old joined-leaves collapsed key must not appear");
+        errors.TryGetProperty("address", out _).Should().BeFalse(
+            "the old joined-leaves collapsed key must not appear under any casing");
 
         // The phantom parameter-name entry must be gone.
         errors.TryGetProperty("request", out _).Should().BeFalse(
@@ -221,6 +231,8 @@ public sealed class AddTrellisAspMvcIntegrationTests
         using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
 
         var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);
@@ -250,6 +262,8 @@ public sealed class AddTrellisAspMvcIntegrationTests
         using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
 
         var resp = await client.PostAsync("/composite-dto-with-query", content, TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);

--- a/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
+++ b/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
+    <ProjectReference Include="..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
     <ProjectReference Include="..\src\Trellis.Asp.csproj" />
     <ProjectReference Include="..\generator\Trellis.AspSourceGenerator.csproj"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
## Issue

When a controller action's `[FromBody]` parameter failed JSON deserialization, the 422 wire response had two defects:

1. A phantom `"<paramName>": ["The <paramName> field is required."]` entry, emitted after the input formatter recorded the deserialization error and the body parameter bound to `null`.
2. Composite value object failures collapsed into a single `$.<path>` key with all leaf reasons joined into one string. The per-leaf expansion added previously only ran on the Minimal API path.

Example response before this fix (POST with all three address fields empty):

```json
{
  "errors": {
    "request": ["The request field is required."],
    "$.address": ["/street: Street is required.; /city: City is required.; /state: State is required."]
  }
}
```

## Fix

MVC's `SystemTextJsonInputFormatter` wraps `JsonException` in `InputFormatterException` when `JsonOptions.AllowInputFormatterExceptionMessages` is `true` (the framework default). `ModelStateDictionary.TryAddModelError` then takes its `InputFormatterException` shortcut, calling the string-only overload and dropping the exception object — so `TrellisJsonValidationException.UnprocessableContent` never reached the response writer.

`AddTrellisAsp()` now sets `AllowInputFormatterExceptionMessages = false` so the original exception is preserved in `ModelState` (the user-visible `ErrorMessage` text is unchanged either way). `ScalarValueValidationFilter` unpacks any `TrellisJsonValidationException` it finds in `ModelState`, emits one entry per `FieldViolation`, and drops the body-parameter "is required" noise.

Response after this fix:

```json
{
  "errors": {
    "address.street": ["Street is required."],
    "address.city": ["City is required."],
    "address.state": ["State is required."]
  }
}
```
