### PR TITLE
SSO-first IA: multi-IdP hub with Google, Apple, Android, Facebook recipes

### DIFF
--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -21,6 +21,7 @@ sequenceDiagram
     autonumber
     participant Client
     participant JwtBearer
+    participant Endpoint
     participant Pipeline as Mediator pipeline
     participant Provider as IActorProvider
     participant Auth as AuthorizationBehavior
@@ -31,28 +32,32 @@ sequenceDiagram
     JwtBearer->>JwtBearer: Validate signature expiry issuer audience
     JwtBearer->>JwtBearer: Project claims onto HttpContext.User
     Note right of JwtBearer: MapInboundClaims remaps short to long form
-    JwtBearer->>Pipeline: Endpoint invoked
+    JwtBearer->>Endpoint: Authenticated request
+    Endpoint->>Pipeline: Send command or query
     Pipeline->>Provider: GetCurrentActorAsync
     Provider-->>Pipeline: Maybe of Actor
 
     alt No usable actor
-        Pipeline-->>Client: 401 with synthesized WWW-Authenticate
+        Pipeline-->>Endpoint: Error Unauthorized
+        Endpoint-->>Client: 401 with synthesized WWW-Authenticate
     else Actor resolved
         Pipeline->>Auth: Check IAuthorize.RequiredPermissions
     end
 
     alt Static permission missing
-        Auth-->>Client: 403 Forbidden
+        Auth-->>Endpoint: Error Forbidden
+        Endpoint-->>Client: 403 Forbidden
     else Static permission ok
         Auth->>ResAuth: Load resource and call Authorize
     end
 
     alt Resource auth denied
-        ResAuth-->>Client: 403 Forbidden
+        ResAuth-->>Endpoint: Error Forbidden
+        Endpoint-->>Client: 403 Forbidden
     else Authorized
         ResAuth->>Handler: Invoke
-        Handler-->>ResAuth: Result of T
-        ResAuth-->>Client: Endpoint maps via ToHttpResponse to 200 or 201 or 204
+        Handler-->>Endpoint: Result of T
+        Endpoint-->>Client: ToHttpResponse maps to 200 or 201 or 204
     end
 ```
 
@@ -228,7 +233,7 @@ The actor providers ship in `Trellis.Asp` under namespace `Trellis.Asp.Authoriza
 
 ## Quick start
 
-Authenticate with `JwtBearer`, register `EntraActorProvider`, then read the current `Actor` from any endpoint or handler.
+Authenticate with `JwtBearer` against any OIDC provider, register an `IActorProvider`, then read the current `Actor` from any endpoint or handler. This article shows the framework mechanics; for IdP-specific wiring (Google, Microsoft Entra ID, Apple, Auth0, Okta, Keycloak, Facebook) see [Single Sign-On Integration](integration-sso.md).
 
 ```csharp
 using System.Linq;
@@ -236,27 +241,34 @@ using System.Threading;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
+var auth = builder.Configuration.GetSection("Authentication");
 
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        // Required: keep claim names round-tripping with their RFC 7519 / OIDC short forms.
-        // Without this, JwtBearer remaps "tid", "amr", "sub" etc. onto WS-* long-form URNs
-        // before they reach HttpContext.User. EntraActorProvider's default MapAttributes
-        // checks short claim names directly ("tid", "amr") so the default ABAC attributes
-        // — Actor.GetAttribute(ActorAttributes.TenantId) and ActorAttributes.MfaAuthenticated
-        // — would silently come back empty / false under the ASP.NET default of true.
-        // See "MapInboundClaims and the short↔long fallback" below for the deeper trap.
+        options.Authority = auth["Authority"];   // e.g. https://your-tenant.auth0.com/
+        options.Audience  = auth["Audience"];    // your API audience
+
+        // Recommended: keep claim names round-tripping with their RFC 7519 / OIDC short forms.
+        // ASP.NET Core's default of `true` silently remaps short claim names ("sub", "tid", "amr")
+        // onto WS-* long-form URNs before they reach HttpContext.User. The actor providers'
+        // short↔long fallback hides this, but configuring it explicitly keeps the wire shape
+        // predictable. See "MapInboundClaims and the short↔long fallback" below for the trap.
         options.MapInboundClaims = false;
     });
 builder.Services.AddAuthorization();
-builder.Services.AddEntraActorProvider();
+builder.Services.AddClaimsActorProvider(options =>
+{
+    options.ActorIdClaim     = "sub";
+    options.PermissionsClaim = "permissions";
+});
 
 var app = builder.Build();
 
@@ -273,8 +285,6 @@ app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationT
     {
         actor.Id,
         Permissions = actor.Permissions.OrderBy(p => p).ToArray(),
-        TenantId = actor.GetAttribute(ActorAttributes.TenantId),
-        Mfa = actor.GetAttribute(ActorAttributes.MfaAuthenticated),
     });
 });
 
@@ -284,7 +294,12 @@ app.Run();
 > [!NOTE]
 > The provider extracts an `Actor` from `HttpContext.User`. It does **not** validate tokens — keep your normal authentication middleware in place.
 
+> [!TIP]
+> Microsoft Entra ID consumers can substitute `AddEntraActorProvider()` for `AddClaimsActorProvider(...)` to opt in to Entra-specific defaults (App Roles via `roles`, ABAC attributes from `tid` / `oid` / `amr`). See [SSO → Microsoft (Entra ID)](integration-sso.md#microsoft-entra-id).
+
 ## Entra ID provider
+
+For IdP wiring (Authority URL, audience format, multi-tenant pinning), see [SSO → Microsoft (Entra ID)](integration-sso.md#microsoft-entra-id). The table below covers the framework-side options.
 
 | Member | Default | Override to... |
 |---|---|---|
@@ -296,6 +311,8 @@ app.Run();
 `EntraActorProvider` returns `Maybe<Actor>.None` when no authenticated `ClaimsIdentity` exists or the configured `IdClaimType` is missing from the identity. The short `oid` fallback runs only when `IdClaimType` is left at the default long-form objectidentifier URI (`http://schemas.microsoft.com/identity/claims/objectidentifier`); a non-default `IdClaimType` (e.g. `"sub"`, `"upn"`) is looked up literally with no fallback. The mediator authorization pipeline maps `Maybe.None` to `Error.Unauthorized` (HTTP 401, RFC 9110 §15.5.2). It throws `InvalidOperationException` only when invoked outside an HTTP request scope (no `HttpContext`) — a configuration bug that surfaces as HTTP 500. Any exception thrown by `MapPermissions`, `MapForbiddenPermissions`, or `MapAttributes` is rewrapped in `InvalidOperationException` naming the failing delegate.
 
 ## Generic claims provider
+
+For IdP-specific Quick starts (Google, Apple, Auth0, Okta, Keycloak, Facebook-via-bridge), see [SSO → Provider recipes](integration-sso.md#provider-recipes). The table below covers the framework-side options.
 
 For any flat-claim OIDC token where you can name the id and permissions claim types directly.
 
@@ -776,7 +793,7 @@ If your provider derives actor identity from request data that cannot be cleanly
 
 ## Composition
 
-`AddCachingActorProvider<TInner>()` decorates *any* `IActorProvider` — including a `ClaimsActorProvider` subclass you authored — without changing handler code. Mediator-side composition (which behaviors run, what each emits) is canonical in [Mediator integration](#mediator-integration); for guards that don't fit any mediator authorization shape, the framework supports two escape hatches in order of preference: (1) `IAuthorizeResource<TProjection>` + a custom `IResourceLoader<TMessage, TProjection>` that shapes the projection however your rule needs (see [Resource-based checks](#resource-based-checks-via-iauthorizeresourcetresource)) so the gate stays declarative; (2) plain `Actor` predicates inside a handler's `Result` chain, for guards that depend on handler-local state, span multiple aggregates the mediator pipeline never loads together, or are reused from a service-layer helper called outside the mediator pipeline. The handler-side shape:
+`AddCachingActorProvider<TInner>()` decorates *any* `IActorProvider` — including a `ClaimsActorProvider` subclass you authored — without changing handler code. Mediator-side composition (which behaviors run, what each emits) is canonical in [Mediator integration](#mediator-integration); for a guard that doesn't fit the standard static/load-by-id/via shapes, the framework supports two escape hatches in order of preference: (1) `IAuthorizeResource<TProjection>` + a custom `IResourceLoader<TMessage, TProjection>` that shapes the projection however your rule needs (see [Resource-based checks](#resource-based-checks-via-iauthorizeresourcetresource)) so the gate stays declarative; (2) plain `Actor` predicates inside a handler's `Result` chain, for guards that depend on handler-local state, span multiple aggregates the mediator pipeline never loads together, or are reused from a service-layer helper called outside the mediator pipeline. The handler-side shape:
 
 ```csharp
 using System.Threading;

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -580,10 +580,10 @@ builder.Services.AddAuthorization(options =>
 });
 ```
 
-Each request goes through every listed scheme until one succeeds. The first scheme whose `Authority` / `Audience` matches the token's `iss` / `aud` validates it; the others short-circuit. `HttpContext.User` ends up with the validated principal regardless of which scheme won.
+For each request, ASP.NET Core's `PolicyEvaluator` invokes every scheme listed in the policy and merges the successful principals into `HttpContext.User`. With a single bearer token the issuer/audience match makes exactly one scheme succeed; the others return `AuthenticateResult.NoResult` and contribute nothing. The downstream actor provider sees one validated principal regardless of which scheme matched.
 
 > [!NOTE]
-> If you set a default scheme on `AddAuthentication("Microsoft")`, only that scheme runs by default and the other tokens come back 401. Either omit the default and list every scheme in the authorization policy (as above), or set a [forwarding scheme](https://learn.microsoft.com/aspnet/core/security/authentication/policyschemes) that picks per-request.
+> If your authorization policy does **not** list every scheme, only the default scheme runs and tokens from the other IdPs come back 401. The pattern above sidesteps that by enumerating all schemes in the policy. As an alternative, a [forwarding scheme](https://learn.microsoft.com/aspnet/core/security/authentication/policyschemes) (`AddPolicyScheme(...)` with a `ForwardDefaultSelector` that picks per-request based on token `iss`) lets you keep a single default scheme.
 
 ### Pick an actor provider strategy
 
@@ -655,7 +655,7 @@ For a multi-IdP API the simplest pattern is to derive a stable user key from `(i
 
 - **One audience per scheme.** Each `AddJwtBearer("<scheme>", ...)` validates exactly one (or via `ValidAudiences`, a set of) audience values. A token whose `aud` matches no scheme returns HTTP 401.
 - **Same scope, different schemes.** All registered schemes share `HttpContext.User` — once a token validates, the downstream actor provider, mediator pipeline, and handlers don't know (and don't need to know) which IdP issued it.
-- **WWW-Authenticate.** When every scheme rejects the token, Trellis's [`ResponseFailureWriter` synthesizes a `WWW-Authenticate` header](integration-asp-authorization.md#anatomy-of-a-401) listing each registered Bearer scheme so the client knows which IdPs the API accepts.
+- **WWW-Authenticate.** Trellis's [`ResponseFailureWriter`](integration-asp-authorization.md#anatomy-of-a-401) synthesizes a single `WWW-Authenticate` header from the configured *default* challenge / authenticate scheme — it does not enumerate every registered scheme. With the parameterless `AddAuthentication()` shown above there is no default, so the synthesizer emits nothing. If you need clients to discover multiple Bearer challenges, either (a) set a default scheme on `AddAuthentication("<scheme>")` so synthesis fires, accepting that only that scheme's name is advertised, or (b) emit explicit challenges per scheme via `Error.Unauthorized.Challenges` from your handler / failure mapper, which `ResponseFailureWriter` writes verbatim ahead of the synthesis path.
 - **Diagnostics.** Log `iss` and the winning scheme on first request from each IdP — silent "wrong scheme picked" is almost always an audience mismatch.
 
 ## JWT validation options

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -1,32 +1,35 @@
 ﻿---
 title: Single Sign-On Integration
 package: Trellis.Asp
-topics: [sso, entra, openid, jwt, claims, actor, multi-tenant]
+topics: [sso, oidc, google, entra, microsoft, facebook, auth0, okta, keycloak, jwt, claims, actor, multi-tenant]
 related_api_reference: [trellis-api-asp.md, trellis-api-authorization.md, trellis-api-core.md]
-last_verified: 2026-05-01
+last_verified: 2026-05-15
 audience: [developer]
 ---
 # Single Sign-On Integration
 
-`Trellis.Asp.Authorization` (shipped inside the `Trellis.Asp` package) turns an authenticated `JwtBearer` principal from any OIDC issuer (Entra ID, Auth0, Okta, Google, Keycloak) into a frozen `Actor` so handlers and endpoints stop parsing JWTs.
+`Trellis.Asp.Authorization` (shipped inside the `Trellis.Asp` package) turns an authenticated `JwtBearer` principal from **any OIDC issuer** — Google, Microsoft Entra ID, Facebook, Auth0, Okta, Keycloak, or your own OpenID Connect server — into a frozen `Actor` so handlers and endpoints stop parsing JWTs.
+
+This article is the **entry point** for wiring authentication into a Trellis service. For framework-side authorization mechanics (mediator behaviors, resource authorization, the decision tree, cache partitioning) see [ASP.NET Core Authorization](integration-asp-authorization.md).
 
 ## Patterns Index
 
 | Goal | Use | See |
 |---|---|---|
-| Validate Entra ID v2.0 tokens and project them onto an `Actor` | `AddJwtBearer` + `AddEntraActorProvider(options?)` | [Entra ID provider](#entra-id-provider) |
-| Validate any flat-claim OIDC token (Auth0, Okta, Google) | `AddJwtBearer` + `AddClaimsActorProvider(options?)` | [Generic OIDC provider](#generic-oidc-provider) |
-| Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddClaimsActorProvider(opts?)` for options + `AddCachingActorProvider<T>()` for the wrap | [Nested-claim providers](#nested-claim-providers) |
-| Use `roles` for app permissions (Entra app roles) | Default `EntraActorOptions.MapPermissions` | [Claim mapping](#claim-mapping) |
-| Use delegated scopes (`scp`) for permissions | Override `EntraActorOptions.MapPermissions` | [Scope and permission extraction](#scope-and-permission-extraction) |
-| Accept multi-tenant Entra tokens and pin allowed tenants | `JwtBearerOptions.TokenValidationParameters` + read `ActorAttributes.TenantId` | [Multi-tenant Entra](#multi-tenant-entra) |
+| Validate any standards-compliant OIDC token (Google, Auth0, Okta, Keycloak, custom) | `AddJwtBearer` + `AddClaimsActorProvider(options?)` | [Generic OIDC](#generic-oidc) |
+| Validate Microsoft Entra ID v2.0 tokens with `oid` / `roles` / `tid` / `amr` defaults | `AddJwtBearer` + `AddEntraActorProvider(options?)` | [Microsoft (Entra ID)](#microsoft-entra-id) |
+| Validate Google ID tokens | Authority `https://accounts.google.com` + `ValidIssuers` accepting both forms | [Google sign-in](#google-sign-in) |
+| Validate Sign in with Apple ID tokens from an iOS/macOS app | Authority `https://appleid.apple.com` + bundle id as `Audience` | [Sign in with Apple (iOS / macOS app)](#sign-in-with-apple-ios--macos-app) |
+| Validate Facebook tokens via an OIDC bridge | Authority for your bridge (Auth0/Cognito/etc.) + `AddClaimsActorProvider` | [Facebook (via OIDC bridge)](#facebook-via-oidc-bridge) |
+| Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddCachingActorProvider<T>()` | [Keycloak / nested claims](#keycloak--nested-claims) |
+| Flatten roles, scopes, or `scp` into application permissions | Override `EntraActorOptions.MapPermissions` or use a custom `IActorProvider` | [Scope and permission extraction](#scope-and-permission-extraction) |
+| Accept multi-tenant Entra tokens and pin allowed tenants | `JwtBearerOptions.TokenValidationParameters` + `ActorAttributes.TenantId` | [Multi-tenant Entra](#multi-tenant-entra) |
 | Use a fake actor in Development without a real IdP | `AddDevelopmentActorProvider(options?)` + `X-Test-Actor` header | [Development defaults](#development-defaults) |
-| Combine SSO with Trellis authorization rules | `IAuthorize` / `IAuthorizeResource<T>` via Mediator | [Composition](#composition) |
 
 ## Use this guide when
 
 - You front a Trellis service with `JwtBearer` and need a single, predictable `Actor` shape regardless of which OIDC provider issued the token.
-- You want one configuration story for Entra (app roles), Auth0/Okta (delegated scopes), Google (sign-in only), and Keycloak (nested role claims).
+- You need one configuration story for Google, Sign in with Apple, Microsoft (Entra), Facebook (via an OIDC bridge), Auth0, Okta, and Keycloak.
 - You need a Development-only seam (`X-Test-Actor`) that fail-closes outside `IsDevelopment()`.
 - You need to host a multi-tenant Entra app and pin which tenants may call your API.
 
@@ -36,12 +39,12 @@ audience: [developer]
 
 | API | Kind | Purpose |
 |---|---|---|
-| `AddEntraActorProvider(this IServiceCollection, Action<EntraActorOptions>?)` | DI extension | Scoped `IActorProvider` → `EntraActorProvider` (Entra v2.0 claim shape). |
-| `AddClaimsActorProvider(this IServiceCollection, Action<ClaimsActorOptions>?)` | DI extension | Scoped `IActorProvider` → `ClaimsActorProvider` (configurable flat-claim mapping). |
+| `AddClaimsActorProvider(this IServiceCollection, Action<ClaimsActorOptions>?)` | DI extension | Scoped `IActorProvider` → `ClaimsActorProvider`. The general-purpose provider for any flat-claim OIDC token. |
+| `AddEntraActorProvider(this IServiceCollection, Action<EntraActorOptions>?)` | DI extension | Scoped `IActorProvider` → `EntraActorProvider` (Microsoft Entra ID v2.0 claim shape with `oid` / `roles` / `tid` / `amr` defaults). |
 | `AddDevelopmentActorProvider(this IServiceCollection, Action<DevelopmentActorOptions>?)` | DI extension | Scoped `IActorProvider` → `DevelopmentActorProvider`; reads `X-Test-Actor` JSON header; throws outside `IsDevelopment()`. |
 | `AddCachingActorProvider<T>(this IServiceCollection)` where `T : class, IActorProvider` | DI extension | Wraps `T` in `CachingActorProvider` so a single resolution task is shared per request. |
+| `ClaimsActorOptions` | Options | `ActorIdClaim` (default `"sub"`), `PermissionsClaim` (default `"permissions"`). `Claim.Type` literal match, plus a bidirectional fallback through the provider's curated short↔long mapping table. |
 | `EntraActorOptions` | Options | `IdClaimType`, `MapPermissions`, `MapForbiddenPermissions`, `MapAttributes`. |
-| `ClaimsActorOptions` | Options | `ActorIdClaim` (default `"sub"`), `PermissionsClaim` (default `"permissions"`). `Claim.Type` literal match, plus a bidirectional fallback through the provider's curated short↔long mapping table (`"sub"` ↔ `ClaimTypes.NameIdentifier`, `"role"`/`"roles"` ↔ `ClaimTypes.Role`, etc.). |
 | `DevelopmentActorOptions` | Options | `DefaultActorId`, `DefaultPermissions`, `ThrowOnMalformedHeader`. |
 | `ActorAttributes` (in `Trellis.Authorization`) | Constants | Well-known attribute keys: `TenantId`, `PreferredUsername`, `AuthorizedParty`, `AuthorizedPartyAcr`, `AuthContextClassReference`, `IpAddress`, `MfaAuthenticated`. |
 
@@ -53,11 +56,11 @@ Full signatures: [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md).
 dotnet add package Trellis.Asp
 ```
 
-The actor providers ship in `Trellis.Asp` under namespace `Trellis.Asp.Authorization`. Domain primitives (`Actor`, `IActorProvider`, `ActorAttributes`) come from `Trellis.Authorization`. The legacy `Trellis.Asp.Authorization` package was absorbed into `Trellis.Asp`.
+The actor providers ship in `Trellis.Asp` under namespace `Trellis.Asp.Authorization`. Domain primitives (`Actor`, `IActorProvider`, `ActorAttributes`) come from `Trellis.Authorization`.
 
 ## Quick start
 
-Validate Entra v2.0 tokens with the standard ASP.NET Core `JwtBearer` middleware, register `EntraActorProvider`, and read the resolved `Actor` from a protected endpoint.
+Validate any OIDC token (Auth0, Google, Okta, custom) with the standard ASP.NET Core `JwtBearer` middleware, register `ClaimsActorProvider`, and read the resolved `Actor` from a protected endpoint. The example below uses Auth0; substitute your own `Authority` and `Audience`.
 
 ```csharp
 using System.Linq;
@@ -77,12 +80,20 @@ builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = auth["Authority"];
-        options.Audience  = auth["Audience"];
+        options.Authority = auth["Authority"];   // e.g. https://your-tenant.auth0.com/
+        options.Audience  = auth["Audience"];    // your API audience
+        // Recommended: keep claim names round-tripping with RFC 7519 / OIDC short forms.
+        // ASP.NET Core's default of `true` silently remaps short claim names onto WS-* URNs
+        // before they reach the actor provider — set false unless you know you need it.
+        options.MapInboundClaims = false;
     });
 
 builder.Services.AddAuthorization();
-builder.Services.AddEntraActorProvider();
+builder.Services.AddClaimsActorProvider(options =>
+{
+    options.ActorIdClaim     = "sub";
+    options.PermissionsClaim = "permissions";
+});
 
 var app = builder.Build();
 
@@ -99,8 +110,6 @@ app.MapGet("/me", [Authorize] async (IActorProvider actorProvider, CancellationT
     {
         actor.Id,
         Permissions = actor.Permissions.OrderBy(p => p).ToArray(),
-        TenantId = actor.GetAttribute(ActorAttributes.TenantId),
-        Mfa      = actor.GetAttribute(ActorAttributes.MfaAuthenticated),
     });
 });
 
@@ -112,29 +121,50 @@ Matching `appsettings.json`:
 ```json
 {
   "Authentication": {
-    "Authority": "https://login.microsoftonline.com/<tenant-id>/v2.0",
-    "Audience":  "<api-client-id>"
+    "Authority": "https://your-tenant.auth0.com/",
+    "Audience":  "https://api.example.com"
   }
 }
 ```
 
 > [!NOTE]
-> The actor provider extracts an `Actor` from `HttpContext.User`. It does not validate tokens — keep `AddJwtBearer` (or any other authentication scheme) in front of it.
+> The actor provider extracts an `Actor` from `HttpContext.User`. It does not validate tokens — keep `AddJwtBearer` (or any other authentication scheme) in front of it. For the framework's failure-mode contract (when `Maybe<Actor>.None` becomes 401 vs when a configuration bug becomes 500), see [ASP.NET Core Authorization → Mental model](integration-asp-authorization.md#mental-model).
 
-## Provider configuration
+> [!TIP]
+> Microsoft Entra ID consumers can substitute `AddEntraActorProvider()` for `AddClaimsActorProvider(...)` to opt in to Entra-specific defaults (App Roles, ABAC attributes from `tid`/`oid`/`amr`, multi-tenant). See [Microsoft (Entra ID)](#microsoft-entra-id) below.
+
+## Provider recipes
 
 Pick one provider per environment. The choice is driven by token shape, not by sign-in protocol.
 
 | Provider | Use when |
 |---|---|
+| `ClaimsActorProvider` | Token has a flat actor-id claim and a flat permissions claim (most OIDC issuers — Auth0, Okta, Google, custom). |
 | `EntraActorProvider` | Issuer is Microsoft Entra ID v2.0 and you want `oid` / `roles` / `tid` / `amr` mapped out of the box. |
-| `ClaimsActorProvider` | Token has a flat actor-id claim and a flat permissions claim (Auth0 `permissions`, Okta `scp`, custom OIDC). |
 | Subclass of `ClaimsActorProvider` | Token has nested or computed claims (Keycloak `realm_access.roles`, claims merged from a database). |
 | `DevelopmentActorProvider` | Local development or integration tests — `IsDevelopment()` only. |
 
-### Entra ID provider
+### Generic OIDC
 
-Use `AddEntraActorProvider` for Microsoft Entra ID (Azure AD) v2.0 tokens. The default mapping recognizes the standard Entra claim set without extra configuration.
+For any standards-compliant OIDC issuer — Auth0, Okta, Google, or a custom IdP — register `ClaimsActorProvider` and name the two claim types. The Quick start above shows the canonical shape.
+
+| Provider | Typical `ActorIdClaim` | Typical `PermissionsClaim` |
+|---|---|---|
+| Auth0 (RBAC) | `sub` | `permissions` |
+| Okta (custom claim) | `sub` | `permissions` (or `scp` — see [Scope and permission extraction](#scope-and-permission-extraction)) |
+| Google sign-in | `sub` | none — token only proves identity; load app permissions from your own store |
+| Custom OIDC | `sub` | whatever your IdP emits |
+
+If the token only proves identity (Google is the canonical case), `Actor.Permissions` will be empty. That is a valid starting point: gate endpoints with `[Authorize]` for "signed in" and load fine-grained permissions from your database via a custom `IActorProvider` — see [Database-backed permissions](integration-db-permissions.md) for the wrapping pattern.
+
+### Microsoft (Entra ID)
+
+Microsoft Entra ID is supported as a first-class specialization with extra defaults that cover the standard Entra claim set out of the box. **Use it instead of generic OIDC when** your tokens come from Entra and you want any of:
+
+- **App Roles** — Entra's `roles` claim (one claim per role) flattened automatically into `Actor.Permissions`.
+- **ABAC attributes** — `tid` (tenant id), `oid` (Entra object id), `preferred_username`, `azp`, `azpacr`, `acrs`, `mfa` from `amr`, and request `ip_address` populated automatically into `Actor.Attributes`.
+- **Long-form `oid` fallback** — when `IdClaimType` is the default `http://schemas.microsoft.com/identity/claims/objectidentifier`, the provider falls back to the short `"oid"` claim.
+- **Multi-tenant pinning** — Entra-specific issuer-validator pattern (see [Multi-tenant Entra](#multi-tenant-entra)).
 
 ```csharp
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -150,49 +180,165 @@ services
     {
         options.Authority = auth["Authority"];   // https://login.microsoftonline.com/<tenant-id>/v2.0
         options.Audience  = auth["Audience"];    // api client id (no api:// prefix for v2.0 audiences)
+        options.MapInboundClaims = false;        // recommended; see Quick start
     });
 
 services.AddEntraActorProvider();
 ```
 
-`EntraActorProvider` derives from `ClaimsActorProvider` and overrides `GetCurrentActorAsync` to apply the Entra-specific delegates. When `IdClaimType` is the default long objectidentifier URI it falls back to the short `"oid"` claim before failing. See `EntraActorOptions` defaults in [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#entraactoroptions).
+`EntraActorProvider` derives from `ClaimsActorProvider` and overrides `GetCurrentActorAsync` to apply the Entra-specific delegates. See `EntraActorOptions` defaults in [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#entraactoroptions) and [ASP.NET Core Authorization → Customizing claim mapping](integration-asp-authorization.md#customizing-claim-mapping) for the override delegates (`MapPermissions`, `MapForbiddenPermissions`, `MapAttributes`).
 
-### Generic OIDC provider
+### Google sign-in
 
-For any provider whose token exposes the actor id and permissions as flat claim types — Auth0, Okta, Google, or a custom IdP — register `ClaimsActorProvider` and name the two claim types.
+Google issues OIDC ID tokens that prove identity but carry no application permissions. Validate them with `ClaimsActorProvider` and supply permissions from your own store. Google's `iss` claim has two valid forms (`https://accounts.google.com` and `accounts.google.com`); accept both.
 
 ```csharp
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis.Asp.Authorization;
-
-var auth = configuration.GetSection("Authentication");
 
 services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = auth["Authority"];   // e.g. https://your-tenant.auth0.com/
-        options.Audience  = auth["Audience"];    // your API audience
+        options.Authority = "https://accounts.google.com";
+        options.Audience  = configuration["Authentication:Audience"]; // your OAuth client id
+        options.TokenValidationParameters.ValidIssuers =
+        [
+            "https://accounts.google.com",
+            "accounts.google.com",
+        ];
+        options.MapInboundClaims = false;
     });
 
 services.AddClaimsActorProvider(options =>
 {
-    options.ActorIdClaim     = auth["ActorIdClaim"]     ?? "sub";
-    options.PermissionsClaim = auth["PermissionsClaim"] ?? "permissions";
+    options.ActorIdClaim = "sub";
+    // Google does not emit application permissions in the ID token. Use a database-backed
+    // permission store (see Database-Backed Permissions article) or synthesize via OnTokenValidated.
 });
 ```
 
-| Provider | Typical `ActorIdClaim` | Typical `PermissionsClaim` |
-|---|---|---|
-| Auth0 (RBAC) | `sub` | `permissions` |
-| Okta (custom claim) | `sub` | `permissions` (or `scp` — see [Scope and permission extraction](#scope-and-permission-extraction)) |
-| Google sign-in | `sub` | none — token only proves identity; load app permissions from your own store |
+### Sign in with Apple (iOS / macOS app)
 
-If the token only proves identity (Google is the canonical case), `Actor.Permissions` will be empty. That is a valid starting point: gate endpoints with `[Authorize]` for "signed in" and load fine-grained permissions from your database via a custom `IActorProvider` (see [Composition](#composition)).
+Apple issues OIDC ID tokens through the "Sign in with Apple" flow. A native iOS or macOS app obtains the ID token via `ASAuthorizationAppleIDProvider` and sends it to your Trellis backend as a bearer token; the backend validates it like any other OIDC token. Apple's tokens only prove identity — they carry no application permissions, so load those from your own store (same pattern as Google).
 
-### Nested-claim providers
+**Apple-specific token facts**
+
+| Field | Value |
+|---|---|
+| Issuer (`iss`) | `https://appleid.apple.com` |
+| Audience (`aud`) | The app's **bundle identifier** for a native iOS/macOS app (e.g. `com.example.MyApp`); the **Services ID** for web sign-in. |
+| Subject (`sub`) | A stable, team-scoped opaque user identifier. The same Apple account yields different `sub` values across different Apple developer teams. |
+| `email` | May be present once at first sign-in. May be a **private relay address** (`*@privaterelay.appleid.com`) — treat as opaque, do not use as a primary key. |
+| Name | **Not in the token.** Apple returns the user's full name to the app in the authorization response **only on the first sign-in**; the app must forward it to the backend and the backend must persist it. |
+| Token lifetime | ~10 minutes. Apps refresh via Apple's `/auth/token` endpoint (refresh tokens are long-lived). |
+
+#### Backend wiring
+
+```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://appleid.apple.com";
+        // For a native iOS/macOS app, this is the app's bundle id.
+        // For web (Sign in with Apple JS), this is the Services ID configured in
+        // Apple Developer → Certificates, Identifiers & Profiles.
+        options.Audience  = configuration["Authentication:Audience"]; // e.g. com.example.MyApp
+        options.TokenValidationParameters.ValidIssuer = "https://appleid.apple.com";
+        options.MapInboundClaims = false;
+    });
+
+services.AddClaimsActorProvider(options =>
+{
+    options.ActorIdClaim = "sub";
+    // Apple does not emit application permissions. Load them from your own store
+    // via a database-backed IActorProvider (see the Database-Backed Permissions article)
+    // or synthesize via JwtBearerEvents.OnTokenValidated.
+});
+```
+
+If you support **both** an iOS app (bundle id audience) and a web sign-in (Services ID audience) on the same backend, set `TokenValidationParameters.ValidAudiences` instead of `JwtBearerOptions.Audience`:
+
+```csharp
+options.TokenValidationParameters.ValidAudiences =
+[
+    "com.example.MyApp",            // iOS bundle id
+    "com.example.MyApp.SignInWithApple", // Services ID for web
+];
+```
+
+#### iOS client flow
+
+The iOS app obtains an ID token from Apple, then calls your API with it as a bearer token:
+
+```swift
+import AuthenticationServices
+
+final class SignInDelegate: NSObject, ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard
+            let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let tokenData  = credential.identityToken,
+            let idToken    = String(data: tokenData, encoding: .utf8)
+        else { return }
+
+        // First sign-in only: credential.fullName / credential.email are populated.
+        // Forward them to your backend so it can persist them; subsequent sign-ins
+        // will return nil for both.
+        Task { try await callTrellisApi(idToken: idToken,
+                                        fullName: credential.fullName,
+                                        email: credential.email) }
+    }
+}
+
+func callTrellisApi(idToken: String, fullName: PersonNameComponents?, email: String?) async throws {
+    var request = URLRequest(url: URL(string: "https://api.example.com/me")!)
+    request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+    _ = try await URLSession.shared.data(for: request)
+}
+```
+
+#### Operational notes
+
+- **Capture user details on the first sign-in.** Apple only returns the user's full name and (real) email address in the *authorization response*, not in the ID token, and only on the first sign-in. If the app doesn't forward them to the backend that first time, they're gone — Apple will not resurface them. Persist them server-side keyed by `sub`.
+- **Private relay emails.** When the user chooses "Hide My Email", `email` is a routable `*@privaterelay.appleid.com` address. It is stable for that user/app pair. Don't treat it as a verified contact for spam-sensitive purposes without re-confirming.
+- **`sub` is team-scoped.** If you publish multiple apps under different Apple teams, the same human will have different `sub` values. Don't use `sub` as a cross-app primary key unless all apps share a team.
+- **Server-to-server validation only.** Don't trust the client's claim of "I signed in as X" — the backend must always validate the ID token signature against Apple's JWKS (`AddJwtBearer` does this automatically via OIDC discovery at `https://appleid.apple.com/.well-known/openid-configuration`).
+- **No app roles or scopes.** Treat Sign in with Apple as identity-only and layer your own permissions on top, e.g. via a custom `IActorProvider` that decorates `ClaimsActorProvider` and merges permissions from your database.
+
+### Facebook (via OIDC bridge)
+
+Facebook's Login API is OAuth 2.0 (not OIDC). Use an OIDC bridge — Auth0, Microsoft Entra External Identities, Amazon Cognito, or your own IdentityServer — to issue OIDC tokens after Facebook authentication. The bridge's tokens look like any other OIDC token to Trellis:
+
+```csharp
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = configuration["Authentication:BridgeAuthority"]; // your OIDC bridge
+        options.Audience  = configuration["Authentication:Audience"];
+        options.MapInboundClaims = false;
+    });
+
+services.AddClaimsActorProvider(options =>
+{
+    options.ActorIdClaim     = "sub";
+    options.PermissionsClaim = "permissions"; // however your bridge surfaces app permissions
+});
+```
+
+Bridge-specific configuration (Facebook app id / secret, redirect URIs, identity-provider linking) lives in the bridge's admin console, not in Trellis.
+
+### Keycloak / nested claims
 
 `ClaimsActorOptions` matches `Claim.Type` literally first, then falls back through the provider's curated short↔long mapping table (e.g. `"sub"` ↔ `ClaimTypes.NameIdentifier`, `"role"`/`"roles"` ↔ `ClaimTypes.Role`) — no JSON-path traversal. When a token contains a nested object (e.g. Keycloak's `{ "realm_access": { "roles": [...] } }`), the JWT handler stores the value as a raw JSON string under claim type `"realm_access"`, which is not in the mapping table. Subclass `ClaimsActorProvider` to project it.
 
@@ -250,10 +396,7 @@ public sealed class KeycloakActorProvider(
 }
 
 // Register IOptions<ClaimsActorOptions> first (the subclass shares the base
-// options type), then wrap with the caching helper. AddClaimsActorProvider
-// initially Replaces IActorProvider with ClaimsActorProvider; the subsequent
-// AddCachingActorProvider then Replaces it again with CachingActorProvider
-// wrapping KeycloakActorProvider — that final composition is the one resolved.
+// options type), then wrap with the caching helper.
 services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
 services.AddCachingActorProvider<KeycloakActorProvider>();
 ```
@@ -484,29 +627,6 @@ For test clients, `WebApplicationFactoryExtensions.CreateClientWithActor(...)` w
 
 > [!WARNING]
 > Use the **same SSO provider** in staging and production — only `Authority` and `Audience` should differ between environments. A staging path that swaps `EntraActorProvider` for `ClaimsActorProvider` (or vice versa) will hide token-format and claim-mapping bugs until they hit real users.
-
-## Composition
-
-SSO sits on top of three Trellis seams: actor resolution, mediator authorization, and result pipelines.
-
-- **Actor resolution.** Every `IActorProvider` is scoped, so handlers, behaviors, and endpoints see the same `Actor` for the duration of a request. `AddCachingActorProvider<T>()` decorates any inner provider — Entra, Claims, or your subclass — without changing handler code.
-- **Mediator pipeline.** Once an `IActorProvider` is registered, `AuthorizationBehavior<TMessage, TResponse>` enforces `IAuthorize.RequiredPermissions` and `IAuthorizeResource<T>.Authorize(actor, resource)` and short-circuits the pipeline with a typed `Error.Forbidden`. Commands return `Result<Unit>`; ASP integration maps `Error.Forbidden` to RFC 7807 `403`.
-- **Result pipelines.** Inside handlers, `Actor` predicates return `bool`, so `Result.Ensure(actor.HasPermission(...), new Error.Forbidden(...))` plugs straight into `Bind` / `Map` chains.
-
-```csharp
-using System.Collections.Generic;
-using Mediator;
-using Trellis;
-using Trellis.Authorization;
-
-public sealed record DeleteDocumentCommand(string DocumentId)
-    : ICommand<Result<Unit>>, IAuthorize
-{
-    public IReadOnlyList<string> RequiredPermissions { get; } = ["documents:delete"];
-}
-```
-
-The full mediator + resource-loader wiring (and the `AddResourceAuthorization<TResource, TId, TLoader>` helper) is documented in [ASP.NET Core Authorization → Mediator integration](integration-asp-authorization.md#mediator-integration).
 
 ## Practical guidance
 

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -22,6 +22,7 @@ This article is the **entry point** for wiring authentication into a Trellis ser
 | Validate Sign in with Apple ID tokens from an iOS/macOS app | Authority `https://appleid.apple.com` + bundle id as `Audience` | [Sign in with Apple (iOS / macOS app)](#sign-in-with-apple-ios--macos-app) |
 | Validate Google / Microsoft / OIDC tokens from an Android app | Same as the IdP recipe; client-side flow uses Credential Manager / MSAL / AppAuth | [Android app](#android-app) |
 | Validate Facebook tokens via an OIDC bridge | Authority for your bridge (Auth0/Cognito/etc.) + `AddClaimsActorProvider` | [Facebook (via OIDC bridge)](#facebook-via-oidc-bridge) |
+| Accept tokens from multiple IdPs in one API (e.g. Microsoft + Google + Apple) | Multiple `AddJwtBearer("<scheme>", ...)` + a default policy listing every scheme | [Multiple IdPs in one API](#multiple-idps-in-one-api) |
 | Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddCachingActorProvider<T>()` | [Keycloak / nested claims](#keycloak--nested-claims) |
 | Flatten roles, scopes, or `scp` into application permissions | Override `EntraActorOptions.MapPermissions` or use a custom `IActorProvider` | [Scope and permission extraction](#scope-and-permission-extraction) |
 | Accept multi-tenant Entra tokens and pin allowed tenants | `JwtBearerOptions.TokenValidationParameters` + `ActorAttributes.TenantId` | [Multi-tenant Entra](#multi-tenant-entra) |
@@ -32,6 +33,7 @@ This article is the **entry point** for wiring authentication into a Trellis ser
 - You front a Trellis service with `JwtBearer` and need a single, predictable `Actor` shape regardless of which OIDC provider issued the token.
 - You need one configuration story for Google, Sign in with Apple, Microsoft (Entra), Facebook (via an OIDC bridge), Auth0, Okta, and Keycloak.
 - You need to wire an Android, iOS, or macOS app against the Trellis backend.
+- You need a **single API** to accept tokens from multiple IdPs at once — for example, a web frontend with Sign in with Microsoft *and* Sign in with Google buttons, plus phone apps signing in with Apple or Google.
 - You need a Development-only seam (`X-Test-Actor`) that fail-closes outside `IsDevelopment()`.
 - You need to host a multi-tenant Entra app and pin which tenants may call your API.
 
@@ -525,6 +527,136 @@ services.AddCachingActorProvider<KeycloakActorProvider>();
 ```
 
 `AddClaimsActorProvider(...)` configures `IOptions<ClaimsActorOptions>` (which `KeycloakActorProvider` consumes through its base constructor). `AddCachingActorProvider<T>` then registers `T` as scoped via `TryAddScoped` and wraps it with `CachingActorProvider`, so the JSON parse runs once per request even if multiple handlers ask for the actor. Because every `AddXxxActorProvider` Replaces the `IActorProvider` slot, the order matters: register the inner-provider's options helper first, then wrap.
+
+## Multiple IdPs in one API
+
+A single Trellis service can validate tokens from multiple IdPs at once — a typical "web frontend with Microsoft *and* Google sign-in buttons, plus iOS / Android apps signing in with Apple or Google" deployment. This is plain ASP.NET Core multi-scheme authentication: register one `AddJwtBearer("<scheme>", ...)` per issuer and let `JwtBearerHandler` pick the scheme whose `Authority` / `Audience` matches each incoming token.
+
+### Register one scheme per IdP
+
+```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Asp.Authorization;
+
+builder.Services
+    // No default scheme — the policy below names every accepted scheme explicitly.
+    .AddAuthentication()
+    .AddJwtBearer("Microsoft", o =>
+    {
+        o.Authority = "https://login.microsoftonline.com/<tenant-id>/v2.0";
+        o.Audience  = "<entra-api-client-id>";
+        o.MapInboundClaims = false;
+    })
+    .AddJwtBearer("Google", o =>
+    {
+        o.Authority = "https://accounts.google.com";
+        // The Web OAuth client id from Google Cloud Console — also what Android
+        // Credential Manager passes as setServerClientId.
+        o.Audience  = "<google-web-oauth-client-id>";
+        o.TokenValidationParameters.ValidIssuers =
+        [
+            "https://accounts.google.com",
+            "accounts.google.com",
+        ];
+        o.MapInboundClaims = false;
+    })
+    .AddJwtBearer("Apple", o =>
+    {
+        o.Authority = "https://appleid.apple.com";
+        // Bundle id for the iOS / macOS app; Services ID for web sign-in.
+        // Use ValidAudiences if you accept both.
+        o.Audience  = "<ios-bundle-id>";
+        o.MapInboundClaims = false;
+    });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .AddAuthenticationSchemes("Microsoft", "Google", "Apple")
+        .Build();
+});
+```
+
+Each request goes through every listed scheme until one succeeds. The first scheme whose `Authority` / `Audience` matches the token's `iss` / `aud` validates it; the others short-circuit. `HttpContext.User` ends up with the validated principal regardless of which scheme won.
+
+> [!NOTE]
+> If you set a default scheme on `AddAuthentication("Microsoft")`, only that scheme runs by default and the other tokens come back 401. Either omit the default and list every scheme in the authorization policy (as above), or set a [forwarding scheme](https://learn.microsoft.com/aspnet/core/security/authentication/policyschemes) that picks per-request.
+
+### Pick an actor provider strategy
+
+Different IdPs put the user id in different claims:
+
+| IdP | Default user-id claim |
+|---|---|
+| Microsoft Entra ID v2.0 | `oid` (with `sub` also present, but `sub` is per-(user, audience) — not stable across audiences) |
+| Google | `sub` |
+| Apple | `sub` (team-scoped) |
+| Auth0 / Okta / custom OIDC | `sub` |
+
+Two viable strategies for a multi-IdP API:
+
+**Strategy 1 — One provider, normalize on `sub`.** Register `AddClaimsActorProvider(o => o.ActorIdClaim = "sub")` only. Entra v2.0 tokens carry `sub` alongside `oid`, so the same provider works for all three IdPs. The trade-off: Entra `sub` is **per-audience**, so two Entra-fronted APIs see different `sub` values for the same human; that is fine if you have one API or if you key users by `(iss, sub)`, and wrong if you need a single canonical user id across multiple Entra audiences.
+
+**Strategy 2 — Route by issuer.** Wrap a thin router that inspects `HttpContext.User.FindFirstValue("iss")` and delegates to `EntraActorProvider` for Microsoft tokens (so you keep App Roles, ABAC attributes from `tid` / `oid` / `amr`, and the `oid` ↔ long-form fallback) and to `ClaimsActorProvider` for everything else.
+
+```csharp
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Trellis.Asp.Authorization;
+using Trellis.Authorization;
+
+public sealed class IssuerRoutingActorProvider(
+    IHttpContextAccessor accessor,
+    EntraActorProvider entra,
+    ClaimsActorProvider generic) : IActorProvider
+{
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
+    {
+        var http = accessor.HttpContext
+            ?? throw new InvalidOperationException("No HttpContext available.");
+        var iss = http.User.FindFirstValue("iss");
+        return iss?.StartsWith("https://login.microsoftonline.com/", StringComparison.Ordinal) == true
+            ? entra.GetCurrentActorAsync(cancellationToken)
+            : generic.GetCurrentActorAsync(cancellationToken);
+    }
+}
+
+// Register both inner providers as concrete types, then expose the router as IActorProvider.
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddOptions<EntraActorOptions>();
+builder.Services.AddOptions<ClaimsActorOptions>().Configure(o => o.ActorIdClaim = "sub");
+builder.Services.TryAddScoped<EntraActorProvider>();
+builder.Services.TryAddScoped<ClaimsActorProvider>();
+builder.Services.AddCachingActorProvider<IssuerRoutingActorProvider>();
+```
+
+`AddCachingActorProvider<T>` wraps the router so the issuer lookup + downstream provider call runs once per request even if multiple handlers ask for the `Actor`.
+
+### Permissions across IdPs
+
+Application permissions are an **API-side concept**, not a token-side one. Each IdP carries them differently:
+
+| IdP | Where permissions come from |
+|---|---|
+| Microsoft Entra ID | Entra App Roles → `roles` claim → flattened by `EntraActorOptions.MapPermissions` |
+| Google / Apple | Not in the token; load from your own permission store via a custom `IActorProvider` |
+| Auth0 / Okta | Either `permissions` (RBAC) or `scp` (delegated scopes); see [Scope and permission extraction](#scope-and-permission-extraction) |
+
+For a multi-IdP API the simplest pattern is to derive a stable user key from `(iss, sub)` (or `(iss, oid)` for Entra), look up the user's permissions in your database, and merge them into `Actor.Permissions` — see [SSO → Synthesizing app permissions during token validation](#synthesizing-app-permissions-during-token-validation) for the `OnTokenValidated` hook that runs once per request, and [Database-Backed Permissions](integration-db-permissions.md) for the IActorProvider-wrapping pattern.
+
+### Operational notes
+
+- **One audience per scheme.** Each `AddJwtBearer("<scheme>", ...)` validates exactly one (or via `ValidAudiences`, a set of) audience values. A token whose `aud` matches no scheme returns HTTP 401.
+- **Same scope, different schemes.** All registered schemes share `HttpContext.User` — once a token validates, the downstream actor provider, mediator pipeline, and handlers don't know (and don't need to know) which IdP issued it.
+- **WWW-Authenticate.** When every scheme rejects the token, Trellis's [`ResponseFailureWriter` synthesizes a `WWW-Authenticate` header](integration-asp-authorization.md#anatomy-of-a-401) listing each registered Bearer scheme so the client knows which IdPs the API accepts.
+- **Diagnostics.** Log `iss` and the winning scheme on first request from each IdP — silent "wrong scheme picked" is almost always an audience mismatch.
 
 ## JWT validation options
 

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -530,7 +530,7 @@ services.AddCachingActorProvider<KeycloakActorProvider>();
 
 ## Multiple IdPs in one API
 
-A single Trellis service can validate tokens from multiple IdPs at once — a typical "web frontend with Microsoft *and* Google sign-in buttons, plus iOS / Android apps signing in with Apple or Google" deployment. This is plain ASP.NET Core multi-scheme authentication: register one `AddJwtBearer("<scheme>", ...)` per issuer and let `JwtBearerHandler` pick the scheme whose `Authority` / `Audience` matches each incoming token.
+A single Trellis service can validate tokens from multiple IdPs at once — a typical "web frontend with Microsoft *and* Google sign-in buttons, plus iOS / Android apps signing in with Apple or Google" deployment. This is plain ASP.NET Core multi-scheme authentication: register one `AddJwtBearer("<scheme>", ...)` per issuer and list every scheme in the authorization policy so each is invoked per request.
 
 ### Register one scheme per IdP
 
@@ -580,7 +580,7 @@ builder.Services.AddAuthorization(options =>
 });
 ```
 
-For each request, ASP.NET Core's `PolicyEvaluator` invokes every scheme listed in the policy and merges the successful principals into `HttpContext.User`. With a single bearer token the issuer/audience match makes exactly one scheme succeed; the others return `AuthenticateResult.NoResult` and contribute nothing. The downstream actor provider sees one validated principal regardless of which scheme matched.
+For each request, ASP.NET Core's `PolicyEvaluator` invokes every scheme listed in the policy and merges the successful principals into `HttpContext.User`. With a single bearer token, the non-matching `JwtBearerHandler`s return `AuthenticateResult.Fail(...)` (token signature / issuer / audience validation failed against that scheme's configuration); `PolicyEvaluator` ignores those failures and the policy succeeds as long as one scheme produced a principal. The downstream actor provider sees one validated principal regardless of which scheme matched.
 
 > [!NOTE]
 > If your authorization policy does **not** list every scheme, only the default scheme runs and tokens from the other IdPs come back 401. The pattern above sidesteps that by enumerating all schemes in the policy. As an alternative, a [forwarding scheme](https://learn.microsoft.com/aspnet/core/security/authentication/policyschemes) (`AddPolicyScheme(...)` with a `ForwardDefaultSelector` that picks per-request based on token `iss`) lets you keep a single default scheme.
@@ -615,7 +615,7 @@ using Trellis.Authorization;
 public sealed class IssuerRoutingActorProvider(
     IHttpContextAccessor accessor,
     EntraActorProvider entra,
-    ClaimsActorProvider generic) : IActorProvider
+    ClaimsActorProvider generic) : IActorProvider, IProvideActorVaryHeaders
 {
     public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)
     {
@@ -626,6 +626,12 @@ public sealed class IssuerRoutingActorProvider(
             ? entra.GetCurrentActorAsync(cancellationToken)
             : generic.GetCurrentActorAsync(cancellationToken);
     }
+
+    // CachingActorProvider only delegates IProvideActorVaryHeaders to its directly wrapped
+    // inner. Without this, VaryForActor() output-cache partitioning fails closed because
+    // the wrapped router exposes no vary headers. Every Trellis-supported bearer-token IdP
+    // partitions on the same header.
+    public IReadOnlyCollection<string> VaryByHeaders { get; } = ["Authorization"];
 }
 
 // Register both inner providers as concrete types, then expose the router as IActorProvider.

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -599,12 +599,13 @@ Different IdPs put the user id in different claims:
 
 Two viable strategies for a multi-IdP API:
 
-**Strategy 1 — One provider, normalize on `sub`.** Register `AddClaimsActorProvider(o => o.ActorIdClaim = "sub")` only. Entra v2.0 tokens carry `sub` alongside `oid`, so the same provider works for all three IdPs. The trade-off: Entra `sub` is **per-audience**, so two Entra-fronted APIs see different `sub` values for the same human; that is fine if you have one API or if you key users by `(iss, sub)`, and wrong if you need a single canonical user id across multiple Entra audiences.
+**Strategy 1 — One provider, normalize on `sub`.** Register `AddClaimsActorProvider(o => o.ActorIdClaim = "sub")` only. Entra v2.0 tokens carry `sub` alongside `oid`, so the same provider works for every IdP listed above. The trade-off: Entra `sub` is **per-audience**, so two Entra-fronted APIs see different `sub` values for the same human; that is fine if you have one API or if you key users by `(iss, sub)`, and wrong if you need a single canonical user id across multiple Entra audiences.
 
 **Strategy 2 — Route by issuer.** Wrap a thin router that inspects `HttpContext.User.FindFirstValue("iss")` and delegates to `EntraActorProvider` for Microsoft tokens (so you keep App Roles, ABAC attributes from `tid` / `oid` / `amr`, and the `oid` ↔ long-form fallback) and to `ClaimsActorProvider` for everything else.
 
 ```csharp
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -20,6 +20,7 @@ This article is the **entry point** for wiring authentication into a Trellis ser
 | Validate Microsoft Entra ID v2.0 tokens with `oid` / `roles` / `tid` / `amr` defaults | `AddJwtBearer` + `AddEntraActorProvider(options?)` | [Microsoft (Entra ID)](#microsoft-entra-id) |
 | Validate Google ID tokens | Authority `https://accounts.google.com` + `ValidIssuers` accepting both forms | [Google sign-in](#google-sign-in) |
 | Validate Sign in with Apple ID tokens from an iOS/macOS app | Authority `https://appleid.apple.com` + bundle id as `Audience` | [Sign in with Apple (iOS / macOS app)](#sign-in-with-apple-ios--macos-app) |
+| Validate Google / Microsoft / OIDC tokens from an Android app | Same as the IdP recipe; client-side flow uses Credential Manager / MSAL / AppAuth | [Android app](#android-app) |
 | Validate Facebook tokens via an OIDC bridge | Authority for your bridge (Auth0/Cognito/etc.) + `AddClaimsActorProvider` | [Facebook (via OIDC bridge)](#facebook-via-oidc-bridge) |
 | Project nested JSON claims (Keycloak `realm_access.roles`) | Subclass `ClaimsActorProvider` + `AddCachingActorProvider<T>()` | [Keycloak / nested claims](#keycloak--nested-claims) |
 | Flatten roles, scopes, or `scp` into application permissions | Override `EntraActorOptions.MapPermissions` or use a custom `IActorProvider` | [Scope and permission extraction](#scope-and-permission-extraction) |
@@ -30,6 +31,7 @@ This article is the **entry point** for wiring authentication into a Trellis ser
 
 - You front a Trellis service with `JwtBearer` and need a single, predictable `Actor` shape regardless of which OIDC provider issued the token.
 - You need one configuration story for Google, Sign in with Apple, Microsoft (Entra), Facebook (via an OIDC bridge), Auth0, Okta, and Keycloak.
+- You need to wire an Android, iOS, or macOS app against the Trellis backend.
 - You need a Development-only seam (`X-Test-Actor`) that fail-closes outside `IsDevelopment()`.
 - You need to host a multi-tenant Entra app and pin which tenants may call your API.
 
@@ -314,6 +316,127 @@ func callTrellisApi(idToken: String, fullName: PersonNameComponents?, email: Str
 - **`sub` is team-scoped.** If you publish multiple apps under different Apple teams, the same human will have different `sub` values. Don't use `sub` as a cross-app primary key unless all apps share a team.
 - **Server-to-server validation only.** Don't trust the client's claim of "I signed in as X" — the backend must always validate the ID token signature against Apple's JWKS (`AddJwtBearer` does this automatically via OIDC discovery at `https://appleid.apple.com/.well-known/openid-configuration`).
 - **No app roles or scopes.** Treat Sign in with Apple as identity-only and layer your own permissions on top, e.g. via a custom `IActorProvider` that decorates `ClaimsActorProvider` and merges permissions from your database.
+
+### Android app
+
+An Android app authenticates the user against an OIDC provider on the device, obtains an ID token, and sends it to the Trellis backend as a bearer token. The **backend wiring is identical to the IdP-specific recipe above** — the choice of `Authority` and `Audience` is dictated by which IdP the app signed in with (Google, Microsoft Entra, Auth0, your own OIDC server). What changes on Android is the client-side library and a few audience-naming quirks.
+
+| IdP from the Android app | Recommended client library | Backend recipe |
+|---|---|---|
+| Google sign-in | [Credential Manager](https://developer.android.com/identity/sign-in/credential-manager-siwg) (`androidx.credentials`) with `GetGoogleIdOption` | [Google sign-in](#google-sign-in) |
+| Microsoft Entra ID (work / school / personal MS accounts) | [MSAL for Android](https://learn.microsoft.com/entra/identity-platform/msal-android) (`com.microsoft.identity.client:msal`) | [Microsoft (Entra ID)](#microsoft-entra-id) |
+| Auth0 | [Auth0 Android SDK](https://auth0.com/docs/quickstart/native/android) | [Generic OIDC](#generic-oidc) (Auth0 row) |
+| Okta | [Okta OIDC Android](https://github.com/okta/okta-oidc-android) (or AppAuth) | [Generic OIDC](#generic-oidc) (Okta row) |
+| Custom / any standards-compliant OIDC | [AppAuth for Android](https://github.com/openid/AppAuth-Android) | [Generic OIDC](#generic-oidc) |
+
+> [!NOTE]
+> The legacy "Google Sign-In for Android" SDK (`com.google.android.gms:play-services-auth`) is deprecated. New apps use Credential Manager. Existing apps on the old SDK still produce a valid OIDC ID token that the backend validates the same way.
+
+#### Google sign-in from Android (Credential Manager)
+
+Google sign-in from Android has one quirk the backend recipe doesn't mention: the audience claim. When the Android app calls Credential Manager with `setServerClientId(...)`, it passes the **Web OAuth client ID** configured in Google Cloud Console — not the Android OAuth client ID. The ID token Google issues then carries that Web client ID as its `aud` claim. The Trellis backend must validate against the same value.
+
+Google Cloud Console setup:
+
+1. Create an **Android** OAuth client (package name + SHA-1 of your signing key). This client has no client secret. It's what tells Google which app is calling.
+2. Create a **Web application** OAuth client. Its client id is what you pass as `serverClientId` and what the backend validates as `Audience`. The "Web" name is misleading — for native-app server-side validation flows, Google still requires a Web-type client.
+
+Android client (Kotlin):
+
+```kotlin
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+suspend fun signInAndCallApi(context: Context) {
+    val googleIdOption = GetGoogleIdOption.Builder()
+        // The WEB OAuth client id from Google Cloud Console. NOT the Android client id.
+        // The ID token's `aud` claim will equal this value.
+        .setServerClientId("YOUR_WEB_CLIENT_ID.apps.googleusercontent.com")
+        .setFilterByAuthorizedAccounts(false)
+        .build()
+
+    val request = GetCredentialRequest.Builder()
+        .addCredentialOption(googleIdOption)
+        .build()
+
+    val response = CredentialManager.create(context).getCredential(context, request)
+    val credential = GoogleIdTokenCredential.createFrom(response.credential.data)
+    val idToken = credential.idToken
+
+    val http = OkHttpClient()
+    val apiRequest = Request.Builder()
+        .url("https://api.example.com/me")
+        .header("Authorization", "Bearer $idToken")
+        .build()
+    http.newCall(apiRequest).execute().use { /* read response */ }
+}
+```
+
+Backend (`Program.cs`) — same as [Google sign-in](#google-sign-in); make sure `Audience` matches the **Web** client id:
+
+```csharp
+services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://accounts.google.com";
+        options.Audience  = "YOUR_WEB_CLIENT_ID.apps.googleusercontent.com";
+        options.TokenValidationParameters.ValidIssuers =
+        [
+            "https://accounts.google.com",
+            "accounts.google.com",
+        ];
+        options.MapInboundClaims = false;
+    });
+
+services.AddClaimsActorProvider(options => options.ActorIdClaim = "sub");
+```
+
+#### Microsoft Entra ID from Android (MSAL)
+
+MSAL Android acquires an access token for your API's resource scope. The `aud` claim on the resulting JWT is your API client id (the same value the backend validates as `Audience`).
+
+Android client (Kotlin):
+
+```kotlin
+import com.microsoft.identity.client.IPublicClientApplication
+import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.client.SilentAuthenticationCallback
+
+val scopes = arrayOf("api://YOUR_API_CLIENT_ID/.default")
+
+PublicClientApplication.createMultipleAccountPublicClientApplication(
+    context,
+    R.raw.msal_config, // JSON config with client_id, redirect_uri, authorities
+    object : IPublicClientApplication.IMultipleAccountApplicationCreatedListener {
+        override fun onCreated(app: com.microsoft.identity.client.IMultipleAccountPublicClientApplication) {
+            // ... acquireToken(activity, scopes, callback) — see MSAL docs for the full flow.
+            // The resulting authResult.accessToken is what you send as Authorization: Bearer.
+        }
+        override fun onError(exception: com.microsoft.identity.client.exception.MsalException) { /* log */ }
+    },
+)
+```
+
+Backend wiring is identical to [Microsoft (Entra ID)](#microsoft-entra-id). The `msal_config` JSON resource must specify your Entra app's `client_id`, `redirect_uri` (`msauth://<package>/<base64-sha1>`), and the authority (`https://login.microsoftonline.com/<tenant-id>`).
+
+#### Generic OIDC from Android (AppAuth)
+
+[AppAuth for Android](https://github.com/openid/AppAuth-Android) handles the OIDC authorization-code-with-PKCE flow against any standards-compliant issuer (Auth0, Okta, Keycloak, your own IdP). The resulting `AuthState.accessToken` (or `idToken`, depending on which claim your backend validates against) is what gets sent as `Authorization: Bearer …`. Backend wiring matches the corresponding [Generic OIDC](#generic-oidc) row.
+
+#### Operational notes
+
+- **Token type.** Google Credential Manager gives an **ID token** (audience = Web OAuth client id). MSAL gives an **access token** (audience = your API resource). Both arrive at the backend as `Authorization: Bearer …`; the JWT handler validates whichever the `Audience` configuration matches. Don't mix them: an access token sent where the backend expects an ID token (or vice-versa) fails audience validation with HTTP 401.
+- **App identity vs user identity.** The Android OAuth client (Google) or Entra Android client (MSAL) authenticates the *app* to the IdP; the user signs in to the IdP through that app. The token your backend receives identifies the *user*. There's no Trellis-side concept of "this token came from Android" — the backend can't (and shouldn't) distinguish device platforms from a validated token.
+- **HTTPS + certificate pinning.** All API calls from the app must be HTTPS. Android 7+ ignores user-installed CAs for app traffic by default; this is correct for production. If you need certificate pinning, configure it in `network_security_config.xml`.
+- **Refresh tokens stay on the device.** The backend never sees a refresh token. The app refreshes the access/ID token via the IdP (Credential Manager / MSAL / AppAuth handle this) and sends the fresh bearer token on each call.
+- **No `X-Test-Actor` from device builds.** [Development defaults](#development-defaults) is for local backend dev only. Don't ship a debug build that sends `X-Test-Actor` — the provider fails closed outside `IsDevelopment()` on the backend, but the convention is to not depend on it from a real device at all.
+- **Permissions still come from your store.** Google / Apple / generic OIDC tokens carry identity only. Layer Trellis permissions on top via a database-backed `IActorProvider` regardless of which Android sign-in flow the app uses. Entra tokens with `roles` are the exception (App Roles flatten into `Actor.Permissions` via the default Entra mapping).
 
 ### Facebook (via OIDC bridge)
 

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -321,7 +321,7 @@ func callTrellisApi(idToken: String, fullName: PersonNameComponents?, email: Str
 
 ### Android app
 
-An Android app authenticates the user against an OIDC provider on the device, obtains an ID token, and sends it to the Trellis backend as a bearer token. The **backend wiring is identical to the IdP-specific recipe above** — the choice of `Authority` and `Audience` is dictated by which IdP the app signed in with (Google, Microsoft Entra, Auth0, your own OIDC server). What changes on Android is the client-side library and a few audience-naming quirks.
+An Android app authenticates the user against an OIDC provider on the device, obtains a bearer token (an OIDC ID token from Google's Credential Manager / Apple, or an OAuth 2.0 access token from MSAL; AppAuth can return either), and sends it to the Trellis backend as `Authorization: Bearer <token>`. The **backend wiring is identical to the IdP-specific recipe above** — the choice of `Authority` and `Audience` is dictated by which IdP the app signed in with (Google, Microsoft Entra, Auth0, your own OIDC server) and by which token type that flow produces. What changes on Android is the client-side library and a few audience-naming quirks.
 
 | IdP from the Android app | Recommended client library | Backend recipe |
 |---|---|---|
@@ -479,6 +479,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Trellis;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 
@@ -609,6 +610,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Trellis;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -52,10 +52,10 @@
     href: integration.md
   - name: ASP.NET Core
     href: integration-aspnet.md
+  - name: Single Sign-On (Google, Microsoft, OIDC)
+    href: integration-sso.md
   - name: ASP.NET Core Authorization
     href: integration-asp-authorization.md
-  - name: Setting Up Single Sign-On (SSO)
-    href: integration-sso.md
   - name: Testing with Entra ID Tokens
     href: integration-entra-testing.md
   - name: Database-Backed Permissions


### PR DESCRIPTION
The Single Sign-On article led with Microsoft Entra ID and demoted other IdPs to a generic OIDC subsection with no coverage for Apple, Android clients, or Facebook. The ASP.NET Core Authorization article duplicated IdP wiring through an Entra-specific Quick start, and its end-to-end sequence diagram skipped the Endpoint participant so the final `ToHttpResponse` mapping incorrectly originated from `ResourceAuthorizationBehavior`.

- `toc.yml`: SSO entry moved above ASP.NET Core Authorization; renamed to highlight Google / Microsoft / OIDC coverage.
- `integration-sso.md`: rewritten as the multi-IdP hub. Provider recipes in order Generic OIDC, Microsoft (Entra ID), Google sign-in, Sign in with Apple (iOS / macOS app), Android app, Facebook (via OIDC bridge), Keycloak / nested claims. Quick start switched from Entra-specific to generic OIDC. Composition section removed (canonical home is the authorization article).
- `integration-asp-authorization.md`: Quick start switched to generic OIDC + `ClaimsActorProvider` with cross-link to the SSO recipe; Entra ID and Generic claims provider sections cross-link to SSO for IdP wiring. End-to-end Mermaid diagram gains an Endpoint participant so the `ToHttpResponse` mapping originates from the endpoint, not from a mediator behavior. Composition prose qualifier reworded.
- Android section covers Credential Manager (Google) with the Web-OAuth-client-id quirk, MSAL (Entra), AppAuth (generic OIDC), and the ID-token-vs-access-token audience-validation trap.
- Apple section covers iOS / macOS `ASAuthorizationAppleIDProvider` with the first-sign-in name/email delivery quirk, private relay emails, and team-scoped `sub`.