### PR TITLE
Lower mediator per-message log level from Information to Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,32 @@ Also in this release:
 
 ### Changed (Breaking)
 
+#### `Trellis.Mediator.LoggingBehavior` — per-message logs lowered from `Information` to `Debug`
+
+The mediator pipeline's `LoggingBehavior` previously emitted both the entry log (`Handling {MessageName}`) and the success-exit log (`Handled {MessageName} in {ElapsedMs:0.00}ms`) at `LogLevel.Information`. Under ASP.NET Core's default minimum log level (`Information`), every mediator dispatch produced two log lines per request — flooding production logs and burying the actual `Failed:` warnings during test runs.
+
+Per-call timing is cross-cutting observability noise, not a business event. This release lowers both the entry and success-exit lines to `LogLevel.Debug`. Failure exits stay at `LogLevel.Warning` so they continue to surface at the default minimum level. Failures that bypass mediator logging (exceptions in non-Trellis pipeline behaviors, etc.) are unaffected.
+
+| Stage | Before | After |
+|---|---|---|
+| `Handling {MessageName}` | `Information` | **`Debug`** |
+| `Handled {MessageName} in {…}ms` (success) | `Information` | **`Debug`** |
+| `Handled {…} — Failed: {ErrorSummary}` (failure) | `Warning` | `Warning` (unchanged) |
+
+**Migration**: consumers that depend on mediator timing in `Information`-level logs (dashboards, log aggregators, structured log queries on the `MessageName` template) must explicitly raise the level via `appsettings.json`:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Trellis.Mediator": "Debug"
+    }
+  }
+}
+```
+
+For most production services, the right path forward is to derive per-message latency from the `Trellis.Mediator` `Activity` source (already populated by `TracingBehavior<,>`) rather than from log lines — the activity carries the same elapsed-ms data plus structured tags and trace-correlation IDs.
+
 #### Binder-level value object validation failures now return 422 (Unprocessable Content), aligning with domain handler failures
 
 The framework previously returned **400 Bad Request** for two distinct condition shapes:

--- a/Trellis.Mediator/src/LoggingBehavior.cs
+++ b/Trellis.Mediator/src/LoggingBehavior.cs
@@ -6,7 +6,11 @@ using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// Pipeline behavior that logs command/query execution with duration and Result outcome.
-/// Logs at Information level for success, Warning level for failure.
+/// Logs at <see cref="LogLevel.Debug"/> for the per-message start/end pair (cross-cutting
+/// observability noise belongs at Debug, not Information; consumers who want per-call timing
+/// in production raise the level via <c>"Trellis.Mediator": "Debug"</c> in their logging
+/// configuration). Failures are logged at <see cref="LogLevel.Warning"/> regardless of
+/// configured minimum level so production logs surface them by default.
 /// </summary>
 /// <typeparam name="TMessage">The message type.</typeparam>
 /// <typeparam name="TResponse">The response type, constrained to <see cref="IResult"/>.</typeparam>
@@ -71,10 +75,10 @@ public sealed partial class LoggingBehavior<TMessage, TResponse>
         return response;
     }
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Handling {MessageName}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Handling {MessageName}")]
     private static partial void LogHandling(ILogger logger, string messageName);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Handled {MessageName} in {ElapsedMs:0.00}ms")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Handled {MessageName} in {ElapsedMs:0.00}ms")]
     private static partial void LogHandled(ILogger logger, string messageName, double elapsedMs);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Handled {MessageName} in {ElapsedMs:0.00}ms — Failed: {ErrorSummary}")]

--- a/Trellis.Mediator/tests/LoggingBehaviorTests.cs
+++ b/Trellis.Mediator/tests/LoggingBehaviorTests.cs
@@ -8,10 +8,10 @@ using Trellis.Mediator.Tests.Helpers;
 /// </summary>
 public class LoggingBehaviorTests
 {
-    #region Successful handler — logs at Information level
+    #region Successful handler — logs at Debug level
 
     [Fact]
-    public async Task Handle_SuccessfulResult_LogsAtInformationLevel()
+    public async Task Handle_SuccessfulResult_LogsAtDebugLevel()
     {
         var logEntries = new List<(LogLevel Level, string Message)>();
         var logger = new FakeLogger<LoggingBehavior<TestCommand, Result<string>>>(logEntries);
@@ -24,16 +24,19 @@ public class LoggingBehaviorTests
 
         result.IsSuccess.Should().BeTrue();
         logEntries.Should().HaveCount(2);
-        logEntries[0].Level.Should().Be(LogLevel.Information);
+        // Debug, not Information: cross-cutting per-call timing should not flood production
+        // logs at the default minimum level. Consumers who want it opt in via
+        // "Trellis.Mediator": "Debug" in appsettings.
+        logEntries[0].Level.Should().Be(LogLevel.Debug);
         logEntries[0].Message.Should().Contain("TestCommand");
-        logEntries[1].Level.Should().Be(LogLevel.Information);
+        logEntries[1].Level.Should().Be(LogLevel.Debug);
         logEntries[1].Message.Should().Contain("TestCommand");
         logEntries[1].Message.Should().Contain("ms");
     }
 
     #endregion
 
-    #region Failed Result — logs at Warning level
+    #region Failed Result — start at Debug, failure exit at Warning
 
     [Fact]
     public async Task Handle_FailedResult_LogsAtWarningLevel()
@@ -49,7 +52,9 @@ public class LoggingBehaviorTests
 
         result.IsFailure.Should().BeTrue();
         logEntries.Should().HaveCount(2);
-        logEntries[0].Level.Should().Be(LogLevel.Information);
+        // Start line is Debug (cross-cutting), failure exit stays Warning so it surfaces
+        // at the default minimum level even when Trellis.Mediator is filtered to Information.
+        logEntries[0].Level.Should().Be(LogLevel.Debug);
         logEntries[1].Level.Should().Be(LogLevel.Warning);
         logEntries[1].Message.Should().Contain("TestCommand");
         // ga-12: Detail is redacted by default (it can contain user input/PII). Only the

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -151,7 +151,7 @@ public sealed partial class LoggingBehavior<TMessage, TResponse> : IPipelineBeha
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public async ValueTask<TResponse> Handle(TMessage message, MessageHandlerDelegate<TMessage, TResponse> next, CancellationToken cancellationToken)` | `ValueTask<TResponse>` | Logs start (Information), end with elapsed milliseconds (Information on success, Warning on failure). On failure emits `error.Code` only by default; the free-text `Error.Detail` is included only when `TrellisMediatorTelemetryOptions.IncludeErrorDetail` is `true`. |
+| `public async ValueTask<TResponse> Handle(TMessage message, MessageHandlerDelegate<TMessage, TResponse> next, CancellationToken cancellationToken)` | `ValueTask<TResponse>` | Logs start (Debug), end with elapsed milliseconds (Debug on success, Warning on failure). Per-call timing is at Debug so production at the default `Information` minimum stays quiet; raise via `"Trellis.Mediator": "Debug"` in logging configuration to opt back in. On failure emits `error.Code` only by default; the free-text `Error.Detail` is included only when `TrellisMediatorTelemetryOptions.IncludeErrorDetail` is `true`. |
 
 ### ResourceAuthorizationBehavior<TMessage, TResource, TResponse>
 **Declaration**

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -525,7 +525,7 @@ On a failed result, both `LoggingBehavior` and `TracingBehavior` always emit:
 - `Error.Code` (operator-defined identifier, e.g., `"orders.cancel"`).
 - The stable `Error` type name (e.g., `Error.Forbidden`) on the activity as `error.type`.
 
-`LoggingBehavior` writes Information on success and Warning on failure; `TracingBehavior` sets `ActivityStatusCode.Error` on the failure path.
+`LoggingBehavior` writes Debug on success and Warning on failure; `TracingBehavior` sets `ActivityStatusCode.Error` on the failure path. Per-call timing is at Debug to keep production logs quiet at the default `Information` minimum; raise via `"Trellis.Mediator": "Debug"` in logging configuration to surface every dispatch.
 
 ### Telemetry redaction
 

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -35,7 +35,7 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 | Surface | Type / API | Emits | Subscribed via |
 |---|---|---|---|
 | Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddSource(TracingBehavior<,>.ActivitySourceName)` (value: `"Trellis.Mediator"`) |
-| Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Information` start, `Information` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider |
+| Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Debug` start, `Debug` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider. Per-call timing is at Debug so production at the default `Information` minimum is quiet; raise via `"Trellis.Mediator": "Debug"` in logging configuration to opt back in. |
 | Redaction | `TrellisMediatorTelemetryOptions` (`Trellis.Mediator`) | Controls whether `Error.Detail` flows into the activity status description and log message | DI singleton, configured via `o.UseMediator(t => ...)` or `AddTrellisBehaviors(t => ...)` |
 | Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | One `Activity` per `TryCreate` / `Parse` on a `Required*<TSelf>` value object | `tracing.AddPrimitiveValueObjectInstrumentation()` |
 | Result / ROP tracing | `Trellis.Core` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddResultsInstrumentation()` |
@@ -161,9 +161,11 @@ builder.Services.AddOpenTelemetry()
 
 | Stage | Level | Template |
 |---|---|---|
-| Entry | `Information` | `Handling {MessageName}` |
-| Success exit | `Information` | `Handled {MessageName} in {ElapsedMs:0.00}ms` |
+| Entry | `Debug` | `Handling {MessageName}` |
+| Success exit | `Debug` | `Handled {MessageName} in {ElapsedMs:0.00}ms` |
 | Failure exit | `Warning` | `Handled {MessageName} in {ElapsedMs:0.00}ms — Failed: {ErrorSummary}` |
+
+> **Why Debug for the success path?** Cross-cutting per-message timing is observability noise, not a business event — at `Information` minimum (the ASP.NET Core default), every request would flood the log with at least two lines per mediator dispatch. Raise to `"Trellis.Mediator": "Debug"` in `appsettings.Development.json` (or any environment) to opt back in. Failures stay at `Warning` so they surface at the default minimum level even when Trellis.Mediator is filtered to Information.
 
 `{MessageName}` is `typeof(TMessage).Name`. `{ErrorSummary}` is `error.Code` by default; it becomes `error.GetDisplayMessage()` (which includes `Error.Detail`) only when `IncludeErrorDetail = true`. Because the log entries are written inside the mediator activity, every entry already carries the trace/span IDs propagated by your logging provider's OTel integration.
 


### PR DESCRIPTION
## Issue

Trellis.Mediator.LoggingBehavior emitted Handling and Handled log lines at LogLevel.Information. Under ASP.NET Core's default Information minimum, every mediator dispatch produced two lines per request, flooding production logs and drowning real Failed: warnings during test runs.

Lab cycle 3 (2026-05-08) confirmed this as the top daily-DX friction across both Opus 4.7 (B1) and GPT-5.5 ("Mediator/test logging volume makes failure output noisy").

## Fix

Lower the entry and success-exit lines to LogLevel.Debug. Failure exits stay at LogLevel.Warning so they continue to surface at the default minimum.

| Stage | Before | After |
|---|---|---|
| Handling MessageName | Information | Debug |
| Handled MessageName in Xms (success) | Information | Debug |
| Handled ... Failed: ErrorSummary (failure) | Warning | Warning (unchanged) |

## Migration (breaking)

Consumers that depend on Information-level mediator timing logs must explicitly raise the level via ppsettings.json. Production services should derive per-message latency from the Trellis.Mediator Activity source (already populated by TracingBehavior) — same elapsed-ms data plus structured tags + trace correlation IDs.