### PR TITLE
Pin Recipes 16-20: add missing compile-checked demonstrators

### DIFF
--- a/Examples/CookbookSnippets/CookbookSnippets.csproj
+++ b/Examples/CookbookSnippets/CookbookSnippets.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />
     <ProjectReference Include="..\..\Trellis.Asp\generator\Trellis.AspSourceGenerator.csproj"
                       OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Trellis.Http\src\Trellis.Http.csproj" />
     <ProjectReference Include="..\..\Trellis.Authorization\src\Trellis.Authorization.csproj" />
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\src\Trellis.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\generator\Trellis.EntityFrameworkCore.Generator.csproj"

--- a/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
+++ b/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
@@ -1,0 +1,87 @@
+﻿// Cookbook Recipe 16 — Unit of work in handlers: Add staging vs immediate SaveAsync.
+namespace CookbookSnippets.Recipe16;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Mediator;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.EntityFrameworkCore;
+using Trellis.FluentValidation;
+using Trellis.Mediator;
+
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+
+public sealed record Money(decimal Amount);
+
+public sealed record CreateOrderCommand(Money Total) : ICommand<Result<OrderId>>;
+
+public sealed class Order : Aggregate<OrderId>
+{
+    public Money Total { get; private set; } = default!;
+
+    private Order(OrderId id) : base(id) { }
+
+    public static Result<Order> Create(Money total) =>
+        OrderId.TryCreate(Guid.NewGuid())
+            .Map(id => new Order(id) { Total = total });
+}
+
+public interface IOrderRepository
+{
+    void Add(Order order);
+    void Remove(Order order);
+    Task<Result<Trellis.Unit>> RemoveByIdAsync(OrderId id, CancellationToken ct = default);
+}
+
+public sealed class EfOrderRepository(DbContext context) : RepositoryBase<Order, OrderId>(context), IOrderRepository;
+
+public sealed class CreateOrderHandler(IOrderRepository repo)
+    : ICommandHandler<CreateOrderCommand, Result<OrderId>>
+{
+    public ValueTask<Result<OrderId>> Handle(CreateOrderCommand command, CancellationToken cancellationToken) =>
+        Order.Create(command.Total)
+            .Tap(repo.Add)
+            .Map(o => o.Id)
+            .AsValueTask();
+}
+
+public sealed class Recipe16DbContext(DbContextOptions<Recipe16DbContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+}
+
+internal static class Recipe16Demonstrator
+{
+    public static void RepositoryBaseStagesWithoutSaving(EfOrderRepository repo, Order order)
+    {
+        repo.Add(order);
+        repo.Remove(order);
+        Task<Result<Trellis.Unit>> removed = repo.RemoveByIdAsync(order.Id);
+
+        _ = removed;
+    }
+
+    public static Task<Result<int>> ExplicitDbContextSaveResult(Recipe16DbContext db, CancellationToken ct) =>
+        db.SaveChangesResultAsync(ct);
+
+    public static IServiceCollection UnitOfWorkRegistration(IServiceCollection services) =>
+        services
+            .AddTrellisBehaviors()
+            .AddTrellisFluentValidation(typeof(Recipe16Demonstrator).Assembly)
+            .AddTrellisUnitOfWork<Recipe16DbContext>()
+            .AddScoped<IOrderRepository, EfOrderRepository>();
+
+    public static void TransactionalBehaviorTypePin()
+    {
+        Type behavior = typeof(TransactionalCommandBehavior<CreateOrderCommand, Result<OrderId>>);
+        _ = behavior;
+    }
+}
+
+#if FALSE
+// Wrong — explicit SaveChangesAsync in the handler bypasses TransactionalCommandBehavior.
+// Wrong — SaveAsync is a FakeRepository test convenience; EF repositories should not expose it.
+#endif

--- a/Examples/CookbookSnippets/Recipe17_DomainEvents.cs
+++ b/Examples/CookbookSnippets/Recipe17_DomainEvents.cs
@@ -1,0 +1,79 @@
+﻿// Cookbook Recipe 17 — Defining custom domain events: OccurredAt is the only timestamp.
+namespace CookbookSnippets.Recipe17;
+
+using System;
+using System.Collections.Generic;
+using Trellis;
+
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+
+public sealed partial class ActorId : RequiredGuid<ActorId>;
+
+public sealed partial class TrackingNumber : RequiredString<TrackingNumber>;
+
+public sealed class Money(decimal amount) : ValueObject
+{
+    public decimal Amount { get; } = amount;
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Amount;
+    }
+}
+
+public partial class OrderStatus : RequiredEnum<OrderStatus>
+{
+    public static readonly OrderStatus Draft = new();
+    public static readonly OrderStatus Submitted = new();
+}
+
+public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset OccurredAt) : IDomainEvent;
+
+public sealed record OrderApproved(OrderId OrderId, ActorId ApprovedBy, DateTimeOffset OccurredAt) : IDomainEvent;
+
+public sealed record OrderShipped(OrderId OrderId, TrackingNumber Tracking, DateTimeOffset OccurredAt) : IDomainEvent;
+
+public sealed class Order : Aggregate<OrderId>
+{
+    public Money Total { get; private set; } = default!;
+    public OrderStatus Status { get; private set; } = OrderStatus.Draft;
+    public DateTimeOffset? SubmittedAt { get; private set; }
+
+    private Order(OrderId id) : base(id) { }
+
+    public static Result<Order> Create(OrderId id, Money total) =>
+        Result.Ok(new Order(id) { Total = total });
+
+    public Result<Order> Submit(TimeProvider clock)
+    {
+        var occurredAt = clock.GetUtcNow();
+        return this.ToResult()
+            .Ensure(_ => Status == OrderStatus.Draft, Error.UnprocessableContent.ForRule("order.already-submitted", "Already submitted"))
+            .Tap(_ =>
+            {
+                Status = OrderStatus.Submitted;
+                SubmittedAt = occurredAt;
+                DomainEvents.Add(new OrderSubmitted(Id, Total, occurredAt));
+            });
+    }
+}
+
+internal static class Recipe17Demonstrator
+{
+    public static void DomainEventSurface(OrderSubmitted submitted, TimeProvider clock)
+    {
+        DateTimeOffset occurredAt = ((IDomainEvent)submitted).OccurredAt;
+        DateTimeOffset now = clock.GetUtcNow();
+        OrderApproved approved = new(submitted.OrderId, ActorId.NewUniqueV7(), now);
+
+        _ = (occurredAt, approved);
+    }
+}
+
+#if FALSE
+// Wrong — omitting OccurredAt does not implement IDomainEvent.
+// public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset SubmittedAt) : IDomainEvent;
+
+// Wrong — a semantic timestamp duplicates the canonical OccurredAt timestamp.
+// public sealed record OrderSubmitted(OrderId OrderId, Money Total, DateTimeOffset SubmittedAt, DateTimeOffset OccurredAt) : IDomainEvent;
+#endif

--- a/Examples/CookbookSnippets/Recipe18_DtoToCommand.cs
+++ b/Examples/CookbookSnippets/Recipe18_DtoToCommand.cs
@@ -1,0 +1,63 @@
+﻿// Cookbook Recipe 18 — DTO primitives to value-object command: no test-only Unwrap().
+namespace CookbookSnippets.Recipe18;
+
+using System.Threading;
+using System.Threading.Tasks;
+using global::Mediator;
+using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
+using Trellis.Primitives;
+
+public sealed record CreateCustomerRequest(string Email, string CustomerName);
+
+public sealed partial class CustomerId : RequiredGuid<CustomerId>;
+
+public sealed record CustomerResponse(CustomerId Id, string Email, string CustomerName);
+
+[StringLength(200, MinimumLength = 1)]
+public sealed partial class CustomerName : RequiredString<CustomerName>;
+
+public sealed record CreateCustomerCommand(EmailAddress Email, CustomerName CustomerName)
+    : ICommand<Result<CustomerResponse>>
+{
+    public static Result<CreateCustomerCommand> TryCreate(CreateCustomerRequest request) =>
+        Result.Combine(
+                EmailAddress.TryCreate(request.Email, nameof(request.Email)),
+                CustomerName.TryCreate(request.CustomerName, nameof(request.CustomerName)))
+            .Map((email, customerName) => new CreateCustomerCommand(email, customerName));
+}
+
+[ApiController]
+[Route("customers")]
+public sealed class CustomersController(ISender sender) : ControllerBase
+{
+    [HttpPost]
+    public ValueTask<ActionResult<CustomerResponse>> Create(
+        [FromBody] CreateCustomerRequest request,
+        CancellationToken ct) =>
+        CreateCustomerCommand.TryCreate(request)
+            .BindAsync(command => sender.Send(command, ct))
+            .ToHttpResponseAsync()
+            .AsActionResultAsync<CustomerResponse>();
+}
+
+internal static class Recipe18Demonstrator
+{
+    public static Result<CreateCustomerCommand> CombineDtoFields(CreateCustomerRequest request) =>
+        Result.Combine(
+                EmailAddress.TryCreate(request.Email, nameof(request.Email)),
+                CustomerName.TryCreate(request.CustomerName, nameof(request.CustomerName)))
+            .Map((email, customerName) => new CreateCustomerCommand(email, customerName));
+
+    public static Task<Result<CustomerResponse>> BindValidCommandAsync(CreateCustomerRequest request, ISender sender, CancellationToken ct) =>
+        CreateCustomerCommand.TryCreate(request)
+            .BindAsync(command => sender.Send(command, ct).AsTask());
+}
+
+#if FALSE
+// WRONG — Unwrap() is test-only and turns validation failures into thrown exceptions.
+// var command = new CreateCustomerCommand(
+//     EmailAddress.TryCreate(request.Email).Unwrap(),
+//     CustomerName.TryCreate(request.CustomerName).Unwrap());
+#endif

--- a/Examples/CookbookSnippets/Recipe19_HttpClient.cs
+++ b/Examples/CookbookSnippets/Recipe19_HttpClient.cs
@@ -1,0 +1,49 @@
+﻿// Cookbook Recipe 19 — HTTP client result safety and optional reads.
+namespace CookbookSnippets.Recipe19;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Http;
+
+[JsonSerializable(typeof(OrderDto))]
+public sealed partial class OrderJsonContext : JsonSerializerContext;
+
+public sealed record OrderDto(Guid Id, decimal Total);
+
+public static class Recipe19CompiledSurface
+{
+    public static Task<Result<OrderDto>> GetRequiredOrderAsync(HttpClient client, Guid id, CancellationToken ct) =>
+        client.GetAsync($"/orders/{id}", ct)
+            .ToResultAsync()
+            .ReadJsonAsync(OrderJsonContext.Default.OrderDto, ct);
+
+    public static Task<Result<Maybe<OrderDto>>> FindOrderAsync(HttpClient client, Guid id, CancellationToken ct) =>
+        client.GetAsync($"/orders/{id}", ct)
+            .ReadJsonOrNoneOn404Async(OrderJsonContext.Default.OrderDto, ct);
+
+    public static Task<Result<OrderDto>> GetRequiredOrderWithStatusMapAsync(HttpClient client, Guid id, CancellationToken ct) =>
+        client.GetAsync($"/orders/{id}", ct)
+            .ToResultAsync(status => status == HttpStatusCode.NotFound
+                ? new Error.NotFound(ResourceRef.For<OrderDto>(id))
+                : null)
+            .ReadJsonAsync(OrderJsonContext.Default.OrderDto, ct);
+}
+
+internal static class Recipe19Demonstrator
+{
+    public static Task<Result<HttpResponseMessage>> StrictToResult(Task<HttpResponseMessage> response) =>
+        response.ToResultAsync();
+
+    public static Task<Result<HttpResponseMessage>> StatusMapping(Task<HttpResponseMessage> response) =>
+        response.ToResultAsync(status => status == HttpStatusCode.Forbidden
+            ? new Error.Forbidden("orders.read")
+            : null);
+
+    public static Task<Result<Maybe<OrderDto>>> OptionalRead(Task<HttpResponseMessage> response, CancellationToken ct) =>
+        response.ReadJsonOrNoneOn404Async(OrderJsonContext.Default.OrderDto, ct);
+}

--- a/Examples/CookbookSnippets/Recipe20_SequenceTraverse.cs
+++ b/Examples/CookbookSnippets/Recipe20_SequenceTraverse.cs
@@ -1,0 +1,96 @@
+﻿// Cookbook Recipe 20 — Fail-fast vs accumulating: Sequence/Traverse vs SequenceAll/TraverseAll.
+namespace CookbookSnippets.Recipe20;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Trellis;
+using Trellis.Primitives;
+
+public sealed record CreateContactRow(string Email, string Name);
+
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+
+public sealed class Order : Aggregate<OrderId>
+{
+    private Order(OrderId id) : base(id) { }
+
+    public static Order ForTesting(OrderId id) => new(id);
+}
+
+public interface IOrderRepository
+{
+    Task<Result<Order>> LoadAsync(OrderId id, CancellationToken ct);
+}
+
+public sealed class Recipe20CompiledSurface(IOrderRepository repo)
+{
+    public Result<IReadOnlyList<EmailAddress>> ValidateAddresses(IEnumerable<CreateContactRow> rows)
+    {
+        _ = repo;
+        return rows.TraverseAll(row => EmailAddress.TryCreate(row.Email));
+    }
+
+    public Task<Result<IReadOnlyList<Order>>> LoadOrders(IEnumerable<OrderId> ids, CancellationToken ct) =>
+        ids.TraverseAsync((id, c) =>
+        {
+            _ = c.CanBeCanceled;
+            return repo.LoadAsync(id, c);
+        }, ct);
+}
+
+internal static class Recipe20Demonstrator
+{
+    public static Result<IReadOnlyList<EmailAddress>> FailFastTraverse(IEnumerable<CreateContactRow> rows) =>
+        rows.Traverse(row => EmailAddress.TryCreate(row.Email));
+
+    public static Result<IReadOnlyList<EmailAddress>> AccumulatingTraverse(IEnumerable<CreateContactRow> rows) =>
+        rows.TraverseAll(row => EmailAddress.TryCreate(row.Email));
+
+    public static Result<IReadOnlyList<EmailAddress>> FailFastSequence(IEnumerable<Result<EmailAddress>> results) =>
+        results.Sequence();
+
+    public static Result<IReadOnlyList<EmailAddress>> AccumulatingSequence(IEnumerable<Result<EmailAddress>> results) =>
+        results.SequenceAll();
+
+    public static Task<Result<IReadOnlyList<EmailAddress>>> TaskTraverse(IEnumerable<CreateContactRow> rows) =>
+        rows.TraverseAsync(row => Task.FromResult(EmailAddress.TryCreate(row.Email)));
+
+    public static Task<Result<IReadOnlyList<EmailAddress>>> TaskTraverseWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAsync((row, token) => Task.FromResult(EmailAddress.TryCreate(row.Email, nameof(row.Email))), ct);
+
+    public static ValueTask<Result<IReadOnlyList<EmailAddress>>> ValueTaskTraverse(IEnumerable<CreateContactRow> rows) =>
+        rows.TraverseAsync(row => new ValueTask<Result<EmailAddress>>(EmailAddress.TryCreate(row.Email)));
+
+    public static ValueTask<Result<IReadOnlyList<EmailAddress>>> ValueTaskTraverseWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAsync((row, token) => new ValueTask<Result<EmailAddress>>(EmailAddress.TryCreate(row.Email, nameof(row.Email))), ct);
+
+    public static Task<Result<Unit>> UnitTraverseWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAsync((row, token) => Task.FromResult(EmailAddress.TryCreate(row.Email).Map(_ => Unit.Default)), ct);
+
+    public static Task<Result<IReadOnlyList<EmailAddress>>> TaskTraverseAll(IEnumerable<CreateContactRow> rows) =>
+        rows.TraverseAllAsync(row => Task.FromResult(EmailAddress.TryCreate(row.Email)));
+
+    public static Task<Result<IReadOnlyList<EmailAddress>>> TaskTraverseAllWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAllAsync((row, token) => Task.FromResult(EmailAddress.TryCreate(row.Email, nameof(row.Email))), ct);
+
+    public static ValueTask<Result<IReadOnlyList<EmailAddress>>> ValueTaskTraverseAll(IEnumerable<CreateContactRow> rows) =>
+        rows.TraverseAllAsync(row => new ValueTask<Result<EmailAddress>>(EmailAddress.TryCreate(row.Email)));
+
+    public static ValueTask<Result<IReadOnlyList<EmailAddress>>> ValueTaskTraverseAllWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAllAsync((row, token) => new ValueTask<Result<EmailAddress>>(EmailAddress.TryCreate(row.Email, nameof(row.Email))), ct);
+
+    public static Task<Result<Unit>> UnitTraverseAllWithCancellation(IEnumerable<CreateContactRow> rows, CancellationToken ct) =>
+        rows.TraverseAllAsync((row, token) => Task.FromResult(EmailAddress.TryCreate(row.Email).Map(_ => Unit.Default)), ct);
+
+    public static Error CombineErrors(Error first, Error second)
+    {
+        Error? accumulated = null;
+        accumulated = accumulated.Combine(first);
+        return accumulated.Combine(second);
+    }
+}
+
+#if FALSE
+// Wrong — manual loop with early return loses every error after the first and often reaches for test-only Unwrap().
+#endif


### PR DESCRIPTION
## Summary

Five new compile-checked demonstrator files closing the gap surfaced by the audit that followed PR #483:

- Recipes 16, 17, 18, 19, 20 previously had **no backing snippet** in `Examples/CookbookSnippets/`. Their entire code surface — fence content AND prose claims — was unverified.
- Each new file mirrors the recipe's ```csharp``` code blocks and adds prose-claim pins analogous to `Recipe1InheritedSurface` from PR #483.

| Recipe | File | Pins |
|---|---|---|
| 16 — Unit of work | `Recipe16_UnitOfWork.cs` | `RepositoryBase.Add/Remove/RemoveByIdAsync`, `SaveChangesResultAsync`, `AddTrellisUnitOfWork`, `TransactionalCommandBehavior` |
| 17 — Domain events | `Recipe17_DomainEvents.cs` | `IDomainEvent.OccurredAt`, `TimeProvider.GetUtcNow`, aggregate `DomainEvents` access |
| 18 — DTO → command | `Recipe18_DtoToCommand.cs` | DTO primitives, VO `TryCreate`, `Result.Combine`, `BindAsync`, ASP response mapping |
| 19 — HTTP client | `Recipe19_HttpClient.cs` | `ToResultAsync`, status-map overload, `ReadJsonAsync`, `ReadJsonOrNoneOn404Async` |
| 20 — Sequence/Traverse | `Recipe20_SequenceTraverse.cs` | `Sequence`/`Traverse`, `SequenceAll`/`TraverseAll`, async overloads, `Error.Combine` |

## Why

Cookbook hygiene PR #483 established the rule: any API claim in cookbook prose should have a paired compile-checked demonstrator. The audit that followed found 5 recipes with no demonstrator file at all — far more exposed than Recipe 1 (which at least had a demonstrator, just missing prose-pin coverage). Creating the 5 files closes the entire "this recipe has zero compile-check" gap for ~25% of the cookbook in one commit per recipe.

## What's NOT in this PR

The same audit found prose-claim gaps in Recipes 2, 3, 4, 6, 7, 8, 9, 10, 12, 13, 14, 21 — each of which already has a demonstrator but is missing pins for specific prose claims. Closing those is a separate follow-up PR; this one stays focused on the "missing-file" structural gap.

## Verification

- `dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors.
- No cookbook bugs surfaced during the audit. The prose claims in recipes 16-20 were all source-accurate; demonstrators compile against current Trellis source without modification.

## Commits

```
321b971c Pin Recipe 20 — sequence traverse via compile-checked demonstrator
fa527c1f Pin Recipe 19 — HTTP client via compile-checked demonstrator
2ba38d57 Pin Recipe 18 — DTO to command via compile-checked demonstrator
1700a778 Pin Recipe 17 — domain events via compile-checked demonstrator
6a06c023 Pin Recipe 16 — unit of work via compile-checked demonstrator
```
