### PR TITLE
Distinguish 401 (no actor) from 403 (insufficient permissions) per RFC 9110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### `IActorProvider.GetCurrentActorAsync` returns `Task<Maybe<Actor>>` (breaking)
+
+`IActorProvider.GetCurrentActorAsync` now returns `Task<Maybe<Actor>>` instead of `Task<Actor>`. "No authenticated actor on this request" is client-error state expressed via `Maybe<Actor>.None`; the mediator authorization pipeline maps it to `Error.Unauthorized` (HTTP 401, RFC 9110 §15.5.2). Provider implementations should throw `InvalidOperationException` only for genuine infrastructure or configuration failures (no `HttpContext`, mapping delegate threw, option misconfigured); those still surface as `Error.InternalServerError` (HTTP 500), which is correct because they are bugs rather than authentication state.
+
+Before this change the framework returned HTTP 500 in the "no actor" case (provider threw → `ExceptionBehavior` caught → `Error.InternalServerError`) instead of the RFC-correct 401, conflating client-error state with server bugs.
+
+**Migration for custom `IActorProvider` implementations:**
+
+```csharp
+// Before
+public Task<Actor> GetCurrentActorAsync(CancellationToken ct = default)
+{
+    if (httpContext.User.Identity?.IsAuthenticated != true)
+        throw new InvalidOperationException("No authenticated user...");
+    return Task.FromResult(BuildActor(httpContext.User));
+}
+
+// After
+public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken ct = default)
+{
+    if (httpContext.User.Identity?.IsAuthenticated != true)
+        return Task.FromResult(Maybe<Actor>.None);
+    return Task.FromResult(Maybe.From(BuildActor(httpContext.User)));
+}
+```
+
+The framework providers (`ClaimsActorProvider`, `EntraActorProvider`, `DevelopmentActorProvider`, `CachingActorProvider`, `TestActorProvider`) are migrated. The bundled `AuthorizationBehavior`, `ResourceAuthorizationBehavior`, and `ResourceAuthorizationViaBehavior` share an internal `ActorResolution.TryResolveAsync` helper that maps `Maybe<Actor>.None` → `Error.Unauthorized` consistently across all three.
+
+The mediator-emitted 401 carries an empty `Error.Unauthorized.Challenges` array, deferring the `WWW-Authenticate` header to the configured ASP.NET Core authentication handler (which knows the scheme and parameters). RFC 9110 §11.6.1 strict compliance still requires the auth handler to write the challenge.
+
+#### `CachingActorProvider` now caches synchronous failures from the inner provider
+
+`CachingActorProvider` previously documented "the failure is cached for the remainder of the request scope; subsequent calls re-throw the same exception." That contract held only for asynchronous (faulted-task) failures — synchronous throws from the inner provider escaped `LazyInitializer.EnsureInitialized` without setting `_cachedTask`, so subsequent calls in the same request retried the inner provider. The wrapper now converts synchronous throws into `Task.FromException<Maybe<Actor>>(ex)` before caching, matching the documented contract for both sync and async failure shapes.
+
+### Fixed
+
+#### `ProblemDetails.Instance` populated from request URL ([#496](https://github.com/xavierjohn/Trellis/pull/496))
+
+All nine `Trellis.Asp` ProblemDetails emission sites now populate `ProblemDetails.Instance` from `HttpContext.Request.GetEncodedPathAndQuery()` per RFC 9457 §3.1: `ResponseFailureWriter` (both `Results.Problem` and `Results.ValidationProblem` branches), `ScalarValueValidationEndpointFilter` (Minimal API), three sites in `ScalarValueValidationFilter` (MVC), and four sites in `ScalarValueValidationMiddleware`. Server-relative form (path + query, percent-encoded) avoids host disclosure for services behind reverse proxies. The shipped contract documented in `trellis-api-core.md`, `trellis-api-asp.md`, `trellis-api-testing-reference.md`, `integration-aspnet.md`, `integration-testing.md`, `migration.md`, `Trellis.Asp/README.md`, and `Trellis.Asp/NUGET_README.md` is aligned with this behavior. `ResourceRef` integration into `Instance` (using the typed payload's resource identity when the request URL doesn't carry it) is tracked as a follow-up.
+
 ### Added
 
 #### `Trellis.Asp.ApiVersioning` package — `CreatedAtVersionedRoute` helpers + `TRLS023` analyzer

--- a/Examples/SsoExample/Controllers/MeController.cs
+++ b/Examples/SsoExample/Controllers/MeController.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Trellis.Authorization;
 
 namespace SsoExample.Controllers;

--- a/Examples/SsoExample/Controllers/MeController.cs
+++ b/Examples/SsoExample/Controllers/MeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Trellis.Authorization;
 
 namespace SsoExample.Controllers;
@@ -10,7 +11,10 @@ public class MeController(IActorProvider actorProvider) : ControllerBase
     [HttpGet]
     public async Task<IActionResult> Get(CancellationToken ct)
     {
-        var actor = await actorProvider.GetCurrentActorAsync(ct);
+        var maybeActor = await actorProvider.GetCurrentActorAsync(ct);
+        if (!maybeActor.TryGetValue(out var actor))
+            return Unauthorized();
+
         return Ok(new
         {
             actor.Id,

--- a/Trellis.Asp/src/Authorization/CachingActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/CachingActorProvider.cs
@@ -24,7 +24,7 @@ public sealed class CachingActorProvider : IActorProvider
 {
     private readonly IActorProvider _inner;
     private readonly CancellationToken _requestAborted;
-    private Task<Actor>? _cachedTask;
+    private Task<Maybe<Actor>>? _cachedTask;
 
     /// <summary>
     /// Initializes a new <see cref="CachingActorProvider"/>.
@@ -38,14 +38,32 @@ public sealed class CachingActorProvider : IActorProvider
     }
 
     /// <inheritdoc />
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
         // The shared resolution uses HttpContext.RequestAborted so expensive work
         // (e.g., DB queries) is canceled when the HTTP request ends, but individual
         // callers' tokens don't cancel the shared task for other callers.
+        //
+        // LazyInitializer.EnsureInitialized leaves _cachedTask unset when the factory throws
+        // synchronously (e.g., the inner provider throws InvalidOperationException before
+        // returning a Task — typical of providers that validate prerequisites synchronously).
+        // Without the try/catch wrapper the next call would retry the inner provider, which
+        // breaks the documented "failure cached for the remainder of the request" contract
+        // and re-runs expensive synchronous prerequisites for every behavior in the pipeline.
+        // Wrapping converts synchronous throws into a faulted Task that gets cached.
         var task = LazyInitializer.EnsureInitialized(
             ref _cachedTask,
-            () => _inner.GetCurrentActorAsync(_requestAborted));
+            () =>
+            {
+                try
+                {
+                    return _inner.GetCurrentActorAsync(_requestAborted);
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException<Maybe<Actor>>(ex);
+                }
+            });
 
         // If the caller's token differs and is cancelable, apply it to the await only.
         return cancellationToken.CanBeCanceled && cancellationToken != _requestAborted
@@ -53,7 +71,7 @@ public sealed class CachingActorProvider : IActorProvider
             : task!;
     }
 
-    private static async Task<Actor> WaitWithCancellation(Task<Actor> task, CancellationToken ct)
+    private static async Task<Maybe<Actor>> WaitWithCancellation(Task<Maybe<Actor>> task, CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
         return await task.WaitAsync(ct).ConfigureAwait(false);

--- a/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
@@ -96,8 +96,14 @@ public class ClaimsActorOptions
 /// Claim mapping is controlled by <see cref="ClaimsActorOptions"/>.
 /// </para>
 /// <para>
-/// This provider assumes authentication has already occurred. It throws
-/// <see cref="InvalidOperationException"/> if no authenticated user exists.
+/// This provider assumes authentication has already occurred. It returns
+/// <see cref="Maybe{T}.None"/> when the request has no usable authenticated actor —
+/// no authenticated <see cref="System.Security.Claims.ClaimsIdentity"/>, or the configured
+/// <see cref="ClaimsActorOptions.ActorIdClaim"/> is missing from the authenticated identity —
+/// and the mediator authorization pipeline maps that to <see cref="Error.Unauthorized"/>
+/// (HTTP 401). It throws <see cref="InvalidOperationException"/> only when invoked outside
+/// an HTTP request scope (no <c>HttpContext</c>); that is a configuration bug, not
+/// authentication state, and surfaces as HTTP 500.
 /// </para>
 /// <para>
 /// <b>Extending for nested or computed claims.</b> The default mapping is flat
@@ -125,27 +131,38 @@ public class ClaimsActorProvider(
     protected ClaimsActorOptions Options { get; } = options.Value;
 
     /// <inheritdoc />
-    public virtual Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public virtual Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        // HttpContext missing is genuinely exceptional: the provider was invoked outside an
+        // HTTP request scope (e.g., from a background worker or test bootstrap). That's a
+        // configuration bug, not authentication state — throw rather than return None, which
+        // would mask the bug as a 401.
         var httpContext = HttpContextAccessor.HttpContext
             ?? throw new InvalidOperationException(
                 "No HttpContext available. Ensure this is called within an HTTP request scope.");
 
-        var identity = httpContext.User.Identities.FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity
-            ?? throw new InvalidOperationException(
-                "No authenticated user. Ensure authentication middleware runs before actor resolution.");
+        // The request has no authenticated identity (no Authorization header, anonymous-tolerant
+        // endpoint, expired/invalid token accepted as anonymous, etc.). Client-error state →
+        // Maybe.None → the mediator pipeline emits 401.
+        var identity = httpContext.User.Identities.FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity;
+        if (identity is null)
+            return Task.FromResult(Maybe<Actor>.None);
 
-        var actorId = identity.FindFirst(Options.ActorIdClaim)?.Value
-            ?? throw new InvalidOperationException(
-                $"Claim '{Options.ActorIdClaim}' not found in the authenticated user's claims.");
+        // Authenticated identity is present but the configured ActorIdClaim is missing. From
+        // the framework's POV we can't identify the actor — same client-facing outcome as no
+        // identity. (Whether this is a token-shape issue or a server-side option misconfig
+        // is indistinguishable here; both want a 401 retry by the client.)
+        var actorId = identity.FindFirst(Options.ActorIdClaim)?.Value;
+        if (actorId is null)
+            return Task.FromResult(Maybe<Actor>.None);
 
         var permissions = identity.FindAll(Options.PermissionsClaim)
             .Select(c => c.Value)
             .ToFrozenSet();
 
         var actor = Actor.Create(actorId, permissions);
-        return Task.FromResult(actor);
+        return Task.FromResult(Maybe.From(actor));
     }
 }

--- a/Trellis.Asp/src/Authorization/DevelopmentActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/DevelopmentActorProvider.cs
@@ -46,7 +46,7 @@ public sealed partial class DevelopmentActorProvider(
     internal const string HeaderName = "X-Test-Actor";
 
     /// <inheritdoc />
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -55,15 +55,20 @@ public sealed partial class DevelopmentActorProvider(
                 "DevelopmentActorProvider is not allowed outside Development environments. " +
                 "Use AddClaimsActorProvider or AddEntraActorProvider for production.");
 
+        // DevelopmentActorProvider always yields a usable actor (default or parsed) — never
+        // Maybe.None. That preserves the development convenience of running test requests
+        // without sending an explicit X-Test-Actor header. Production providers (Claims/Entra)
+        // return Maybe.None for the unauthenticated case; the development provider intentionally
+        // does not, so dev workflows are unaffected by the 401 contract.
         var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is null)
-            return Task.FromResult(CreateDefaultActor());
+            return Task.FromResult(Maybe.From(CreateDefaultActor()));
 
         var headerValue = httpContext.Request.Headers[HeaderName].FirstOrDefault();
         if (string.IsNullOrEmpty(headerValue))
-            return Task.FromResult(CreateDefaultActor());
+            return Task.FromResult(Maybe.From(CreateDefaultActor()));
 
-        return Task.FromResult(ParseActorFromHeader(headerValue));
+        return Task.FromResult(Maybe.From(ParseActorFromHeader(headerValue)));
     }
 
     private Actor ParseActorFromHeader(string headerValue)

--- a/Trellis.Asp/src/Authorization/EntraActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/EntraActorProvider.cs
@@ -18,8 +18,14 @@ using Trellis.Authorization;
 /// </para>
 /// <para>
 /// This provider assumes authentication has already occurred (e.g., via
-/// <c>AddMicrosoftIdentityWebApi</c>). It throws
-/// <see cref="InvalidOperationException"/> if no authenticated user exists.
+/// <c>AddMicrosoftIdentityWebApi</c>). It returns <see cref="Maybe{T}.None"/> when the
+/// request has no usable authenticated actor — no authenticated
+/// <see cref="System.Security.Claims.ClaimsIdentity"/>, or the configured
+/// <see cref="EntraActorOptions.IdClaimType"/> is missing (and the short <c>oid</c>
+/// fallback also misses) — and the mediator authorization pipeline maps that to
+/// <see cref="Error.Unauthorized"/> (HTTP 401). It throws
+/// <see cref="InvalidOperationException"/> only for genuine configuration failures
+/// (no <c>HttpContext</c>, or a <c>Map*</c> delegate threw); those surface as HTTP 500.
 /// </para>
 /// </remarks>
 public sealed class EntraActorProvider : ClaimsActorProvider
@@ -46,26 +52,31 @@ public sealed class EntraActorProvider : ClaimsActorProvider
         _entraOptions = options.Value;
 
     /// <inheritdoc />
-    public override Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public override Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        // HttpContext missing is a configuration bug, not authentication state. Throw to
+        // surface as 500; do not mask as 401 via Maybe.None.
         var httpContext = HttpContextAccessor.HttpContext
             ?? throw new InvalidOperationException(
                 "No HttpContext available. Ensure this is called within an HTTP request scope.");
 
         var user = httpContext.User;
 
-        var identity = user.Identities.FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity
-            ?? throw new InvalidOperationException(
-                "No authenticated user. Ensure authentication middleware runs before actor resolution.");
+        // No authenticated identity → client-error state → Maybe.None → 401.
+        var identity = user.Identities.FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity;
+        if (identity is null)
+            return Task.FromResult(Maybe<Actor>.None);
 
         var claims = identity.Claims;
 
-        var id = ResolveActorId(identity, _entraOptions)
-            ?? throw new InvalidOperationException(
-                $"Claim '{_entraOptions.IdClaimType}' not found in the authenticated user's claims. " +
-                "Verify the token configuration or set EntraActorOptions.IdClaimType.");
+        // Authenticated identity present but the configured ID claim is missing — client
+        // can't be identified, treat as unauthenticated for the response. (Token-shape vs
+        // server-side misconfig is indistinguishable here; same 401 outcome serves both.)
+        var id = ResolveActorId(identity, _entraOptions);
+        if (id is null)
+            return Task.FromResult(Maybe<Actor>.None);
 
         var permissions = InvokeMapping(
             "MapPermissions",
@@ -80,7 +91,7 @@ public sealed class EntraActorProvider : ClaimsActorProvider
             () => _entraOptions.MapAttributes(claims, httpContext));
 
         var actor = new Actor(id, permissions, forbiddenPermissions, attributes);
-        return Task.FromResult(actor);
+        return Task.FromResult(Maybe.From(actor));
     }
 
     private static string? ResolveActorId(ClaimsIdentity identity, EntraActorOptions config)

--- a/Trellis.Asp/tests/Authorization/CachingActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/CachingActorProviderTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.AspNetCore.Http;
 using Trellis.Authorization;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="CachingActorProvider"/> — the caching decorator for actor providers.
@@ -23,7 +24,7 @@ public class CachingActorProviderTests
         var result1 = await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken);
         var result2 = await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken);
 
-        result1.Should().BeSameAs(result2);
+        result1.Unwrap().Should().BeSameAs(result2.Unwrap());
         callCount.Should().Be(1, "inner provider should only be called once");
     }
 
@@ -34,7 +35,7 @@ public class CachingActorProviderTests
         var inner = new CountingActorProvider(actor, () => { });
         var caching = new CachingActorProvider(inner, s_nullAccessor);
 
-        var result = await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var result = (await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         result.Id.Should().Be("user-1");
         result.HasPermission("Write").Should().BeTrue();
@@ -79,23 +80,63 @@ public class CachingActorProviderTests
 
     #endregion
 
+    #region Failure caching
+
+    [Fact]
+    public async Task GetCurrentActorAsync_InnerThrowsSynchronously_FailureIsCachedAndReplayed()
+    {
+        // The XML doc on CachingActorProvider promises that failures from the inner provider
+        // are cached for the request scope so subsequent behaviors in the pipeline don't
+        // re-run expensive prerequisites (e.g. DB lookups) that already failed. Synchronous
+        // throws (typical of providers that validate prerequisites before returning a Task)
+        // must be cached the same way as faulted Tasks.
+        var callCount = 0;
+        var inner = new ThrowingSyncProvider(() =>
+        {
+            callCount++;
+            throw new InvalidOperationException("boom");
+        });
+        var caching = new CachingActorProvider(inner, s_nullAccessor);
+
+        var act1 = async () => await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var act2 = async () => await caching.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        await act1.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+        await act2.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+
+        callCount.Should().Be(1,
+            "synchronous failures from the inner provider must be cached for the request scope, "
+            + "matching the contract documented on CachingActorProvider");
+    }
+
+    #endregion
+
     #region Helpers
 
     private sealed class CountingActorProvider(Actor actor, Action onCall) : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             onCall();
-            return Task.FromResult(actor);
+            return Task.FromResult(Maybe.From(actor));
         }
     }
 
     private sealed class TokenCapturingProvider(Actor actor, Action<CancellationToken> onCall) : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             onCall(cancellationToken);
-            return Task.FromResult(actor);
+            return Task.FromResult(Maybe.From(actor));
+        }
+    }
+
+    private sealed class ThrowingSyncProvider(Action onCall) : IActorProvider
+    {
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        {
+            onCall();
+            return Task.FromResult(Maybe<Actor>.None); // unreachable — onCall throws
         }
     }
 

--- a/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
@@ -3,6 +3,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="ClaimsActorProvider"/> — the generic OIDC/JWT claims-based actor provider.
@@ -32,7 +33,7 @@ public class ClaimsActorProviderTests
     {
         var user = AuthenticatedUser(new Claim("sub", "user-sub-123"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-sub-123");
     }
@@ -45,7 +46,7 @@ public class ClaimsActorProviderTests
             new Claim("permissions", "orders:read"),
             new Claim("permissions", "orders:write"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEquivalentTo(["orders:read", "orders:write"]);
     }
@@ -55,7 +56,7 @@ public class ClaimsActorProviderTests
     {
         var user = AuthenticatedUser(new Claim("sub", "user-1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEmpty();
     }
@@ -70,7 +71,7 @@ public class ClaimsActorProviderTests
         var user = AuthenticatedUser(new Claim("oid", "user-oid-456"));
         var options = new ClaimsActorOptions { ActorIdClaim = "oid" };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-oid-456");
     }
@@ -84,7 +85,7 @@ public class ClaimsActorProviderTests
             new Claim("roles", "Editor"));
         var options = new ClaimsActorOptions { PermissionsClaim = "roles" };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEquivalentTo(["Admin", "Editor"]);
     }
@@ -106,26 +107,29 @@ public class ClaimsActorProviderTests
     }
 
     [Fact]
-    public async Task GetCurrentActorAsync_NotAuthenticated_ThrowsInvalidOperationException()
+    public async Task GetCurrentActorAsync_NotAuthenticated_ReturnsNone()
     {
+        // No authenticated identity is client-error state, not infrastructure failure.
+        // The provider returns Maybe<Actor>.None and the mediator pipeline emits HTTP 401.
         var user = new ClaimsPrincipal(new ClaimsIdentity()); // no auth type
         var provider = CreateProvider(user);
 
-        Func<Task> act = async () => await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var result = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*authenticated*");
+        result.HasNoValue.Should().BeTrue();
     }
 
     [Fact]
-    public async Task GetCurrentActorAsync_MissingActorIdClaim_ThrowsInvalidOperationException()
+    public async Task GetCurrentActorAsync_MissingActorIdClaim_ReturnsNone()
     {
+        // Authenticated identity is present but the configured ActorIdClaim is missing.
+        // From the framework's POV the actor is unidentifiable — same client-facing outcome
+        // as no identity. Provider returns Maybe<Actor>.None; mediator emits HTTP 401.
         var user = AuthenticatedUser(new Claim("oid", "user-1")); // has oid but not sub
 
-        Func<Task> act = async () => await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var result = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*sub*not found*");
+        result.HasNoValue.Should().BeTrue();
     }
 
     #endregion
@@ -144,7 +148,7 @@ public class ClaimsActorProviderTests
             new Claim("app_metadata", nested));
         var options = new ClaimsActorOptions { PermissionsClaim = "app_metadata" };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEquivalentTo([nested],
             "the default provider returns the raw claim value verbatim and does not parse JSON");
@@ -162,7 +166,7 @@ public class ClaimsActorProviderTests
         var accessor = new HttpContextAccessor { HttpContext = httpContext };
         var provider = new NestedJsonRolesActorProvider(accessor, Options.Create(new ClaimsActorOptions()));
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-1");
         actor.Permissions.Should().BeEquivalentTo(["orders:read", "orders:write"]);
@@ -172,7 +176,7 @@ public class ClaimsActorProviderTests
         IHttpContextAccessor httpContextAccessor,
         IOptions<ClaimsActorOptions> options) : ClaimsActorProvider(httpContextAccessor, options)
     {
-        public override Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public override Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -189,7 +193,7 @@ public class ClaimsActorProviderTests
                     .Select(e => e.GetString()!)
                     .ToHashSet();
 
-            return Task.FromResult(Actor.Create(id, permissions));
+            return Task.FromResult(Maybe.From(Actor.Create(id, permissions)));
         }
     }
 
@@ -218,7 +222,7 @@ public class ClaimsActorProviderTests
         var provider = CreateProvider(principal);
 
         // Act
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         // Assert — actor should ONLY have claims from the authenticated identity
         actor.Id.Should().Be("real-user-123", "should read from authenticated identity, not spoofed");
@@ -249,7 +253,7 @@ public class ClaimsActorProviderTests
         var provider = CreateProvider(principal);
 
         // Act
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         // Assert
         actor.Id.Should().Be("real-user-123", "should ignore unauthenticated identity even when listed first");
@@ -267,7 +271,7 @@ public class ClaimsActorProviderTests
     {
         var user = AuthenticatedUser(new Claim("sub", "user-1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.ForbiddenPermissions.Should().BeEmpty();
     }
@@ -277,7 +281,7 @@ public class ClaimsActorProviderTests
     {
         var user = AuthenticatedUser(new Claim("sub", "user-1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Attributes.Should().BeEmpty();
     }

--- a/Trellis.Asp/tests/Authorization/DevelopmentActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/DevelopmentActorProviderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="DevelopmentActorProvider"/> — the development/testing actor provider
@@ -121,7 +122,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-1");
         actor.Permissions.Should().BeEquivalentTo(["orders:create", "orders:read"]);
@@ -134,7 +135,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.ForbiddenPermissions.Should().Contain("orders:delete");
         actor.HasPermission("orders:delete").Should().BeFalse("deny overrides allow");
@@ -148,7 +149,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute("tid").Should().Be("tenant-1");
         actor.GetAttribute("region").Should().Be("us-west");
@@ -161,7 +162,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-1");
         actor.Permissions.Should().BeEmpty();
@@ -174,7 +175,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("minimal-user");
         actor.Permissions.Should().BeEmpty();
@@ -192,7 +193,7 @@ public class DevelopmentActorProviderTests
         var context = new DefaultHttpContext();
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
         actor.Permissions.Should().BeEmpty();
@@ -209,7 +210,7 @@ public class DevelopmentActorProviderTests
         };
         var provider = CreateProvider(context, options: options);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("admin");
         actor.Permissions.Should().BeEquivalentTo(["orders:create", "orders:read"]);
@@ -220,7 +221,7 @@ public class DevelopmentActorProviderTests
     {
         var provider = CreateProvider(httpContext: null);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -232,7 +233,7 @@ public class DevelopmentActorProviderTests
         context.Request.Headers[DevelopmentActorProvider.HeaderName] = "";
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -247,7 +248,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader("not valid json {{{");
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -258,7 +259,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader("""{"Permissions":["orders:read"]}""");
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -269,7 +270,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader("""{"Id":"","Permissions":["orders:read"]}""");
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -306,7 +307,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader("""{"Id":"user-1","Permissions":[123,true]}""");
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("development");
     }
@@ -330,7 +331,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("round-trip-user");
         actor.Permissions.Should().BeEquivalentTo(["orders:create", "orders:read", "products:manage-stock"]);
@@ -347,7 +348,7 @@ public class DevelopmentActorProviderTests
         var context = CreateHttpContextWithHeader(header);
         var provider = CreateProvider(context);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("case-user");
         actor.Permissions.Should().Contain("orders:read");

--- a/Trellis.Asp/tests/Authorization/EntraActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/EntraActorProviderTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Trellis.Testing;
 
 /// <summary>
 /// Tests for <see cref="EntraActorProvider"/> default and customized claim mapping.
@@ -40,7 +41,7 @@ public class EntraActorProviderTests
         var user = AuthenticatedUser(
             new Claim(OidClaimType, "user-oid-123"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-oid-123");
     }
@@ -51,7 +52,7 @@ public class EntraActorProviderTests
         var user = AuthenticatedUser(
             new Claim("oid", "user-oid-short-123"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-oid-short-123");
     }
@@ -64,7 +65,7 @@ public class EntraActorProviderTests
             new Claim("roles", "Documents.Read"),
             new Claim("roles", "Documents.Write"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEquivalentTo(["Documents.Read", "Documents.Write"]);
     }
@@ -75,7 +76,7 @@ public class EntraActorProviderTests
         var user = AuthenticatedUser(
             new Claim(OidClaimType, "user-1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.ForbiddenPermissions.Should().BeEmpty();
     }
@@ -87,7 +88,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("tid", "tenant-abc"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.TenantId).Should().Be("tenant-abc");
     }
@@ -99,7 +100,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("preferred_username", "alice@contoso.com"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.PreferredUsername).Should().Be("alice@contoso.com");
     }
@@ -111,7 +112,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("azp", "app-client-id"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.AuthorizedParty).Should().Be("app-client-id");
     }
@@ -123,7 +124,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("azpacr", "2"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.AuthorizedPartyAcr).Should().Be("2");
     }
@@ -135,7 +136,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("acrs", "c1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.AuthContextClassReference).Should().Be("c1");
     }
@@ -146,7 +147,7 @@ public class EntraActorProviderTests
         var user = AuthenticatedUser(
             new Claim(OidClaimType, "user-1"));
 
-        var actor = await CreateProvider(user, remoteIp: IPAddress.Parse("10.0.0.1")).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, remoteIp: IPAddress.Parse("10.0.0.1")).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.IpAddress).Should().Be("10.0.0.1");
     }
@@ -157,7 +158,7 @@ public class EntraActorProviderTests
         var user = AuthenticatedUser(
             new Claim(OidClaimType, "user-1"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.HasAttribute(ActorAttributes.IpAddress).Should().BeFalse();
     }
@@ -170,7 +171,7 @@ public class EntraActorProviderTests
             new Claim("amr", "pwd"),
             new Claim("amr", "mfa"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.MfaAuthenticated).Should().Be("true");
     }
@@ -185,7 +186,7 @@ public class EntraActorProviderTests
             new Claim("amr", "pwd"),
             new Claim("amr", mfaValue));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.MfaAuthenticated).Should().Be("true");
     }
@@ -197,7 +198,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim("amr", "pwd"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute(ActorAttributes.MfaAuthenticated).Should().Be("false");
     }
@@ -227,7 +228,7 @@ public class EntraActorProviderTests
         var principal = new ClaimsPrincipal(new[] { authenticatedIdentity, spoofedIdentity });
         var provider = CreateProvider(principal);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("real-user-oid", "should read from authenticated identity, not spoofed");
         actor.HasPermission("Documents.Read").Should().BeTrue();
@@ -257,7 +258,7 @@ public class EntraActorProviderTests
         var principal = new ClaimsPrincipal(new[] { spoofedIdentity, authenticatedIdentity });
         var provider = CreateProvider(principal);
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("real-user-oid", "should ignore unauthenticated identity even when listed first");
         actor.HasPermission("Documents.Read").Should().BeTrue();
@@ -282,29 +283,31 @@ public class EntraActorProviderTests
     }
 
     [Fact]
-    public async Task GetCurrentActorAsync_NotAuthenticated_ThrowsInvalidOperationException()
+    public async Task GetCurrentActorAsync_NotAuthenticated_ReturnsNone()
     {
+        // No authenticated identity is client-error state. Provider returns Maybe<Actor>.None;
+        // mediator pipeline emits HTTP 401.
         var user = new ClaimsPrincipal(new ClaimsIdentity()); // no auth type = not authenticated
         var provider = CreateProvider(user);
 
-        var act = async () => await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var result = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*authenticated*");
+        result.HasNoValue.Should().BeTrue();
     }
 
     [Fact]
-    public async Task GetCurrentActorAsync_MissingOidClaim_ThrowsInvalidOperationException()
+    public async Task GetCurrentActorAsync_MissingOidClaim_ReturnsNone()
     {
+        // Authenticated identity present but the configured OID claim is missing — actor is
+        // unidentifiable, same 401 outcome as no identity.
         var user = AuthenticatedUser(
             new Claim("sub", "user-1")); // has sub but not oid
 
         var provider = CreateProvider(user);
 
-        var act = async () => await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var result = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*objectidentifier*");
+        result.HasNoValue.Should().BeTrue();
     }
 
     #endregion
@@ -318,7 +321,7 @@ public class EntraActorProviderTests
             new Claim("sub", "user-sub-456"));
 
         var options = new EntraActorOptions { IdClaimType = "sub" };
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-sub-456");
     }
@@ -338,7 +341,7 @@ public class EntraActorProviderTests
                 .ToHashSet()
         };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().BeEquivalentTo(["User.Read", "Mail.Send"]);
     }
@@ -359,7 +362,7 @@ public class EntraActorProviderTests
                 .ToHashSet()
         };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.ForbiddenPermissions.Should().Contain("Documents.Read");
         actor.HasPermission("Documents.Read").Should().BeFalse("deny overrides allow");
@@ -379,7 +382,7 @@ public class EntraActorProviderTests
                 .ToDictionary(c => "region", c => c.Value)
         };
 
-        var actor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.GetAttribute("region").Should().Be("us-west-2");
     }
@@ -441,7 +444,7 @@ public class EntraActorProviderTests
             new Claim(OidClaimType, "user-1"),
             new Claim(ClaimTypes.Role, "Admin.FullAccess"));
 
-        var actor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Permissions.Should().Contain("Admin.FullAccess");
     }

--- a/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp/tests/Authorization/ServiceCollectionExtensionsTests.cs
@@ -227,7 +227,7 @@ public class ServiceCollectionExtensionsTests
 
     private sealed class FakeActorProvider : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(Actor.Create("test", new HashSet<string>()));
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Maybe.From(Actor.Create("test", new HashSet<string>())));
     }
 }

--- a/Trellis.Authorization/src/IActorProvider.cs
+++ b/Trellis.Authorization/src/IActorProvider.cs
@@ -2,24 +2,38 @@
 
 /// <summary>
 /// Provides the current authenticated actor for authorization behaviors.
-/// Implement in the API/ACL layer, typically extracting from HttpContext.User
-/// or resolving permissions from a database.
-/// Register as scoped in DI.
+/// Implement in the API/ACL layer, typically extracting from <c>HttpContext.User</c>
+/// or resolving permissions from a database. Register as scoped in DI.
 /// </summary>
 public interface IActorProvider
 {
     /// <summary>
-    /// Returns the current actor. Implementations must throw
-    /// <see cref="InvalidOperationException"/> (or an equivalent) when no authenticated user
-    /// exists for the current request — authentication should be handled before the request
-    /// reaches the mediator pipeline.
+    /// Returns the current authenticated actor for the request, or <see cref="Maybe{T}.None"/>
+    /// when the request has no usable authenticated actor.
     /// </summary>
     /// <param name="cancellationToken">Token to cancel the asynchronous operation.</param>
-    /// <returns>The current authenticated <see cref="Actor"/>.</returns>
+    /// <returns>
+    /// <para>
+    /// <see cref="Maybe.From{T}"/> wrapping the resolved <see cref="Actor"/> when an
+    /// authenticated identity is present and the framework can identify the actor.
+    /// </para>
+    /// <para>
+    /// <see cref="Maybe{T}.None"/> when the request has no usable authenticated actor —
+    /// typically the request lacks credentials, the authentication middleware did not produce
+    /// an authenticated identity, or the authenticated identity is missing the claim needed
+    /// to identify the actor. The Trellis mediator authorization pipeline maps this to
+    /// <see cref="Error.Unauthorized"/> (HTTP 401) per RFC 9110 §15.5.2. "No authenticated
+    /// actor" is client-error state, not an exception — model it via the return value, not by
+    /// throwing.
+    /// </para>
+    /// </returns>
     /// <exception cref="InvalidOperationException">
-    /// Recommended exception type when the actor cannot be resolved (e.g. unauthenticated
-    /// request, missing claims). Concrete implementations may throw a more specific
-    /// subclass — see <c>Trellis.Asp.Authorization</c> providers for examples.
+    /// Thrown only for genuine infrastructure or configuration failures — for example, the
+    /// provider was invoked outside an HTTP request scope (missing <c>HttpContext</c>), a
+    /// user-supplied mapping delegate threw, or an option is misconfigured. The mediator
+    /// pipeline does not catch this case; it surfaces as <see cref="Error.InternalServerError"/>
+    /// (HTTP 500), which is correct because these are bugs rather than authentication state.
+    /// Do not throw for "missing actor" — return <see cref="Maybe{T}.None"/> instead.
     /// </exception>
-    Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default);
+    Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default);
 }

--- a/Trellis.Mediator/src/ActorResolution.cs
+++ b/Trellis.Mediator/src/ActorResolution.cs
@@ -1,0 +1,50 @@
+namespace Trellis.Mediator;
+
+using Trellis.Authorization;
+
+/// <summary>
+/// Internal helper shared by the three authorization pipeline behaviors
+/// (<see cref="AuthorizationBehavior{TMessage,TResponse}"/>,
+/// <see cref="ResourceAuthorizationBehavior{TMessage,TResource,TResponse}"/>,
+/// <see cref="ResourceAuthorizationViaBehavior{TMessage,TLeaf,TOwner,TResponse}"/>).
+/// Centralises the "resolve current actor or short-circuit with HTTP 401" idiom so the three
+/// behaviors cannot drift on the 401 vs 500 distinction.
+/// </summary>
+internal static class ActorResolution
+{
+    /// <summary>
+    /// Resolves the current actor via <paramref name="actorProvider"/>. Returns the actor on
+    /// success; returns <see langword="null"/> when no authenticated actor is available, in
+    /// which case the caller should short-circuit the pipeline with
+    /// <see cref="Error.Unauthorized"/> (HTTP 401).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// "No authenticated actor" is modelled as <see cref="Maybe{T}.None"/> on the
+    /// <see cref="IActorProvider"/> contract — client-error state, not an exception. Provider
+    /// implementations that legitimately cannot operate (no <c>HttpContext</c>, mapping
+    /// delegate threw, etc.) still throw <see cref="System.InvalidOperationException"/>, which
+    /// propagates here unhandled and is caught later by
+    /// <see cref="ExceptionBehavior{TMessage,TResponse}"/> as <see cref="Error.InternalServerError"/>
+    /// (HTTP 500). That preserves the bug-vs-auth-state distinction.
+    /// </para>
+    /// </remarks>
+    public static async ValueTask<Actor?> TryResolveAsync(
+        IActorProvider actorProvider,
+        CancellationToken cancellationToken)
+    {
+        var maybeActor = await actorProvider.GetCurrentActorAsync(cancellationToken).ConfigureAwait(false);
+        return maybeActor.TryGetValue(out var actor) ? actor : null;
+    }
+
+    /// <summary>
+    /// Canonical <see cref="Error.Unauthorized"/> instance for the "no authenticated actor"
+    /// short-circuit. Empty <see cref="Error.Unauthorized.Challenges"/> defers the
+    /// <c>WWW-Authenticate</c> header to the configured ASP.NET Core authentication handler,
+    /// which knows the scheme name (Bearer, etc.) and parameters; the mediator layer does
+    /// not have that knowledge. Consumers needing strict RFC 9110 §11.6.1 compliance should
+    /// ensure their auth handler writes <c>WWW-Authenticate</c> on 401 responses.
+    /// </summary>
+    public static Error.Unauthorized AuthenticationRequired() =>
+        new() { Detail = "Authentication required." };
+}

--- a/Trellis.Mediator/src/AuthorizationBehavior.cs
+++ b/Trellis.Mediator/src/AuthorizationBehavior.cs
@@ -34,17 +34,9 @@ public sealed class AuthorizationBehavior<TMessage, TResponse>
         MessageHandlerDelegate<TMessage, TResponse> next,
         CancellationToken cancellationToken)
     {
-        var actor = await _actorProvider.GetCurrentActorAsync(cancellationToken).ConfigureAwait(false);
-
-        // The IActorProvider contract requires implementations to throw when no authenticated
-        // actor exists; returning null is a contract violation. Defense-in-depth: surface the
-        // violation here rather than letting it escape as a NullReferenceException from the
-        // permission check below.
+        var actor = await ActorResolution.TryResolveAsync(_actorProvider, cancellationToken).ConfigureAwait(false);
         if (actor is null)
-            throw new InvalidOperationException(
-                "IActorProvider.GetCurrentActorAsync returned null. The contract requires "
-                + "implementations to throw when no authenticated actor exists; returning null is a "
-                + "violation of the IActorProvider contract.");
+            return TResponse.CreateFailure(ActorResolution.AuthenticationRequired());
 
         if (!actor.HasAllPermissions(message.RequiredPermissions))
         {

--- a/Trellis.Mediator/src/ResourceAuthorizationBehavior.cs
+++ b/Trellis.Mediator/src/ResourceAuthorizationBehavior.cs
@@ -71,18 +71,14 @@ public sealed class ResourceAuthorizationBehavior<TMessage, TResource, TResponse
         //    the resource loader from DI. The DI factory or constructor for a custom
         //    IResourceLoader<TMessage, TResource> is arbitrary user code (e.g. it may open a
         //    DbContext or pre-fetch state during construction), so loader *resolution* itself
-        //    counts as I/O for the ga-11 guarantee. The IActorProvider contract requires
-        //    implementations to throw when no authenticated actor exists; the explicit
-        //    null-check is defense-in-depth so a misbehaving provider that returns null
-        //    cannot silently bypass the actor-first ordering (ga-11). Reported by GPT-5.5
-        //    review: the previous order (resolve loader → resolve actor) let an unauthenticated
+        //    counts as I/O for the ga-11 guarantee. "No authenticated actor" is client-error
+        //    state per RFC 9110 §15.5.2; route it to 401 via Error.Unauthorized rather than
+        //    letting it fall through to the resource-load path. Reported by GPT-5.5 review:
+        //    the previous order (resolve loader → resolve actor) let an unauthenticated
         //    caller trigger loader-side effects via the DI factory before the actor check.
-        var actor = await _actorProvider.GetCurrentActorAsync(cancellationToken).ConfigureAwait(false);
+        var actor = await ActorResolution.TryResolveAsync(_actorProvider, cancellationToken).ConfigureAwait(false);
         if (actor is null)
-            throw new InvalidOperationException(
-                "IActorProvider.GetCurrentActorAsync returned null. The contract requires "
-                + "implementations to throw when no authenticated actor exists; returning null is a "
-                + "violation of the IActorProvider contract.");
+            return TResponse.CreateFailure(ActorResolution.AuthenticationRequired());
 
         // 2. Resolve the scoped loader per-request (like middleware resolving scoped services).
         var loader = _serviceProvider.GetService<IResourceLoader<TMessage, TResource>>()

--- a/Trellis.Mediator/src/ResourceAuthorizationViaBehavior.cs
+++ b/Trellis.Mediator/src/ResourceAuthorizationViaBehavior.cs
@@ -118,12 +118,12 @@ public sealed class ResourceAuthorizationViaBehavior<TMessage, TLeaf, TOwner, TR
         MessageHandlerDelegate<TMessage, TResponse> next,
         CancellationToken cancellationToken)
     {
-        var actor = await _actorProvider.GetCurrentActorAsync(cancellationToken).ConfigureAwait(false);
+        // "No authenticated actor" is client-error state per RFC 9110 §15.5.2; route to 401.
+        // Genuine provider failures (missing HttpContext, mapping delegate threw, etc.) still
+        // throw plain InvalidOperationException and surface as 500 via ExceptionBehavior.
+        var actor = await ActorResolution.TryResolveAsync(_actorProvider, cancellationToken).ConfigureAwait(false);
         if (actor is null)
-            throw new InvalidOperationException(
-                "IActorProvider.GetCurrentActorAsync returned null. The contract requires "
-                + "implementations to throw when no authenticated actor exists; returning null is a "
-                + "violation of the IActorProvider contract.");
+            return TResponse.CreateFailure(ActorResolution.AuthenticationRequired());
 
         var leafLoader = _serviceProvider.GetService<IResourceLoader<TMessage, TLeaf>>()
             ?? throw new InvalidOperationException(

--- a/Trellis.Mediator/tests/AuthorizationBehaviorTests.cs
+++ b/Trellis.Mediator/tests/AuthorizationBehaviorTests.cs
@@ -104,23 +104,20 @@ public class AuthorizationBehaviorTests
     }
 
     [Fact]
-    public async Task Handle_ActorProviderReturnsNull_ThrowsInvalidOperationException()
+    public async Task Handle_ActorProviderReturnsNone_EmitsUnauthorized()
     {
-        var behavior = new AuthorizationBehavior<AdminCommand, Result<string>>(new NullActorProvider());
+        // "No authenticated actor" is modelled as Maybe<Actor>.None on the IActorProvider
+        // contract — client-error state, not an exception. The authorization pipeline must
+        // short-circuit with Error.Unauthorized (HTTP 401) and must not invoke the handler.
+        var behavior = new AuthorizationBehavior<AdminCommand, Result<string>>(new NoActorProvider());
         var command = new AdminCommand("data");
         var (next, tracker) = NextDelegate.TrackingAsync<AdminCommand, Result<string>>(
             Result.Ok("should not reach"));
 
-        var act = async () => await behavior.Handle(command, next, CancellationToken.None);
+        var result = await behavior.Handle(command, next, CancellationToken.None);
 
-        // Assert on the contract-violation message (ga-11 / m-3): the previous error message
-        // misleadingly suggested "Ensure an IActorProvider is configured" when really the
-        // IActorProvider implementation is the contractual party that should have thrown.
-        // The assertion locks in the new wording so a regression cannot silently restore the
-        // misleading guidance.
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*IActorProvider.GetCurrentActorAsync returned null*")
-            .WithMessage("*violation of the IActorProvider contract*");
+        result.IsFailure.Should().BeTrue();
+        result.UnwrapError().Should().BeOfType<Error.Unauthorized>();
         tracker.WasInvoked.Should().BeFalse();
     }
 
@@ -166,10 +163,14 @@ public class AuthorizationBehaviorTests
 
     #endregion
 
-    private sealed class NullActorProvider : IActorProvider
+    /// <summary>
+    /// Actor provider that returns <see cref="Maybe{T}.None"/> — represents an unauthenticated
+    /// request. The authorization pipeline maps this to <see cref="Error.Unauthorized"/> (HTTP 401).
+    /// </summary>
+    private sealed class NoActorProvider : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult<Actor>(null!);
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Maybe<Actor>.None);
     }
 
     /// <summary>
@@ -177,10 +178,10 @@ public class AuthorizationBehaviorTests
     /// </summary>
     private sealed class DelayedActorProvider(Actor actor, TimeSpan delay) : IActorProvider
     {
-        public async Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public async Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(delay, cancellationToken);
-            return actor;
+            return Maybe.From(actor);
         }
     }
 
@@ -191,10 +192,10 @@ public class AuthorizationBehaviorTests
     {
         public CancellationToken LastCancellationToken { get; private set; }
 
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             LastCancellationToken = cancellationToken;
-            return Task.FromResult(actor);
+            return Task.FromResult(Maybe.From(actor));
         }
     }
 }

--- a/Trellis.Mediator/tests/GptReviewRegressionTests.cs
+++ b/Trellis.Mediator/tests/GptReviewRegressionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Trellis.Authorization;
 using Trellis.Mediator.Tests.Helpers;
+using Trellis.Testing;
 
 /// <summary>
 /// Regression tests for the three findings surfaced by the GPT-5.5 review of
@@ -37,7 +38,7 @@ public class GptReviewRegressionTests
     /// <c>LoadAsync</c> wasn't called — not that the factory wasn't invoked.
     /// </summary>
     [Fact]
-    public async Task ResourceAuthorization_NullActor_DoesNotInvokeLoaderDIFactory()
+    public async Task ResourceAuthorization_NoActor_DoesNotInvokeLoaderDIFactory()
     {
         var factoryInvocations = 0;
 
@@ -49,14 +50,16 @@ public class GptReviewRegressionTests
         });
 
         var behavior = new ResourceAuthorizationBehavior<ResourceOwnerCommand, TestResource, Result<string>>(
-            actorProvider: new NullActorProvider(),
+            actorProvider: new NoActorProvider(),
             serviceProvider: services.BuildServiceProvider());
 
         var command = new ResourceOwnerCommand("res-1");
         var next = NextDelegate.ReturningAsync<ResourceOwnerCommand, Result<string>>(Result.Ok("Done"));
 
-        await FluentActions.Invoking(() => behavior.Handle(command, next, CancellationToken.None).AsTask())
-            .Should().ThrowAsync<InvalidOperationException>();
+        var result = await behavior.Handle(command, next, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.UnwrapError().Should().BeOfType<Error.Unauthorized>();
 
         factoryInvocations.Should().Be(0,
             "ga-11 requires that no I/O — including DI factory invocations — runs when the caller is unauthenticated. "
@@ -237,14 +240,15 @@ public class GptReviewRegressionTests
     }
 
     /// <summary>
-    /// Actor provider whose <see cref="GetCurrentActorAsync"/> returns null — simulates a
-    /// misbehaving <see cref="IActorProvider"/> implementation that violates the contract by
-    /// returning null instead of throwing. Used by the ga-11 regression test.
+    /// Actor provider whose <see cref="GetCurrentActorAsync"/> returns
+    /// <see cref="Maybe{T}.None"/> — represents an unauthenticated request. The authorization
+    /// pipeline must short-circuit with <see cref="Error.Unauthorized"/> before the resource
+    /// loader runs. Used by the ga-11 regression test.
     /// </summary>
-    private sealed class NullActorProvider : IActorProvider
+    private sealed class NoActorProvider : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult<Actor>(null!);
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Maybe<Actor>.None);
     }
 
     /// <summary>

--- a/Trellis.Mediator/tests/Helpers/FakeActorProvider.cs
+++ b/Trellis.Mediator/tests/Helpers/FakeActorProvider.cs
@@ -5,14 +5,27 @@ using Trellis.Authorization;
 /// <summary>
 /// Fake <see cref="IActorProvider"/> for testing authorization behaviors.
 /// </summary>
-internal sealed class FakeActorProvider(Actor actor) : IActorProvider
+internal sealed class FakeActorProvider : IActorProvider
 {
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult(actor);
+    private readonly Maybe<Actor> _actor;
+
+    public FakeActorProvider(Actor actor) => _actor = Maybe.From(actor);
+
+    private FakeActorProvider(Maybe<Actor> actor) => _actor = actor;
+
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_actor);
 
     public static FakeActorProvider WithPermissions(string userId, params string[] permissions)
         => new(Actor.Create(userId, permissions.ToHashSet()));
 
     public static FakeActorProvider NoPermissions(string userId = "user-1")
         => new(Actor.Create(userId, new HashSet<string>()));
+
+    /// <summary>
+    /// Fake provider that returns <see cref="Maybe{T}.None"/> — represents an unauthenticated
+    /// request. The authorization pipeline should map this to <see cref="Error.Unauthorized"/>
+    /// (HTTP 401).
+    /// </summary>
+    public static FakeActorProvider Anonymous() => new(Maybe<Actor>.None);
 }

--- a/Trellis.Mediator/tests/ResourceAuthorizationBehaviorTests.cs
+++ b/Trellis.Mediator/tests/ResourceAuthorizationBehaviorTests.cs
@@ -151,28 +151,27 @@ public class ResourceAuthorizationBehaviorTests
     #region Actor checked before resource load
 
     [Fact]
-    public async Task Handle_NullActor_ThrowsBeforeResourceLoaderIsCalled()
+    public async Task Handle_NoActor_EmitsUnauthorizedBeforeResourceLoaderIsCalled()
     {
         // ga-11: the resource loader must not run when the caller is unauthenticated.
         // Loader I/O is expensive (DB) and can leak existence by timing — gate on actor first.
+        // "No authenticated actor" is modelled as Maybe<Actor>.None on IActorProvider; the
+        // pipeline maps it to Error.Unauthorized (HTTP 401).
         var loader = new FakeResourceLoader<ResourceOwnerCommand>(new TestResource("res-1", "owner-1"));
         var services = new ServiceCollection();
         services.AddScoped<IResourceLoader<ResourceOwnerCommand, TestResource>>(_ => loader);
         var sp = services.BuildServiceProvider();
 
         var behavior = new ResourceAuthorizationBehavior<ResourceOwnerCommand, TestResource, Result<string>>(
-            new NullActorProvider(), sp);
+            new NoActorProvider(), sp);
 
         var command = new ResourceOwnerCommand("res-1");
         var next = NextDelegate.ReturningAsync<ResourceOwnerCommand, Result<string>>(Result.Ok("Done"));
 
-        // Lock in the new contract-violation message so a regression cannot restore the
-        // misleading "Ensure an IActorProvider is configured" guidance (m-3 from PR #459).
-        await FluentActions.Invoking(() => behavior.Handle(command, next, CancellationToken.None).AsTask())
-            .Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*IActorProvider.GetCurrentActorAsync returned null*")
-            .WithMessage("*violation of the IActorProvider contract*");
+        var result = await behavior.Handle(command, next, CancellationToken.None);
 
+        result.IsFailure.Should().BeTrue();
+        result.UnwrapError().Should().BeOfType<Error.Unauthorized>();
         loader.WasCalled.Should().BeFalse();
     }
 
@@ -217,24 +216,22 @@ public class ResourceAuthorizationBehaviorTests
     }
 
     [Fact]
-    public async Task Handle_ActorProviderReturnsNull_ThrowsInvalidOperationException()
+    public async Task Handle_ActorProviderReturnsNone_EmitsUnauthorized()
     {
         var services = new ServiceCollection();
         services.AddScoped<IResourceLoader<ResourceOwnerCommand, TestResource>>(_ =>
             new FakeResourceLoader<ResourceOwnerCommand>(new TestResource("res-1", "owner-1")));
         var behavior = new ResourceAuthorizationBehavior<ResourceOwnerCommand, TestResource, Result<string>>(
-            new NullActorProvider(),
+            new NoActorProvider(),
             services.BuildServiceProvider());
         var command = new ResourceOwnerCommand("res-1");
         var next = NextDelegate.ReturningAsync<ResourceOwnerCommand, Result<string>>(
             Result.Ok("should not reach"));
 
-        var act = async () => await behavior.Handle(command, next, CancellationToken.None);
+        var result = await behavior.Handle(command, next, CancellationToken.None);
 
-        // Lock in the new contract-violation message wording (m-3 from PR #459).
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*IActorProvider.GetCurrentActorAsync returned null*")
-            .WithMessage("*violation of the IActorProvider contract*");
+        result.IsFailure.Should().BeTrue();
+        result.UnwrapError().Should().BeOfType<Error.Unauthorized>();
     }
 
     #endregion
@@ -323,10 +320,10 @@ public class ResourceAuthorizationBehaviorTests
         }
     }
 
-    private sealed class NullActorProvider : IActorProvider
+    private sealed class NoActorProvider : IActorProvider
     {
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult<Actor>(null!);
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Maybe<Actor>.None);
     }
 
     /// <summary>
@@ -336,10 +333,10 @@ public class ResourceAuthorizationBehaviorTests
     {
         public CancellationToken LastCancellationToken { get; private set; }
 
-        public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
         {
             LastCancellationToken = cancellationToken;
-            return Task.FromResult(actor);
+            return Task.FromResult(Maybe.From(actor));
         }
     }
 

--- a/Trellis.Testing/src/TestActorProvider.cs
+++ b/Trellis.Testing/src/TestActorProvider.cs
@@ -45,8 +45,8 @@ public sealed class TestActorProvider : IActorProvider
     }
 
     /// <inheritdoc />
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult(_asyncLocalActor.Value ?? _defaultActor);
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(Maybe.From(_asyncLocalActor.Value ?? _defaultActor));
 
     /// <summary>
     /// Temporarily replaces the current actor for the current async flow.

--- a/Trellis.Testing/tests/Fakes/TestActorProviderTests.cs
+++ b/Trellis.Testing/tests/Fakes/TestActorProviderTests.cs
@@ -16,7 +16,7 @@ public class TestActorProviderTests
 
         var provider = new TestActorProvider(actor);
 
-        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Should().BeSameAs(actor);
+        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Should().BeSameAs(actor);
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class TestActorProviderTests
     {
         var provider = new TestActorProvider("user-1", "Read", "Write");
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
         actor.Id.Should().Be("user-1");
         actor.HasPermission("Read").Should().BeTrue();
         actor.HasPermission("Write").Should().BeTrue();
@@ -35,7 +35,7 @@ public class TestActorProviderTests
     {
         var provider = new TestActorProvider("user-1");
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
         actor.Id.Should().Be("user-1");
         actor.HasPermission("Read").Should().BeFalse();
     }
@@ -53,7 +53,7 @@ public class TestActorProviderTests
 
         await using (provider.WithActor(scoped))
         {
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Should().BeSameAs(scoped);
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Should().BeSameAs(scoped);
         }
     }
 
@@ -69,7 +69,7 @@ public class TestActorProviderTests
             // Actor changed inside scope
         }
 
-        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Should().BeSameAs(original);
+        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Should().BeSameAs(original);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class TestActorProviderTests
 
         await using (provider.WithActor("user-1", "Read"))
         {
-            var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+            var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
             actor.Id.Should().Be("user-1");
             actor.HasPermission("Read").Should().BeTrue();
             actor.HasPermission("Admin").Should().BeFalse();
@@ -96,7 +96,7 @@ public class TestActorProviderTests
             // Actor changed inside scope
         }
 
-        var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
         actor.Id.Should().Be("admin");
         actor.HasPermission("Admin").Should().BeTrue();
     }
@@ -108,17 +108,17 @@ public class TestActorProviderTests
 
         await using (provider.WithActor("user-1", "Read"))
         {
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-1");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-1");
 
             await using (provider.WithActor("user-2", "Write"))
             {
-                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-2");
+                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-2");
             }
 
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-1");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-1");
         }
 
-        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("admin");
+        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("admin");
     }
 
     [Fact]
@@ -129,10 +129,10 @@ public class TestActorProviderTests
 
         using (provider.WithActor("user-1", "Read"))
         {
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-1");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-1");
         }
 
-        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Should().BeSameAs(original);
+        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Should().BeSameAs(original);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class TestActorProviderTests
         {
             // Second dispose should be a no-op, not restore to "admin" again
             await scope.DisposeAsync();
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-2");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-2");
         }
     }
 
@@ -162,7 +162,7 @@ public class TestActorProviderTests
     {
         var provider = new TestActorProvider("user-1", "Read");
 
-        var actor = await ((IActorProvider)provider).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var actor = (await ((IActorProvider)provider).GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
         actor.Id.Should().Be("user-1");
     }
@@ -174,13 +174,13 @@ public class TestActorProviderTests
 
         await using (provider.WithActor("user-1", "Read"))
         {
-            var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+            var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
             actor.Id.Should().Be("user-1");
             actor.HasPermission("Read").Should().BeTrue();
             actor.HasPermission("Admin").Should().BeFalse();
         }
 
-        var restoredActor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+        var restoredActor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
         restoredActor.Id.Should().Be("admin");
     }
 
@@ -204,11 +204,11 @@ public class TestActorProviderTests
                 ready.SetResult();
                 await hold.Task;
                 // Should still see user-1 even though task2 changed the actor in its flow
-                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-1");
+                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-1");
             }
 
             // After dispose, this flow falls back to the default actor
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("admin");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("admin");
         }, ct);
 
         var task2 = Task.Run(async () =>
@@ -216,11 +216,11 @@ public class TestActorProviderTests
             await ready.Task; // Ensure task1 scope is active
             await using (provider.WithActor("user-2", "Write"))
             {
-                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("user-2");
+                (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("user-2");
             }
 
             // After dispose, this flow also falls back to the default actor
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("admin");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("admin");
 
             hold.SetResult(); // Let task1 verify
         }, ct);
@@ -228,7 +228,7 @@ public class TestActorProviderTests
         await Task.WhenAll(task1, task2);
 
         // Default actor is restored outside any scope
-        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("admin");
+        (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("admin");
     }
 
     [Fact]
@@ -249,13 +249,13 @@ public class TestActorProviderTests
                 // Synchronize so all scopes overlap
                 barrier.SignalAndWait(ct);
 
-                var actor = await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+                var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
                 actor.Id.Should().Be(userId);
                 actor.HasPermission(permission).Should().BeTrue();
             }
 
             // After dispose, default is visible again in this flow
-            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Id.Should().Be("admin");
+            (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap().Id.Should().Be("admin");
         }, ct));
 
         await Task.WhenAll(tasks);

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -436,7 +436,7 @@ Hydrates an `Actor` from the current `HttpContext.User` using flat JWT/OIDC clai
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public virtual Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Actor>` | Throws `InvalidOperationException` when `HttpContext` is missing, no authenticated identity exists, or the configured `ActorIdClaim` is missing. Permissions come from `FindAll(PermissionsClaim)` snapshotted into a `FrozenSet<string>`; `Actor.Create(actorId, permissions)` is used so forbidden permissions and attributes default to empty. |
+| `public virtual Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Returns `Maybe<Actor>.None` when no authenticated identity exists or the configured `ActorIdClaim` is missing from the authenticated identity — the mediator pipeline maps `Maybe.None` to `Error.Unauthorized` (HTTP 401). Throws `InvalidOperationException` only when `HttpContext` is missing (configuration bug, surfaces as HTTP 500). On success, permissions come from `FindAll(PermissionsClaim)` snapshotted into a `FrozenSet<string>` and the result is wrapped via `Maybe.From(Actor.Create(actorId, permissions))` so forbidden permissions and attributes default to empty. |
 
 ### `EntraActorOptions`
 
@@ -464,7 +464,7 @@ public sealed class EntraActorProvider : ClaimsActorProvider
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public EntraActorProvider(IHttpContextAccessor httpContextAccessor, IOptions<EntraActorOptions> options)` | — | Builds the Entra-specific provider; passes `ActorIdClaim = options.Value.IdClaimType` and `PermissionsClaim = "roles"` to the base. |
-| `public override Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Actor>` | Throws the same missing-context / missing-identity failures as `ClaimsActorProvider`. When `IdClaimType` is the long objectidentifier claim, falls back to the short `"oid"` claim before failing. Wraps any exception from `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` in `InvalidOperationException`. |
+| `public override Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Returns `Maybe<Actor>.None` when no authenticated identity exists or the configured ID claim is missing — the mediator pipeline maps that to `Error.Unauthorized` (HTTP 401). When `IdClaimType` is the long objectidentifier claim, falls back to the short `"oid"` claim before returning `None`. Throws `InvalidOperationException` only when `HttpContext` is missing (configuration bug, surfaces as HTTP 500); any exception from `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped in `InvalidOperationException` naming the failing delegate. |
 
 ### `DevelopmentActorOptions`
 
@@ -496,7 +496,7 @@ Reads the `X-Test-Actor` header (JSON: `{ "Id": ..., "Permissions": [...], "Forb
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Actor>` | Throws `InvalidOperationException` whenever `!hostEnvironment.IsDevelopment()`, regardless of header presence. In Development, returns `Actor.Create(DefaultActorId, DefaultPermissions)` when `HttpContext` is null or the header is missing/empty. Malformed JSON logs a warning and falls back unless `ThrowOnMalformedHeader` is `true`. |
+| `public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Throws `InvalidOperationException` whenever `!hostEnvironment.IsDevelopment()`, regardless of header presence. In Development, always returns `Maybe.From(actor)` — never `Maybe.None` — so dev workflows are unaffected by the 401 contract: `Maybe.From(Actor.Create(DefaultActorId, DefaultPermissions))` when `HttpContext` is null or the header is missing/empty, otherwise the parsed actor wrapped via `Maybe.From`. Malformed JSON logs a warning and falls back unless `ThrowOnMalformedHeader` is `true`. |
 
 ### `CachingActorProvider`
 
@@ -511,7 +511,7 @@ Decorator that caches the inner provider's resolution task per request scope usi
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public CachingActorProvider(IActorProvider inner, IHttpContextAccessor httpContextAccessor)` | — | `inner` cannot be null. |
-| `public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Actor>` | Returns the cached task; if `cancellationToken` differs from `RequestAborted`, applies it via `Task.WaitAsync`. |
+| `public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Returns the cached task — including a cached `Maybe<Actor>.None` when the inner provider resolved no authenticated actor — so the inner provider runs once per request scope. If `cancellationToken` differs from `RequestAborted`, applies it via `Task.WaitAsync`. |
 
 ### Namespace `Trellis.Asp.ModelBinding`
 

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -120,7 +120,11 @@ public interface IActorProvider
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Actor>` | Returns the current authenticated actor. Implementations must throw `InvalidOperationException` (or a more specific subclass) when the request is unauthenticated or the actor cannot be resolved. Register as scoped. |
+| `Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Returns the current authenticated actor wrapped in `Maybe.From(...)`, or `Maybe<Actor>.None` when the request has no usable authenticated actor. The mediator authorization pipeline maps `Maybe.None` to `Error.Unauthorized` (HTTP 401) per RFC 9110 §15.5.2. Implementations should throw `InvalidOperationException` only for genuine infrastructure or configuration failures (no `HttpContext`, mapping delegate threw, etc.) — those still surface as `Error.InternalServerError` (HTTP 500). "No actor" is client-error state, not an exception. Register as scoped. |
+
+**401 vs 500 contract.** `Maybe<Actor>.None` means the framework cannot identify an actor for the request — typically the request lacks credentials, the auth middleware did not produce an authenticated identity, or the configured actor-id claim is missing from an otherwise authenticated identity. All three are classes of client error and the mediator pipeline emits HTTP 401. A thrown `InvalidOperationException` means the provider itself cannot operate (no `HttpContext`, malformed configuration, mapping delegate failure) — that's a server bug and surfaces as HTTP 500.
+
+> ⚠️ **`WWW-Authenticate` header on the 401.** RFC 9110 §11.6.1 requires `WWW-Authenticate` on 401 responses. The mediator-emitted `Error.Unauthorized` carries an empty `Challenges` array by default, deferring the header to the configured ASP.NET Core authentication handler (which knows the scheme name and parameters; the mediator layer does not). Consumers needing strict §11.6.1 compliance should ensure their auth handler writes `WWW-Authenticate` on 401 responses. The framework's bundled `ClaimsActorProvider`/`EntraActorProvider` follow this layering: the auth handler owns the challenge.
 
 ### `IAuthorize`
 

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -78,7 +78,7 @@ public sealed class AuthorizationBehavior<TMessage, TResponse>(IActorProvider ac
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public async ValueTask<TResponse> Handle(TMessage message, MessageHandlerDelegate<TMessage, TResponse> next, CancellationToken cancellationToken)` | `ValueTask<TResponse>` | Resolves the current actor, checks `RequiredPermissions` with `HasAllPermissions`, and returns `TResponse.CreateFailure(new Error.Forbidden("authorization.insufficient.permissions") { Detail = "Insufficient permissions." })` when authorization fails. Throws `InvalidOperationException` when no actor can be resolved. |
+| `public async ValueTask<TResponse> Handle(TMessage message, MessageHandlerDelegate<TMessage, TResponse> next, CancellationToken cancellationToken)` | `ValueTask<TResponse>` | Resolves the current actor via `IActorProvider`. When the provider returns `Maybe<Actor>.None`, short-circuits with `TResponse.CreateFailure(new Error.Unauthorized { Detail = "Authentication required." })` (HTTP 401, RFC 9110 §15.5.2). When the actor is present but lacks one of `RequiredPermissions`, short-circuits with `TResponse.CreateFailure(new Error.Forbidden("authorization.insufficient.permissions") { Detail = "Insufficient permissions." })` (HTTP 403). The 401 vs 403 distinction is shared with `ResourceAuthorizationBehavior` and `ResourceAuthorizationViaBehavior` via the internal `ActorResolution.TryResolveAsync` / `ActorResolution.AuthenticationRequired()` helpers; provider-side `InvalidOperationException` (genuine bugs — no `HttpContext`, mapping delegate threw, etc.) propagates uncaught and surfaces as `Error.InternalServerError` (HTTP 500) via `ExceptionBehavior`. |
 
 ### ExceptionBehavior<TMessage, TResponse>
 **Declaration**
@@ -613,8 +613,8 @@ public sealed class OrderResourceLoader : SharedResourceLoaderById<Order, OrderI
 
 public sealed class StaticActorProvider : IActorProvider
 {
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(Actor.Create("user-1", new HashSet<string> { "orders:read" }));
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(Maybe.From(Actor.Create("user-1", new HashSet<string> { "orders:read" })));
 }
 ```
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -402,7 +402,7 @@ public sealed class TestActorProvider : IActorProvider
     public TestActorProvider(Actor actor);
     public TestActorProvider(string userId, params string[] permissions);
 
-    public Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default);
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default);
 
     public TestActorScope WithActor(Actor actor);
     public TestActorScope WithActor(string userId, params string[] permissions);

--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -87,7 +87,10 @@ app.UseAuthorization();
 
 app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationToken ct) =>
 {
-    var actor = await actorProvider.GetCurrentActorAsync(ct);
+    var maybeActor = await actorProvider.GetCurrentActorAsync(ct);
+    if (!maybeActor.TryGetValue(out var actor))
+        return Results.Unauthorized();
+
     return Results.Ok(new
     {
         actor.Id,
@@ -112,7 +115,7 @@ app.Run();
 | `EntraActorOptions.MapForbiddenPermissions` | empty `HashSet<string>` | Project a deny-list claim or DB lookup. |
 | `EntraActorOptions.MapAttributes` | extracts `tid`, `preferred_username`, `azp`, `azpacr`, `acrs`; adds `ip_address` from `Connection.RemoteIpAddress` and `mfa = "true"\|"false"` from any `amr` claim equal to `"mfa"` | Add tenant-scoped or request-scoped attributes. |
 
-`EntraActorProvider` throws `InvalidOperationException` when no `HttpContext` is available, no authenticated `ClaimsIdentity` exists, or the configured `IdClaimType` is missing (and the short `oid` fallback also misses). Any exception thrown by `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped in `InvalidOperationException` naming the failing delegate.
+`EntraActorProvider` returns `Maybe<Actor>.None` when no authenticated `ClaimsIdentity` exists or the configured `IdClaimType` is missing (and the short `oid` fallback also misses); the mediator authorization pipeline maps `Maybe.None` to `Error.Unauthorized` (HTTP 401, RFC 9110 §15.5.2). It throws `InvalidOperationException` only when invoked outside an HTTP request scope (no `HttpContext`) — a configuration bug that surfaces as HTTP 500. Any exception thrown by `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped in `InvalidOperationException` naming the failing delegate.
 
 ## Generic claims provider
 
@@ -192,13 +195,21 @@ public sealed class DatabaseActorProvider(
     IHttpContextAccessor httpContextAccessor,
     IPermissionStore permissionStore) : IActorProvider
 {
-    public async Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public async Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
-        var userId = httpContextAccessor.HttpContext?.User.FindFirst("sub")?.Value
-            ?? throw new InvalidOperationException("Missing user id.");
+        // HttpContext missing is a configuration bug, not authentication state — throw
+        // so it surfaces as HTTP 500 rather than masquerading as a 401.
+        var httpContext = httpContextAccessor.HttpContext
+            ?? throw new InvalidOperationException("No HttpContext available.");
+
+        // No authenticated identity / missing id claim → no usable actor → Maybe.None,
+        // which the mediator pipeline maps to Error.Unauthorized (HTTP 401).
+        var userId = httpContext.User.FindFirst("sub")?.Value;
+        if (userId is null)
+            return Maybe<Actor>.None;
 
         var permissions = await permissionStore.GetPermissionsAsync(userId, cancellationToken);
-        return Actor.Create(userId, permissions);
+        return Maybe.From(Actor.Create(userId, permissions));
     }
 }
 
@@ -414,7 +425,9 @@ public static class DocumentService
         string id,
         CancellationToken ct)
     {
-        var actor = await actors.GetCurrentActorAsync(ct);
+        var maybeActor = await actors.GetCurrentActorAsync(ct);
+        if (!maybeActor.TryGetValue(out var actor))
+            return Result.Fail<Document>(new Error.Unauthorized { Detail = "Authentication required." });
 
         return await repo.GetByIdAsync(id, ct)
             .EnsureAsync(

--- a/docs/docfx_project/articles/integration-db-permissions.md
+++ b/docs/docfx_project/articles/integration-db-permissions.md
@@ -79,20 +79,24 @@ public sealed class DatabaseActorProvider(
     IHttpContextAccessor accessor,
     IPermissionRepository repo) : IActorProvider
 {
-    public async Task<Actor> GetCurrentActorAsync(CancellationToken ct = default)
+    public async Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken ct = default)
     {
+        // Missing HttpContext is a configuration bug (provider invoked outside an HTTP
+        // request scope) — throw so it surfaces as HTTP 500 rather than masquerading as 401.
         var principal = accessor.HttpContext?.User
             ?? throw new InvalidOperationException("No HttpContext is available.");
 
+        // Unauthenticated request → no usable actor → Maybe.None → mediator pipeline
+        // emits Error.Unauthorized (HTTP 401).
         if (principal.Identity?.IsAuthenticated != true)
-            throw new InvalidOperationException("The current request is not authenticated.");
+            return Maybe<Actor>.None;
 
-        var externalId = principal.FindFirstValue("oid")
-            ?? principal.FindFirstValue("sub")
-            ?? throw new InvalidOperationException("No 'oid' or 'sub' claim was found.");
+        var externalId = principal.FindFirstValue("oid") ?? principal.FindFirstValue("sub");
+        if (externalId is null)
+            return Maybe<Actor>.None;
 
         var permissions = await repo.GetPermissionsForUserAsync(externalId, ct).ConfigureAwait(false);
-        return Actor.Create(externalId, permissions);
+        return Maybe.From(Actor.Create(externalId, permissions));
     }
 }
 
@@ -229,7 +233,7 @@ The provider in [Quick start](#quick-start) is the canonical shape. It does thre
 | Extract `oid` (then fall back to `sub`) | Matches the `EntraActorProvider` precedence; both Entra v1.0 and v2.0 tokens resolve. |
 | Call the repository, then `Actor.Create(...)` | `Actor.Create` snapshots permissions into a `FrozenSet<string>` for O(1) lookups. |
 
-Throwing `InvalidOperationException` on missing context / unauthenticated requests follows the contract documented for `IActorProvider.GetCurrentActorAsync` ([`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md#iactorprovider)).
+Returning `Maybe<Actor>.None` for unauthenticated requests and throwing `InvalidOperationException` only for missing-`HttpContext` configuration bugs follows the contract documented for `IActorProvider.GetCurrentActorAsync` ([`trellis-api-authorization.md`](../api_reference/trellis-api-authorization.md#iactorprovider)). The mediator authorization pipeline maps `Maybe.None` to `Error.Unauthorized` (HTTP 401, RFC 9110 §15.5.2); the throw surfaces as `Error.InternalServerError` (HTTP 500), which is correct because it is a bug rather than authentication state.
 
 ## Carrying ABAC attributes
 
@@ -244,15 +248,18 @@ public sealed class TenantAwareActorProvider(
     IHttpContextAccessor accessor,
     IPermissionRepository repo) : IActorProvider
 {
-    public async Task<Actor> GetCurrentActorAsync(CancellationToken ct = default)
+    public async Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken ct = default)
     {
         var ctx = accessor.HttpContext
             ?? throw new InvalidOperationException("No HttpContext is available.");
         var principal = ctx.User;
 
-        var externalId = principal.FindFirstValue("oid")
-            ?? principal.FindFirstValue("sub")
-            ?? throw new InvalidOperationException("No 'oid' or 'sub' claim was found.");
+        if (principal.Identity?.IsAuthenticated != true)
+            return Maybe<Actor>.None;
+
+        var externalId = principal.FindFirstValue("oid") ?? principal.FindFirstValue("sub");
+        if (externalId is null)
+            return Maybe<Actor>.None;
 
         var permissions = await repo
             .GetPermissionsForUserAsync(externalId, ct)
@@ -264,11 +271,11 @@ public sealed class TenantAwareActorProvider(
         if (ctx.Connection.RemoteIpAddress is { } ip)
             attributes[ActorAttributes.IpAddress] = ip.ToString();
 
-        return new Actor(
+        return Maybe.From(new Actor(
             id: externalId,
             permissions: permissions,
             forbiddenPermissions: new HashSet<string>(StringComparer.Ordinal),
-            attributes: attributes);
+            attributes: attributes));
     }
 }
 ```

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -91,7 +91,10 @@ app.UseAuthorization();
 
 app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationToken ct) =>
 {
-    var actor = await actorProvider.GetCurrentActorAsync(ct);
+    var maybeActor = await actorProvider.GetCurrentActorAsync(ct);
+    if (!maybeActor.TryGetValue(out var actor))
+        return Results.Unauthorized();
+
     return Results.Ok(new
     {
         actor.Id,
@@ -217,16 +220,24 @@ public sealed class KeycloakActorProvider(
     IHttpContextAccessor accessor,
     IOptions<ClaimsActorOptions> options) : ClaimsActorProvider(accessor, options)
 {
-    public override Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    public override Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var identity = HttpContextAccessor.HttpContext?.User.Identities
-            .FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity
-            ?? throw new InvalidOperationException("No authenticated user.");
+        // No HttpContext is a configuration bug → throw → HTTP 500.
+        var httpContext = HttpContextAccessor.HttpContext
+            ?? throw new InvalidOperationException("No HttpContext available.");
 
-        var sub = identity.FindFirst(Options.ActorIdClaim)?.Value
-            ?? throw new InvalidOperationException($"Claim '{Options.ActorIdClaim}' missing.");
+        // No authenticated identity / missing id claim → no usable actor → Maybe.None,
+        // which the mediator pipeline maps to Error.Unauthorized (HTTP 401).
+        var identity = httpContext.User.Identities
+            .FirstOrDefault(i => i.IsAuthenticated) as ClaimsIdentity;
+        if (identity is null)
+            return Task.FromResult(Maybe<Actor>.None);
+
+        var sub = identity.FindFirst(Options.ActorIdClaim)?.Value;
+        if (sub is null)
+            return Task.FromResult(Maybe<Actor>.None);
 
         var raw = identity.FindFirst("realm_access")?.Value;
         var roles = raw is null
@@ -234,7 +245,7 @@ public sealed class KeycloakActorProvider(
             : (JsonSerializer.Deserialize(raw, KeycloakJsonContext.Default.RealmAccess)?.Roles
                 ?? Array.Empty<string>()).ToFrozenSet();
 
-        return Task.FromResult(Actor.Create(sub, roles));
+        return Task.FromResult(Maybe.From(Actor.Create(sub, roles)));
     }
 }
 
@@ -255,7 +266,7 @@ Trellis does not own JWT validation — that lives in `Microsoft.AspNetCore.Auth
 
 | `JwtBearerOptions` setting | Effect on Trellis |
 |---|---|
-| `Authority` | Determines OIDC discovery / signing keys. If validation fails, `HttpContext.User` is unauthenticated and any actor provider throws `InvalidOperationException("No authenticated user.")`. |
+| `Authority` | Determines OIDC discovery / signing keys. If validation fails, `HttpContext.User` is unauthenticated and the actor provider returns `Maybe<Actor>.None`, which the mediator pipeline maps to `Error.Unauthorized` (HTTP 401). |
 | `Audience` (or `TokenValidationParameters.ValidAudiences`) | Must match the token `aud`. Mismatched audiences never reach the actor provider — the request is rejected with `401`. |
 | `TokenValidationParameters.ValidIssuers` | Required when `Authority` does not match the literal `iss` claim (Google emits both `https://accounts.google.com` and `accounts.google.com`). |
 | `TokenValidationParameters.ValidateIssuer = false` | Multi-tenant Entra requires this; tenant pinning then lives in `MapAttributes` or a custom validator. See [Multi-tenant Entra](#multi-tenant-entra). |

--- a/docs/docfx_project/articles/integration-testing.md
+++ b/docs/docfx_project/articles/integration-testing.md
@@ -89,7 +89,7 @@ public sealed class Order : Aggregate<OrderId>
 }
 
 var actorProvider = new TestActorProvider("user-1", "Orders.Read", "Orders.Write");
-var actor = await actorProvider.GetCurrentActorAsync();
+var actor = (await actorProvider.GetCurrentActorAsync()).GetValueOrThrow();
 
 actor.HasPermission("Orders.Read").Should().BeTrue();
 
@@ -269,7 +269,7 @@ var provider = new TestActorProvider("admin", "Orders.Read", "Orders.Write");
 
 await using (provider.WithActor("user-1", "Orders.Read"))
 {
-    var actor = await provider.GetCurrentActorAsync();
+    var actor = (await provider.GetCurrentActorAsync()).GetValueOrThrow();
     actor.Id.Should().Be("user-1");
     actor.HasPermission("Orders.Read").Should().BeTrue();
     actor.HasPermission("Orders.Write").Should().BeFalse();
@@ -283,7 +283,7 @@ var richActor = new Actor(
 
 await using (provider.WithActor(richActor))
 {
-    var actor = await provider.GetCurrentActorAsync();
+    var actor = (await provider.GetCurrentActorAsync()).GetValueOrThrow();
     actor.Attributes["tenant"].Should().Be("acme");
 }
 ```
@@ -401,7 +401,9 @@ public sealed class PlaceOrderHandler(FakeRepository<Order, OrderId> repo, TestA
 {
     public async Task<Result<OrderId>> HandleAsync(PlaceOrder cmd, CancellationToken ct)
     {
-        var actor = await actors.GetCurrentActorAsync(ct);
+        var maybeActor = await actors.GetCurrentActorAsync(ct);
+        if (!maybeActor.TryGetValue(out var actor))
+            return Result.Fail<OrderId>(new Error.Unauthorized { Detail = "Authentication required." });
         if (!actor.HasPermission("Orders.Write"))
             return Result.Fail<OrderId>(new Error.Forbidden("Orders.Write"));
 


### PR DESCRIPTION
**Issue:** When `IActorProvider` could not identify an actor for a request, Trellis returned **HTTP 500**. The provider threw `InvalidOperationException`, `ExceptionBehavior` caught it and converted it to `Error.InternalServerError`. The correct status per RFC 9110 §15.5.2 is **401 Unauthorized** — *"no authenticated actor"* is client-error state, not a server bug. The 403 path (actor present, insufficient permissions) was already correct.

**Fix:** Change `IActorProvider.GetCurrentActorAsync` to return `Task<Maybe<Actor>>` instead of `Task<Actor>`. *"No actor"* is now expressed as `Maybe.None`, consistent with the rest of the framework's ROP-first design (throws are reserved for genuine `Result<T>`-pipeline-bypass cases). The mediator authorization behaviors (`AuthorizationBehavior`, `ResourceAuthorizationBehavior`, `ResourceAuthorizationViaBehavior`) share a new internal `ActorResolution` helper that maps `Maybe.None` to `Error.Unauthorized` (HTTP 401). Provider-side `InvalidOperationException` is reserved for genuine bugs (no `HttpContext`, mapping delegate threw, option misconfigured) and still surfaces as 500 — the bug-vs-auth-state distinction is the whole point.

**Provider migrations:**
- `ClaimsActorProvider` / `EntraActorProvider` — return `Maybe<Actor>.None` for "no authenticated identity" and "configured actor-id claim missing"; still throw for "no `HttpContext`" config bug.
- `DevelopmentActorProvider` — preserves its dev-fallback behavior (always returns `Maybe.From(default-or-parsed actor)`, never `None`); production providers ship the 401 contract.
- `CachingActorProvider` — type updates **plus a co-shipped fix for a pre-existing bug**: synchronous throws from the inner provider escaped `LazyInitializer.EnsureInitialized` without being cached, contradicting the documented *"failure cached for the request scope"* contract. The wrapper now converts sync throws into `Task.FromException` so the cache holds for both sync and async failure shapes. New regression test `GetCurrentActorAsync_InnerThrowsSynchronously_FailureIsCachedAndReplayed` pins this.
- `TestActorProvider` — wraps existing returns in `Maybe.From(...)`.

**WWW-Authenticate trade-off (documented limitation):** The mediator-emitted 401 carries an empty `Error.Unauthorized.Challenges` array, deferring `WWW-Authenticate` to the configured ASP.NET Core authentication handler (which knows the scheme name and parameters; the mediator layer does not). RFC 9110 §11.6.1 strict compliance still requires the auth handler to write the challenge. Challenge synthesis is tracked as a separate BACKLOG item.

**Breaking change:** Custom `IActorProvider` implementations must update from *"throw `InvalidOperationException` for missing actor"* to *"return `Maybe.None` for missing actor"*. One-line migration per provider — see `CHANGELOG.md` for the before/after sample.

**Docs aligned with shipped behavior:** `trellis-api-authorization.md`, `trellis-api-mediator.md`, `trellis-api-asp.md`, `trellis-api-testing-reference.md`, `integration-asp-authorization.md`, `integration-sso.md`, `integration-db-permissions.md`, `integration-testing.md`, `CHANGELOG.md`, plus XML doc text in `ClaimsActorProvider` and `EntraActorProvider`.