### PR TITLE
Expand TRLS013 message for EF Core IQueryable guidance

### DIFF
--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -145,10 +145,12 @@ public static class DiagnosticDescriptors
         id: TrellisDiagnosticIds.UnsafeMaybeValueInLinq,
         title: "Unsafe access to Maybe.Value in LINQ projection",
         messageFormat: "Accessing '{0}' in a LINQ projection without filtering by {1} first may throw at runtime. " +
-                       "Filter via .Where(x => x.HasValue) before the projection (or use .Match) to clear this warning. " +
-                       "For EF Core IQueryable, prefer composing the predicate with " +
-                       "Trellis.EntityFrameworkCore.MaybeQueryableExtensions " +
-                       "(WhereHasValue / WhereEquals / WhereLessThan / WhereGreaterThan, plus matching OrderBy*/ThenBy*) " +
+                       "Filter via .Where(x => x.HasValue) before the projection (or use .Match(...)) to clear this warning. " +
+                       "For EF Core IQueryable, prefer composing the query with " +
+                       "Trellis.EntityFrameworkCore.MaybeQueryableExtensions: " +
+                       "predicate helpers WhereHasValue / WhereNone / WhereEquals / " +
+                       "WhereLessThan / WhereLessThanOrEqual / WhereGreaterThan / WhereGreaterThanOrEqual, " +
+                       "and ordering helpers OrderByMaybe / OrderByMaybeDescending / ThenByMaybe / ThenByMaybeDescending, " +
                        "so .Value never appears in the chain.",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -145,7 +145,11 @@ public static class DiagnosticDescriptors
         id: TrellisDiagnosticIds.UnsafeMaybeValueInLinq,
         title: "Unsafe access to Maybe.Value in LINQ projection",
         messageFormat: "Accessing '{0}' in a LINQ projection without filtering by {1} first may throw at runtime. " +
-                       "Filter via .Where(x => x.HasValue) before the projection, or use .Match.",
+                       "Filter via .Where(x => x.HasValue) before the projection (or use .Match) to clear this warning. " +
+                       "For EF Core IQueryable, prefer composing the predicate with " +
+                       "Trellis.EntityFrameworkCore.MaybeQueryableExtensions " +
+                       "(WhereHasValue / WhereEquals / WhereLessThan / WhereGreaterThan, plus matching OrderBy*/ThenBy*) " +
+                       "so .Value never appears in the chain.",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/Trellis.Analyzers/tests/UnsafeValueInLinqAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueInLinqAnalyzerTests.cs
@@ -14,10 +14,15 @@ public class UnsafeValueInLinqAnalyzerTests
         var message = DiagnosticDescriptors.UnsafeMaybeValueInLinq.MessageFormat.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         message.Should().Contain(".Where(x => x.HasValue)");
+        message.Should().Contain(".Match(...)");
         message.Should().Contain("MaybeQueryableExtensions");
-        message.Should().Contain("WhereHasValue");
         message.Should().Contain("IQueryable");
+        message.Should().Contain("WhereHasValue");
+        message.Should().Contain("WhereNone");
+        message.Should().Contain("OrderByMaybe");
+        message.Should().Contain("ThenByMaybe");
     }
+
     [Fact]
     public async Task Select_MaybeValue_WithoutWhere_ReportsDiagnostic()
     {

--- a/Trellis.Analyzers/tests/UnsafeValueInLinqAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueInLinqAnalyzerTests.cs
@@ -9,6 +9,16 @@ using Xunit;
 public class UnsafeValueInLinqAnalyzerTests
 {
     [Fact]
+    public void MessageFormat_names_MaybeQueryableExtensions_for_IQueryable_path()
+    {
+        var message = DiagnosticDescriptors.UnsafeMaybeValueInLinq.MessageFormat.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        message.Should().Contain(".Where(x => x.HasValue)");
+        message.Should().Contain("MaybeQueryableExtensions");
+        message.Should().Contain("WhereHasValue");
+        message.Should().Contain("IQueryable");
+    }
+    [Fact]
     public async Task Select_MaybeValue_WithoutWhere_ReportsDiagnostic()
     {
         const string source = """


### PR DESCRIPTION
The UnsafeMaybeValueInLinq diagnostic message now explicitly references Trellis.EntityFrameworkCore.MaybeQueryableExtensions and its relevant methods for EF Core IQueryable scenarios, guiding users to safer patterns. Added a test to ensure the message includes these references and is clear for EF Core users.