### PR TITLE
Pin prose claims in Recipes 3, 7, 8, 9, 13, 14

### DIFF
--- a/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
+++ b/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
@@ -47,3 +47,21 @@ public sealed class ListOrdersHandler(AppDbContext db)
             AppliedLimit: applied));
     }
 }
+internal static class Recipe3PageSurface
+{
+    public static void Page_RecordStructSurface()
+    {
+        Page<OrderListItem> capped = new(
+            Items: [],
+            Next: null,
+            Previous: null,
+            RequestedLimit: 100,
+            AppliedLimit: 25);
+
+        bool wasCapped = capped.WasCapped;
+        Page<OrderListItem> empty = Page.Empty<OrderListItem>(requestedLimit: 100, appliedLimit: 25);
+        IReadOnlyList<OrderListItem> defaultItems = default(Page<OrderListItem>).Items;
+
+        _ = (wasCapped, empty, defaultItems);
+    }
+}

--- a/Examples/CookbookSnippets/Recipe07_Authorization.cs
+++ b/Examples/CookbookSnippets/Recipe07_Authorization.cs
@@ -39,3 +39,45 @@ public static class AuthorizationDi
         return services;
     }
 }
+internal static class Recipe7AuthorizationSurface
+{
+    public static void AuthorizationBehavior_RegistrationSurface(IServiceCollection services, DeleteOrderCommand command)
+    {
+        services.AddTrellisBehaviors();
+        Type behaviorType = typeof(AuthorizationBehavior<,>);
+        IReadOnlyList<string> permissions = command.RequiredPermissions;
+
+        _ = (behaviorType, permissions);
+    }
+
+    public static async Task IResourceLoader_LoadAsyncSignature(UpdateOrderCommand command, CancellationToken cancellationToken)
+    {
+        IResourceLoader<UpdateOrderCommand, Order> loader = new PerCommandOrderLoader();
+        Result<Order> loaded = await loader.LoadAsync(command, cancellationToken);
+
+        _ = loaded;
+    }
+
+    public static async Task SharedResourceLoader_ByIdSurface(UpdateOrderCommand command, CancellationToken cancellationToken)
+    {
+        Type identifyResourceType = typeof(IIdentifyResource<Order, OrderId>);
+        OrderId id = command.GetResourceId();
+
+        SharedResourceLoaderById<Order, OrderId> loader = new SharedOrderLoader();
+        Result<Order> loaded = await loader.GetByIdAsync(id, cancellationToken);
+
+        _ = (identifyResourceType, loaded);
+    }
+
+    private sealed class PerCommandOrderLoader : IResourceLoader<UpdateOrderCommand, Order>
+    {
+        public Task<Result<Order>> LoadAsync(UpdateOrderCommand message, CancellationToken cancellationToken) =>
+            Task.FromResult(Result.Fail<Order>(new Error.NotFound(ResourceRef.For<Order>(message.OrderId))));
+    }
+
+    private sealed class SharedOrderLoader : SharedResourceLoaderById<Order, OrderId>
+    {
+        public override Task<Result<Order>> GetByIdAsync(OrderId id, CancellationToken cancellationToken) =>
+            Task.FromResult(Result.Fail<Order>(new Error.NotFound(ResourceRef.For<Order>(id))));
+    }
+}

--- a/Examples/CookbookSnippets/Recipe08_MaybeMapping.cs
+++ b/Examples/CookbookSnippets/Recipe08_MaybeMapping.cs
@@ -52,3 +52,54 @@ public static class FixPattern
         b.HasIndex("Status", "_email");
     }
 }
+internal static class Recipe8MaybeMappingSurface
+{
+    public static void InterceptorRegistrationSurface(DbContextOptionsBuilder<DbContext> typedBuilder, DbContextOptionsBuilder untypedBuilder)
+    {
+        DbContextOptionsBuilder<DbContext> typed = typedBuilder.AddTrellisInterceptors();
+        DbContextOptionsBuilder untyped = untypedBuilder.AddTrellisInterceptors();
+        Type interceptorType = typeof(MaybeQueryInterceptor);
+
+        _ = (typed, untyped, interceptorType);
+    }
+
+    public static void MaybeExpressionShapes(EmailAddress fallback)
+    {
+        System.Linq.Expressions.Expression<Func<Customer, bool>> hasValue = c => c.Email.HasValue;
+        System.Linq.Expressions.Expression<Func<Customer, EmailAddress>> value = c => c.Email.Value;
+        System.Linq.Expressions.Expression<Func<Customer, EmailAddress>> defaulted = c => c.Email.GetValueOrDefault(fallback);
+        System.Linq.Expressions.Expression<Func<Customer, bool>> noneComparison = c => c.Email == Maybe<EmailAddress>.None;
+
+        _ = (hasValue, value, defaulted, noneComparison);
+    }
+
+    public static async Task SpecificationAndFakeRepository_QueryAsync(Customer customer, CancellationToken cancellationToken)
+    {
+        Specification<Customer> specification = new CustomersWithEmailSpecification();
+        var repository = new Trellis.Testing.FakeRepository<Customer, CustomerId>();
+        repository.Add(customer);
+
+        IReadOnlyList<Customer> matches = await repository.QueryAsync(specification, cancellationToken);
+
+        _ = matches;
+    }
+
+    public static void MaybeQueryableExtensionsSurface(IQueryable<Customer> customers, EmailAddress email)
+    {
+        IQueryable<Customer> hasValue = customers.WhereHasValue(c => c.Email);
+        IQueryable<Customer> none = customers.WhereNone(c => c.Email);
+        IQueryable<Customer> equals = customers.WhereEquals(c => c.Email, email);
+        IQueryable<Customer> lessThan = customers.WhereLessThan(c => c.Email, email);
+        IQueryable<Customer> greaterThanOrEqual = customers.WhereGreaterThanOrEqual(c => c.Email, email);
+        IOrderedQueryable<Customer> ordered = customers.OrderByMaybe(c => c.Email);
+        IOrderedQueryable<Customer> thenOrdered = ordered.ThenByMaybe(c => c.Email);
+
+        _ = (hasValue, none, equals, lessThan, greaterThanOrEqual, ordered, thenOrdered);
+    }
+
+    private sealed class CustomersWithEmailSpecification : Specification<Customer>
+    {
+        public override System.Linq.Expressions.Expression<Func<Customer, bool>> ToExpression() =>
+            customer => customer.Email.HasValue;
+    }
+}

--- a/Examples/CookbookSnippets/Recipe09_StateMachine.cs
+++ b/Examples/CookbookSnippets/Recipe09_StateMachine.cs
@@ -38,3 +38,40 @@ public sealed class DocumentService
         return result.Tap(newState => doc.State = newState);
     }
 }
+internal static class Recipe9StateMachineSurface
+{
+    public static void LazyStateMachine_FireResultSurface(Document document)
+    {
+        var machine = new LazyStateMachine<DocumentState, DocumentTrigger>(
+            () => document.State,
+            state => document.State = state,
+            Configure);
+
+        StateMachine<DocumentState, DocumentTrigger> stateless = machine.Machine;
+        Result<DocumentState> result = machine.FireResult(DocumentTrigger.Submit);
+
+        _ = (stateless, result);
+    }
+
+    public static void InvalidTransition_ErrorSurface()
+    {
+        var machine = new StateMachine<DocumentState, DocumentTrigger>(DocumentState.Draft);
+        machine.Configure(DocumentState.Draft).Permit(DocumentTrigger.Submit, DocumentState.Submitted);
+
+        Result<DocumentState> invalid = machine.FireResult(DocumentTrigger.Approve);
+        Error? error = invalid.Error;
+        Error.UnprocessableContent? unprocessable = error as Error.UnprocessableContent;
+        EquatableArray<RuleViolation> rules = unprocessable?.Rules ?? EquatableArray<RuleViolation>.Empty;
+        string reasonCode = rules.Items[0].ReasonCode;
+
+        _ = reasonCode;
+    }
+
+    private static void Configure(StateMachine<DocumentState, DocumentTrigger> machine)
+    {
+        machine.Configure(DocumentState.Draft).Permit(DocumentTrigger.Submit, DocumentState.Submitted);
+        machine.Configure(DocumentState.Submitted)
+               .Permit(DocumentTrigger.Approve, DocumentState.Approved)
+               .Permit(DocumentTrigger.Reject, DocumentState.Draft);
+    }
+}

--- a/Examples/CookbookSnippets/Recipe13_OwnedValueObject.cs
+++ b/Examples/CookbookSnippets/Recipe13_OwnedValueObject.cs
@@ -120,3 +120,56 @@ internal static class OverrideExample
             owned.HasIndex(a => a.Country);
         });
 }
+[OwnedEntity]
+public partial class LineItem : ValueObject
+{
+    public string Sku { get; private set; } = null!;
+    public int Quantity { get; private set; }
+
+    private LineItem(string sku, int quantity)
+    {
+        Sku = sku;
+        Quantity = quantity;
+    }
+
+    public static Result<LineItem> TryCreate(string sku, int quantity) =>
+        string.IsNullOrWhiteSpace(sku) || quantity <= 0
+            ? Result.Fail<LineItem>(Error.UnprocessableContent.ForRule("line.item.invalid"))
+            : Result.Ok(new LineItem(sku.Trim(), quantity));
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Sku;
+        yield return Quantity;
+    }
+}
+
+public sealed partial class OrderId : RequiredGuid<OrderId>;
+
+public sealed class PurchaseOrder : Aggregate<OrderId>
+{
+    internal const string LineItemsField = nameof(_lineItems);
+    private readonly List<LineItem> _lineItems = [];
+
+    public IReadOnlyCollection<LineItem> LineItems => _lineItems.AsReadOnly();
+
+    private PurchaseOrder(OrderId id) : base(id) { }
+}
+
+internal static class Recipe13OwnedValueObjectSurface
+{
+    public static void ApplyTrellisConventions_ReflectionOverload(ModelConfigurationBuilder configurationBuilder)
+    {
+        ModelConfigurationBuilder builder = configurationBuilder.ApplyTrellisConventions(typeof(Customer).Assembly);
+        Type attributeType = typeof(OwnedEntityAttribute);
+
+        _ = (builder, attributeType);
+    }
+
+    public static void OwnedCollection_BackFieldSurface(EntityTypeBuilder<PurchaseOrder> builder) =>
+        builder.OwnsMany<LineItem>(PurchaseOrder.LineItemsField, owned =>
+        {
+            owned.WithOwner();
+            owned.Property(item => item.Sku).HasMaxLength(64);
+        });
+}

--- a/Examples/CookbookSnippets/Recipe14_OptionalDtoFields.cs
+++ b/Examples/CookbookSnippets/Recipe14_OptionalDtoFields.cs
@@ -77,3 +77,18 @@ public static class WiringFix
         return services;
     }
 }
+internal static class Recipe14OptionalDtoFieldsSurface
+{
+    public static void PublicConverterAndBinderSurface()
+    {
+        var factory = new Trellis.Asp.Validation.MaybeScalarValueJsonConverterFactory();
+        bool scalarMaybe = factory.CanConvert(typeof(Maybe<PhoneNumber>));
+        bool compositeMaybe = factory.CanConvert(typeof(Maybe<ShippingAddress>));
+
+        Type binderType = typeof(Trellis.Asp.ModelBinding.MaybeModelBinder<PhoneNumber, string>);
+
+        // COOKBOOK BUG: MaybeSuppressChildValidationMetadataProvider is internal, so an external
+        // compile-checked demonstrator cannot reference it; prose should avoid naming it as public API.
+        _ = (scalarMaybe, compositeMaybe, binderType);
+    }
+}


### PR DESCRIPTION
## Summary

Six existing demonstrator files extended with prose-claim pins, closing the remaining 🔴 gaps from the audit that followed PR #483. Companion to PR #484 (which created 5 new demonstrator files for recipes that previously had none).

| Recipe | File | Pinning class | API surfaces pinned |
|---|---|---|---|
| 3 | `Recipe03_PaginatedQuery.cs` | `Recipe3PageSurface` | `Page<T>.WasCapped`, `Page.Empty<T>(req, app)`, default `Items` surface, `readonly record struct` shape |
| 7 | `Recipe07_Authorization.cs` | `Recipe7AuthorizationSurface` | `AuthorizationBehavior`, `IResourceLoader<TResource,TId>`, `SharedResourceLoaderById<TResource,TId>`, `IIdentifyResource<TResource,TId>` |
| 8 | `Recipe08_MaybeMapping.cs` | `Recipe8MaybeMappingSurface` | `AddTrellisInterceptors`, `MaybeQueryableExtensions`, `Specification<T>`, `FakeRepository<T,TId>.QueryAsync` |
| 9 | `Recipe09_StateMachine.cs` | `Recipe9StateMachineSurface` | `LazyStateMachine<TState,TTrigger>`, `FireResult`, invalid-transition error surface |
| 13 | `Recipe13_OwnedValueObject.cs` | `Recipe13OwnedValueObjectSurface` | `ApplyTrellisConventions(...)`, owned-collection helpers, `[OwnedEntity]` attribute surface |
| 14 | `Recipe14_OptionalDtoFields.cs` | `Recipe14OptionalDtoFieldsSurface` | Public converter/binder types |

**48 API invocations added** across the 6 files. Each is now a compile-checked contract — if the framework signature drifts, CI breaks the demonstrator and the cookbook prose must be updated.

## Cookbook bug surfaced

While writing the Recipe 14 pinning class, the agent found that the cookbook prose names `MaybeSuppressChildValidationMetadataProvider` as if it's a public type — but it's actually `internal`. A `// COOKBOOK BUG:` comment is in the demonstrator file flagging this. Follow-up: reword the Recipe 14 prose to either drop the explicit type name or move the internal type into a public surface if appropriate.

## Verification

- `dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors.
- `dotnet test --solution Trellis.slnx --no-build -v q` — all green, 0 failures.

## Commits

```
b56533dc Pin Recipe 14 optional DTO field prose claims via compile-checked surface
3dea5659 Pin Recipe 13 owned value object prose claims via compile-checked surface
7874d030 Pin Recipe 9 state machine prose claims via compile-checked surface
50f73d19 Pin Recipe 8 Maybe mapping prose claims via compile-checked surface
6407afbe Pin Recipe 7 authorization prose claims via compile-checked surface
2b6e195c Pin Recipe 3 paginated query prose claims via compile-checked surface
```

## What's left after this PR

The audit also identified medium-severity (🟡) gaps in Recipes 2, 4, 6, 10, 12, 21. Those are smaller per-recipe and can be a separate follow-up — most are single-pin extensions for things like behavior type-name pins or async overload references.
