### PR TITLE
Fix Recipe 7 AddResourceAuthorization wiring to pass loader assembly

### DIFF
--- a/Examples/CookbookSnippets/Recipe07_Authorization.cs
+++ b/Examples/CookbookSnippets/Recipe07_Authorization.cs
@@ -2,6 +2,7 @@
 namespace CookbookSnippets.Recipe07;
 
 using System.Collections.Generic;
+using System.Reflection;
 using CookbookSnippets.Recipe01;
 using global::Mediator;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,7 +36,13 @@ public static class AuthorizationDi
     {
         services.AddTrellisBehaviors();
         services.AddClaimsActorProvider();
-        services.AddResourceAuthorization(typeof(UpdateOrderCommand).Assembly);
+        // Pass both the assembly that holds command/query types AND the assembly that holds
+        // IResourceLoader<,> implementations (typically the ACL assembly). The demonstrator
+        // packs everything into CookbookSnippets, so the same reference appears twice here —
+        // in a real layered app these are two distinct assemblies.
+        Assembly applicationAssembly = typeof(UpdateOrderCommand).Assembly;
+        Assembly aclAssembly = typeof(AuthorizationDi).Assembly; // same assembly in this demo
+        services.AddResourceAuthorization(applicationAssembly, aclAssembly);
         return services;
     }
 }

--- a/Examples/CookbookSnippets/Recipe07_Authorization.cs
+++ b/Examples/CookbookSnippets/Recipe07_Authorization.cs
@@ -2,6 +2,7 @@
 namespace CookbookSnippets.Recipe07;
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using CookbookSnippets.Recipe01;
 using global::Mediator;
@@ -36,13 +37,18 @@ public static class AuthorizationDi
     {
         services.AddTrellisBehaviors();
         services.AddClaimsActorProvider();
-        // Pass both the assembly that holds command/query types AND the assembly that holds
-        // IResourceLoader<,> implementations (typically the ACL assembly). The demonstrator
-        // packs everything into CookbookSnippets, so the same reference appears twice here —
-        // in a real layered app these are two distinct assemblies.
+        // Pass every assembly that holds command/query types AND every assembly that holds
+        // IResourceLoader<,> implementations (typically the ACL assembly). The scanner does
+        // not de-duplicate, so deduplicate locally before calling — otherwise the same assembly
+        // scanned twice registers ResourceAuthorizationBehavior twice and the loader runs twice
+        // per request. In a real layered app these are two distinct assemblies; the demonstrator
+        // packs everything into CookbookSnippets, so .Distinct() collapses to one.
         Assembly applicationAssembly = typeof(UpdateOrderCommand).Assembly;
         Assembly aclAssembly = typeof(AuthorizationDi).Assembly; // same assembly in this demo
-        services.AddResourceAuthorization(applicationAssembly, aclAssembly);
+        Assembly[] scanAssemblies = new[] { applicationAssembly, aclAssembly }
+            .Distinct()
+            .ToArray();
+        services.AddResourceAuthorization(scanAssemblies);
         return services;
     }
 }

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -492,6 +492,8 @@ services.AddClaimsActorProvider();               // ClaimsActorProvider for ASP.
 // ACL assembly, not the Application assembly — passing only the Application assembly will
 // register ResourceAuthorizationBehavior<,,> without discovering the shared loader and the
 // pipeline will fail at runtime when it cannot resolve IResourceLoader<TMessage, TResource>.
+// Note: the scanner does not de-duplicate assemblies; if the two layers happen to collapse
+// to one assembly, pass it once (or .Distinct() the array) to avoid registering the behavior twice.
 services.AddResourceAuthorization(
     typeof(UpdateOrderCommand).Assembly,        // Application assembly (commands + IAuthorizeResource)
     typeof(OrderResourceLoader).Assembly);      // ACL assembly (IResourceLoader<,> implementations)

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -487,7 +487,14 @@ public sealed record UpdateOrderCommand(OrderId OrderId, Money NewTotal)
 // DI wiring
 services.AddTrellisBehaviors();
 services.AddClaimsActorProvider();               // ClaimsActorProvider for ASP.NET Core
-services.AddResourceAuthorization(typeof(UpdateOrderCommand).Assembly);
+// Pass every assembly that contains command/query types AND every assembly that contains
+// IResourceLoader<,> implementations. In a layered app the loader typically lives in the
+// ACL assembly, not the Application assembly — passing only the Application assembly will
+// register ResourceAuthorizationBehavior<,,> without discovering the shared loader and the
+// pipeline will fail at runtime when it cannot resolve IResourceLoader<TMessage, TResource>.
+services.AddResourceAuthorization(
+    typeof(UpdateOrderCommand).Assembly,        // Application assembly (commands + IAuthorizeResource)
+    typeof(OrderResourceLoader).Assembly);      // ACL assembly (IResourceLoader<,> implementations)
 ```
 
 **What it shows.** `IAuthorize` enforces an AND-permission gate via `AuthorizationBehavior<,>`. `IAuthorizeResource<TResource>` runs *after* `IResourceLoader<TMessage, TResource>` produces the loaded resource, then calls `Authorize(actor, resource)`. Combining `IAuthorizeResource<TResource>` with `IIdentifyResource<TResource, TId>` lets the framework reuse the shared `SharedResourceLoaderById<TResource, TId>` instead of requiring a per-command loader.


### PR DESCRIPTION
## What

Fixes Recipe 7 cookbook prose where `services.AddResourceAuthorization(typeof(UpdateOrderCommand).Assembly)` was shown with only the Application assembly.

## Why

The framework's loader-discovery scanner is constrained to the assemblies passed in (`Trellis.Mediator/src/ServiceCollectionExtensions.cs:360-372`). When `IResourceLoader<,>` implementations live in the ACL assembly (the normal layered-architecture pattern), the snippet as previously written registers `ResourceAuthorizationBehavior<,,>` without discovering the loader. The pipeline then throws at runtime when it cannot resolve `IResourceLoader<TMessage, TResource>`.

Found via review of the AspTemplate resource-auth demo: the template correctly passes both the Application and ACL assemblies, which contradicted the cookbook snippet.

## Changes

- **`trellis-api-cookbook.md`** Recipe 7 — snippet now passes both `typeof(UpdateOrderCommand).Assembly` and `typeof(OrderResourceLoader).Assembly` with a comment explaining the layered pattern. Added a follow-up note that the scanner does not de-duplicate assemblies, so callers whose layers collapse to one assembly should pass it once.

- **`Recipe07_Authorization.cs`** — `AuthorizationDi.Wire` now builds a distinct assembly array before calling `AddResourceAuthorization`. In the demonstrator both layer references collapse to the same assembly; `.Distinct()` prevents duplicate `ResourceAuthorizationBehavior` registration (which would run the auth check twice per request).

## Verification

- `dotnet build Examples/CookbookSnippets/CookbookSnippets.csproj` — 0 errors.

## Review

Pre-submission code-review caught a bug in the first commit (`67ae3ceb`): it passed the same assembly twice in the demonstrator, which actually triggered the framework's non-deduplicating registration. Fixed in commit `a00df0a5` with explicit `.Distinct()` plus a cookbook prose note.
