### PR TITLE
Pin FakeRepository surface in Recipe 16 and EnsureAll in Recipe 20

### DIFF
--- a/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
+++ b/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
@@ -11,6 +11,7 @@ using Trellis;
 using Trellis.EntityFrameworkCore;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
+using Trellis.Testing;
 
 public sealed partial class OrderId : RequiredGuid<OrderId>;
 
@@ -78,6 +79,18 @@ internal static class Recipe16Demonstrator
     {
         Type behavior = typeof(TransactionalCommandBehavior<CreateOrderCommand, Result<OrderId>>);
         _ = behavior;
+    }
+
+    public static async Task FakeRepositorySetupAndConflictResult(Order order)
+    {
+        FakeRepository<Order, OrderId> orders =
+            new FakeRepository<Order, OrderId>()
+                .WithUniqueConstraint(o => o.Total);
+
+        orders.Add(order);
+
+        Result<Trellis.Unit> conflictResult = await orders.SaveAsync(order);
+        _ = conflictResult;
     }
 }
 

--- a/Examples/CookbookSnippets/Recipe20_SequenceTraverse.cs
+++ b/Examples/CookbookSnippets/Recipe20_SequenceTraverse.cs
@@ -89,6 +89,11 @@ internal static class Recipe20Demonstrator
         accumulated = accumulated.Combine(first);
         return accumulated.Combine(second);
     }
+
+    public static Result<EmailAddress> EnsureAllPin(Result<EmailAddress> seed) =>
+        seed.EnsureAll(
+            (email => email.Value.Length > 0, new Error.BadRequest("empty")),
+            (email => email.Value.Contains('@'), new Error.BadRequest("missing_at")));
 }
 
 #if FALSE


### PR DESCRIPTION
## What

Closes two prose-claim gaps in PR #484 (Recipes 16 and 20) that were missed because I didn't run a code-review pass before opening that PR.

## Findings

Audit of merged PRs #484, #485, #486 surfaced:

1. **Recipe 16** — cookbook documents `FakeRepository.Add(T)`, `FakeRepository.SaveAsync(T)`, and `WithUniqueConstraint(...)` as the test-setup + conflict-result pattern, but `Recipe16Demonstrator` never instantiated `FakeRepository<,>` or called those members. A rename would not have been caught by CI.

2. **Recipe 20** — prose names `EnsureAll` as sharing `Error.Combine` semantics with `TraverseAll`/`SequenceAll`, but `Recipe20Demonstrator` never invoked `EnsureAll`.

PRs #485 and #486 audited clean. The audit also confirmed PR #486's Recipe 14 prose reword landed on a real ASP.NET Core MVC type (`SuppressChildValidationMetadataProvider`).

## Changes

- `Recipe16_UnitOfWork.cs`: add `using Trellis.Testing;` and a new `FakeRepositorySetupAndConflictResult(Order)` surface method that instantiates `FakeRepository<Order, OrderId>`, applies `.WithUniqueConstraint(...)`, stages via `.Add(...)`, and awaits `.SaveAsync(...)`.
- `Recipe20_SequenceTraverse.cs`: add an `EnsureAllPin(Result<EmailAddress>)` surface method that exercises the params-tuple `EnsureAll` overload.

## Verification

`dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors. (Side note: the safeguard caught my first draft using `Error.Validation`, which does not exist — fixed to `Error.BadRequest` before push.)

## Process note

This is the gap I should have closed before opening #484. From now on, every PR gets a code-review pass before going up.
