### PR TITLE
Composite VO interior: document supported shapes and DTO seam

### DIFF
--- a/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
@@ -1,0 +1,131 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests.Helpers;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// User-written custom <see cref="JsonConverter{T}"/> for <see cref="TestMixedTypeVo"/>.
+/// Demonstrates the language-level escape hatch when a composite VO's interior holds
+/// shapes that <c>CompositeValueObjectJsonConverter&lt;T&gt;</c> does not support
+/// (<c>Maybe&lt;TPrimitive&gt;</c>, arrays).
+/// <para>
+/// <strong>This is NOT the recommended approach.</strong> The recommended path —
+/// documented in cookbook Recipe 13 §"Supported property shapes inside a composite VO"
+/// and Recipe 14 — is to keep the composite VO clean as a domain type and declare a
+/// wire-shape DTO with nullable transports at the controller/endpoint seam. Writing a
+/// custom converter is a last-resort escape hatch only when the DTO indirection is
+/// genuinely unacceptable; it adds per-VO code, bypasses framework validation
+/// integration, and locks future framework improvements out of the wire path.
+/// </para>
+/// <para>
+/// This converter exists in the test suite to prove the escape hatch works end-to-end
+/// and to document the shape of such a converter for the small minority of services
+/// that need it. Most services should use the DTO seam.
+/// </para>
+/// </summary>
+public sealed class CustomMixedTypeVoJsonConverter : JsonConverter<TestMixedTypeVo>
+{
+    public override void Write(Utf8JsonWriter writer, TestMixedTypeVo value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(value);
+
+        writer.WriteStartObject();
+
+        writer.WriteString("status", value.Status.Value);
+
+        if (value.Count.HasValue)
+            writer.WriteNumber("count", value.Count.Value);
+        else
+            writer.WriteNull("count");
+
+        if (value.Label.HasValue)
+            writer.WriteString("label", value.Label.Value);
+        else
+            writer.WriteNull("label");
+
+        if (value.Snapshots.HasValue)
+        {
+            writer.WritePropertyName("snapshots");
+            writer.WriteStartArray();
+            foreach (var dt in value.Snapshots.Value)
+                writer.WriteStringValue(dt);
+            writer.WriteEndArray();
+        }
+        else
+        {
+            writer.WriteNull("snapshots");
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public override TestMixedTypeVo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected start of object.");
+
+        string? status = null;
+        var count = Maybe<int>.None;
+        var label = Maybe<string>.None;
+        var snapshots = Maybe<DateTime[]>.None;
+
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                continue;
+
+            var name = reader.GetString();
+            reader.Read();
+
+            switch (name)
+            {
+                case "status":
+                    status = reader.GetString();
+                    break;
+                case "count":
+                    count = reader.TokenType == JsonTokenType.Null
+                        ? Maybe<int>.None
+                        : Maybe.From(reader.GetInt32());
+                    break;
+                case "label":
+                    if (reader.TokenType == JsonTokenType.Null)
+                    {
+                        label = Maybe<string>.None;
+                    }
+                    else
+                    {
+                        var s = reader.GetString();
+                        label = s is null ? Maybe<string>.None : Maybe.From(s);
+                    }
+
+                    break;
+                case "snapshots":
+                    if (reader.TokenType == JsonTokenType.Null)
+                    {
+                        snapshots = Maybe<DateTime[]>.None;
+                    }
+                    else if (reader.TokenType == JsonTokenType.StartArray)
+                    {
+                        var list = new List<DateTime>();
+                        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                            list.Add(reader.GetDateTime());
+                        snapshots = Maybe.From(list.ToArray());
+                    }
+
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        if (status is null)
+            throw new JsonException("Missing required property 'status'.");
+
+        var result = TestMixedTypeVo.TryCreate(status, count, label, snapshots);
+        if (!result.TryGetValue(out var vo, out var error))
+            throw new JsonException(error.GetDisplayMessage());
+        return vo;
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
@@ -135,7 +135,22 @@ public sealed class CustomMixedTypeVoJsonConverter : JsonConverter<TestMixedType
                     {
                         var list = new List<DateTime>();
                         while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
-                            list.Add(reader.GetDateTime());
+                        {
+                            if (reader.TokenType != JsonTokenType.String)
+                                throw new JsonException(
+                                    $"Property 'snapshots' array elements must be JSON strings; got token {reader.TokenType}.");
+
+                            try
+                            {
+                                list.Add(reader.GetDateTime());
+                            }
+                            catch (FormatException ex)
+                            {
+                                throw new JsonException(
+                                    "Property 'snapshots' contains an invalid date-time string.", ex);
+                            }
+                        }
+
                         snapshots = Maybe.From(list.ToArray());
                     }
                     else

--- a/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
@@ -112,6 +112,15 @@ public sealed class CustomMixedTypeVoJsonConverter : JsonConverter<TestMixedType
                             list.Add(reader.GetDateTime());
                         snapshots = Maybe.From(list.ToArray());
                     }
+                    else
+                    {
+                        // Any other token (string, number, object, …) is invalid for
+                        // 'snapshots'. Throw rather than silently leaving the reader at
+                        // a non-PropertyName position, which would cause the outer loop
+                        // to start treating that token's children as top-level properties.
+                        throw new JsonException(
+                            $"Property 'snapshots' expects a JSON array or null; got token {reader.TokenType}.");
+                    }
 
                     break;
                 default:

--- a/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/CustomMixedTypeVoJsonConverter.cs
@@ -81,22 +81,48 @@ public sealed class CustomMixedTypeVoJsonConverter : JsonConverter<TestMixedType
             switch (name)
             {
                 case "status":
+                    if (reader.TokenType != JsonTokenType.String)
+                        throw new JsonException(
+                            $"Property 'status' expects a JSON string; got token {reader.TokenType}.");
                     status = reader.GetString();
                     break;
                 case "count":
-                    count = reader.TokenType == JsonTokenType.Null
-                        ? Maybe<int>.None
-                        : Maybe.From(reader.GetInt32());
+                    if (reader.TokenType == JsonTokenType.Null)
+                    {
+                        count = Maybe<int>.None;
+                    }
+                    else if (reader.TokenType == JsonTokenType.Number)
+                    {
+                        try
+                        {
+                            count = Maybe.From(reader.GetInt32());
+                        }
+                        catch (FormatException ex)
+                        {
+                            throw new JsonException("Property 'count' is not a valid integer.", ex);
+                        }
+                    }
+                    else
+                    {
+                        throw new JsonException(
+                            $"Property 'count' expects a JSON number or null; got token {reader.TokenType}.");
+                    }
+
                     break;
                 case "label":
                     if (reader.TokenType == JsonTokenType.Null)
                     {
                         label = Maybe<string>.None;
                     }
-                    else
+                    else if (reader.TokenType == JsonTokenType.String)
                     {
                         var s = reader.GetString();
                         label = s is null ? Maybe<string>.None : Maybe.From(s);
+                    }
+                    else
+                    {
+                        throw new JsonException(
+                            $"Property 'label' expects a JSON string or null; got token {reader.TokenType}.");
                     }
 
                     break;

--- a/Trellis.EntityFrameworkCore/tests/Helpers/TestMixedTypeVo.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/TestMixedTypeVo.cs
@@ -68,8 +68,17 @@ public partial class TestMixedTypeVo : ValueObject
         yield return Status.Value;
         yield return Count.HasValue ? (int?)Count.Value : null;
         yield return Label.HasValue ? Label.Value : null;
-        // Arrays do not implement IComparable; fold to a stable summary so the equality
-        // contract still gives a deterministic answer per array shape.
-        yield return Snapshots.HasValue ? Snapshots.Value.Length : 0;
+        // Yield each element so structural equality compares arrays element-wise
+        // (length-only comparison would let two arrays with the same length but
+        // different contents compare equal — wrong for a ValueObject).
+        if (Snapshots.HasValue)
+        {
+            foreach (var dt in Snapshots.Value)
+                yield return dt;
+        }
+        else
+        {
+            yield return null;
+        }
     }
 }

--- a/Trellis.EntityFrameworkCore/tests/Helpers/TestMixedTypeVo.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/TestMixedTypeVo.cs
@@ -1,0 +1,75 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests.Helpers;
+
+/// <summary>
+/// Exploration fixture: a composite value object that mixes a Trellis scalar VO
+/// (<see cref="TestOrderStatus"/> — a <c>RequiredEnum</c>) with three optional C#-native
+/// shapes that are NOT scalar value objects:
+/// <list type="bullet">
+///   <item><description><see cref="Count"/> — <c>Maybe&lt;int&gt;</c> (primitive value type)</description></item>
+///   <item><description><see cref="Label"/> — <c>Maybe&lt;string&gt;</c> (primitive reference type)</description></item>
+///   <item><description><see cref="Snapshots"/> — <c>Maybe&lt;DateTime[]&gt;</c> (array of primitive value type)</description></item>
+/// </list>
+/// <para>
+/// Used to discover which property shapes are supported on a composite VO interior
+/// for both EF Core persistence and JSON round-trip through
+/// <c>CompositeValueObjectJsonConverter&lt;T&gt;</c>.
+/// </para>
+/// </summary>
+[OwnedEntity]
+public partial class TestMixedTypeVo : ValueObject
+{
+    /// <summary>Required Trellis scalar VO (RequiredEnum).</summary>
+    public TestOrderStatus Status { get; private set; } = null!;
+
+    /// <summary>Optional primitive value type.</summary>
+    public partial Maybe<int> Count { get; private set; }
+
+    /// <summary>Optional primitive reference type.</summary>
+    public partial Maybe<string> Label { get; private set; }
+
+    /// <summary>Optional array of primitive value type.</summary>
+    public partial Maybe<DateTime[]> Snapshots { get; private set; }
+
+    public TestMixedTypeVo(
+        TestOrderStatus status,
+        Maybe<int> count,
+        Maybe<string> label,
+        Maybe<DateTime[]> snapshots)
+    {
+        Status = status;
+        Count = count;
+        Label = label;
+        Snapshots = snapshots;
+    }
+
+    public static TestMixedTypeVo Create(
+        TestOrderStatus status,
+        Maybe<int> count,
+        Maybe<string> label,
+        Maybe<DateTime[]> snapshots) =>
+        new(status, count, label, snapshots);
+
+    /// <summary>
+    /// Required by <c>CompositeValueObjectJsonConverter&lt;TestMixedTypeVo&gt;</c>.
+    /// The converter takes the JSON-side primitive types ('string' for the
+    /// <see cref="TestOrderStatus"/> RequiredEnum, untouched for the three
+    /// <c>Maybe&lt;&gt;</c> properties) and invokes this static factory to construct.
+    /// </summary>
+    public static Result<TestMixedTypeVo> TryCreate(
+        string status,
+        Maybe<int> count,
+        Maybe<string> label,
+        Maybe<DateTime[]> snapshots) =>
+        TestOrderStatus.TryCreate(status)
+            .Map(s => new TestMixedTypeVo(s, count, label, snapshots));
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Status.Value;
+        yield return Count.HasValue ? (int?)Count.Value : null;
+        yield return Label.HasValue ? Label.Value : null;
+        // Arrays do not implement IComparable; fold to a stable summary so the equality
+        // contract still gives a deterministic answer per array shape.
+        yield return Snapshots.HasValue ? Snapshots.Value.Length : 0;
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/Helpers/TestSupportedMixedVo.cs
+++ b/Trellis.EntityFrameworkCore/tests/Helpers/TestSupportedMixedVo.cs
@@ -1,0 +1,86 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests.Helpers;
+
+using Trellis.Primitives;
+
+/// <summary>
+/// Counterpart to <see cref="TestMixedTypeVo"/>: a composite value object that mixes
+/// raw C# primitives from the supported whitelist with a Trellis scalar VO
+/// (<see cref="TestOrderStatus"/>) — and explicitly NO <c>Maybe&lt;&gt;</c> fields.
+/// This is the all-required mixed VO shape that round-trips cleanly through both
+/// EF Core <em>and</em> <c>CompositeValueObjectJsonConverter</c>.
+/// </summary>
+/// <remarks>
+/// The converter's <c>WritePrimitive</c> / <c>ReadPrimitive</c> methods support exactly:
+/// <c>string</c>, <c>decimal</c>, <c>int</c>, <c>long</c>, <c>short</c>, <c>byte</c>,
+/// <c>double</c>, <c>float</c>, <c>bool</c>, <c>Guid</c>, <c>DateTime</c>,
+/// <c>DateTimeOffset</c>. Trellis scalar VOs flatten to their underlying primitive on
+/// the wire and so are also supported. ANY <c>Maybe&lt;T&gt;</c> on the composite VO
+/// interior breaks JSON round-trip (regardless of the inner type) because the
+/// converter has no <c>Maybe&lt;&gt;</c> handling — see <see cref="TestMixedTypeVo"/>.
+/// </remarks>
+[OwnedEntity]
+public partial class TestSupportedMixedVo : ValueObject
+{
+    public TestOrderStatus Status { get; private set; } = null!;
+    public string Label { get; private set; } = string.Empty;
+    public int Count { get; private set; }
+    public Guid Id { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public decimal Score { get; private set; }
+    public bool IsActive { get; private set; }
+
+    public TestSupportedMixedVo(
+        TestOrderStatus status,
+        string label,
+        int count,
+        Guid id,
+        DateTimeOffset createdAt,
+        decimal score,
+        bool isActive)
+    {
+        Status = status;
+        Label = label;
+        Count = count;
+        Id = id;
+        CreatedAt = createdAt;
+        Score = score;
+        IsActive = isActive;
+    }
+
+    public static TestSupportedMixedVo Create(
+        TestOrderStatus status,
+        string label,
+        int count,
+        Guid id,
+        DateTimeOffset createdAt,
+        decimal score,
+        bool isActive) =>
+        new(status, label, count, id, createdAt, score, isActive);
+
+    /// <summary>
+    /// Required by <c>CompositeValueObjectJsonConverter&lt;TestSupportedMixedVo&gt;</c>.
+    /// The <c>status</c> parameter is <c>string</c> — the Trellis scalar VO
+    /// <see cref="TestOrderStatus"/> flattens to its primitive on the wire.
+    /// </summary>
+    public static Result<TestSupportedMixedVo> TryCreate(
+        string status,
+        string label,
+        int count,
+        Guid id,
+        DateTimeOffset createdAt,
+        decimal score,
+        bool isActive) =>
+        TestOrderStatus.TryCreate(status)
+            .Map(s => new TestSupportedMixedVo(s, label, count, id, createdAt, score, isActive));
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Status.Value;
+        yield return Label;
+        yield return Count;
+        yield return Id;
+        yield return CreatedAt;
+        yield return Score;
+        yield return IsActive;
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/MixedTypeCompositeVoTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/MixedTypeCompositeVoTests.cs
@@ -214,11 +214,13 @@ public class MixedTypeCompositeVoTests : IDisposable
     //
     // To answer the question "is a mixed VO possible at all?" — yes, when every field is
     // either a raw primitive from the converter's whitelist (string, decimal, int, long,
-    // short, byte, double, float, bool, Guid, DateTime, DateTimeOffset), a Trellis scalar
+    // short, byte, double, float, bool, Guid, DateTime, DateTimeOffset) or a Trellis scalar
     // value object that flattens to one of those primitives (RequiredEnum, RequiredGuid,
-    // RequiredString, PhoneNumber, EmailAddress, ...), or `Maybe<TScalarVO>` (handled by
-    // `MaybeScalarValueJsonConverterFactory`). The fixture below mixes all three classes
-    // and round-trips cleanly through both EF Core AND the composite JSON converter.
+    // RequiredString, PhoneNumber, EmailAddress, ...). The fixture below mixes both and
+    // round-trips cleanly through both EF Core AND the composite JSON converter. Note:
+    // any `Maybe<T>` property (including `Maybe<TScalarVO>`) is NOT supported by the
+    // composite converter — the converter never delegates property serialization to STJ,
+    // so factory-based scalar-Maybe handling does not engage here.
 
     private static JsonSerializerOptions SupportedMixedOptions()
     {
@@ -270,6 +272,62 @@ public class MixedTypeCompositeVoTests : IDisposable
 
         loaded.Should().NotBeNull();
         loaded.Should().Be(original);
+    }
+
+    [Fact]
+    public async Task SupportedMixed_EfRoundTrip_AllFieldsPopulated_RoundTripsCleanly()
+    {
+        // Mirrors the JSON happy-path test: same shape and values, but exercised through
+        // the EF Core persistence path. Proves the supported-mixed fixture works
+        // end-to-end across both wire and storage seams, matching the cookbook's
+        // "this is the canonical mixed VO shape" claim.
+        var ct = TestContext.Current.CancellationToken;
+        var original = TestSupportedMixedVo.Create(
+            TestOrderStatus.Shipped,
+            label: "alpha",
+            count: 7,
+            id: Guid.Parse("019e1942-1a4a-796c-856e-95f8996eacb3"),
+            createdAt: new DateTimeOffset(2026, 5, 11, 12, 0, 0, TimeSpan.Zero),
+            score: 99.5m,
+            isActive: true);
+
+        Context.SupportedEntities.Add(new SupportedMixedVoEntity { Id = 10, Mixed = original });
+        await Context.SaveChangesAsync(ct);
+        Context.ChangeTracker.Clear();
+
+        var loaded = await Context.SupportedEntities.FindAsync([10], ct);
+
+        loaded.Should().NotBeNull();
+        loaded!.Mixed.Status.Should().Be(TestOrderStatus.Shipped);
+        loaded.Mixed.Label.Should().Be("alpha");
+        loaded.Mixed.Count.Should().Be(7);
+        loaded.Mixed.Id.Should().Be(original.Id);
+        loaded.Mixed.CreatedAt.Should().Be(original.CreatedAt);
+        loaded.Mixed.Score.Should().Be(99.5m);
+        loaded.Mixed.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SupportedMixed_EfRoundTrip_BoundaryValues_RoundTripCleanly()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var original = TestSupportedMixedVo.Create(
+            TestOrderStatus.Draft,
+            label: string.Empty,
+            count: 0,
+            id: Guid.Empty,
+            createdAt: DateTimeOffset.MinValue,
+            score: 0m,
+            isActive: false);
+
+        Context.SupportedEntities.Add(new SupportedMixedVoEntity { Id = 11, Mixed = original });
+        await Context.SaveChangesAsync(ct);
+        Context.ChangeTracker.Clear();
+
+        var loaded = await Context.SupportedEntities.FindAsync([11], ct);
+
+        loaded.Should().NotBeNull();
+        loaded!.Mixed.Should().Be(original);
     }
 
     // -------- Probe 5: user-written custom converter rescues the broken shape ---------
@@ -376,6 +434,7 @@ internal sealed class MixedTypeVoEntity
 internal sealed class MixedTypeVoDbContext : DbContext
 {
     public DbSet<MixedTypeVoEntity> Entities => Set<MixedTypeVoEntity>();
+    public DbSet<SupportedMixedVoEntity> SupportedEntities => Set<SupportedMixedVoEntity>();
 
     public MixedTypeVoDbContext(DbContextOptions<MixedTypeVoDbContext> options) : base(options) { }
 

--- a/Trellis.EntityFrameworkCore/tests/MixedTypeCompositeVoTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/MixedTypeCompositeVoTests.cs
@@ -1,0 +1,384 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Trellis.EntityFrameworkCore.Tests.Helpers;
+using Trellis.Primitives;
+using Trellis.Testing;
+using Xunit;
+
+/// <summary>
+/// Exploration suite for mixed-type composite value objects — a composite VO that mixes
+/// a Trellis scalar VO (<see cref="TestOrderStatus"/>) with C#-native types wrapped in
+/// <see cref="Maybe{T}"/> (<c>Maybe&lt;int&gt;</c>, <c>Maybe&lt;string&gt;</c>,
+/// <c>Maybe&lt;DateTime[]&gt;</c>).
+///
+/// The framework today proves <c>string Name + Maybe&lt;PhoneNumber&gt; Phone</c> works
+/// (see <c>CompositeValueObjectConventionTests.MaybeScalarInsideRequiredCompositeVo_*</c>).
+/// These tests extend that coverage to the broader user shape captured in BACKLOG P1-Test-1
+/// and document per-field what is supported and what is not, for both EF Core round-trip
+/// and JSON round-trip through <c>CompositeValueObjectJsonConverter&lt;T&gt;</c>.
+/// </summary>
+public class MixedTypeCompositeVoTests : IDisposable
+{
+    private MixedTypeVoDbContext? _context;
+    private SqliteConnection? _connection;
+
+    private MixedTypeVoDbContext Context
+    {
+        get
+        {
+            if (_context is not null)
+                return _context;
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+            var options = new DbContextOptionsBuilder<MixedTypeVoDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+            _context = new MixedTypeVoDbContext(options);
+            _context.Database.EnsureCreated();
+            return _context;
+        }
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+        _connection?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // -------- Probe 1: model builds ----------------------------------------------------
+
+    [Fact]
+    public void ModelBuilds_ApplyTrellisConventions_AcceptsAllPropertyShapes()
+    {
+        // Tells us whether ApplyTrellisConventions / MaybeConvention rejects any of the
+        // fixture's property shapes (Maybe<int>, Maybe<string>, Maybe<DateTime[]>,
+        // RequiredEnum<TestOrderStatus>). Throws ⇒ that shape is not supported on a
+        // composite VO interior and the rest of the suite is moot.
+        var act = () =>
+        {
+            using var ctx = Context;
+            _ = ctx.Model;
+        };
+
+        act.Should().NotThrow();
+    }
+
+    // -------- Probe 2: EF Core round-trip ---------------------------------------------
+
+    [Fact]
+    public async Task EfRoundTrip_AllFieldsPopulated_RoundTripsCleanly()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var snapshots = new[] { new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc) };
+
+        Context.Entities.Add(new MixedTypeVoEntity
+        {
+            Id = 1,
+            Mixed = TestMixedTypeVo.Create(
+                TestOrderStatus.Confirmed,
+                Maybe.From(42),
+                Maybe.From("hello"),
+                Maybe.From(snapshots)),
+        });
+        await Context.SaveChangesAsync(ct);
+        Context.ChangeTracker.Clear();
+
+        var loaded = await Context.Entities.FindAsync([1], ct);
+
+        loaded.Should().NotBeNull();
+        loaded!.Mixed.Status.Should().Be(TestOrderStatus.Confirmed);
+        loaded.Mixed.Count.HasValue.Should().BeTrue("Maybe<int> round-trips through MaybeConvention");
+        loaded.Mixed.Count.Value.Should().Be(42);
+        loaded.Mixed.Label.HasValue.Should().BeTrue("Maybe<string> round-trips through MaybeConvention");
+        loaded.Mixed.Label.Value.Should().Be("hello");
+        loaded.Mixed.Snapshots.HasValue.Should().BeTrue("Maybe<DateTime[]> round-trips if the underlying provider supports arrays");
+        loaded.Mixed.Snapshots.Value.Should().Equal(snapshots);
+    }
+
+    [Fact]
+    public async Task EfRoundTrip_AllMaybesNone_RoundTripsAsNone()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        Context.Entities.Add(new MixedTypeVoEntity
+        {
+            Id = 2,
+            Mixed = TestMixedTypeVo.Create(
+                TestOrderStatus.Draft,
+                Maybe<int>.None,
+                Maybe<string>.None,
+                Maybe<DateTime[]>.None),
+        });
+        await Context.SaveChangesAsync(ct);
+        Context.ChangeTracker.Clear();
+
+        var loaded = await Context.Entities.FindAsync([2], ct);
+
+        loaded.Should().NotBeNull();
+        loaded!.Mixed.Status.Should().Be(TestOrderStatus.Draft);
+        loaded.Mixed.Count.Should().BeNone();
+        loaded.Mixed.Label.Should().BeNone();
+        loaded.Mixed.Snapshots.Should().BeNone();
+    }
+
+    // -------- Probe 3: JSON round-trip via CompositeValueObjectJsonConverter ----------
+    //
+    // Finding: TestMixedTypeVo declares `Maybe<int>`, `Maybe<string>`, and `Maybe<DateTime[]>`
+    // properties. The CompositeValueObjectJsonConverter rejects all three at WRITE time
+    // with `TrellisJsonValidationException: Unsupported primitive type 'Maybe<TPrimitive>'`,
+    // regardless of whether the value is `Some` or `None`. Declaring any one such property
+    // renders the entire composite VO non-serializable through this converter.
+    //
+    // This is fail-loud (good — caller sees an exception, not silent data corruption) but
+    // there is no compile-time enforcement: the type compiles, EF Core round-trips it
+    // cleanly (see Probe 2), and the JSON failure only manifests on first serialize. A
+    // future TRLS rule could mirror TRLS020's DTO-side check on composite VO interiors.
+
+    private static JsonSerializerOptions CompositeOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new CompositeValueObjectJsonConverter<TestMixedTypeVo>());
+        return options;
+    }
+
+    [Fact]
+    public void JsonSerialize_AnyMaybePropertyOnComposite_FailsAtFirstSuchProperty()
+    {
+        // Documented behavior: a composite VO that declares ANY `Maybe<T>` property fails
+        // JSON serialization, regardless of value (Some or None). The serializer trips on
+        // the first declared Maybe<> property (here `Count`, a `Maybe<int>`) and the rest
+        // of the body is never written. We construct the VO with everything at None to
+        // prove the failure is type-driven, not value-driven. The single assertion below
+        // captures the rule; tests of the same failure on `Maybe<string>` / `Maybe<DateTime[]>`
+        // in isolation would only repeat this — the converter's whitelist is identical for
+        // every position.
+        var vo = TestMixedTypeVo.Create(
+            TestOrderStatus.Draft,
+            Maybe<int>.None,
+            Maybe<string>.None,
+            Maybe<DateTime[]>.None);
+
+        var act = () => JsonSerializer.Serialize(vo, CompositeOptions());
+
+        var ex = act.Should().Throw<TrellisJsonValidationException>(
+                "ANY Maybe<T> property on a composite VO trips CompositeValueObjectJsonConverter")
+            .Which;
+        ex.Message.Should().Contain("Unsupported primitive type");
+        ex.Message.Should().Contain("Maybe");
+        // Trips on the first declared Maybe<> property (Count → Maybe<int>).
+        ex.Message.Should().Contain("'count'");
+    }
+
+    [Fact]
+    public void JsonDeserialize_SparseBody_AllMaybePropertiesAreRequiredOnWire()
+    {
+        // Distinct deserialize-side finding: even though Maybe<T> fields are conceptually
+        // optional in the domain, the converter treats them as required JSON properties —
+        // a body that omits them throws TrellisJsonValidationException with
+        // "Required properties missing", NOT the "Unsupported primitive type" error from
+        // the write path. So absence in the domain (Maybe<>.None) is NOT the same as
+        // absence on the wire when the composite VO converter is in play.
+        var act = () => JsonSerializer.Deserialize<TestMixedTypeVo>(
+            """{"status":"Draft"}""", CompositeOptions());
+
+        act.Should().Throw<TrellisJsonValidationException>()
+            .And.Message.Should().Contain("Required properties missing");
+    }
+
+    [Fact]
+    public void JsonDeserialize_BodyWithExplicitNulls_HitsUnsupportedPrimitiveType()
+    {
+        // Once all properties are present (even as nulls), the converter advances past
+        // the required-property check and runs into the read-side Maybe<TPrimitive>
+        // primitive-type rejection. Note: the read-side message wording differs from
+        // the write-side wording.
+        // - Write side: "Unsupported primitive type 'Maybe`1[System.Int32]' for JSON property 'count'."
+        // - Read side:  "Composite value object 'TestMixedTypeVo' uses unsupported primitive 'Maybe`1' for property 'count'."
+        // Both are TrellisJsonValidationException; assertion below uses the common
+        // "unsupported primitive" substring (lowercase, present in both).
+        const string body = """{"status":"Draft","count":null,"label":null,"snapshots":null}""";
+
+        var act = () => JsonSerializer.Deserialize<TestMixedTypeVo>(body, CompositeOptions());
+
+        var ex = act.Should().Throw<TrellisJsonValidationException>().Which;
+        ex.Message.ToLowerInvariant().Should().Contain("unsupported primitive");
+        ex.Message.Should().Contain("Maybe");
+    }
+
+    // -------- Probe 4: counterpart "supported mixed VO" round-trips cleanly -----------
+    //
+    // To answer the question "is a mixed VO possible at all?" — yes, when every field is
+    // either a raw primitive from the converter's whitelist (string, decimal, int, long,
+    // short, byte, double, float, bool, Guid, DateTime, DateTimeOffset), a Trellis scalar
+    // value object that flattens to one of those primitives (RequiredEnum, RequiredGuid,
+    // RequiredString, PhoneNumber, EmailAddress, ...), or `Maybe<TScalarVO>` (handled by
+    // `MaybeScalarValueJsonConverterFactory`). The fixture below mixes all three classes
+    // and round-trips cleanly through both EF Core AND the composite JSON converter.
+
+    private static JsonSerializerOptions SupportedMixedOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new CompositeValueObjectJsonConverter<TestSupportedMixedVo>());
+        return options;
+    }
+
+    [Fact]
+    public void SupportedMixed_JsonRoundTrip_AllFieldsPopulated_RoundTripsCleanly()
+    {
+        var original = TestSupportedMixedVo.Create(
+            TestOrderStatus.Shipped,
+            label: "alpha",
+            count: 7,
+            id: Guid.Parse("019e1942-1a4a-796c-856e-95f8996eacb3"),
+            createdAt: new DateTimeOffset(2026, 5, 11, 12, 0, 0, TimeSpan.Zero),
+            score: 99.5m,
+            isActive: true);
+
+        var json = JsonSerializer.Serialize(original, SupportedMixedOptions());
+        var loaded = JsonSerializer.Deserialize<TestSupportedMixedVo>(json, SupportedMixedOptions());
+
+        loaded.Should().NotBeNull();
+        loaded!.Status.Should().Be(TestOrderStatus.Shipped);
+        loaded.Label.Should().Be("alpha");
+        loaded.Count.Should().Be(7);
+        loaded.Id.Should().Be(original.Id);
+        loaded.CreatedAt.Should().Be(original.CreatedAt);
+        loaded.Score.Should().Be(99.5m);
+        loaded.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SupportedMixed_JsonRoundTrip_BoundaryValues_RoundTripCleanly()
+    {
+        // Empty string, zero numerics, Guid.Empty, default DateTimeOffset, false bool.
+        var original = TestSupportedMixedVo.Create(
+            TestOrderStatus.Draft,
+            label: string.Empty,
+            count: 0,
+            id: Guid.Empty,
+            createdAt: DateTimeOffset.MinValue,
+            score: 0m,
+            isActive: false);
+
+        var json = JsonSerializer.Serialize(original, SupportedMixedOptions());
+        var loaded = JsonSerializer.Deserialize<TestSupportedMixedVo>(json, SupportedMixedOptions());
+
+        loaded.Should().NotBeNull();
+        loaded.Should().Be(original);
+    }
+
+    // -------- Probe 5: user-written custom converter rescues the broken shape ---------
+    //
+    // Direct answer to "can the user work around the framework gap": yes. The user
+    // writes a `JsonConverter<TestMixedTypeVo>` that handles each `Maybe<TPrimitive>`
+    // field explicitly (null for None, inner value for Some) and bypasses the
+    // framework's `CompositeValueObjectJsonConverter`. The VO itself stays unchanged.
+    // See `Helpers/CustomMixedTypeVoJsonConverter.cs`.
+
+    private static JsonSerializerOptions CustomConverterOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new CustomMixedTypeVoJsonConverter());
+        return options;
+    }
+
+    [Fact]
+    public void CustomConverter_AllFieldsPopulated_RoundTripsThroughJson()
+    {
+        var snapshots = new[]
+        {
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var original = TestMixedTypeVo.Create(
+            TestOrderStatus.Confirmed,
+            Maybe.From(42),
+            Maybe.From("hello"),
+            Maybe.From(snapshots));
+
+        var json = JsonSerializer.Serialize(original, CustomConverterOptions());
+        var loaded = JsonSerializer.Deserialize<TestMixedTypeVo>(json, CustomConverterOptions());
+
+        loaded.Should().NotBeNull();
+        loaded!.Status.Should().Be(TestOrderStatus.Confirmed);
+        loaded.Count.Should().HaveValueEqualTo(42);
+        loaded.Label.Should().HaveValueEqualTo("hello");
+        loaded.Snapshots.HasValue.Should().BeTrue();
+        loaded.Snapshots.Value.Should().Equal(snapshots);
+    }
+
+    [Fact]
+    public void CustomConverter_AllOptionalsNone_RoundTripsCleanly()
+    {
+        var original = TestMixedTypeVo.Create(
+            TestOrderStatus.Draft,
+            Maybe<int>.None,
+            Maybe<string>.None,
+            Maybe<DateTime[]>.None);
+
+        var json = JsonSerializer.Serialize(original, CustomConverterOptions());
+        var loaded = JsonSerializer.Deserialize<TestMixedTypeVo>(json, CustomConverterOptions());
+
+        loaded.Should().NotBeNull();
+        loaded!.Status.Should().Be(TestOrderStatus.Draft);
+        loaded.Count.Should().BeNone();
+        loaded.Label.Should().BeNone();
+        loaded.Snapshots.Should().BeNone();
+    }
+
+    [Fact]
+    public void CustomConverter_MixedSomeAndNone_RoundTripsCleanly()
+    {
+        // Partial population: some Maybe<> fields Some, others None — the converter
+        // must emit JSON null for None entries and parse them back as None on read.
+        var original = TestMixedTypeVo.Create(
+            TestOrderStatus.Confirmed,
+            Maybe.From(7),
+            Maybe<string>.None,
+            Maybe.From(new[] { new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc) }));
+
+        var json = JsonSerializer.Serialize(original, CustomConverterOptions());
+
+        // Wire-shape sanity check: None must be emitted as JSON null.
+        json.Should().Contain("\"label\":null");
+        json.Should().Contain("\"count\":7");
+
+        var loaded = JsonSerializer.Deserialize<TestMixedTypeVo>(json, CustomConverterOptions());
+
+        loaded.Should().NotBeNull();
+        loaded!.Count.Should().HaveValueEqualTo(7);
+        loaded.Label.Should().BeNone();
+        loaded.Snapshots.HasValue.Should().BeTrue();
+    }
+}
+
+// ----- DI scaffolding for the supported-mixed fixture ------------------------------
+
+internal sealed class SupportedMixedVoEntity
+{
+    public int Id { get; set; }
+    public TestSupportedMixedVo Mixed { get; set; } = null!;
+}
+
+// ----- DI scaffolding ---------------------------------------------------------------
+
+internal sealed class MixedTypeVoEntity
+{
+    public int Id { get; set; }
+    public TestMixedTypeVo Mixed { get; set; } = null!;
+}
+
+internal sealed class MixedTypeVoDbContext : DbContext
+{
+    public DbSet<MixedTypeVoEntity> Entities => Set<MixedTypeVoEntity>();
+
+    public MixedTypeVoDbContext(DbContextOptions<MixedTypeVoDbContext> options) : base(options) { }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) =>
+        configurationBuilder.ApplyTrellisConventions(typeof(TestMixedTypeVo).Assembly);
+}

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1032,7 +1032,7 @@ The intentional split is: keep the framework converter simple; route consumers w
 | `decimal`, `int`, `long`, `short`, `byte`, `double`, `float`, `bool` | ✅ Supported as-is | Use directly. |
 | `Guid`, `DateTime`, `DateTimeOffset` | ✅ Supported as-is | Use directly. |
 | Trellis scalar VO (`RequiredString<>`, `RequiredInt<>`, `RequiredGuid<>`, `RequiredEnum<>`, `RequiredDateTime<>`, …) — and shipped concretes like `EmailAddress`, `PhoneNumber`, `Money.Currency` | ✅ Flattens to underlying primitive on the wire | Use directly. The composite converter detects `IScalarValue<,>` and reads/writes the inner primitive. |
-| Nested composite owned VO (e.g., `Money` inside an aggregate response) | ❌ **Not supported** — `CompositeValueObjectJsonConverter<TOuter>` does not delegate back to `JsonSerializer` for nested objects, so an inner `[JsonConverter(typeof(CompositeValueObjectJsonConverter<TInner>))]` does not engage; the outer converter trips on the unsupported "primitive" type at first access. | **Map to a DTO** — declare the nested VO as a separate property on the wire-shape DTO (each composite VO has its own `[JsonConverter]` engagement only when STJ sees the type at the top of a property — not when it's owned by another composite converter). |
+| Nested composite owned VO (e.g., a nested `Money` or `ShippingAddress` as a property of another composite VO) | ❌ **Not supported.** `CompositeValueObjectJsonConverter<TOuter>` does not delegate to `JsonSerializer` for property values — it only reads/writes its own primitive whitelist directly. Adding `[JsonConverter]` to the inner type does not help, because the outer converter never asks STJ for an inner converter; it tries to treat the nested type as one of its primitives and trips on the first access. | **Map to a DTO** — declare each nested composite as its own property on the wire-shape DTO. Nested composite VOs serialize correctly only when STJ sees them at the top of a property of a non-Trellis-composite-converter type (i.e., a plain record/class with `[JsonConverter]` on the nested VO type itself). |
 | `Maybe<T>` for any T (primitive, scalar VO, composite VO, array) | ❌ **Not supported.** Throws `TrellisJsonValidationException: "Unsupported primitive type 'Maybe`1...'"` regardless of value (`Some` or `None`). | **Map to a wire-shape DTO.** See Recipe 14 — the same `T?` + adapt-at-the-seam pattern applies whether the optional is on the DTO itself or inside a composite VO. |
 | Array (`T[]`), collection (`List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`) | ❌ Not supported. | **Map to a DTO** with the array on the wire-shape type. |
 
@@ -1043,7 +1043,7 @@ The intentional split is: keep the framework converter simple; route consumers w
 [OwnedEntity]
 public partial class CustomerProfile : ValueObject
 {
-    public TestOrderStatus Status { get; private set; } = null!;
+    public OrderStatus Status { get; private set; } = null!;
     public partial Maybe<int> AgeYears { get; private set; }             // not JSON-serializable on this VO
     public partial Maybe<string> Nickname { get; private set; }          // not JSON-serializable
     public partial Maybe<DateTime[]> LoginHistory { get; private set; }  // not JSON-serializable

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1020,6 +1020,58 @@ The string `"_lineItems"` is unfortunately part of the public mapping contract: 
 
 **Why no `[OwnedEntity]`-style convention for collections (yet).** `[OwnedEntity]` + `CompositeValueObjectConvention` discovers composite owned *value objects* by attribute. An equivalent collection convention would need to walk every aggregate, find `IReadOnlyList<T>` / `IReadOnlyCollection<T>` properties whose `T` is an entity, locate a matching `_camelCase` backing field, and register the `OwnsMany` against it. This is on the roadmap (tracked as the analogue of `MaybeConvention` for collections); for now the cookbook pattern above is the supported approach.
 
+### Supported property shapes inside a composite VO — when to map to a DTO instead
+
+`CompositeValueObjectJsonConverter<T>` is deliberately small. It supports a closed list of primitive types directly and routes Trellis scalar value objects through their underlying primitives. Anything else — including any `Maybe<T>`, arrays, collections, and nested composites without their own `[JsonConverter]` — throws `TrellisJsonValidationException` at the first JSON access. **EF Core persistence is more permissive** (`Maybe<T>`, arrays, and nested composites work) so the JSON gap only surfaces when the composite VO crosses an HTTP boundary.
+
+The intentional split is: keep the framework converter simple; route consumers with richer shapes through a wire-shape DTO at the controller/endpoint seam (Recipe 14 generalised).
+
+| Property type on a composite VO interior | JSON via `CompositeValueObjectJsonConverter`? | Recommended path |
+|---|---|---|
+| `string` | ✅ Supported as-is | Use directly. |
+| `decimal`, `int`, `long`, `short`, `byte`, `double`, `float`, `bool` | ✅ Supported as-is | Use directly. |
+| `Guid`, `DateTime`, `DateTimeOffset` | ✅ Supported as-is | Use directly. |
+| Trellis scalar VO (`RequiredString<>`, `RequiredInt<>`, `RequiredGuid<>`, `RequiredEnum<>`, `RequiredDateTime<>`, …) — and shipped concretes like `EmailAddress`, `PhoneNumber`, `Money.Currency` | ✅ Flattens to underlying primitive on the wire | Use directly. The composite converter detects `IScalarValue<,>` and reads/writes the inner primitive. |
+| Nested composite owned VO (e.g., `Money` inside an aggregate response) | ❌ **Not supported** — `CompositeValueObjectJsonConverter<TOuter>` does not delegate back to `JsonSerializer` for nested objects, so an inner `[JsonConverter(typeof(CompositeValueObjectJsonConverter<TInner>))]` does not engage; the outer converter trips on the unsupported "primitive" type at first access. | **Map to a DTO** — declare the nested VO as a separate property on the wire-shape DTO (each composite VO has its own `[JsonConverter]` engagement only when STJ sees the type at the top of a property — not when it's owned by another composite converter). |
+| `Maybe<T>` for any T (primitive, scalar VO, composite VO, array) | ❌ **Not supported.** Throws `TrellisJsonValidationException: "Unsupported primitive type 'Maybe`1...'"` regardless of value (`Some` or `None`). | **Map to a wire-shape DTO.** See Recipe 14 — the same `T?` + adapt-at-the-seam pattern applies whether the optional is on the DTO itself or inside a composite VO. |
+| Array (`T[]`), collection (`List<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`) | ❌ Not supported. | **Map to a DTO** with the array on the wire-shape type. |
+
+**When to use a DTO at the seam (the general rule).** If a composite VO's interior holds any property shape outside the supported list — most commonly `Maybe<TPrimitive>` or arrays — keep the VO clean as a domain type and declare a wire-shape DTO at the controller/endpoint:
+
+```csharp
+// Domain VO: clean, persists fine via EF Core, but cannot serialize as-is.
+[OwnedEntity]
+public partial class CustomerProfile : ValueObject
+{
+    public TestOrderStatus Status { get; private set; } = null!;
+    public partial Maybe<int> AgeYears { get; private set; }             // not JSON-serializable on this VO
+    public partial Maybe<string> Nickname { get; private set; }          // not JSON-serializable
+    public partial Maybe<DateTime[]> LoginHistory { get; private set; }  // not JSON-serializable
+    // ...TryCreate, GetEqualityComponents...
+}
+
+// Wire-shape DTO at the API seam: everything as nullable transports the converter can serialize.
+public sealed record CustomerProfileDto(string Status, int? AgeYears, string? Nickname, DateTime[]? LoginHistory)
+{
+    public Result<CustomerProfile> ToDomain() =>
+        CustomerProfile.TryCreate(
+            Status,
+            AgeYears.AsMaybe(),
+            Nickname is null ? Maybe<string>.None : Maybe.From(Nickname),
+            LoginHistory is null ? Maybe<DateTime[]>.None : Maybe.From(LoginHistory));
+
+    public static CustomerProfileDto From(CustomerProfile vo) =>
+        new(vo.Status.Value,
+            vo.AgeYears.AsNullable(),
+            vo.Nickname.HasValue ? vo.Nickname.Value : null,
+            vo.LoginHistory.HasValue ? vo.LoginHistory.Value : null);
+}
+```
+
+The controller takes `CustomerProfileDto` on inbound requests, calls `.ToDomain()` to lift to the domain VO, and projects back via `CustomerProfileDto.From(...)` on responses. The Trellis scalar `Maybe<>` extensions (`AsMaybe` / `AsNullable`) and `Maybe.From` handle the lift cleanly.
+
+**Last-resort escape hatch — write your own `JsonConverter<TComposite>`.** If a service genuinely cannot tolerate the DTO indirection (rare — usually a sign the design wants tightening), the language's standard mechanism still applies: declare `[JsonConverter(typeof(YourCustomConverter))]` on the composite VO and implement `Read`/`Write` directly. The framework does not provide help for this path; the trade-off is more code per-VO in exchange for putting the domain shape directly on the wire. This is not the recommended path — favour the DTO seam unless there is a concrete reason not to.
+
 ---
 
 ## Recipe 14 — Optional fields in request DTOs: `Maybe<TScalar>` vs nullable transport
@@ -1032,6 +1084,9 @@ The answer depends on whether the inner type is a **scalar** (single-primitive) 
 |---|---|---|
 | `Maybe<TScalar>` where `TScalar : IScalarValue<TScalar, TPrimitive>` (e.g., `Maybe<EmailAddress>`, `Maybe<PhoneNumber>`) | **Use `Maybe<T>` directly on the DTO.** | `AddTrellisAsp()` registers `MaybeScalarValueJsonConverterFactory` (JSON) and `MaybeModelBinder<T,P>` (route/query/header); MVC child-validation suppression for `None` scalar-maybe values is handled internally by the Trellis MVC integration. Call `AddTrellisAsp(...)` before MVC model binding is configured. `null`/missing → `None`; valid → `Maybe.From(validated)`; invalid → ProblemDetails with the same field path the domain emits. |
 | `Maybe<TComposite>` where `TComposite : ValueObject` with multiple fields (e.g., `Maybe<ShippingAddress>`) | **Use a nullable transport (`TComposite?`) and adapt at the controller seam.** | No `MaybeCompositeValueObjectJsonConverterFactory` ships today — System.Text.Json would default-construct the inner type, bypassing `TryCreate`. Wrap with `Maybe.From(...)` inside the controller. |
+| `Maybe<TPrimitive>` (e.g., `Maybe<int>`, `Maybe<string>`, `Maybe<Guid>`) | **Use `TPrimitive?` on the DTO and `.AsMaybe()` at the seam.** | No JSON converter ships for arbitrary primitive `Maybe<>` — `MaybeScalarValueJsonConverterFactory` only handles `Maybe<T>` where `T : IScalarValue<,>`. If the primitive carries domain meaning, prefer wrapping it in a scalar value object (e.g., `Age : RequiredInt<Age>`) and using `Maybe<Age>` — that shape *is* factory-handled. |
+
+> **The same DTO pattern applies inside a composite VO.** If a *composite value object's interior* contains `Maybe<TPrimitive>` / arrays / collections, `CompositeValueObjectJsonConverter` rejects them too (see Recipe 13 §"Supported property shapes inside a composite VO"). Keep the composite VO clean as a domain type and declare a wire-shape DTO with nullable transports, then lift on inbound (`.AsMaybe()` / `Maybe.From(...)`) and project on outbound (`.AsNullable()`).
 
 ### Pattern A — scalar `Maybe<T>` directly on the DTO
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1022,7 +1022,7 @@ The string `"_lineItems"` is unfortunately part of the public mapping contract: 
 
 ### Supported property shapes inside a composite VO — when to map to a DTO instead
 
-`CompositeValueObjectJsonConverter<T>` is deliberately small. It supports a closed list of primitive types directly and routes Trellis scalar value objects through their underlying primitives. Anything else — including any `Maybe<T>`, arrays, collections, and nested composites without their own `[JsonConverter]` — throws `TrellisJsonValidationException` at the first JSON access. **EF Core persistence is more permissive** (`Maybe<T>`, arrays, and nested composites work) so the JSON gap only surfaces when the composite VO crosses an HTTP boundary.
+`CompositeValueObjectJsonConverter<T>` is deliberately small. It supports a closed list of primitive types directly and routes Trellis scalar value objects through their underlying primitives. Anything else — including any `Maybe<T>`, arrays, collections, and nested composite VO properties — throws `TrellisJsonValidationException` at the first JSON access. The converter never delegates property reads/writes back to `JsonSerializer`, so adding `[JsonConverter]` to an inner composite type does not rescue the nested case. **EF Core persistence is more permissive** (`Maybe<T>`, arrays, and nested composites work) so the JSON gap only surfaces when the composite VO crosses an HTTP boundary.
 
 The intentional split is: keep the framework converter simple; route consumers with richer shapes through a wire-shape DTO at the controller/endpoint seam (Recipe 14 generalised).
 


### PR DESCRIPTION
## The issue

`CompositeValueObjectJsonConverter<T>` accepts a closed primitive whitelist plus `IScalarValue<,>` flattening for Trellis scalar value objects. Everything else — any `Maybe<T>`, arrays, collections, nested composite VOs — throws `TrellisJsonValidationException` at first JSON access. The cookbook did not document this scope, so users with richer composite VO interiors discovered the limitation only at runtime.

## The fix

Document the scope clearly and route richer shapes through a wire-shape DTO at the API seam.

**Cookbook** (`trellis-api-cookbook.md`):

- Recipe 13 gains a new subsection *"Supported property shapes inside a composite VO — when to map to a DTO instead"* with a per-shape decision table and a worked DTO example using `.AsMaybe()` / `.AsNullable()` / `Maybe.From(...)` adapters.
- Recipe 14 gains a `Maybe<TPrimitive>` row plus a cross-reference to Recipe 13.

**Tests** (`Trellis.EntityFrameworkCore.Tests`):

- `TestMixedTypeVo` — fixture with `RequiredEnum + Maybe<int> + Maybe<string> + Maybe<DateTime[]>`. EF Core round-trip works; JSON throws specific exception messages, now locked in as regression guards.
- `TestSupportedMixedVo` — fixture with raw primitives plus a Trellis scalar VO. EF and JSON both round-trip cleanly.
- `CustomMixedTypeVoJsonConverter` — user-written escape-hatch example, explicitly documented as NOT the recommended path, with a cross-reference to Recipe 13.

The cookbook's general rule: stay within the supported shape, or keep the composite VO clean as a domain type and use a wire-shape DTO with nullable transports at the API seam. The custom converter path exists but is not recommended.