### PR TITLE
Close cookbook hygiene audit: medium-severity gaps + Recipe 14 prose fix

### DIFF
--- a/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
+++ b/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
@@ -73,3 +73,15 @@ public static class FixPattern
                         ResourceRef.For<Order>(id), "already_exists")),
                     none: () => Result.Ok(id)));
 }
+
+internal static class Recipe2BehaviorSurface
+{
+    public static void PipelineBehaviorTypes()
+    {
+        Type validationBehaviorType = typeof(ValidationBehavior<,>);
+        Type messageValidatorType = typeof(IMessageValidator<>);
+        Type transactionalBehaviorType = typeof(TransactionalCommandBehavior<,>);
+
+        _ = (validationBehaviorType, messageValidatorType, transactionalBehaviorType);
+    }
+}

--- a/Examples/CookbookSnippets/Recipe04_MinimalApi.cs
+++ b/Examples/CookbookSnippets/Recipe04_MinimalApi.cs
@@ -37,3 +37,14 @@ public static class MinimalApiSample
         app.Run();
     }
 }
+
+internal static class Recipe4ResponseBuilderSurface
+{
+    public static void ToHttpResponseReturnsIResult()
+    {
+        Result<Order> result = default;
+        Microsoft.AspNetCore.Http.IResult response = result.ToHttpResponse();
+
+        _ = response;
+    }
+}

--- a/Examples/CookbookSnippets/Recipe06_ConditionalGet.cs
+++ b/Examples/CookbookSnippets/Recipe06_ConditionalGet.cs
@@ -33,3 +33,33 @@ public static class ConditionalGetSample
                 .EvaluatePreconditions());
         });
 }
+
+internal static class Recipe6ConditionalGetSurface
+{
+    public static void ETagOverloads()
+    {
+        var weak = EntityTagValue.Weak("sha256-deadbeef");
+        var options = new HttpResponseOptionsBuilder<BlobContent>()
+            .WithETag(b => b.Sha256Hex)
+            .WithETag(_ => weak);
+
+        _ = (weak, options);
+    }
+
+    public static void RangeOutcomeCases()
+    {
+        RangeOutcome full = new RangeOutcome.FullRepresentation();
+        RangeOutcome partial = new RangeOutcome.PartialContent(0, 99, 100);
+        RangeOutcome notSatisfiable = new RangeOutcome.NotSatisfiable(100);
+
+        long completeLength = partial switch
+        {
+            RangeOutcome.FullRepresentation => 0,
+            RangeOutcome.PartialContent pc => pc.CompleteLength,
+            RangeOutcome.NotSatisfiable ns => ns.CompleteLength,
+            _ => 0,
+        };
+
+        _ = (full, partial, notSatisfiable, completeLength);
+    }
+}

--- a/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
+++ b/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
@@ -44,3 +44,38 @@ public class PlaceOrderHandlerTests
     }
 #pragma warning restore CA1707
 }
+
+internal static class Recipe10TestingSurface
+{
+    public static void ValidationAssertionSurface()
+    {
+        var error = Error.UnprocessableContent.ForField(
+            "currency",
+            "invalid_length",
+            "Currency must be 3 characters.");
+
+        ValidationErrorAssertions assertions = error.Should();
+        assertions
+            .HaveFieldErrorWithDetail("currency", "Currency must be 3 characters.")
+            .And.HaveFieldCount(1);
+
+        _ = assertions;
+    }
+
+    public static async Task AsyncResultAssertionSurface()
+    {
+        var idResult = Result.Ok(1);
+        var failureResult = Result.Fail<int>(new Error.Unexpected("async_assertion_failure"));
+        Task<Result<int>> taskResult = Task.FromResult(idResult);
+        ValueTask<Result<int>> valueTaskResult = new(idResult);
+        Task<Result<int>> failureTaskResult = Task.FromResult(failureResult);
+        ValueTask<Result<int>> failureValueTaskResult = new(failureResult);
+
+        var taskAssertion = await taskResult.BeSuccessAsync();
+        var valueTaskAssertion = await valueTaskResult.BeSuccessAsync();
+        var taskFailureAssertion = await failureTaskResult.BeFailureAsync();
+        var valueTaskFailureAssertion = await failureValueTaskResult.BeFailureAsync();
+
+        _ = (taskAssertion, valueTaskAssertion, taskFailureAssertion, valueTaskFailureAssertion);
+    }
+}

--- a/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
+++ b/Examples/CookbookSnippets/Recipe12_DiPlaybook.cs
@@ -7,6 +7,7 @@ using CookbookSnippets.Recipe07;
 using CookbookSnippets.Stubs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
 using Trellis.Asp.Routing;
 using Trellis.EntityFrameworkCore;
 using Trellis.ServiceDefaults;
@@ -41,5 +42,27 @@ public static class CompositionRoot
         services.AddScoped<IOrderRepository, EfOrderRepository>();
 
         return services;
+    }
+}
+
+internal static class Recipe12CompositionSurface
+{
+    public static void AdditionalBuilderModules()
+    {
+        var entraServices = new ServiceCollection()
+            .AddTrellis(options => options.UseEntraActorProvider());
+
+        var developmentServices = new ServiceCollection()
+            .AddTrellis(options => options.UseDevelopmentActorProvider());
+
+        var cachedActorServices = new ServiceCollection()
+            .AddTrellis(options => options
+                .UseClaimsActorProvider()
+                .UseCachingActorProvider<ClaimsActorProvider>());
+
+        var domainEventServices = new ServiceCollection()
+            .AddTrellis(options => options.UseDomainEvents(typeof(CompositionRoot).Assembly));
+
+        _ = (entraServices, developmentServices, cachedActorServices, domainEventServices);
     }
 }

--- a/Examples/CookbookSnippets/Recipe14_OptionalDtoFields.cs
+++ b/Examples/CookbookSnippets/Recipe14_OptionalDtoFields.cs
@@ -17,8 +17,8 @@ public sealed partial class EmailAddress : RequiredString<EmailAddress>;
 public sealed partial class PhoneNumber : RequiredString<PhoneNumber>;
 
 // Pattern A — scalar Maybe<T> directly on the DTO.
-// AddTrellisAsp() registers MaybeScalarValueJsonConverterFactory, MaybeModelBinder, and
-// MaybeSuppressChildValidationMetadataProvider so this round-trips correctly.
+// AddTrellisAsp() registers MaybeScalarValueJsonConverterFactory and MaybeModelBinder;
+// MVC child-validation suppression is handled internally so this round-trips correctly.
 public sealed record CreateCustomerRequestA(
     EmailAddress Email,
     Maybe<PhoneNumber> PhoneNumber);
@@ -86,9 +86,6 @@ internal static class Recipe14OptionalDtoFieldsSurface
         bool compositeMaybe = factory.CanConvert(typeof(Maybe<ShippingAddress>));
 
         Type binderType = typeof(Trellis.Asp.ModelBinding.MaybeModelBinder<PhoneNumber, string>);
-
-        // COOKBOOK BUG: MaybeSuppressChildValidationMetadataProvider is internal, so an external
-        // compile-checked demonstrator cannot reference it; prose should avoid naming it as public API.
         _ = (scalarMaybe, compositeMaybe, binderType);
     }
 }

--- a/Examples/CookbookSnippets/Recipe21_ParallelAsync.cs
+++ b/Examples/CookbookSnippets/Recipe21_ParallelAsync.cs
@@ -109,3 +109,43 @@ internal sealed class WrongHandler(
     }
 }
 #endif
+
+internal static class Recipe21ParallelAsyncSurface
+{
+    public static async Task ThreeFactoryArity()
+    {
+        var result = await Result.ParallelAsync(
+            LoadNumberAsync,
+            LoadNameAsync,
+            LoadAvailableAsync)
+            .WhenAllAsync();
+
+        _ = result;
+    }
+
+    public static async Task NineFactoryArity()
+    {
+        var result = await Result.ParallelAsync(
+            LoadNumberAsync,
+            LoadNameAsync,
+            LoadAvailableAsync,
+            LoadNumberAsync,
+            LoadNameAsync,
+            LoadAvailableAsync,
+            LoadNumberAsync,
+            LoadNameAsync,
+            LoadAvailableAsync)
+            .WhenAllAsync();
+
+        _ = result;
+    }
+
+    private static Task<Result<int>> LoadNumberAsync() =>
+        Task.FromResult(Result.Ok(1));
+
+    private static Task<Result<string>> LoadNameAsync() =>
+        Task.FromResult(Result.Ok("ready"));
+
+    private static Task<Result<bool>> LoadAvailableAsync() =>
+        Task.FromResult(Result.Ok(true));
+}

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -726,7 +726,7 @@ public class PlaceOrderHandlerTests
 }
 ```
 
-**What it shows.** `ResultAssertions<TValue>.HaveValue(...)` does structural comparison; `UnwrapError()` is the safe accessor that *only* returns the error and is intended for use after `Should().BeFailure...`. Calling `.Should()` on an `Error.UnprocessableContent` returns the specialized `ValidationErrorAssertions` (with `HaveFieldError`, `HaveFieldErrorWithDetail`, `HaveFieldCount`). Async pipelines should be awaited *first* and asserted after — `await result.Should().BeSuccessAsync()` is wrong because `BeSuccess()` is sync; the awaited `Result<T>` is what you assert on.
+**What it shows.** `ResultAssertions<TValue>.HaveValue(...)` does structural comparison; `UnwrapError()` is the safe accessor that *only* returns the error and is intended for use after `Should().BeFailure...`. Calling `.Should()` on an `Error.UnprocessableContent` returns the specialized `ValidationErrorAssertions` (with `HaveFieldError`, `HaveFieldErrorWithDetail`, `HaveFieldCount`). Async assertions have two valid shapes: await the pipeline first and assert the resulting `Result<T>`, or call `BeSuccessAsync` / `BeFailureAsync` directly on `Task<Result<T>>` or `ValueTask<Result<T>>`. The unsupported shape is `await result.Should().BeSuccessAsync()` because `.Should()` returns synchronous `ResultAssertions<TValue>`.
 
 ---
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1021,7 +1021,7 @@ The answer depends on whether the inner type is a **scalar** (single-primitive) 
 
 | Inner type | Pattern | Why |
 |---|---|---|
-| `Maybe<TScalar>` where `TScalar : IScalarValue<TScalar, TPrimitive>` (e.g., `Maybe<EmailAddress>`, `Maybe<PhoneNumber>`) | **Use `Maybe<T>` directly on the DTO.** | `AddTrellisAsp()` registers `MaybeScalarValueJsonConverterFactory` (JSON), `MaybeModelBinder<T,P>` (route/query/header), and `MaybeSuppressChildValidationMetadataProvider` (stops `ValidationVisitor` from touching `.Value` when `None`). `null`/missing → `None`; valid → `Maybe.From(validated)`; invalid → ProblemDetails with the same field path the domain emits. |
+| `Maybe<TScalar>` where `TScalar : IScalarValue<TScalar, TPrimitive>` (e.g., `Maybe<EmailAddress>`, `Maybe<PhoneNumber>`) | **Use `Maybe<T>` directly on the DTO.** | `AddTrellisAsp()` registers `MaybeScalarValueJsonConverterFactory` (JSON) and `MaybeModelBinder<T,P>` (route/query/header); MVC child-validation suppression for `None` scalar-maybe values is handled internally by the Trellis MVC integration. Call `AddTrellisAsp(...)` before MVC model binding is configured. `null`/missing → `None`; valid → `Maybe.From(validated)`; invalid → ProblemDetails with the same field path the domain emits. |
 | `Maybe<TComposite>` where `TComposite : ValueObject` with multiple fields (e.g., `Maybe<ShippingAddress>`) | **Use a nullable transport (`TComposite?`) and adapt at the controller seam.** | No `MaybeCompositeValueObjectJsonConverterFactory` ships today — System.Text.Json would default-construct the inner type, bypassing `TryCreate`. Wrap with `Maybe.From(...)` inside the controller. |
 
 ### Pattern A — scalar `Maybe<T>` directly on the DTO


### PR DESCRIPTION
## What

Closes out the cookbook-hygiene sweep started in #483 by handling the audit's 🟡 medium-severity prose-claim gaps, plus the Recipe 14 cookbook bug surfaced in #485.

## Why

PRs #483, #484, #485 brought every active recipe under a compile-checked demonstrator and closed the 🔴 high-severity prose-claim gaps. This PR finishes the audit: 🟡 medium-severity gaps in Recipes 2, 4, 6, 10, 12, 21 are now pinned, and Recipe 14 no longer names an `internal` type as if it were public.

## Changes

| Commit | Recipe | Pinning class | New API invocations |
| --- | --- | --- | --- |
| `96bdeb9` | 2 | `Recipe2BehaviorSurface` | 3 |
| `8a0959f` | 4 | `Recipe4ResponseBuilderSurface` | 1 |
| `b4894bf` | 6 | `Recipe6ConditionalGetSurface` | 6 |
| `6add8ae` | 10 | `Recipe10TestingSurface` | 7 |
| `b5e1a35` | 12 | `Recipe12CompositionSurface` | 9 |
| `0e9819d` | 21 | `Recipe21ParallelAsyncSurface` | 4 |
| `2db5556` | 14 | — | Cookbook prose reword + remove `// COOKBOOK BUG:` comment |

Total: 30 new prose-claim pins + 1 cookbook prose fix.

### Recipe 14 prose fix

The cookbook previously named `MaybeSuppressChildValidationMetadataProvider` directly, but that type is `internal`. The prose now describes the behavior ("child-validation suppression is handled internally by the Trellis MVC integration; ensure `AddTrellisAsp(...)` is called before model binding") instead of naming the internal type.

## Verification

- `dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors
- `dotnet test --solution Trellis.slnx --no-build` — all green

## Closes the audit

After this PR, every active recipe (1–21 except retired #15 and stub #11) has compile-checked prose-claim coverage. No further hygiene PRs are needed from the audit.
