### PR TITLE
Expand anti-pattern gallery: TRLS013/015/020/036/037/038

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -1,10 +1,10 @@
 ﻿---
 package: Trellis.Analyzers (applied form)
 namespaces: [Trellis, Trellis.Analyzers]
-types: [TRLS001, TRLS003, TRLS010, TRLS016, TRLS017, TRLS018, TRLS019]
+types: [TRLS001, TRLS003, TRLS010, TRLS013, TRLS015, TRLS016, TRLS017, TRLS018, TRLS019, TRLS020, TRLS036, TRLS037, TRLS038]
 related_docs: [trellis-api-analyzers.md, trellis-api-cookbook.md]
-version: v3
-last_verified: 2026-05-10
+version: v4
+last_verified: 2026-05-11
 audience: [llm]
 ---
 # Trellis Anti-Pattern → Fix Gallery
@@ -111,3 +111,137 @@ return default(Maybe<Email>);                      // TRLS019 — equivalent to 
 return Result.Ok();
 return Maybe<Email>.None;
 ```
+
+## TRLS013 — Unsafe `Maybe<T>.Value` in LINQ projection
+
+Direct `.Value` access on `Maybe<T>` inside Select-family LINQ projections throws for `None` elements unless an earlier `.Where(...)` lambda mentions `HasValue`.
+
+Pick FIX 1 for in-memory or analyzer-clean projection pipelines: filter first, then project.
+
+```csharp
+// WRONG — projection reads Maybe<T>.Value before proving every element has a value
+IEnumerable<int> numbers = values.Select(m => m.Value);
+
+// FIX 1 — prior Where lambda mentions HasValue before the Value projection
+IEnumerable<int> numbers = values
+    .Where(m => m.HasValue)
+    .Select(m => m.Value);
+```
+
+Pick FIX 2 for EF Core query composition over mapped `Maybe<T>` properties: register the interceptor and use the typed query helpers for predicates when they match the query.
+
+```csharp
+// FIX 2 — EF Core path: enable Trellis query rewriting and prefer typed Maybe predicates
+optionsBuilder.AddTrellisInterceptors();
+
+IQueryable<Order> submitted = db.Orders.WhereHasValue(o => o.SubmittedAt);
+```
+
+> TRLS013 suppression is keyword-presence based: the prior `.Where(...)` body only has to mention `HasValue`, so predicate-shape verification (for example, distinguishing `m => m.HasValue` from `m => !m.HasValue`) is a known limitation. The analyzer recognizes prior `.Where(...)` chains for projections; `MaybeQueryableExtensions` are the EF translation path, not a general-purpose TRLS013 suppression mechanism.
+
+## TRLS015 — Use `SaveChangesResultAsync` instead of `SaveChangesAsync`
+
+Direct `SaveChanges`/`SaveChangesAsync` calls bypass the Result pipeline and turn database errors into unhandled exceptions.
+
+Pick FIX 1 when the non-UoW caller discards the affected-row count.
+
+```csharp
+// WRONG — raw EF save bypasses Result error handling
+await db.SaveChangesAsync(ct);
+
+// FIX 1 — preserve Result pipeline semantics when the count is not needed
+await db.SaveChangesResultUnitAsync(ct);
+```
+
+Pick FIX 2 when the non-UoW caller needs the affected-row count.
+
+```csharp
+// WRONG — raw EF save returns an int by throwing on database failures
+int count = await db.SaveChangesAsync(ct);
+
+// FIX 2 — keep the affected-row count inside Result<int>
+Result<int> result = await db.SaveChangesResultAsync(ct);
+```
+
+> Under `AddTrellisUnitOfWork<TContext>`, repositories should stage changes only and not call `SaveChanges`/`SaveChangesAsync` at all. `TransactionalCommandBehavior` owns commit.
+
+## TRLS020 — Composite value object DTO property missing `CompositeValueObjectJsonConverter`
+
+Composite value objects exposed through request/response DTOs must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` so JSON binding round-trips through `TryCreate`.
+
+```csharp
+// WRONG — DTO exposes a composite value object whose type has no converter
+public sealed record CreateInvoiceRequest(Money Total);
+
+// FIX 1 — put the converter on the composite value object type
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<Money>))]
+[OwnedEntity]
+public sealed partial class Money : ValueObject
+{
+}
+
+public sealed record CreateInvoiceRequest(Money Total);
+```
+
+> The current TRLS020 analyzer checks the composite value object type for the converter attribute. A property-level `JsonConverter` may be a valid `System.Text.Json` technique, but it is not the analyzer-clean shape in the current source/tests.
+
+## TRLS036 — `[OwnedEntity]` type must be `partial`
+
+Type is decorated with `[OwnedEntity]` but is not declared `partial`, so the source generator cannot emit the private parameterless constructor.
+
+```csharp
+// WRONG — generator cannot add the EF constructor to a non-partial type
+[OwnedEntity]
+public sealed class Address : ValueObject
+{
+}
+
+// FIX 1 — make the owned value object partial so generation can extend it
+[OwnedEntity]
+public sealed partial class Address : ValueObject
+{
+}
+```
+
+> Severity: Error. TRLS038 is reported first when the type also fails to inherit from `ValueObject`, so a non-partial non-`ValueObject` type emits TRLS038 rather than both diagnostics.
+
+## TRLS037 — `[OwnedEntity]` type already declares a parameterless constructor
+
+Type already has a parameterless constructor; remove it to let the `[OwnedEntity]` source generator emit one, or remove the `[OwnedEntity]` attribute.
+
+```csharp
+// WRONG — hand-written parameterless constructor suppresses generator emission
+[OwnedEntity]
+public sealed partial class Address : ValueObject
+{
+    public Address() { }
+}
+
+// FIX 1 — delete the hand-written parameterless constructor and let the generator own it
+[OwnedEntity]
+public sealed partial class Address : ValueObject
+{
+}
+```
+
+> Severity: Warning. Any explicit parameterless constructor suppresses the generated one. Default guidance is to delete it; keep a private one only with a documented reason and the understanding that generator emission is intentionally suppressed.
+
+## TRLS038 — `[OwnedEntity]` type must inherit from `ValueObject`
+
+Type is decorated with `[OwnedEntity]` but does not inherit from `Trellis.ValueObject`; `[OwnedEntity]` is only supported on `ValueObject`-derived types.
+
+```csharp
+// WRONG — [OwnedEntity] is applied to a plain class
+[OwnedEntity]
+public sealed partial class Address
+{
+}
+
+// FIX 1 — make the owned entity a Trellis ValueObject
+[OwnedEntity]
+public sealed partial class Address : ValueObject
+{
+}
+```
+
+> Severity: Error. When TRLS038 fires, the generator skips source generation for that type.

--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -167,23 +167,43 @@ Result<int> result = await db.SaveChangesResultAsync(ct);
 
 ## TRLS020 — Composite value object DTO property missing `CompositeValueObjectJsonConverter`
 
-Composite value objects exposed through request/response DTOs must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` so JSON binding round-trips through `TryCreate`.
+Composite value objects exposed through request/response DTOs must carry `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` on the value-object type so JSON binding round-trips through `TryCreate`. The analyzer only inspects DTOs that are visible through a controller `[FromBody]` parameter or response type, a minimal API endpoint handler parameter, or a Mediator message type — the DTO type alone is not enough to trip the rule.
 
 ```csharp
-// WRONG — DTO exposes a composite value object whose type has no converter
+// WRONG — composite [OwnedEntity] value object exposed as a [FromBody] DTO property without the converter
+[OwnedEntity]
+public sealed partial class Money : ValueObject
+{
+    public string Currency { get; }
+    public decimal Amount { get; }
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Currency;
+        yield return Amount;
+    }
+}
+
 public sealed record CreateInvoiceRequest(Money Total);
+
+[ApiController]
+[Route("invoices")]
+public sealed class InvoicesController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Create([FromBody] CreateInvoiceRequest request) => Ok();
+}
 
 // FIX 1 — put the converter on the composite value object type
 [JsonConverter(typeof(CompositeValueObjectJsonConverter<Money>))]
 [OwnedEntity]
 public sealed partial class Money : ValueObject
 {
+    // ...same body as above...
 }
-
-public sealed record CreateInvoiceRequest(Money Total);
 ```
 
-> The current TRLS020 analyzer checks the composite value object type for the converter attribute. A property-level `JsonConverter` may be a valid `System.Text.Json` technique, but it is not the analyzer-clean shape in the current source/tests.
+> The current TRLS020 analyzer checks the composite value object **type** for the converter attribute, not the DTO property. A property-level `JsonConverter` may be a valid `System.Text.Json` technique, but it is not the analyzer-clean shape in the current source/tests.
 
 ## TRLS036 — `[OwnedEntity]` type must be `partial`
 


### PR DESCRIPTION
## What

Expands the anti-pattern gallery (`trellis-api-anti-patterns.md`) with six new analyzer-rule entries: TRLS013, TRLS015, TRLS020, TRLS036, TRLS037, TRLS038.

## Why

The gallery previously covered TRLS001, TRLS003, TRLS010, TRLS016, TRLS017, TRLS018, TRLS019. Other rules that AI sessions trip on regularly (LINQ-over-`Maybe<T>`, raw `SaveChangesAsync`, missing JSON converters, `[OwnedEntity]` shape errors) lacked applied-form WRONG/FIX entries. AI sessions were finding only the descriptor text when they grepped these IDs, not idiomatic fixes.

## What's new

Each section follows the existing gallery style: one-line context sentence echoing the descriptor, WRONG/FIX code fences, optional `>` callout for analyzer subtleties.

- **TRLS013** — Unsafe `Maybe<T>.Value` in LINQ. FIX 1 (in-memory `.Where(m => m.HasValue).Select(m => m.Value)`) + FIX 2 (EF path: `AddTrellisInterceptors()` + `MaybeQueryableExtensions`). Callout clarifies that `WhereHasValue` is the EF translation path, not a general TRLS013 suppression mechanism.
- **TRLS015** — Use `SaveChangesResultAsync`. FIX 1 (count discarded → `SaveChangesResultUnitAsync`) + FIX 2 (count needed → `Result<int>`). Callout reminds: under `AddTrellisUnitOfWork<TContext>`, repositories don't call SaveChanges at all.
- **TRLS020** — Composite VO DTO missing JSON converter. Callout notes the analyzer currently checks the value-object type for the attribute, not the DTO property.
- **TRLS036** — `[OwnedEntity]` must be `partial` (Error).
- **TRLS037** — `[OwnedEntity]` already declares parameterless ctor (Warning).
- **TRLS038** — `[OwnedEntity]` must inherit from `ValueObject` (Error).

## Front-matter

Bumped `version: v3` → `v4`; `last_verified: 2026-05-11`; appended new IDs to `types:`.

## Grounding

Every section was sourced from `DiagnosticDescriptors.cs` / `OwnedEntityGenerator.cs` and (where available) the existing analyzer tests and per-rule articles. No invented APIs.

## Verification

Doc-only change. `dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors.
