### PR TITLE
Clarify three high-friction XML doc summaries (F5)

### DIFF
--- a/Trellis.Authorization/src/SharedResourceLoaderById.cs
+++ b/Trellis.Authorization/src/SharedResourceLoaderById.cs
@@ -40,6 +40,12 @@ public abstract class SharedResourceLoaderById<TResource, TId>
     /// Loads the resource by ID.
     /// Return <c>Result.Fail</c> with a <see cref="Error.NotFound"/> if the resource does not exist.
     /// </summary>
+    /// <remarks>
+    /// The method is named <c>GetByIdAsync</c> (not <c>LoadByIdAsync</c> as the class name might
+    /// suggest). The <c>Loader</c> in <see cref="SharedResourceLoaderById{TResource, TId}"/> refers
+    /// to the loader role in the authorization pipeline, while the actual fetch method follows
+    /// the canonical <c>GetByIdAsync</c> naming used by the rest of the framework.
+    /// </remarks>
     /// <param name="id">The resource identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>

--- a/Trellis.Mediator/src/ServiceCollectionExtensions.cs
+++ b/Trellis.Mediator/src/ServiceCollectionExtensions.cs
@@ -236,6 +236,13 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// <para>
+    /// Despite the feature name (<i>resource authorization</i>), this extension lives in the
+    /// <c>Trellis.Mediator</c> namespace — not <c>Trellis.Authorization</c> — because the
+    /// resource is loaded by a Mediator pipeline behavior. Add
+    /// <c>using Trellis.Mediator;</c> in your composition root (e.g.,
+    /// <c>DependencyInjection.cs</c>) to bring this method into scope.
+    /// </para>
+    /// <para>
     /// Prefer <see cref="AddResourceAuthorization(IServiceCollection, Assembly[])"/> for automatic
     /// discovery. Use this explicit overload for AOT/trimming scenarios where assembly scanning
     /// is not available.
@@ -280,6 +287,13 @@ public static class ServiceCollectionExtensions
     /// (containing <see cref="IResourceLoader{TMessage, TResource}"/> implementations).</param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
+    /// <para>
+    /// Despite the feature name (<i>resource authorization</i>), this extension lives in the
+    /// <c>Trellis.Mediator</c> namespace — not <c>Trellis.Authorization</c> — because the
+    /// resource is loaded by a Mediator pipeline behavior. Add
+    /// <c>using Trellis.Mediator;</c> in your composition root (e.g.,
+    /// <c>DependencyInjection.cs</c>) to bring this method into scope.
+    /// </para>
     /// <para>
     /// For each concrete type that implements <see cref="IAuthorizeResource{TResource}"/>,
     /// the method extracts <c>TResource</c> and resolves <c>TResponse</c> from

--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -277,6 +277,15 @@ public class Money : ValueObject
     /// <summary>
     /// Creates a zero-value Money instance for the specified currency.
     /// </summary>
+    /// <param name="currencyCode">ISO 4217 currency code. Defaults to <c>"USD"</c>.</param>
+    /// <returns>
+    /// A <see cref="Result{T}"/> wrapping the constructed <see cref="Money"/>. Returns the
+    /// success branch when <paramref name="currencyCode"/> is a supported currency, and the
+    /// failure branch when it is not — the currency code is validated at construction time,
+    /// so this method is not a plain <see cref="Money"/> factory. Consumers must unwrap the
+    /// result (typically with <c>.TryGetValue(...)</c> or <c>.Match(...)</c>) before using
+    /// the value.
+    /// </returns>
     public static Result<Money> Zero(string currencyCode = "USD") => TryCreate(0, currencyCode);
 
     /// <summary>


### PR DESCRIPTION
Three XML doc clarifications surfaced by the 2026-05-06 lab feedback (lab finding F5). Each one targets a documented friction point where Opus tried the wrong API shape first and lost ~10-20 minutes before grepping.

## Issue

Three commonly-used members had documentation that omitted information consumers needed at the call site:

1. `Money.Zero(currencyCode = "USD")` — summary did not say the return type is `Result<Money>`. Consumers wrote `Money.Zero()` assuming a plain `Money`.
2. `SharedResourceLoaderById<TResource, TId>.GetByIdAsync` — class name suggests `LoadByIdAsync`/`LoadAsync`/`FindAsync`. The actual method is `GetByIdAsync`.
3. `services.AddResourceAuthorization<...>()` — feature is called *resource authorization* but the extension lives in `Trellis.Mediator`, not `Trellis.Authorization`.

## Fix

1. Money.Zero: expanded summary explicitly notes the `Result<Money>` return and that the currency code is validated.
2. SharedResourceLoaderById.GetByIdAsync: added remarks block clarifying the method-vs-class-name divergence.
3. AddResourceAuthorization (both overloads): added a leading remarks paragraph stating the extension lives in `Trellis.Mediator` and `using Trellis.Mediator;` is the right import.