### PR TITLE
ClaimsActorProvider: short↔long claim-name fallback for JwtBearer.MapInboundClaims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ The mediator-emitted 401 carries an empty `Error.Unauthorized.Challenges` array,
 
 ### Fixed
 
+#### `ClaimsActorProvider` short↔long claim-name fallback for `JwtBearer.MapInboundClaims`
+
+`ClaimsActorProvider` previously did literal-match lookup of `ClaimsActorOptions.ActorIdClaim` against `ClaimsIdentity`. Combined with ASP.NET Core's `JwtBearerOptions.MapInboundClaims = true` default — which remaps RFC 7519 short claim names (e.g. `"sub"`) onto WS-* long-form URNs (e.g. `ClaimTypes.NameIdentifier`) before the principal reaches Trellis — the default `ActorIdClaim = "sub"` couldn't find the (now-remapped) claim, returned `Maybe<Actor>.None`, and the mediator emitted **401 on every authenticated request** with no diagnostic. The most common Trellis + JwtBearer integration footgun.
+
+`ClaimsActorProvider` now performs the literal lookup first, then falls back to the well-known short↔long counterpart from the JWT inbound claim-name map (`"sub"` ↔ `NameIdentifier`, `"email"` ↔ `Email`, `"role"`/`"roles"` ↔ `Role`, `"name"`/`"unique_name"` ↔ `Name`, `"family_name"` ↔ `Surname`, `"given_name"` ↔ `GivenName`, `"gender"` ↔ `Gender`, `"birthdate"` ↔ `DateOfBirth`, `"website"` ↔ `Webpage`, `"actort"` ↔ `Actor`, `"nameid"` ↔ `NameIdentifier`). Bidirectional — works under both `MapInboundClaims = true` and `MapInboundClaims = false`. The literal match takes precedence when both forms are present. The fallback fires a debug-level log entry naming the resolved counterpart, so operators can spot the `MapInboundClaims = true` default in their pipeline.
+
+Same Postel's-law robustness pattern `EntraActorProvider` has used for its `oid` ↔ `objectidentifier` lookup since the package shipped.
+
+`ClaimsActorProvider`'s constructor gained an optional `ILogger<ClaimsActorProvider>` parameter. The default `AddClaimsActorProvider(...)` registration extension wires it automatically; manual constructions pass `null` for no logging. `EntraActorProvider` (which subclasses `ClaimsActorProvider`) is unaffected — its `GetCurrentActorAsync` override does its own claim resolution.
+
 #### `ProblemDetails.Instance` populated from request URL ([#496](https://github.com/xavierjohn/Trellis/pull/496))
 
 All nine `Trellis.Asp` ProblemDetails emission sites now populate `ProblemDetails.Instance` from `HttpContext.Request.GetEncodedPathAndQuery()` per RFC 9457 §3.1: `ResponseFailureWriter` (both `Results.Problem` and `Results.ValidationProblem` branches), `ScalarValueValidationEndpointFilter` (Minimal API), three sites in `ScalarValueValidationFilter` (MVC), and four sites in `ScalarValueValidationMiddleware`. Server-relative form (path + query, percent-encoded) avoids host disclosure for services behind reverse proxies. The shipped contract documented in `trellis-api-core.md`, `trellis-api-asp.md`, `trellis-api-testing-reference.md`, `integration-aspnet.md`, `integration-testing.md`, `migration.md`, `Trellis.Asp/README.md`, and `Trellis.Asp/NUGET_README.md` is aligned with this behavior. `ResourceRef` integration into `Instance` (using the typed payload's resource identity when the request URL doesn't carry it) is tracked as a follow-up.

--- a/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
@@ -175,11 +175,24 @@ public class ClaimsActorProvider : IActorProvider
             ["actort"] = ClaimTypes.Actor,
         }.ToFrozenDictionary(StringComparer.Ordinal);
 
-    /// <summary>Inverse lookup table built from <see cref="KnownShortToLongClaimNames"/>.</summary>
-    private static readonly FrozenDictionary<string, string> KnownLongToShortClaimNames =
+    /// <summary>
+    /// Inverse lookup table built from <see cref="KnownShortToLongClaimNames"/>: each long-form
+    /// URN maps to the <em>set</em> of short forms that alias to it. Multi-valued because
+    /// several short forms can collapse onto the same long form (e.g. <c>"sub"</c> and
+    /// <c>"nameid"</c> both alias to <see cref="ClaimTypes.NameIdentifier"/>; <c>"name"</c> and
+    /// <c>"unique_name"</c> both alias to <see cref="ClaimTypes.Name"/>; <c>"role"</c> and
+    /// <c>"roles"</c> both alias to <see cref="ClaimTypes.Role"/>). The reverse fallback must
+    /// iterate every candidate short form — picking only one canonical short form would
+    /// silently fail to resolve tokens carrying the alternate short variant and reproduce
+    /// the same silent-401 footgun this fallback exists to prevent.
+    /// </summary>
+    private static readonly FrozenDictionary<string, FrozenSet<string>> KnownLongToShortClaimNames =
         KnownShortToLongClaimNames
             .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
-            .ToFrozenDictionary(g => g.Key, g => g.First().Key, StringComparer.Ordinal);
+            .ToFrozenDictionary(
+                g => g.Key,
+                g => g.Select(kvp => kvp.Key).ToFrozenSet(StringComparer.Ordinal),
+                StringComparer.Ordinal);
 
     private readonly ILogger<ClaimsActorProvider>? _logger;
 
@@ -256,31 +269,51 @@ public class ClaimsActorProvider : IActorProvider
 
     /// <summary>
     /// Looks up <paramref name="configuredClaim"/> on the identity; if not found, tries the
-    /// well-known short↔long counterpart from <see cref="KnownShortToLongClaimNames"/>.
+    /// well-known short↔long counterpart(s) from <see cref="KnownShortToLongClaimNames"/>.
     /// Returns the resolved value, or <see langword="null"/> when neither form is present.
     /// </summary>
+    /// <remarks>
+    /// The forward direction (configured short → long) has a single counterpart per short
+    /// form. The reverse direction (configured long → short) iterates every short form that
+    /// aliases to the long form (e.g., <c>NameIdentifier</c> ← {<c>sub</c>, <c>nameid</c>};
+    /// <c>Name</c> ← {<c>name</c>, <c>unique_name</c>}; <c>Role</c> ← {<c>role</c>,
+    /// <c>roles</c>}) — picking only one short form would silently fail to resolve tokens
+    /// that carry the alternate variant.
+    /// </remarks>
     private string? ResolveClaimWithFallback(ClaimsIdentity identity, string configuredClaim)
     {
         var literal = identity.FindFirst(configuredClaim)?.Value;
         if (literal is not null)
             return literal;
 
-        // The configured claim wasn't found literally. Try the well-known counterpart.
-        string? counterpart = null;
+        // Forward direction: configured short form → its single long-form counterpart.
         if (KnownShortToLongClaimNames.TryGetValue(configuredClaim, out var longForm))
-            counterpart = longForm;
-        else if (KnownLongToShortClaimNames.TryGetValue(configuredClaim, out var shortForm))
-            counterpart = shortForm;
+        {
+            var forward = identity.FindFirst(longForm)?.Value;
+            if (forward is not null)
+            {
+                LogClaimNameFallback(_logger, configuredClaim, longForm);
+                return forward;
+            }
+        }
 
-        if (counterpart is null)
-            return null;
+        // Reverse direction: configured long form → iterate every short form that maps to it.
+        // Picking only one canonical short would miss tokens carrying the alternate variant
+        // (e.g., "nameid" instead of "sub" for ClaimTypes.NameIdentifier).
+        if (KnownLongToShortClaimNames.TryGetValue(configuredClaim, out var shortForms))
+        {
+            foreach (var shortForm in shortForms)
+            {
+                var reverse = identity.FindFirst(shortForm)?.Value;
+                if (reverse is not null)
+                {
+                    LogClaimNameFallback(_logger, configuredClaim, shortForm);
+                    return reverse;
+                }
+            }
+        }
 
-        var fallback = identity.FindFirst(counterpart)?.Value;
-        if (fallback is null)
-            return null;
-
-        LogClaimNameFallback(_logger, configuredClaim, counterpart);
-        return fallback;
+        return null;
     }
 
     private static readonly Action<ILogger, string, string, Exception?> _logClaimNameFallback =

--- a/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Frozen;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Trellis.Authorization;
 
@@ -63,12 +64,30 @@ public class ClaimsActorOptions
 {
     /// <summary>
     /// The claim type used to resolve the actor's unique identifier.
-    /// Defaults to <c>"sub"</c> (OIDC standard subject claim).
+    /// Defaults to <c>"sub"</c> (the RFC 7519 / OpenID Connect subject claim).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Matched against <see cref="System.Security.Claims.Claim.Type"/> verbatim;
     /// no dotted-path traversal. See the <see cref="ClaimsActorOptions"/> remarks
     /// for nested-claim guidance.
+    /// </para>
+    /// <para>
+    /// <b>JwtBearer <c>MapInboundClaims</c> robustness.</b> ASP.NET Core's
+    /// <c>JwtBearerOptions.MapInboundClaims</c> defaults to <see langword="true"/>,
+    /// which remaps RFC 7519 short claim names (e.g. <c>"sub"</c>) onto WS-* long-form
+    /// URNs (e.g. <see cref="System.Security.Claims.ClaimTypes.NameIdentifier"/>)
+    /// before they reach <see cref="System.Security.Claims.ClaimsIdentity"/>. If the
+    /// configured <see cref="ActorIdClaim"/> is not found literally,
+    /// <see cref="ClaimsActorProvider"/> automatically falls back to the well-known
+    /// short↔long counterpart from the JWT inbound claim-name map (<c>sub</c> ↔
+    /// <c>NameIdentifier</c>, <c>email</c> ↔ <c>Email</c>, <c>role</c>/<c>roles</c> ↔
+    /// <c>Role</c>, <c>name</c>/<c>unique_name</c> ↔ <c>Name</c>, etc.) so the default
+    /// configuration just-works with either <c>MapInboundClaims = true</c> or
+    /// <c>MapInboundClaims = false</c>. The fallback emits a debug-level log entry
+    /// when it fires. Recommended for new services: set <c>MapInboundClaims = false</c>
+    /// on <c>AddJwtBearer(...)</c> so claim names round-trip with their RFC names.
+    /// </para>
     /// </remarks>
     public string ActorIdClaim { get; set; } = "sub";
 
@@ -116,19 +135,83 @@ public class ClaimsActorOptions
 /// is a worked example.
 /// </para>
 /// </remarks>
-public class ClaimsActorProvider(
-    IHttpContextAccessor httpContextAccessor,
-    IOptions<ClaimsActorOptions> options) : IActorProvider
+public class ClaimsActorProvider : IActorProvider
 {
+    /// <summary>
+    /// Well-known short → long claim name pairs that match
+    /// <c>JwtSecurityTokenHandler.DefaultInboundClaimTypeMap</c> /
+    /// <c>JsonWebTokenHandler.DefaultInboundClaimTypeMap</c>. When
+    /// <c>JwtBearerOptions.MapInboundClaims = true</c> (the ASP.NET Core default),
+    /// the handler emits the long-form WS-* URN onto the <see cref="ClaimsIdentity"/>
+    /// instead of the short RFC 7519 / OIDC claim name. The provider treats these
+    /// pairs as equivalent: if the configured claim name is not found, the
+    /// counterpart from this map is tried as a fallback (Postel's-law robustness
+    /// against ASP.NET Core's legacy MapInboundClaims default — same shape that
+    /// <see cref="EntraActorProvider"/> uses for its <c>oid</c> lookup).
+    /// </summary>
+    /// <remarks>
+    /// Bidirectional lookup is performed in <see cref="ResolveClaimWithFallback"/>:
+    /// configured short → mapped long, configured long → mapped short.
+    /// Hardcoded to avoid taking a dependency on
+    /// <c>System.IdentityModel.Tokens.Jwt</c> from this package; the mapping table is
+    /// effectively frozen — no new entries have been added to the JWT inbound map
+    /// in years.
+    /// </remarks>
+    private static readonly FrozenDictionary<string, string> KnownShortToLongClaimNames =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["sub"] = ClaimTypes.NameIdentifier,
+            ["nameid"] = ClaimTypes.NameIdentifier,
+            ["name"] = ClaimTypes.Name,
+            ["unique_name"] = ClaimTypes.Name,
+            ["email"] = ClaimTypes.Email,
+            ["role"] = ClaimTypes.Role,
+            ["roles"] = ClaimTypes.Role,
+            ["family_name"] = ClaimTypes.Surname,
+            ["given_name"] = ClaimTypes.GivenName,
+            ["gender"] = ClaimTypes.Gender,
+            ["birthdate"] = ClaimTypes.DateOfBirth,
+            ["website"] = ClaimTypes.Webpage,
+            ["actort"] = ClaimTypes.Actor,
+        }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>Inverse lookup table built from <see cref="KnownShortToLongClaimNames"/>.</summary>
+    private static readonly FrozenDictionary<string, string> KnownLongToShortClaimNames =
+        KnownShortToLongClaimNames
+            .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
+            .ToFrozenDictionary(g => g.Key, g => g.First().Key, StringComparer.Ordinal);
+
+    private readonly ILogger<ClaimsActorProvider>? _logger;
+
+    /// <summary>
+    /// Initializes a new <see cref="ClaimsActorProvider"/>.
+    /// </summary>
+    /// <param name="httpContextAccessor">Accessor for the current request's <see cref="HttpContext"/>.</param>
+    /// <param name="options">Claim-name mapping options.</param>
+    /// <param name="logger">
+    /// Optional logger; when supplied, emits a debug-level message the first time the
+    /// short↔long claim-name fallback fires for a given request. Helpful for diagnosing
+    /// "always 401" issues caused by <c>JwtBearerOptions.MapInboundClaims = true</c>.
+    /// </param>
+    public ClaimsActorProvider(
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<ClaimsActorOptions> options,
+        ILogger<ClaimsActorProvider>? logger = null)
+    {
+        HttpContextAccessor = httpContextAccessor;
+        Options = options.Value;
+        _logger = logger;
+    }
+
     /// <summary>
     /// The HTTP context accessor used to retrieve the current user.
     /// </summary>
-    protected IHttpContextAccessor HttpContextAccessor { get; } = httpContextAccessor;
+    protected IHttpContextAccessor HttpContextAccessor { get; }
 
     /// <summary>
     /// The configured claim mapping options.
     /// </summary>
-    protected ClaimsActorOptions Options { get; } = options.Value;
+    protected ClaimsActorOptions Options { get; }
 
     /// <inheritdoc />
     public virtual Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
@@ -154,7 +237,12 @@ public class ClaimsActorProvider(
         // the framework's POV we can't identify the actor — same client-facing outcome as no
         // identity. (Whether this is a token-shape issue or a server-side option misconfig
         // is indistinguishable here; both want a 401 retry by the client.)
-        var actorId = identity.FindFirst(Options.ActorIdClaim)?.Value;
+        //
+        // Fallback: if the configured claim is one of the well-known JWT short↔long pairs
+        // (e.g., "sub" ↔ ClaimTypes.NameIdentifier), also try its counterpart. This is the
+        // robustness measure for ASP.NET Core's JwtBearerOptions.MapInboundClaims = true
+        // default, which silently remaps RFC 7519 short names onto WS-* long-form URNs.
+        var actorId = ResolveClaimWithFallback(identity, Options.ActorIdClaim);
         if (actorId is null)
             return Task.FromResult(Maybe<Actor>.None);
 
@@ -164,5 +252,51 @@ public class ClaimsActorProvider(
 
         var actor = Actor.Create(actorId, permissions);
         return Task.FromResult(Maybe.From(actor));
+    }
+
+    /// <summary>
+    /// Looks up <paramref name="configuredClaim"/> on the identity; if not found, tries the
+    /// well-known short↔long counterpart from <see cref="KnownShortToLongClaimNames"/>.
+    /// Returns the resolved value, or <see langword="null"/> when neither form is present.
+    /// </summary>
+    private string? ResolveClaimWithFallback(ClaimsIdentity identity, string configuredClaim)
+    {
+        var literal = identity.FindFirst(configuredClaim)?.Value;
+        if (literal is not null)
+            return literal;
+
+        // The configured claim wasn't found literally. Try the well-known counterpart.
+        string? counterpart = null;
+        if (KnownShortToLongClaimNames.TryGetValue(configuredClaim, out var longForm))
+            counterpart = longForm;
+        else if (KnownLongToShortClaimNames.TryGetValue(configuredClaim, out var shortForm))
+            counterpart = shortForm;
+
+        if (counterpart is null)
+            return null;
+
+        var fallback = identity.FindFirst(counterpart)?.Value;
+        if (fallback is null)
+            return null;
+
+        LogClaimNameFallback(_logger, configuredClaim, counterpart);
+        return fallback;
+    }
+
+    private static readonly Action<ILogger, string, string, Exception?> _logClaimNameFallback =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Debug,
+            new EventId(1, nameof(ClaimsActorProvider)),
+            "ClaimsActorProvider resolved actor id via short<->long claim-name fallback. " +
+            "Configured ActorIdClaim '{ConfiguredClaim}' was not present on the authenticated " +
+            "identity; resolved via the well-known counterpart '{ResolvedClaim}'. This typically " +
+            "indicates JwtBearerOptions.MapInboundClaims = true (the ASP.NET Core default); " +
+            "set MapInboundClaims = false to keep claim names round-tripping with their RFC 7519 / " +
+            "OIDC names. The fallback continues to accept both forms.");
+
+    private static void LogClaimNameFallback(ILogger<ClaimsActorProvider>? logger, string configured, string resolved)
+    {
+        if (logger is not null)
+            _logClaimNameFallback(logger, configured, resolved, null);
     }
 }

--- a/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
+++ b/Trellis.Asp/src/Authorization/ClaimsActorProvider.cs
@@ -202,8 +202,10 @@ public class ClaimsActorProvider : IActorProvider
     /// <param name="httpContextAccessor">Accessor for the current request's <see cref="HttpContext"/>.</param>
     /// <param name="options">Claim-name mapping options.</param>
     /// <param name="logger">
-    /// Optional logger; when supplied, emits a debug-level message the first time the
-    /// short↔long claim-name fallback fires for a given request. Helpful for diagnosing
+    /// Optional logger; when supplied, emits a debug-level message each time the
+    /// short↔long claim-name fallback resolves the actor id (no per-request
+    /// deduplication — the fallback runs at most once per request today, so the
+    /// log fires at most once per request as a consequence). Helpful for diagnosing
     /// "always 401" issues caused by <c>JwtBearerOptions.MapInboundClaims = true</c>.
     /// </param>
     public ClaimsActorProvider(

--- a/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
@@ -137,6 +137,60 @@ public class ClaimsActorProviderTests
             "custom claim names not in the JWT well-known mapping table get literal lookup only — no fallback");
     }
 
+    [Theory]
+    [InlineData("nameid")]
+    [InlineData("sub")]
+    public async Task GetCurrentActorAsync_LongFormConfigured_FallsBackToAnyShortFormThatMapsToIt_NameIdentifier(string shortForm)
+    {
+        // Multiple short forms can map to the same long form: both "sub" and "nameid" alias
+        // to ClaimTypes.NameIdentifier in the JWT inbound map. When the consumer configures
+        // the long form and the token carries EITHER short variant, the fallback must try
+        // every candidate short form — not just one canonical pick — otherwise the same
+        // silent-401 footgun reappears for the long-form-configured branch.
+        var user = AuthenticatedUser(new Claim(shortForm, $"value-{shortForm}"));
+        var options = new ClaimsActorOptions { ActorIdClaim = ClaimTypes.NameIdentifier };
+
+        var maybeActor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeTrue(
+            $"reverse fallback for ClaimTypes.NameIdentifier must accept any of its mapped short forms — including '{shortForm}'");
+        maybeActor.Unwrap().Id.Should().Be($"value-{shortForm}");
+    }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("unique_name")]
+    public async Task GetCurrentActorAsync_LongFormConfigured_FallsBackToAnyShortFormThatMapsToIt_Name(string shortForm)
+    {
+        // Same coverage for the "name" / "unique_name" → ClaimTypes.Name collision pair.
+        var user = AuthenticatedUser(new Claim(shortForm, $"value-{shortForm}"));
+        var options = new ClaimsActorOptions { ActorIdClaim = ClaimTypes.Name };
+
+        var maybeActor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeTrue(
+            $"reverse fallback for ClaimTypes.Name must accept any of its mapped short forms — including '{shortForm}'");
+        maybeActor.Unwrap().Id.Should().Be($"value-{shortForm}");
+    }
+
+    [Theory]
+    [InlineData("role")]
+    [InlineData("roles")]
+    public async Task GetCurrentActorAsync_LongFormConfigured_FallsBackToAnyShortFormThatMapsToIt_Role(string shortForm)
+    {
+        // Same coverage for the "role" / "roles" → ClaimTypes.Role collision pair.
+        // Completes the matrix: every long-form key in KnownLongToShortClaimNames that has
+        // more than one short-form mapping is exercised in both directions.
+        var user = AuthenticatedUser(new Claim(shortForm, $"value-{shortForm}"));
+        var options = new ClaimsActorOptions { ActorIdClaim = ClaimTypes.Role };
+
+        var maybeActor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeTrue(
+            $"reverse fallback for ClaimTypes.Role must accept any of its mapped short forms — including '{shortForm}'");
+        maybeActor.Unwrap().Id.Should().Be($"value-{shortForm}");
+    }
+
     #endregion
 
     #region Custom claim mapping

--- a/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/ClaimsActorProviderTests.cs
@@ -63,6 +63,82 @@ public class ClaimsActorProviderTests
 
     #endregion
 
+    #region MapInboundClaims fallback — JwtBearerHandler default-config compatibility
+
+    [Fact]
+    public async Task GetCurrentActorAsync_DefaultActorIdClaim_FallsBackToLongFormUrn_WhenJwtMapInboundClaimsRemappedSub()
+    {
+        // ASP.NET Core's JwtBearerHandler defaults to MapInboundClaims = true, which remaps
+        // the RFC 7519 / OIDC short claim name "sub" onto the WS-* long-form URN
+        // ClaimTypes.NameIdentifier. With the default ClaimsActorOptions.ActorIdClaim = "sub",
+        // the literal lookup fails and the provider returns Maybe.None — the mediator then
+        // emits 401 on every authenticated request, indistinguishable from "no token". This
+        // is the most common Trellis + JwtBearer integration footgun.
+        //
+        // The fallback resolves the actor id from the long-form WS-* URN counterpart when
+        // the configured short-form claim is not found (and vice versa) — same Postel's-law
+        // robustness pattern EntraActorProvider already uses for its oid lookup.
+        var user = AuthenticatedUser(new Claim(ClaimTypes.NameIdentifier, "user-sub-123"));
+
+        var maybeActor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeTrue(
+            "ClaimsActorProvider should resolve actor id via the WS-* long-form URN fallback when JwtBearerHandler's default MapInboundClaims has remapped the 'sub' claim");
+        maybeActor.Unwrap().Id.Should().Be("user-sub-123");
+    }
+
+    [Fact]
+    public async Task GetCurrentActorAsync_CustomActorIdClaim_FallsBackToShortForm_WhenLongFormConfiguredButShortFormPresent()
+    {
+        // Reverse direction: consumer explicitly set ActorIdClaim to the long-form URN
+        // (e.g., to match older code) but the token's identity carries the short-form claim
+        // (because MapInboundClaims = false was set on JwtBearerHandler). The fallback runs
+        // bidirectionally so both configurations resolve.
+        var user = AuthenticatedUser(new Claim("sub", "user-sub-456"));
+        var options = new ClaimsActorOptions { ActorIdClaim = ClaimTypes.NameIdentifier };
+
+        var maybeActor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeTrue(
+            "fallback is bidirectional — configured long-form should also try the short-form counterpart");
+        maybeActor.Unwrap().Id.Should().Be("user-sub-456");
+    }
+
+    [Fact]
+    public async Task GetCurrentActorAsync_ActorIdClaim_PrefersLiteralMatchOverFallback_WhenBothShortAndLongFormPresent()
+    {
+        // When the configured claim matches a real claim on the identity, the literal match
+        // wins — no fallback is consulted. Defensive case for tokens that carry both forms
+        // (e.g., MapInboundClaims true + an explicit "sub" claim added by the IdP); we want
+        // the user's configured intent to drive resolution.
+        var user = AuthenticatedUser(
+            new Claim("sub", "literal-match"),
+            new Claim(ClaimTypes.NameIdentifier, "fallback-match"));
+
+        var maybeActor = await CreateProvider(user).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.Unwrap().Id.Should().Be("literal-match",
+            "the literal match on the configured claim name takes precedence over the fallback");
+    }
+
+    [Fact]
+    public async Task GetCurrentActorAsync_ActorIdClaim_NotInKnownMapping_DoesNotFireFallback()
+    {
+        // The fallback only covers the specific short↔long claim names that JwtBearerHandler's
+        // DefaultInboundClaimTypeMap remaps. Arbitrary custom claim names (consumer-supplied,
+        // not in the well-known JWT inbound mapping) get literal-only lookup — no fuzzy
+        // matching against unrelated claims.
+        var user = AuthenticatedUser(new Claim("some-other-claim", "value"));
+        var options = new ClaimsActorOptions { ActorIdClaim = "tenant-custom-id" };
+
+        var maybeActor = await CreateProvider(user, options).GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        maybeActor.HasValue.Should().BeFalse(
+            "custom claim names not in the JWT well-known mapping table get literal lookup only — no fallback");
+    }
+
+    #endregion
+
     #region Custom claim mapping
 
     [Fact]

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -414,8 +414,8 @@ public class ClaimsActorOptions
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `ActorIdClaim` | `string` | Claim type used for `Actor.Id`. Default: `"sub"`. Matched verbatim against `Claim.Type`; no dotted/JSON-path traversal. |
-| `PermissionsClaim` | `string` | Claim type used for permissions. Default: `"permissions"`. Multi-valued JWT claims arrive as repeated `Claim` instances and are aggregated via `FindAll`. |
+| `ActorIdClaim` | `string` | Claim type used for `Actor.Id`. Default: `"sub"` (RFC 7519 / OIDC subject claim). Matched against `Claim.Type` literally first; if the configured name is not found, falls back to its well-known short↔long counterpart from the JWT inbound claim-name map (e.g., `"sub"` ↔ `ClaimTypes.NameIdentifier`, `"email"` ↔ `ClaimTypes.Email`, `"role"`/`"roles"` ↔ `ClaimTypes.Role`, `"name"`/`"unique_name"` ↔ `ClaimTypes.Name`). The bidirectional fallback makes the default just-work against both `JwtBearerOptions.MapInboundClaims = true` (ASP.NET default, remaps short → long-form URN) and `MapInboundClaims = false`. The fallback emits a debug-level log entry when it fires. No dotted/JSON-path traversal. |
+| `PermissionsClaim` | `string` | Claim type used for permissions. Default: `"permissions"`. Multi-valued JWT claims arrive as repeated `Claim` instances and are aggregated via `FindAll`. Literal-match only — does **not** use the short↔long fallback (the most common permissions claim shape, `"permissions"`, is not in the JWT inbound map; for `"roles"`/`"role"` consumers should either set `MapInboundClaims = false` on `AddJwtBearer` or configure `PermissionsClaim = ClaimTypes.Role` explicitly). |
 
 ### `ClaimsActorProvider`
 

--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -123,8 +123,8 @@ For any flat-claim OIDC token where you can name the id and permissions claim ty
 
 | Member | Default | Notes |
 |---|---|---|
-| `ClaimsActorOptions.ActorIdClaim` | `"sub"` | Verbatim claim-type match — no JSON-path traversal. |
-| `ClaimsActorOptions.PermissionsClaim` | `"permissions"` | Multi-valued JWT claims arrive as repeated `Claim` instances and are aggregated via `FindAll`. |
+| `ClaimsActorOptions.ActorIdClaim` | `"sub"` (RFC 7519 / OIDC subject claim) | Literal `Claim.Type` match first; if not found, falls back to the well-known short↔long counterpart (e.g., `"sub"` ↔ `ClaimTypes.NameIdentifier`) so the default just-works against either `JwtBearerOptions.MapInboundClaims = true` or `false`. Emits a debug-level log entry when the fallback fires. No JSON-path traversal. |
+| `ClaimsActorOptions.PermissionsClaim` | `"permissions"` | Multi-valued JWT claims arrive as repeated `Claim` instances and are aggregated via `FindAll`. Literal-only (no short↔long fallback) — see options table in [trellis-api-asp.md](../api_reference/trellis-api-asp.md#claimsactoroptions). |
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -136,6 +136,8 @@ builder.Services.AddClaimsActorProvider(options =>
     options.PermissionsClaim = "permissions";
 });
 ```
+
+> **JwtBearer integration tip.** ASP.NET Core's `AddJwtBearer(...)` defaults to `MapInboundClaims = true`, which remaps the JWT `"sub"` claim onto the WS-* long-form URN (`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`) before the principal reaches Trellis. `ClaimsActorProvider`'s short↔long claim-name fallback hides this from you — the default `ActorIdClaim = "sub"` resolves the actor correctly under either setting. New services should set `MapInboundClaims = false` on `AddJwtBearer(...)` to keep claim names round-tripping with their RFC 7519 names; the fallback continues to accept both forms.
 
 `ClaimsActorProvider.GetCurrentActorAsync` is `virtual` — subclass it to compute permissions from nested claims, look them up in a store, etc., then register your subclass via `AddCachingActorProvider<TYourProvider>()` to amortize the cost across the request.
 


### PR DESCRIPTION
**Issue:** Default `ClaimsActorOptions.ActorIdClaim = "sub"` (RFC 7519 / OIDC standard) combined with ASP.NET Core's `JwtBearerOptions.MapInboundClaims = true` default causes **401 on every authenticated request**. `MapInboundClaims = true` remaps the JWT `"sub"` claim onto the WS-* long-form URN `ClaimTypes.NameIdentifier` before the principal reaches Trellis. The literal `FindFirst("sub")` lookup then finds nothing, the provider returns `Maybe<Actor>.None`, and the mediator emits 401 — indistinguishable on the wire from "no token". The most common Trellis + JwtBearer integration footgun, surfaced by the recent ASP.NET Core 10 authorization research survey.

**Fix:** `ClaimsActorProvider` resolves `ActorIdClaim` literally first; if not found, falls back to the well-known short↔long counterpart from the JWT inbound claim-name map (`sub` ↔ `NameIdentifier`, `email` ↔ `Email`, `role`/`roles` ↔ `Role`, `name`/`unique_name` ↔ `Name`, `family_name` ↔ `Surname`, `given_name` ↔ `GivenName`, `gender` ↔ `Gender`, `birthdate` ↔ `DateOfBirth`, `website` ↔ `Webpage`, `actort` ↔ `Actor`, `nameid` ↔ `NameIdentifier`). Bidirectional. Literal match always takes precedence when both forms are present. Emits a debug-level log entry when the fallback fires so operators can spot the `MapInboundClaims = true` default in their pipeline.

Same Postel's-law robustness pattern `EntraActorProvider` has used for its `oid` ↔ `objectidentifier` lookup since the package shipped. Keeps the RFC-aligned `"sub"` default — consumers do not need to know about WS-* URN conventions. The hardcoded mapping table avoids taking a dependency on `System.IdentityModel.Tokens.Jwt`.

`PermissionsClaim` remains literal-only — documented with a hint to set `MapInboundClaims = false` or use `ClaimTypes.Role` explicitly when consuming the `"roles"` claim.

`ClaimsActorProvider`'s constructor gained an optional `ILogger<ClaimsActorProvider>` parameter (default `null`); the default `AddClaimsActorProvider(...)` registration extension wires it automatically via DI. `EntraActorProvider` (subclass with its own `GetCurrentActorAsync` override) is unaffected — its overridden method does its own `oid` resolution path.

Docs updated: `trellis-api-asp.md` (`ClaimsActorOptions` table), `integration-asp-authorization.md` (Generic claims provider section + JwtBearer integration callout), `CHANGELOG.md`.