### PR TITLE
Return 422 for binder-level value object validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (Breaking)
+
+#### Binder-level value object validation failures now return 422 (Unprocessable Content), aligning with domain handler failures
+
+The framework previously returned **400 Bad Request** for two distinct condition shapes:
+
+1. **Trellis-driven semantic validation failures during binding** — composite value object `TryCreate` failures inside `CompositeValueObjectJsonConverter`, missing required composite properties, unsupported primitive types, JSON shape mismatches, and scalar value object `TryCreate` failures on query/route parameters.
+2. **Plain JSON syntax errors** — malformed JSON tokens, unclosed braces, and other `System.Text.Json.JsonException`s that aren't a `TrellisJsonValidationException`.
+
+Domain handler failures returning `Result.Fail(Error.UnprocessableContent(...))` already returned **422 Unprocessable Content** via `ResponseFailureWriter`. Clients had to special-case both for the same logical "your input is invalid" condition.
+
+This release aligns the status code with the actual semantic distinction in RFC 9110 §15.5.21 ("well-formed but unable to be processed due to semantic errors"):
+
+- **422** — `TrellisJsonValidationException` from any source (composite VO converter, scalar VO TryCreate failure, `ValidationErrorsContext`-collected errors), via `ScalarValueValidationMiddleware`, `ScalarValueValidationFilter`, and `ScalarValueValidationEndpointFilter`.
+- **400** — plain `JsonException` (the bytes are not valid JSON, RFC 9110 §15.5.1).
+
+**Mixed-failure precedence**: when a request contains both a plain JSON syntax error AND a Trellis semantic failure (e.g., malformed body + invalid query scalar VO), 400 wins. The bytes weren't valid JSON, which is a more fundamental client error than any semantic failure on the same request.
+
+`ProblemDetails.Type`, `Title`, and `Status` populate via the framework defaults (no Trellis override) — `https://tools.ietf.org/html/rfc4918#section-11.2` for 422, `https://tools.ietf.org/html/rfc9110#section-15.5.1` for 400.
+
+**Migration**: clients with `if (statusCode == 400)` checks for input validation should switch to `if (statusCode == 400 || statusCode == 422)` or — better — handle both via the shared `ValidationProblemDetails.Errors` shape, which is unchanged.
+
 ### Fixed
 
 #### MVC body-validation responses no longer include a phantom body-parameter entry and now expand composite value object failures into per-leaf entries

--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -88,9 +88,9 @@ Accept: application/json
   "overdraftLimit":       { "amount":   0.00, "currency": "USD" }
 }
 
-### Open account — invalid Money (negative amount fails JSON deserialization → 400)
+### Open account — invalid Money (negative amount fails value-level validation → 422)
 ### @parity: status-only
-# @expect status: 400
+# @expect status: 422
 POST {{host}}/api/accounts
 Content-Type: application/json
 Accept: application/json

--- a/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.MinimalApi.Tests/ShowcaseMinimalApiTests.cs
@@ -170,7 +170,7 @@ public class ShowcaseMinimalApiTests : IClassFixture<WebApplicationFactory<Progr
             content,
             Ct);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         var body = await response.Content.ReadAsStringAsync(Ct);
         body.Should().NotContain("The request body contains invalid JSON",
             "the framework should surface the curated TrellisJsonValidationException message instead of the generic placeholder");

--- a/Trellis.Asp/src/Validation/ScalarValueValidationEndpointFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationEndpointFilter.cs
@@ -41,7 +41,12 @@ public sealed class ScalarValueValidationEndpointFilter : IEndpointFilter
             var dictionary = validationError.Fields.Items
                 .GroupBy(fv => JsonPointerToMvc.Translate(fv.Field.Path))
                 .ToDictionary(g => g.Key, g => g.Select(fv => fv.Detail ?? fv.ReasonCode).ToArray());
-            return Results.ValidationProblem(dictionary);
+
+            // Trellis-driven scalar VO validation rejection — semantic per RFC 9110 §15.5.21.
+            // Aligns with the status code emitted by the rest of the framework
+            // (ResponseFailureWriter for domain handler failures, ScalarValueValidationFilter
+            // and ScalarValueValidationMiddleware for the same condition on other code paths).
+            return Results.ValidationProblem(dictionary, statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         return await next(context).ConfigureAwait(false);

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -100,6 +101,13 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         string? entryParentPath = null;
         var trellisEntryKeys = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
 
+        // Precedence guard: a plain JsonException in ModelState means the request body is
+        // not valid JSON — a more fundamental client error than any semantic failure that
+        // happened on the same request. The 400 path stays authoritative in that case so
+        // we don't promote a request with malformed bytes to 422 just because one segment
+        // of the input also failed Trellis validation.
+        var hasPlainJsonException = false;
+
         foreach (var (key, entry) in context.ModelState)
         {
             foreach (var error in entry.Errors)
@@ -113,10 +121,14 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
                     trellisEntryKeys.Add(key);
                     break;
                 }
+                else if (error.Exception is System.Text.Json.JsonException)
+                {
+                    hasPlainJsonException = true;
+                }
             }
         }
 
-        if (trellisEx is null)
+        if (trellisEx is null || hasPlainJsonException)
             return false;
 
         var freshModelState = new ModelStateDictionary();
@@ -159,8 +171,8 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         }
 
         var factory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
-        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, freshModelState, statusCode: 400);
-        context.Result = new BadRequestObjectResult(problemDetails);
+        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, freshModelState, statusCode: 422);
+        context.Result = new ObjectResult(problemDetails) { StatusCode = StatusCodes.Status422UnprocessableEntity };
         return true;
     }
 
@@ -191,15 +203,15 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
         }
 
         var factory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
-        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, modelState, statusCode: 400);
-        context.Result = new BadRequestObjectResult(problemDetails);
+        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, modelState, statusCode: 422);
+        context.Result = new ObjectResult(problemDetails) { StatusCode = StatusCodes.Status422UnprocessableEntity };
     }
 
-    private static BadRequestObjectResult CreateValidationProblemResult(ActionExecutingContext context)
+    private static ObjectResult CreateValidationProblemResult(ActionExecutingContext context, int statusCode)
     {
         var factory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
-        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, context.ModelState, statusCode: 400);
-        return new BadRequestObjectResult(problemDetails);
+        var problemDetails = factory.CreateValidationProblemDetails(context.HttpContext, context.ModelState, statusCode: statusCode);
+        return new ObjectResult(problemDetails) { StatusCode = statusCode };
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.",
@@ -207,6 +219,14 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
     private static void ValidateScalarValueParameters(ActionExecutingContext context)
     {
         var actionParameters = context.ActionDescriptor.Parameters;
+
+        // Track whether THIS pass identified any scalar-value-object failures so the final
+        // result discrimination can choose the correct status code:
+        //   - Scalar VO failure (binder couldn't construct the value, or TryCreate rejected it)
+        //     → 422 Unprocessable Content (semantic per RFC 9110 §15.5.21).
+        //   - Pre-existing ModelState invalidity from non-Trellis sources (plain JsonException
+        //     for malformed JSON, [Required] field missing, type-conversion failures) → 400.
+        var addedScalarValueFailure = false;
 
         foreach (var parameter in actionParameters)
         {
@@ -219,21 +239,30 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
             if (!ScalarValueTypeHelper.IsScalarValue(underlyingType))
                 continue;
 
-            // Check if the parameter value is null (indicates binding failure for non-nullable IScalarValue)
-            if (context.ActionArguments.TryGetValue(parameter.Name!, out var value) && value is null)
+            // A scalar-VO parameter has failed semantic validation in either of two shapes:
+            //   (a) binding succeeded but produced null (action argument is null);
+            //   (b) the binder rejected the value at bind-time and added a ModelState entry
+            //       under the parameter name (action argument absent from the dictionary).
+            // Both are semantic failures of the input value, not JSON syntax errors.
+            var hasArg = context.ActionArguments.TryGetValue(parameter.Name!, out var value);
+            var valueIsNull = hasArg && value is null;
+            var hasModelStateError = context.ModelState.TryGetValue(parameter.Name!, out var mse)
+                && mse is { Errors.Count: > 0 };
+
+            if (!valueIsNull && !hasModelStateError)
+                continue;
+
+            var rawValue = GetRawParameterValue(context, parameter.Name!);
+            if (rawValue is null)
+                continue;
+
+            if (ShouldTreatEmptyQueryValueAsMissing(context, parameter, rawValue))
+                continue;
+
+            // Only synthesize a TryCreate-derived error if the binder didn't already record
+            // one for this parameter — avoids duplicate entries on the wire.
+            if (!hasModelStateError)
             {
-                // Check whether a raw value was actually provided in the request.
-                // If no raw value exists in route data or query string, the parameter
-                // was simply not provided (e.g., optional query param like OrderState? state).
-                // Only validate when a raw value is present but binding produced null (invalid input).
-                var rawValue = GetRawParameterValue(context, parameter.Name!);
-                if (rawValue is null)
-                    continue;
-
-                if (ShouldTreatEmptyQueryValueAsMissing(context, parameter, rawValue))
-                    continue;
-
-                // Call TryCreate to get the real validation error (e.g., with valid values list)
                 var errors = ScalarValueTypeHelper.GetValidationErrors(underlyingType, rawValue, parameter.Name!);
 
                 if (errors is not null)
@@ -244,20 +273,53 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
                 }
                 else
                 {
-                    // Fallback if TryCreate method wasn't found
+                    // Fallback when TryCreate is not available. Avoid reflecting the raw
+                    // request value into the response so we don't leak unexpected user input
+                    // (XSS-adjacent surface even with JSON escaping; mirrors the middleware's
+                    // hardening on the same path).
                     var typeName = underlyingType.Name;
                     var errorMessage = string.IsNullOrEmpty(rawValue)
                         ? $"'{parameter.Name}' is required."
-                        : $"'{rawValue}' is not a valid {typeName}.";
+                        : $"'{parameter.Name}' is not in a valid format for {typeName}.";
 
                     context.ModelState.AddModelError(parameter.Name!, errorMessage);
                 }
             }
+
+            addedScalarValueFailure = true;
         }
 
-        // Return validation problem if any errors were added
-        if (!context.ModelState.IsValid)
-            context.Result = CreateValidationProblemResult(context);
+        if (addedScalarValueFailure)
+        {
+            // Precedence guard: if a plain JsonException is also present (the body had a JSON
+            // syntax error in the same request), 400 wins. The bytes weren't valid JSON, which
+            // is a more fundamental client error than a semantic failure on a route/query VO.
+            var hasPlainJsonException = false;
+            foreach (var (_, entry) in context.ModelState)
+            {
+                foreach (var error in entry.Errors)
+                {
+                    if (error.Exception is System.Text.Json.JsonException
+                        and not TrellisJsonValidationException)
+                    {
+                        hasPlainJsonException = true;
+                        break;
+                    }
+                }
+
+                if (hasPlainJsonException) break;
+            }
+
+            context.Result = CreateValidationProblemResult(
+                context,
+                statusCode: hasPlainJsonException
+                    ? StatusCodes.Status400BadRequest
+                    : StatusCodes.Status422UnprocessableEntity);
+        }
+        else if (!context.ModelState.IsValid)
+        {
+            context.Result = CreateValidationProblemResult(context, statusCode: StatusCodes.Status400BadRequest);
+        }
     }
 
     private static string? GetRawParameterValue(ActionExecutingContext context, string parameterName)

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -16,7 +16,11 @@ using Trellis.Asp.Validation;
 /// <summary>
 /// An action filter that checks for validation errors collected during JSON deserialization
 /// and validates <see cref="IScalarValue{TSelf, TPrimitive}"/> route/query parameters.
-/// Returns a 400 Bad Request response with validation problem details when validation fails.
+/// Returns a <c>ValidationProblemDetails</c> response — 422 Unprocessable Content for
+/// Trellis-driven semantic validation failures (composite VO converter, scalar VO TryCreate,
+/// <see cref="ValidationErrorsContext"/>-collected errors) per RFC 9110 §15.5.21, and
+/// 400 Bad Request for plain <see cref="System.Text.Json.JsonException"/>s where the bytes
+/// aren't valid JSON per RFC 9110 §15.5.1. When both occur on the same request, 400 wins.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,7 +37,8 @@ using Trellis.Asp.Validation;
 /// If validation errors are detected:
 /// <list type="bullet">
 /// <item>The action is short-circuited (not executed)</item>
-/// <item>A 400 Bad Request response with validation problem details is returned</item>
+/// <item>A <c>ValidationProblemDetails</c> response is returned — 422 for Trellis semantic
+///   validation failures, 400 for plain JSON syntax errors (with 400 winning on mixed requests)</item>
 /// <item>The response format matches ASP.NET Core's standard validation error format</item>
 /// </list>
 /// </para>

--- a/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationFilter.cs
@@ -240,9 +240,19 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
             // Handle nullable types (e.g., OrderState?)
             var underlyingType = Nullable.GetUnderlyingType(parameterType) ?? parameterType;
 
-            // Skip if not an IScalarValue type
-            if (!ScalarValueTypeHelper.IsScalarValue(underlyingType))
+            // Treat both raw IScalarValue and Maybe<IScalarValue> parameters as scalar-VO,
+            // so MaybeModelBinder failures land on the same 422 path as ScalarValueModelBinder
+            // failures (matches ScalarValueValidationMiddleware behavior on the Minimal API path).
+            var isScalarValue = ScalarValueTypeHelper.IsScalarValue(underlyingType);
+            var isMaybeScalarValue = ScalarValueTypeHelper.IsMaybeScalarValue(underlyingType);
+            if (!isScalarValue && !isMaybeScalarValue)
                 continue;
+
+            // The TryCreate helper expects the inner scalar VO type, so unwrap Maybe<T> when
+            // re-running validation to synthesize a structured error.
+            var validationType = isMaybeScalarValue
+                ? ScalarValueTypeHelper.GetMaybeInnerType(underlyingType)!
+                : underlyingType;
 
             // A scalar-VO parameter has failed semantic validation in either of two shapes:
             //   (a) binding succeeded but produced null (action argument is null);
@@ -268,7 +278,7 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
             // one for this parameter — avoids duplicate entries on the wire.
             if (!hasModelStateError)
             {
-                var errors = ScalarValueTypeHelper.GetValidationErrors(underlyingType, rawValue, parameter.Name!);
+                var errors = ScalarValueTypeHelper.GetValidationErrors(validationType, rawValue, parameter.Name!);
 
                 if (errors is not null)
                 {
@@ -282,7 +292,7 @@ public sealed class ScalarValueValidationFilter : IActionFilter, IOrderedFilter
                     // request value into the response so we don't leak unexpected user input
                     // (XSS-adjacent surface even with JSON escaping; mirrors the middleware's
                     // hardening on the same path).
-                    var typeName = underlyingType.Name;
+                    var typeName = validationType.Name;
                     var errorMessage = string.IsNullOrEmpty(rawValue)
                         ? $"'{parameter.Name}' is required."
                         : $"'{parameter.Name}' is not in a valid format for {typeName}.";

--- a/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueValidationMiddleware.cs
@@ -174,16 +174,28 @@ public sealed class ScalarValueValidationMiddleware
         HttpContext context,
         IDictionary<string, string[]> errors)
     {
-        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        // Scalar value object TryCreate rejected the bound value — the request bytes were
+        // well-formed, but the value failed semantic validation. Per RFC 9110 §15.5.21 this
+        // is 422 ("Unprocessable Content"), aligning with the status emitted by Trellis
+        // domain handlers via ResponseFailureWriter for the same logical condition.
+        context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
 
-        // Use Results.ValidationProblem for consistent response format
-        var result = Results.ValidationProblem(errors);
+        var result = Results.ValidationProblem(errors, statusCode: StatusCodes.Status422UnprocessableEntity);
         await result.ExecuteAsync(context).ConfigureAwait(false);
     }
 
     private static async Task WriteJsonDeserializationErrorAsync(HttpContext context, BadHttpRequestException ex)
     {
-        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        // Status-code split. TrellisJsonValidationException is thrown by Trellis converters
+        // when a value-level rule fails (e.g. composite VO TryCreate returned a violation,
+        // missing required property, unsupported primitive type, JSON shape mismatch). The
+        // bytes parsed as JSON; the *values* failed semantic validation → 422.
+        // Plain JsonException (from System.Text.Json's tokenizer/structure errors) means the
+        // bytes are not valid JSON → 400 per RFC 9110 §15.5.1.
+        var statusCode = ex.InnerException is TrellisJsonValidationException
+            ? StatusCodes.Status422UnprocessableEntity
+            : StatusCodes.Status400BadRequest;
+        context.Response.StatusCode = statusCode;
 
         // System.Text.Json populates JsonException.Path automatically as the deserializer
         // unwinds (e.g. "$.items[0].amount"). Pull it from any JsonException — both the
@@ -226,7 +238,7 @@ public sealed class ScalarValueValidationMiddleware
                 }
             }
 
-            var structuredResult = Results.ValidationProblem(perLeafErrors);
+            var structuredResult = Results.ValidationProblem(perLeafErrors, statusCode: statusCode);
             await structuredResult.ExecuteAsync(context).ConfigureAwait(false);
             return;
         }
@@ -246,7 +258,7 @@ public sealed class ScalarValueValidationMiddleware
             [key] = [message],
         };
 
-        var result = Results.ValidationProblem(errors);
+        var result = Results.ValidationProblem(errors, statusCode: statusCode);
         await result.ExecuteAsync(context).ConfigureAwait(false);
     }
 

--- a/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
+++ b/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System.Linq;
 using System.Net;

--- a/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
+++ b/Trellis.Asp/tests/AddTrellisAspMvcIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System.Linq;
 using System.Net;
@@ -187,7 +187,7 @@ public sealed class AddTrellisAspMvcIntegrationTests
 
         var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
 
-        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
 
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);
@@ -232,7 +232,7 @@ public sealed class AddTrellisAspMvcIntegrationTests
 
         var resp = await client.PostAsync("/composite-dto", content, TestContext.Current.CancellationToken);
 
-        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
 
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);
@@ -263,7 +263,7 @@ public sealed class AddTrellisAspMvcIntegrationTests
 
         var resp = await client.PostAsync("/composite-dto-with-query", content, TestContext.Current.CancellationToken);
 
-        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
 
         var bodyText = await resp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(bodyText);

--- a/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
+++ b/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
@@ -1,0 +1,220 @@
+﻿namespace Trellis.Asp.Tests;
+
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Trellis;
+using Trellis.Primitives;
+
+/// <summary>
+/// Pins the status-code split between binder-level VO validation failures (semantic — RFC 9110
+/// §15.5.21 "Unprocessable Content", 422) and JSON syntax errors (RFC 9110 §15.5.1 "Bad Request",
+/// 400). Before this fix, every binder validation failure — including <see cref="TrellisJsonValidationException"/>
+/// thrown by <c>CompositeValueObjectJsonConverter</c> when value-level rules failed, and scalar-VO
+/// <c>TryCreate</c> failures on query/route parameters — surfaced as 400, while the same logical
+/// "input is invalid" failure occurring later in a domain handler returned 422 via
+/// <c>ResponseFailureWriter</c>. Clients had to special-case both. The failure shape is now
+/// status-aligned with the rest of the framework: only well-formed-bytes-but-invalid-JSON-tokens
+/// returns 400.
+/// </summary>
+public sealed class BinderValidationStatusCodeTests
+{
+    private static IHost CreateMvcHost()
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(web => web
+                .UseTestServer()
+                .ConfigureServices(s =>
+                {
+                    s.AddProblemDetails();
+                    s.AddTrellisAsp();
+                    s.AddControllers().AddApplicationPart(typeof(StatusCodeController).Assembly);
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapControllers());
+                }));
+        return builder.Start();
+    }
+
+    [Fact]
+    public async Task mvc_composite_VO_validation_failure_returns_422_with_RFC_compliant_problem_details()
+    {
+        using var host = CreateMvcHost();
+        using var client = host.GetTestClient();
+
+        var json = """{"address":{"street":"","city":"","state":""}}""";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/binder-status/composite", content, TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        await AssertRfc9457ProblemDetails(resp, expectedStatus: 422, expectedErrorKey: "address.street");
+    }
+
+    [Fact]
+    public async Task mvc_scalar_VO_query_validation_failure_returns_422()
+    {
+        using var host = CreateMvcHost();
+        using var client = host.GetTestClient();
+
+        var resp = await client.GetAsync("/binder-status/scalar?value=", TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        await AssertRfc9457ProblemDetails(resp, expectedStatus: 422);
+    }
+
+    [Fact]
+    public async Task mvc_malformed_JSON_returns_400()
+    {
+        using var host = CreateMvcHost();
+        using var client = host.GetTestClient();
+
+        // Truncated/malformed JSON — System.Text.Json raises a plain JsonException, not a
+        // TrellisJsonValidationException. The bytes are not valid JSON, so 400 is correct
+        // per RFC 9110 §15.5.1 ("syntactically malformed message").
+        var json = "{not valid";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/binder-status/composite", content, TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await AssertRfc9457ProblemDetails(resp, expectedStatus: 400);
+    }
+
+    [Fact]
+    public async Task mvc_malformed_JSON_takes_precedence_over_query_scalar_VO_failure_returning_400()
+    {
+        // Mixed-failure precedence: when the body is not valid JSON AND a query scalar VO
+        // ALSO fails, the wire response must be 400. Malformed bytes is a more fundamental
+        // client error than any semantic value-level failure on the same request.
+        using var host = CreateMvcHost();
+        using var client = host.GetTestClient();
+
+        var json = "{not valid";
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        var resp = await client.PostAsync("/binder-status/mixed?value=", content, TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "malformed JSON body must dominate even when a query-bound scalar VO also fails on the same request");
+    }
+
+    private static async Task AssertRfc9457ProblemDetails(
+        HttpResponseMessage response,
+        int expectedStatus,
+        string? expectedErrorKey = null)
+    {
+        // RFC 9457 §3 mandates application/problem+json (or +xml) for the response media type.
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var bodyText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(bodyText);
+        var root = doc.RootElement;
+
+        // RFC 9457 §3.1 fields. `type`, `title`, `status` are the canonical members; framework
+        // defaults must populate them so clients can dispatch on `type` and display `title`
+        // without consulting the HTTP status line.
+        root.TryGetProperty("status", out var statusEl).Should().BeTrue("RFC 9457 §3.1 status member must be present");
+        statusEl.GetInt32().Should().Be(expectedStatus, "the body status field must match the HTTP status line");
+
+        root.TryGetProperty("title", out var titleEl).Should().BeTrue("RFC 9457 §3.1 title member must be present");
+        titleEl.GetString().Should().NotBeNullOrEmpty("title is a short human-readable summary; default suffices");
+
+        root.TryGetProperty("type", out var typeEl).Should().BeTrue("RFC 9457 §3.1 type member must be present");
+        var typeUri = typeEl.GetString();
+        typeUri.Should().NotBeNullOrEmpty("type defaults to about:blank but should never be missing");
+
+        if (expectedErrorKey is not null)
+        {
+            root.TryGetProperty("errors", out var errorsEl).Should().BeTrue();
+            errorsEl.TryGetProperty(expectedErrorKey, out _).Should().BeTrue(
+                $"per-leaf entry {expectedErrorKey} must be present on the validation problem");
+        }
+    }
+}
+
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<StatusCodeAddress>))]
+public sealed class StatusCodeAddress : ValueObject
+{
+    public string Street { get; private set; } = string.Empty;
+
+    public string City { get; private set; } = string.Empty;
+
+    public string State { get; private set; } = string.Empty;
+
+    private StatusCodeAddress() { }
+
+    private StatusCodeAddress(string street, string city, string state)
+    {
+        Street = street;
+        City = city;
+        State = state;
+    }
+
+    public static Result<StatusCodeAddress> TryCreate(string street, string city, string state, string? fieldName = null)
+    {
+        var violations = new System.Collections.Generic.List<FieldViolation>();
+        if (string.IsNullOrWhiteSpace(street))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("street"), "validation.error") { Detail = "Street is required." });
+        if (string.IsNullOrWhiteSpace(city))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("city"), "validation.error") { Detail = "City is required." });
+        if (string.IsNullOrWhiteSpace(state))
+            violations.Add(new FieldViolation(InputPointer.ForProperty("state"), "validation.error") { Detail = "State is required." });
+
+        return violations.Count > 0
+            ? Result.Fail<StatusCodeAddress>(new Error.UnprocessableContent(EquatableArray.Create(violations.ToArray())))
+            : Result.Ok(new StatusCodeAddress(street, city, state));
+    }
+
+    protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+    {
+        yield return Street;
+        yield return City;
+        yield return State;
+    }
+}
+
+public sealed record StatusCodeRequest
+{
+    public StatusCodeAddress Address { get; init; } = null!;
+}
+
+public sealed class StatusCodeScalar : ScalarValueObject<StatusCodeScalar, string>, IScalarValue<StatusCodeScalar, string>
+{
+    private StatusCodeScalar(string value) : base(value) { }
+
+    public static Result<StatusCodeScalar> TryCreate(string? value, string? fieldName = null)
+    {
+        var field = fieldName ?? "value";
+        return string.IsNullOrWhiteSpace(value)
+            ? Result.Fail<StatusCodeScalar>(new Error.UnprocessableContent(EquatableArray.Create(
+                new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = $"{field} is required." })))
+            : Result.Ok(new StatusCodeScalar(value));
+    }
+}
+
+[ApiController]
+[Route("binder-status")]
+public sealed class StatusCodeController : ControllerBase
+{
+    [HttpPost("composite")]
+    public IActionResult PostComposite([FromBody] StatusCodeRequest request) => Ok();
+
+    [HttpGet("scalar")]
+    public IActionResult GetScalar([FromQuery] StatusCodeScalar value) => Ok();
+
+    [HttpPost("mixed")]
+    public IActionResult PostMixed(
+        [FromQuery] StatusCodeScalar value,
+        [FromBody] StatusCodeRequest request) => Ok();
+}

--- a/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
+++ b/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
@@ -92,6 +92,21 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
+    public async Task mvc_Maybe_scalar_VO_query_validation_failure_returns_422()
+    {
+        // Maybe<TScalar> query parameters are bound by MaybeModelBinder. When binding fails
+        // (e.g., raw value provided but TryCreate rejected it), the failure must be classified
+        // as semantic (422), matching plain IScalarValue parameters and the Minimal API path.
+        using var host = CreateMvcHost();
+        using var client = host.GetTestClient();
+
+        var resp = await client.GetAsync("/binder-status/maybe-scalar?value=bad", TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        await AssertRfc9457ProblemDetails(resp, expectedStatus: 422);
+    }
+
+    [Fact]
     public async Task mvc_malformed_JSON_takes_precedence_over_query_scalar_VO_failure_returning_400()
     {
         // Mixed-failure precedence: when the body is not valid JSON AND a query scalar VO
@@ -196,10 +211,22 @@ public sealed class StatusCodeScalar : ScalarValueObject<StatusCodeScalar, strin
     public static Result<StatusCodeScalar> TryCreate(string? value, string? fieldName = null)
     {
         var field = fieldName ?? "value";
-        return string.IsNullOrWhiteSpace(value)
-            ? Result.Fail<StatusCodeScalar>(new Error.UnprocessableContent(EquatableArray.Create(
-                new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = $"{field} is required." })))
-            : Result.Ok(new StatusCodeScalar(value));
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Result.Fail<StatusCodeScalar>(new Error.UnprocessableContent(EquatableArray.Create(
+                new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = $"{field} is required." })));
+        }
+
+        // Sentinel that lets tests force a TryCreate rejection even when the raw input is
+        // non-empty (e.g., for `Maybe<StatusCodeScalar>` parameters where empty would bind
+        // as None instead of triggering validation).
+        if (value == "bad")
+        {
+            return Result.Fail<StatusCodeScalar>(new Error.UnprocessableContent(EquatableArray.Create(
+                new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = $"{field} cannot be 'bad'." })));
+        }
+
+        return Result.Ok(new StatusCodeScalar(value));
     }
 }
 
@@ -212,6 +239,9 @@ public sealed class StatusCodeController : ControllerBase
 
     [HttpGet("scalar")]
     public IActionResult GetScalar([FromQuery] StatusCodeScalar value) => Ok();
+
+    [HttpGet("maybe-scalar")]
+    public IActionResult GetMaybeScalar([FromQuery] Maybe<StatusCodeScalar> value) => Ok();
 
     [HttpPost("mixed")]
     public IActionResult PostMixed(

--- a/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
+++ b/Trellis.Asp/tests/BinderValidationStatusCodeTests.cs
@@ -47,7 +47,7 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
-    public async Task mvc_composite_VO_validation_failure_returns_422_with_RFC_compliant_problem_details()
+    public async Task Mvc_CompositeVoValidationFailure_Returns422WithRfcCompliantProblemDetails()
     {
         using var host = CreateMvcHost();
         using var client = host.GetTestClient();
@@ -62,7 +62,7 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
-    public async Task mvc_scalar_VO_query_validation_failure_returns_422()
+    public async Task Mvc_ScalarVoQueryValidationFailure_Returns422()
     {
         using var host = CreateMvcHost();
         using var client = host.GetTestClient();
@@ -74,7 +74,7 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
-    public async Task mvc_malformed_JSON_returns_400()
+    public async Task Mvc_MalformedJson_Returns400()
     {
         using var host = CreateMvcHost();
         using var client = host.GetTestClient();
@@ -92,7 +92,7 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
-    public async Task mvc_Maybe_scalar_VO_query_validation_failure_returns_422()
+    public async Task Mvc_MaybeScalarVoQueryValidationFailure_Returns422()
     {
         // Maybe<TScalar> query parameters are bound by MaybeModelBinder. When binding fails
         // (e.g., raw value provided but TryCreate rejected it), the failure must be classified
@@ -107,7 +107,7 @@ public sealed class BinderValidationStatusCodeTests
     }
 
     [Fact]
-    public async Task mvc_malformed_JSON_takes_precedence_over_query_scalar_VO_failure_returning_400()
+    public async Task Mvc_MalformedJson_TakesPrecedenceOverQueryScalarVoFailure_Returns400()
     {
         // Mixed-failure precedence: when the body is not valid JSON AND a query scalar VO
         // ALSO fails, the wire response must be 400. Malformed bytes is a more fundamental

--- a/Trellis.Asp/tests/ScalarValueValidationEndpointFilterTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationEndpointFilterTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Trellis.Asp/tests/ScalarValueValidationEndpointFilterTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationEndpointFilterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -70,7 +70,7 @@ public class ScalarValueValidationEndpointFilterTests
             result.Should().BeOfType<ProblemHttpResult>();
 
             var validationProblem = (ProblemHttpResult)result!;
-            validationProblem.StatusCode.Should().Be(400);
+            validationProblem.StatusCode.Should().Be(422);
         }
     }
 
@@ -92,7 +92,7 @@ public class ScalarValueValidationEndpointFilterTests
             // Assert
             result.Should().BeOfType<ProblemHttpResult>();
             var validationProblem = (ProblemHttpResult)result!;
-            validationProblem.StatusCode.Should().Be(400);
+            validationProblem.StatusCode.Should().Be(422);
         }
     }
 
@@ -116,7 +116,7 @@ public class ScalarValueValidationEndpointFilterTests
             // Assert
             result.Should().BeOfType<ProblemHttpResult>();
             var validationProblem = (ProblemHttpResult)result!;
-            validationProblem.StatusCode.Should().Be(400);
+            validationProblem.StatusCode.Should().Be(422);
         }
     }
 
@@ -205,7 +205,7 @@ public class ScalarValueValidationEndpointFilterTests
             // Assert
             result.Should().BeOfType<ProblemHttpResult>();
             var validationProblem = (ProblemHttpResult)result!;
-            validationProblem.StatusCode.Should().Be(400);
+            validationProblem.StatusCode.Should().Be(422);
         }
     }
 
@@ -251,7 +251,7 @@ public class ScalarValueValidationEndpointFilterTests
         {
             result.Should().BeOfType<ProblemHttpResult>();
             var validationProblem = (ProblemHttpResult)result!;
-            validationProblem.StatusCode.Should().Be(400);
+            validationProblem.StatusCode.Should().Be(422);
         }
     }
 

--- a/Trellis.Asp/tests/ScalarValueValidationFilterTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationFilterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.Collections.Generic;
@@ -75,14 +75,14 @@ public class ScalarValueValidationFilterTests
 
             // Assert
             context.Result.Should().NotBeNull();
-            context.Result.Should().BeOfType<BadRequestObjectResult>();
+            context.Result.Should().BeOfType<ObjectResult>();
 
-            var badRequestResult = (BadRequestObjectResult)context.Result!;
-            badRequestResult.StatusCode.Should().Be(400);
+            var badRequestResult = (ObjectResult)context.Result!;
+            badRequestResult.StatusCode.Should().Be(422);
             badRequestResult.Value.Should().BeOfType<ValidationProblemDetails>();
 
             var problemDetails = (ValidationProblemDetails)badRequestResult.Value!;
-            problemDetails.Status.Should().Be(400);
+            problemDetails.Status.Should().Be(422);
             problemDetails.Title.Should().Be("One or more validation errors occurred.");
             problemDetails.Errors.Should().HaveCount(2);
             problemDetails.Errors["Email"].Should().Contain("Email is required.");
@@ -262,14 +262,14 @@ public class ScalarValueValidationFilterTests
             filter.OnActionExecuting(context);
 
             // Assert
-            var badRequestResult = context.Result as BadRequestObjectResult;
+            var badRequestResult = context.Result as ObjectResult;
             badRequestResult.Should().NotBeNull();
 
             var problemDetails = badRequestResult!.Value as ValidationProblemDetails;
             problemDetails.Should().NotBeNull();
-            problemDetails!.Type.Should().Be("https://tools.ietf.org/html/rfc9110#section-15.5.1");
+            problemDetails!.Type.Should().Be("https://tools.ietf.org/html/rfc4918#section-11.2");
             problemDetails.Title.Should().Be("One or more validation errors occurred.");
-            problemDetails.Status.Should().Be(400);
+            problemDetails.Status.Should().Be(422);
             problemDetails.Errors.Should().HaveCount(2);
             problemDetails.Errors.Should().ContainKey("Field1");
             problemDetails.Errors.Should().ContainKey("Field2");
@@ -293,7 +293,7 @@ public class ScalarValueValidationFilterTests
         filter.OnActionExecuting(context);
 
         // Assert - should get rich error from TryCreate
-        context.Result.Should().NotBeNull().And.BeOfType<BadRequestObjectResult>();
+        context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
         var problemDetails = GetValidationProblemDetails(context);
         problemDetails.Errors.Should().ContainKey("code");
         problemDetails.Errors["code"].Should().Contain(e => e.Contains("ORD-"));
@@ -315,7 +315,7 @@ public class ScalarValueValidationFilterTests
         filter.OnActionExecuting(context);
 
         // Assert
-        context.Result.Should().NotBeNull().And.BeOfType<BadRequestObjectResult>();
+        context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
         var problemDetails = GetValidationProblemDetails(context);
         problemDetails.Errors.Should().ContainKey("code");
         problemDetails.Errors["code"].Should().Contain(e => e.Contains("ORD-"));
@@ -394,7 +394,7 @@ public class ScalarValueValidationFilterTests
         filter.OnActionExecuting(context);
 
         // Assert
-        context.Result.Should().NotBeNull().And.BeOfType<BadRequestObjectResult>();
+        context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
         var problemDetails = GetValidationProblemDetails(context);
         problemDetails.Errors.Should().ContainKey("code");
     }
@@ -415,7 +415,7 @@ public class ScalarValueValidationFilterTests
         filter.OnActionExecuting(context);
 
         // Assert - only the IScalarValue param should have an error
-        context.Result.Should().NotBeNull().And.BeOfType<BadRequestObjectResult>();
+        context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
         var problemDetails = GetValidationProblemDetails(context);
         problemDetails.Errors.Should().ContainKey("code");
         problemDetails.Errors.Keys.Should().NotContain("id");
@@ -538,8 +538,8 @@ public class ScalarValueValidationFilterTests
 
     private static ValidationProblemDetails GetValidationProblemDetails(ActionExecutingContext context)
     {
-        context.Result.Should().NotBeNull().And.BeOfType<BadRequestObjectResult>();
-        var badRequest = (BadRequestObjectResult)context.Result!;
+        context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
+        var badRequest = (ObjectResult)context.Result!;
         badRequest.Value.Should().NotBeNull().And.BeOfType<ValidationProblemDetails>();
         return (ValidationProblemDetails)badRequest.Value!;
     }

--- a/Trellis.Asp/tests/ScalarValueValidationFilterTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationFilterTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using System.Collections.Generic;
@@ -59,7 +59,7 @@ public class ScalarValueValidationFilterTests
     }
 
     [Fact]
-    public void OnActionExecuting_WithValidationErrors_ShortCircuitsWithBadRequest()
+    public void OnActionExecuting_WithValidationErrors_ShortCircuitsWithUnprocessableContent()
     {
         // Arrange
         var filter = new ScalarValueValidationFilter();
@@ -77,11 +77,11 @@ public class ScalarValueValidationFilterTests
             context.Result.Should().NotBeNull();
             context.Result.Should().BeOfType<ObjectResult>();
 
-            var badRequestResult = (ObjectResult)context.Result!;
-            badRequestResult.StatusCode.Should().Be(422);
-            badRequestResult.Value.Should().BeOfType<ValidationProblemDetails>();
+            var unprocessableResult = (ObjectResult)context.Result!;
+            unprocessableResult.StatusCode.Should().Be(422);
+            unprocessableResult.Value.Should().BeOfType<ValidationProblemDetails>();
 
-            var problemDetails = (ValidationProblemDetails)badRequestResult.Value!;
+            var problemDetails = (ValidationProblemDetails)unprocessableResult.Value!;
             problemDetails.Status.Should().Be(422);
             problemDetails.Title.Should().Be("One or more validation errors occurred.");
             problemDetails.Errors.Should().HaveCount(2);
@@ -262,10 +262,10 @@ public class ScalarValueValidationFilterTests
             filter.OnActionExecuting(context);
 
             // Assert
-            var badRequestResult = context.Result as ObjectResult;
-            badRequestResult.Should().NotBeNull();
+            var unprocessableResult = context.Result as ObjectResult;
+            unprocessableResult.Should().NotBeNull();
 
-            var problemDetails = badRequestResult!.Value as ValidationProblemDetails;
+            var problemDetails = unprocessableResult!.Value as ValidationProblemDetails;
             problemDetails.Should().NotBeNull();
             problemDetails!.Type.Should().Be("https://tools.ietf.org/html/rfc4918#section-11.2");
             problemDetails.Title.Should().Be("One or more validation errors occurred.");
@@ -539,9 +539,9 @@ public class ScalarValueValidationFilterTests
     private static ValidationProblemDetails GetValidationProblemDetails(ActionExecutingContext context)
     {
         context.Result.Should().NotBeNull().And.BeOfType<ObjectResult>();
-        var badRequest = (ObjectResult)context.Result!;
-        badRequest.Value.Should().NotBeNull().And.BeOfType<ValidationProblemDetails>();
-        return (ValidationProblemDetails)badRequest.Value!;
+        var result = (ObjectResult)context.Result!;
+        result.Value.Should().NotBeNull().And.BeOfType<ValidationProblemDetails>();
+        return (ValidationProblemDetails)result.Value!;
     }
 
     private static ActionExecutingContext CreateActionExecutingContext()

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System;
 using System.IO;
@@ -352,7 +352,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("code")[0].GetString()
@@ -376,7 +376,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("code")[0].GetString()
@@ -400,7 +400,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("code")[0].GetString()
@@ -424,7 +424,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("code")[0].GetString()
@@ -488,7 +488,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("code")[0].GetString()
@@ -561,7 +561,7 @@ public class ScalarValueValidationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         var errors = problem.GetProperty("errors");
@@ -672,7 +672,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert - falls through from the unusable string overload to primitive TryCreate.
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("val")[0].GetString()
@@ -696,7 +696,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         var problem = JsonSerializer.Deserialize<JsonElement>(body);
         problem.GetProperty("errors").GetProperty("val")[0].GetString()
@@ -749,7 +749,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         body.Should().NotContain("<script>", "user input should not be reflected in error responses");
         body.Should().NotContain("alert", "user input should not be reflected in error responses");
@@ -772,7 +772,7 @@ public class ScalarValueValidationMiddlewareTests
         await middleware.InvokeAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        context.Response.StatusCode.Should().Be(422);
         var body = await ReadResponseBodyAsync(context);
         body.Should().NotContain("IntOnlyScalarValue", "internal type names should not be exposed to clients");
     }

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System;
 using System.IO;
@@ -336,7 +336,7 @@ public class ScalarValueValidationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_ForScalarValue_Returns400WithRichErrors()
+    public async Task InvokeAsync_BindingFailure_ForScalarValue_Returns422WithRichErrors()
     {
         // Arrange
         var paramInfo = typeof(ScalarValueValidationMiddlewareTests)
@@ -360,7 +360,7 @@ public class ScalarValueValidationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_ForScalarValueWithQualifiedTypeName_Returns400WithRichErrors()
+    public async Task InvokeAsync_BindingFailure_ForScalarValueWithQualifiedTypeName_Returns422WithRichErrors()
     {
         // Arrange
         var paramInfo = typeof(ScalarValueValidationMiddlewareTests)
@@ -384,7 +384,7 @@ public class ScalarValueValidationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_ForScalarValueWithNestedTypeName_Returns400WithRichErrors()
+    public async Task InvokeAsync_BindingFailure_ForScalarValueWithNestedTypeName_Returns422WithRichErrors()
     {
         // Arrange
         var paramInfo = typeof(ScalarValueValidationMiddlewareTests)
@@ -408,7 +408,7 @@ public class ScalarValueValidationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_BindingFailure_ForMaybeScalarValue_Returns400WithRichErrors()
+    public async Task InvokeAsync_BindingFailure_ForMaybeScalarValue_Returns422WithRichErrors()
     {
         // Arrange
         var paramInfo = typeof(ScalarValueValidationMiddlewareTests)

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareWireShapeTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareWireShapeTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System.Collections.Generic;
 using System.IO;

--- a/Trellis.Asp/tests/ScalarValueValidationMiddlewareWireShapeTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationMiddlewareWireShapeTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System.Collections.Generic;
 using System.IO;
@@ -62,7 +62,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
         errors.Should().ContainKey("items[0].amount");
@@ -80,7 +80,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
         errors.Should().ContainKey(string.Empty,
@@ -116,7 +116,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
         errors.Should().ContainKey("amount");
@@ -310,7 +310,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -352,7 +352,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -386,7 +386,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -420,7 +420,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -455,7 +455,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -490,7 +490,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 
@@ -528,7 +528,7 @@ public sealed class ScalarValueValidationMiddlewareWireShapeTests
         var middleware = new ScalarValueValidationMiddleware(_ => throw bre);
         await middleware.InvokeAsync(ctx);
 
-        ctx.Response.StatusCode.Should().Be(400);
+        ctx.Response.StatusCode.Should().Be(422);
         var problem = await ReadProblemAsync(ctx);
         var errors = ReadErrors(problem);
 

--- a/Trellis.Asp/tests/ScalarValueValidationTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using System.Text.Json;
 using FluentAssertions;

--- a/Trellis.Asp/tests/ScalarValueValidationTests.cs
+++ b/Trellis.Asp/tests/ScalarValueValidationTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.Asp.Tests;
+namespace Trellis.Asp.Tests;
 
 using System.Text.Json;
 using FluentAssertions;
@@ -427,7 +427,7 @@ public class ScalarValueValidationTests
             result.Should().BeAssignableTo<Microsoft.AspNetCore.Http.IResult>();
             var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
             problemResult.Should().NotBeNull();
-            problemResult!.StatusCode.Should().Be(400);
+            problemResult!.StatusCode.Should().Be(422);
         }
     }
 


### PR DESCRIPTION
## Issue

The framework returned **400 Bad Request** for two distinct condition shapes:

1. **Trellis-driven semantic validation failures during binding** — composite VO `TryCreate` failures inside `CompositeValueObjectJsonConverter`, missing required composite properties, unsupported primitive types, JSON shape mismatches, scalar VO `TryCreate` failures on query/route parameters.
2. **Plain JSON syntax errors** — malformed JSON tokens, unclosed braces, other `System.Text.Json.JsonException`s that aren't a `TrellisJsonValidationException`.

Domain handler failures returning `Result.Fail(Error.UnprocessableContent(...))` already returned **422 Unprocessable Content** via `ResponseFailureWriter`. Clients had to special-case both for the same logical "your input is invalid" condition.

## Fix

Align with RFC 9110 §15.5.21 ("well-formed but unable to be processed due to semantic errors"):

- **422** — `TrellisJsonValidationException` from any source (composite VO converter, scalar VO TryCreate failure, `ValidationErrorsContext`-collected errors), via `ScalarValueValidationMiddleware`, `ScalarValueValidationFilter`, and `ScalarValueValidationEndpointFilter`.
- **400** — plain `JsonException` (the bytes are not valid JSON, RFC 9110 §15.5.1).

**Mixed-failure precedence**: when a request contains both a plain JSON syntax error AND a Trellis semantic failure (e.g., malformed body + invalid query scalar VO), 400 wins. The bytes weren't valid JSON, which is a more fundamental client error than any semantic failure on the same request.

`ProblemDetails.Type`, `Title`, and `Status` populate via the framework defaults (no Trellis override) — `https://tools.ietf.org/html/rfc4918#section-11.2` for 422, `https://tools.ietf.org/html/rfc9110#section-15.5.1` for 400.

Secondary hardening: the MVC scalar-VO fallback error message no longer reflects the raw user input (mirrors the middleware's existing hardening on the same code path).

## Breaking change

Clients with `if (statusCode == 400)` checks for input validation should switch to `if (statusCode == 400 || statusCode == 422)` or — better — handle both via the shared `ValidationProblemDetails.Errors` shape, which is unchanged.
