### PR TITLE
RequiredXxx<T> POLA realignment: [NotDefault] and [Trim] attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### `RequiredXxx<T>` family POLA realignment (breaking)
+
+The `RequiredXxx<T>` family now follows a single, uniform rule: **reject only null**. Per-type "zero value" rejection (`""` for `RequiredString`, `0` for numerics, `Guid.Empty`, `DateTime.MinValue`) becomes opt-in via the new `[NotDefault]` attribute. String trim becomes opt-in via the new `[Trim]` attribute. This realigns the family with `RequiredInt<T>(0)` — which has always succeeded — and matches the Principle of Least Astonishment.
+
+| Type | Before | After (no attributes) | After (`[NotDefault]`) |
+|---|---|---|---|
+| `RequiredInt<T>` / `RequiredLong<T>` / `RequiredDecimal<T>` | reject null | reject null | reject null + `0` (per-type wording "cannot be zero.") |
+| `RequiredString<T>` | reject null + empty + whitespace; auto-trim | reject null only | reject null + `""` (after `[Trim]` if present) |
+| `RequiredGuid<T>` | reject null + `Guid.Empty` | reject null only | reject null + `Guid.Empty` (per-type wording "cannot be Guid.Empty.") |
+| `RequiredDateTime<T>` | reject null + `DateTime.MinValue` | reject null only | reject null + `DateTime.MinValue` (per-type wording "cannot be DateTime.MinValue.") |
+| `RequiredBool<T>` | reject null | reject null | **analyzer + generator error** (degenerate single-value type) |
+| `RequiredEnum<T>` | reject unknown member name | reject unknown member name | **analyzer + generator error** (smart-enum has no CLR default) |
+
+**Migration:** add `[NotDefault]` (and `[Trim]` for strings) to any partial class derived from `RequiredString` / `RequiredGuid` / `RequiredDateTime` whose original strict behavior must be preserved. For `RequiredString`-derived types the equivalent of today's defaults is `[Trim, NotDefault]`. New compile-time diagnostics:
+
+- `TRLS040` — `[NotDefault]` on `RequiredBool<T>` is not supported.
+- `TRLS041` — `[Trim]` on a non-`RequiredString` Required type is not supported.
+- `TRLS042` — `[NotDefault]` on `RequiredEnum<T>` is not supported.
+
+**EF Core read-path impact (named breaking change).** `TrellisScalarConverter` calls `TryCreate` to rehydrate every row read from the database, so today's strict behavior was acting as a database invariant guard: a column containing `Guid.Empty` / `""` / `DateTime.MinValue` (legacy data, raw SQL, external writers) failed loudly via `TrellisPersistenceMappingException`. After the realignment an undecorated ID type silently rehydrates the sentinel value. **For any `RequiredGuid` / `RequiredDateTime` used as an `Aggregate<TId>` / `Entity<TId>` ID or as an EF-mapped property, add `[NotDefault]` to preserve the rehydration guarantee.**
+
+**`ValidateAdditional` override impact.** Subtype `ValidateAdditional` overrides on `RequiredString` that previously relied on non-empty / trimmed input will now receive `""` or whitespace if the type is undecorated. Indexing into `value[0]` etc. throws. Either add `[Trim, NotDefault]` or harden the override.
+
+Validation order in the generated `TryCreate`: `null → [Trim] → [NotDefault] → [StringLength] / [Range] → ValidateAdditional`. With `[Trim]` absent, `[StringLength]` measures the raw input — a behavior change from today.
+
+### Added
+
+#### `[NotDefault]` and `[Trim]` attributes for `RequiredXxx<T>` types
+
+Two new opt-in attributes in the `Trellis` namespace alongside `[StringLength]` / `[Range]`. Both are consumed at compile time by the primitive value-object source generator with no runtime reflection cost. See the `Changed` section above for the full behavior matrix.
+
 #### `IActorProvider.GetCurrentActorAsync` returns `Task<Maybe<Actor>>` (breaking)
 
 `IActorProvider.GetCurrentActorAsync` now returns `Task<Maybe<Actor>>` instead of `Task<Actor>`. "No authenticated actor on this request" is client-error state expressed via `Maybe<Actor>.None`; the mediator authorization pipeline maps it to `Error.Unauthorized` (HTTP 401, RFC 9110 §15.5.2). Provider implementations should throw `InvalidOperationException` only for genuine infrastructure or configuration failures (no `HttpContext`, mapping delegate threw, option misconfigured); those still surface as `Error.InternalServerError` (HTTP 500), which is correct because they are bugs rather than authentication state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The `RequiredXxx<T>` family now follows a single, uniform rule: **reject only nu
 | `RequiredGuid<T>` | reject null | reject null + `Guid.Empty` (wording: "cannot be Guid.Empty.") |
 | `RequiredDateTime<T>` | reject null | reject null + `DateTime.MinValue` (wording: "cannot be DateTime.MinValue.") |
 | `RequiredBool<T>` | reject null | **compile-time error** (degenerate single-value type) |
-| `RequiredEnum<T>` | reject unknown member name | **compile-time error** (smart-enum has no CLR default) |
+| `RequiredEnum<T>` | reject null + unknown member name | **compile-time error** (smart-enum has no CLR default) |
 
 Validation order in the generated `TryCreate`: `null → [Trim] → [NotDefault] → [StringLength] / [Range] → ValidateAdditional`. With `[Trim]` absent, `[StringLength]` measures the raw input.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,28 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### `RequiredXxx<T>` family POLA realignment (breaking)
 
-The `RequiredXxx<T>` family now follows a single, uniform rule: **reject only null**. Per-type "zero value" rejection (`""` for `RequiredString`, `0` for numerics, `Guid.Empty`, `DateTime.MinValue`) becomes opt-in via the new `[NotDefault]` attribute. String trim becomes opt-in via the new `[Trim]` attribute. This realigns the family with `RequiredInt<T>(0)` — which has always succeeded — and matches the Principle of Least Astonishment.
+The `RequiredXxx<T>` family now follows a single, uniform rule: **reject only null**. Per-type "zero value" rejection (`""` for `RequiredString`, `0` for numerics, `Guid.Empty`, `DateTime.MinValue`) is opt-in via the new `[NotDefault]` attribute. String trim is opt-in via the new `[Trim]` attribute. This realigns the family with `RequiredInt<T>(0)` — which has always succeeded — and matches the Principle of Least Astonishment.
 
-| Type | Before | After (no attributes) | After (`[NotDefault]`) |
-|---|---|---|---|
-| `RequiredInt<T>` / `RequiredLong<T>` / `RequiredDecimal<T>` | reject null | reject null | reject null + `0` (per-type wording "cannot be zero.") |
-| `RequiredString<T>` | reject null + empty + whitespace; auto-trim | reject null only | reject null + `""` (after `[Trim]` if present) |
-| `RequiredGuid<T>` | reject null + `Guid.Empty` | reject null only | reject null + `Guid.Empty` (per-type wording "cannot be Guid.Empty.") |
-| `RequiredDateTime<T>` | reject null + `DateTime.MinValue` | reject null only | reject null + `DateTime.MinValue` (per-type wording "cannot be DateTime.MinValue.") |
-| `RequiredBool<T>` | reject null | reject null | **analyzer + generator error** (degenerate single-value type) |
-| `RequiredEnum<T>` | reject unknown member name | reject unknown member name | **analyzer + generator error** (smart-enum has no CLR default) |
+| Type | Default (no attributes) | With `[NotDefault]` |
+|---|---|---|
+| `RequiredInt<T>` / `RequiredLong<T>` / `RequiredDecimal<T>` | reject null | reject null + `0` (wording: "cannot be zero.") |
+| `RequiredString<T>` | reject null | reject null + `""` (after `[Trim]` if present) |
+| `RequiredGuid<T>` | reject null | reject null + `Guid.Empty` (wording: "cannot be Guid.Empty.") |
+| `RequiredDateTime<T>` | reject null | reject null + `DateTime.MinValue` (wording: "cannot be DateTime.MinValue.") |
+| `RequiredBool<T>` | reject null | **compile-time error** (degenerate single-value type) |
+| `RequiredEnum<T>` | reject unknown member name | **compile-time error** (smart-enum has no CLR default) |
 
-**Migration:** add `[NotDefault]` (and `[Trim]` for strings) to any partial class derived from `RequiredString` / `RequiredGuid` / `RequiredDateTime` whose original strict behavior must be preserved. For `RequiredString`-derived types the equivalent of today's defaults is `[Trim, NotDefault]`. New compile-time diagnostics:
+Validation order in the generated `TryCreate`: `null → [Trim] → [NotDefault] → [StringLength] / [Range] → ValidateAdditional`. With `[Trim]` absent, `[StringLength]` measures the raw input.
+
+New compile-time diagnostics:
 
 - `TRLS040` — `[NotDefault]` on `RequiredBool<T>` is not supported.
 - `TRLS041` — `[Trim]` on a non-`RequiredString` Required type is not supported.
 - `TRLS042` — `[NotDefault]` on `RequiredEnum<T>` is not supported.
 
-**EF Core read-path impact (named breaking change).** `TrellisScalarConverter` calls `TryCreate` to rehydrate every row read from the database, so today's strict behavior was acting as a database invariant guard: a column containing `Guid.Empty` / `""` / `DateTime.MinValue` (legacy data, raw SQL, external writers) failed loudly via `TrellisPersistenceMappingException`. After the realignment an undecorated ID type silently rehydrates the sentinel value. **For any `RequiredGuid` / `RequiredDateTime` used as an `Aggregate<TId>` / `Entity<TId>` ID or as an EF-mapped property, add `[NotDefault]` to preserve the rehydration guarantee.**
-
-**`ValidateAdditional` override impact.** Subtype `ValidateAdditional` overrides on `RequiredString` that previously relied on non-empty / trimmed input will now receive `""` or whitespace if the type is undecorated. Indexing into `value[0]` etc. throws. Either add `[Trim, NotDefault]` or harden the override.
-
-Validation order in the generated `TryCreate`: `null → [Trim] → [NotDefault] → [StringLength] / [Range] → ValidateAdditional`. With `[Trim]` absent, `[StringLength]` measures the raw input — a behavior change from today.
+The EF Core `TrellisScalarConverter` calls `TryCreate` to rehydrate every row, so lenient-by-default types now accept persisted sentinel values (`Guid.Empty`, `""`, `DateTime.MinValue`) instead of throwing `TrellisPersistenceMappingException`. Add `[NotDefault]` to any `RequiredGuid` / `RequiredDateTime` used as an `Aggregate<TId>` / `Entity<TId>` ID or as an EF-mapped property to keep the strict rehydration guarantee.
 
 ### Added
 

--- a/Examples/TestingPatterns/ValueObject/FirstName.cs
+++ b/Examples/TestingPatterns/ValueObject/FirstName.cs
@@ -2,6 +2,7 @@
 
 using Trellis;
 
+[Trim, NotDefault]
 internal partial class FirstName : RequiredString<FirstName>
 {
 }

--- a/Examples/TestingPatterns/ValueObject/LastName.cs
+++ b/Examples/TestingPatterns/ValueObject/LastName.cs
@@ -2,6 +2,7 @@
 
 using Trellis;
 
+[Trim, NotDefault]
 internal partial class LastName : RequiredString<LastName>
 {
 }

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -134,4 +134,13 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS039 — Scalar value object wraps a primitive that is not supported by the AOT-safe JSON converter generator.</summary>
     public const string UnsupportedScalarValuePrimitiveForAotJson = "TRLS039";
+
+    /// <summary>TRLS040 — <c>[NotDefault]</c> is not supported on <c>RequiredBool&lt;T&gt;</c> (a bool that rejects <c>false</c> would be degenerate).</summary>
+    public const string NotDefaultOnRequiredBool = "TRLS040";
+
+    /// <summary>TRLS041 — <c>[Trim]</c> is only valid on <c>RequiredString&lt;T&gt;</c>-derived types.</summary>
+    public const string TrimOnNonStringRequired = "TRLS041";
+
+    /// <summary>TRLS042 — <c>[NotDefault]</c> is not supported on <c>RequiredEnum&lt;T&gt;</c> (smart-enum has no CLR <c>default(T)</c>).</summary>
+    public const string NotDefaultOnRequiredEnum = "TRLS042";
 }

--- a/Trellis.Asp/tests/RequiredXxxBinderLenienceTests.cs
+++ b/Trellis.Asp/tests/RequiredXxxBinderLenienceTests.cs
@@ -1,0 +1,188 @@
+﻿namespace Trellis.Asp.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Trellis;
+using Trellis.Asp.ModelBinding;
+using Trellis.Testing;
+using Xunit;
+
+// --- Lenient and strict generated Required* test fixtures ---
+
+public partial class AspLenientGuid : RequiredGuid<AspLenientGuid> { }
+
+[NotDefault]
+public partial class AspStrictGuid : RequiredGuid<AspStrictGuid> { }
+
+public partial class AspLenientString : RequiredString<AspLenientString> { }
+
+[Trim, NotDefault]
+public partial class AspStrictString : RequiredString<AspStrictString> { }
+
+public partial class AspLenientInt : RequiredInt<AspLenientInt> { }
+
+[NotDefault]
+public partial class AspStrictInt : RequiredInt<AspStrictInt> { }
+
+/// <summary>
+/// ASP-boundary regression coverage for the <c>RequiredXxx&lt;T&gt;</c> POLA realignment:
+/// proves that the new attribute-driven validation flows through
+/// <see cref="ScalarValueModelBinder{TValue, TPrimitive}"/> on the route / query / form / header
+/// path. Lenient (undecorated) types accept the per-type sentinel value via the binder; strict
+/// (<c>[NotDefault]</c>) types reject with the per-type wording.
+/// </summary>
+/// <remarks>
+/// Mirrors the EF rehydration test (<c>RequiredXxxRehydrationLenienceTests</c>) and the
+/// composite flow-through test (<c>CompositeRequiredStringFlowThroughTests</c>) at the ASP
+/// model-binder boundary. JSON-body coverage (via <c>ParsableJsonConverter&lt;T&gt;</c>) is
+/// already exercised by the composite flow-through tests since the composite converter
+/// delegates through the same inner <c>TryCreate</c>.
+/// </remarks>
+public class RequiredXxxBinderLenienceTests
+{
+    // ---- Guid ----
+
+    [Fact]
+    public async Task LenientGuidBinder_accepts_all_zero_guid()
+    {
+        var binder = new ScalarValueModelBinder<AspLenientGuid, Guid>();
+        var ctx = CreateBindingContext("id", "00000000-0000-0000-0000-000000000000");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeTrue();
+        var bound = ctx.Result.Model as AspLenientGuid;
+        bound.Should().NotBeNull();
+        bound!.Value.Should().Be(Guid.Empty);
+        ctx.ModelState.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StrictGuidBinder_rejects_all_zero_guid_with_per_type_wording()
+    {
+        var binder = new ScalarValueModelBinder<AspStrictGuid, Guid>();
+        var ctx = CreateBindingContext("id", "00000000-0000-0000-0000-000000000000");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeFalse();
+        ctx.ModelState.IsValid.Should().BeFalse();
+        ctx.ModelState["id"]!.Errors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("Asp Strict Guid cannot be Guid.Empty.");
+    }
+
+    // ---- String ----
+
+    [Fact]
+    public async Task LenientStringBinder_accepts_empty_string()
+    {
+        var binder = new ScalarValueModelBinder<AspLenientString, string>();
+        var ctx = CreateBindingContext("name", "");
+
+        await binder.BindModelAsync(ctx);
+
+        // Note: model-binder treats "" as "no value" at the value-provider layer for strings
+        // and short-circuits before reaching TryCreate. This is documented existing behavior
+        // (see ModelBinder_NoValue_DoesNotBind in ModelBindingTests). The point of this test
+        // is to confirm the lenient TryCreate does not reject empty when called directly:
+        AspLenientString.TryCreate("").IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StrictStringBinder_rejects_empty_string_via_direct_TryCreate()
+    {
+        // Empty-string handling at the binder layer is short-circuited; the per-type rejection
+        // path is the strict TryCreate (called by the binder when the value provider yields a
+        // non-empty string and we then strip it via [Trim]). Asserting at TryCreate level keeps
+        // this test stable regardless of value-provider short-circuit policy.
+        var result = AspStrictString.TryCreate("");
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Asp Strict String cannot be empty.");
+
+        // And via binder for a whitespace-only payload that [Trim] reduces to "":
+        var binder = new ScalarValueModelBinder<AspStrictString, string>();
+        var ctx = CreateBindingContext("name", "   ");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeFalse();
+        ctx.ModelState["name"]!.Errors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("Asp Strict String cannot be empty.");
+    }
+
+    [Fact]
+    public async Task LenientStringBinder_accepts_whitespace_verbatim()
+    {
+        var binder = new ScalarValueModelBinder<AspLenientString, string>();
+        var ctx = CreateBindingContext("name", "  hi  ");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeTrue();
+        var bound = ctx.Result.Model as AspLenientString;
+        bound!.Value.Should().Be("  hi  ");
+    }
+
+    // ---- Int ----
+
+    [Fact]
+    public async Task LenientIntBinder_accepts_zero()
+    {
+        var binder = new ScalarValueModelBinder<AspLenientInt, int>();
+        var ctx = CreateBindingContext("count", "0");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeTrue();
+        var bound = ctx.Result.Model as AspLenientInt;
+        bound!.Value.Should().Be(0);
+        ctx.ModelState.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StrictIntBinder_rejects_zero_with_per_type_wording()
+    {
+        var binder = new ScalarValueModelBinder<AspStrictInt, int>();
+        var ctx = CreateBindingContext("count", "0");
+
+        await binder.BindModelAsync(ctx);
+
+        ctx.Result.IsModelSet.Should().BeFalse();
+        ctx.ModelState["count"]!.Errors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("Asp Strict Int cannot be zero.");
+    }
+
+    // ---- Helpers ----
+
+    private static DefaultModelBindingContext CreateBindingContext(string modelName, string? value)
+    {
+        var valueProvider = new SimpleValueProvider();
+        if (value is not null)
+            valueProvider.Add(modelName, value);
+
+        return new DefaultModelBindingContext
+        {
+            ModelName = modelName,
+            ValueProvider = valueProvider,
+            ModelState = new ModelStateDictionary(),
+        };
+    }
+
+    private class SimpleValueProvider : IValueProvider
+    {
+        private readonly Dictionary<string, string> _values = new();
+
+        public void Add(string key, string value) => _values[key] = value;
+
+        public bool ContainsPrefix(string prefix) => _values.ContainsKey(prefix);
+
+        public ValueProviderResult GetValue(string key) =>
+            _values.TryGetValue(key, out var value)
+                ? new ValueProviderResult(value)
+                : ValueProviderResult.None;
+    }
+}

--- a/Trellis.Asp/tests/RequiredXxxBinderLenienceTests.cs
+++ b/Trellis.Asp/tests/RequiredXxxBinderLenienceTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Trellis;
 using Trellis.Asp.ModelBinding;
 using Trellis.Testing;

--- a/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
+++ b/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
@@ -23,6 +23,9 @@
     <ProjectReference Include="..\generator\Trellis.AspSourceGenerator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Trellis.Core\generator\Trellis.Core.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -773,11 +773,11 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(int value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeMin})
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
             if (value > {rangeMax})
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));{notDefaultIfCheck}
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -790,9 +790,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
                 .Ensure(x => x >= {rangeMin}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(x => x <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }}))){notDefaultNullableEnsure};
+                .Ensure(x => x <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -810,9 +810,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             int parsedInt = 0;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }})))
+                .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }}))){notDefaultParsedEnsure}
                 .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }}))){notDefaultParsedEnsure};
+                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1033,11 +1033,11 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(decimal value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {minStr}m)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
             if (value > {maxStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));{notDefaultIfCheck}
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -1050,9 +1050,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
                 .Ensure(x => x >= {minStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(x => x <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }}))){notDefaultNullableEnsure};
+                .Ensure(x => x <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1070,9 +1070,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             decimal parsedDecimal = 0m;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }})))
+                .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }}))){notDefaultParsedEnsure}
                 .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }}))){notDefaultParsedEnsure};
+                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1272,11 +1272,11 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(long value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeLongMin}L)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
             if (value > {rangeLongMax}L)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));{notDefaultIfCheck}
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -1289,9 +1289,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
                 .Ensure(x => x >= {rangeLongMin}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }}))){notDefaultNullableEnsure};
+                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1309,9 +1309,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             long parsedLong = 0;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }})))
+                .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }}))){notDefaultParsedEnsure}
                 .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }}))){notDefaultParsedEnsure};
+                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -905,7 +905,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (string.IsNullOrWhiteSpace(value))
+            if (value is null)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
             if (!int.TryParse(value, System.Globalization.NumberStyles.Integer, provider ?? System.Globalization.CultureInfo.InvariantCulture, out var parsed))
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }})));
@@ -1165,7 +1165,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (string.IsNullOrWhiteSpace(value))
+            if (value is null)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
             if (!decimal.TryParse(value, System.Globalization.NumberStyles.Number, provider ?? System.Globalization.CultureInfo.InvariantCulture, out var parsed))
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }})));
@@ -1404,7 +1404,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (string.IsNullOrWhiteSpace(value))
+            if (value is null)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
             if (!long.TryParse(value, System.Globalization.NumberStyles.Integer, provider ?? System.Globalization.CultureInfo.InvariantCulture, out var parsed))
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }})));

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -141,6 +141,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public const string InvalidStringLengthRange = "TRLS032";
         public const string InvalidRangeMinExceedsMax = "TRLS033";
         public const string DecimalRangeExceedsDecimalRange = "TRLS034";
+        public const string NotDefaultOnRequiredBool = "TRLS040";
+        public const string TrimOnNonStringRequired = "TRLS041";
+        public const string NotDefaultOnRequiredEnum = "TRLS042";
     }
 
     /// <summary>
@@ -244,6 +247,11 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
             var nestedTypeOpen = BuildNestingOpen(g);
             var nestedTypeClose = BuildNestingClose(g);
+
+            // Defense in depth: emit a generator diagnostic for invalid attribute combinations
+            // even if the user suppresses the matching analyzer rule. Skip generation if invalid.
+            if (!ValidateAttributeUsage(g, context))
+                continue;
 
             // RequiredEnum has a completely different structure - handle separately
             if (g.ClassBase == "RequiredEnum")
@@ -407,12 +415,28 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
     }}
     {nestedTypeClose}";
 
-    private static string GenerateGuidMethods(RequiredPartialClassInfo g) =>
-        $@"
+    private static string GenerateGuidMethods(RequiredPartialClassInfo g)
+    {
+        var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be Guid.Empty.""";
+        var notDefaultCheck = g.HasNotDefault
+            ? $@"
+            if (value == Guid.Empty)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})));"
+            : "";
+        var notDefaultNullableEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(x => x != Guid.Empty, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+        var notDefaultParsedEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(_ => parsedGuid != Guid.Empty, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+
+        return $@"
 
         /// <summary>
         /// Optional validation hook. Implement this partial method to add custom validation.
-        /// Called after built-in validations (empty GUID check) pass.
+        /// Called after built-in validations pass.
         /// </summary>
         /// <param name=""value"">The validated Guid value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
@@ -447,9 +471,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(Guid value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (value == Guid.Empty)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -462,8 +484,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = requiredGuidOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => x != Guid.Empty, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -478,11 +499,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            Guid parsedGuid = Guid.Empty;
+            Guid parsedGuid = default;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => Guid.TryParse(x, out parsedGuid), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"" }})))
-                .Ensure(_ => parsedGuid != Guid.Empty, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .Ensure(x => Guid.TryParse(x, out parsedGuid), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -522,9 +542,71 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 onSuccess: created => created,
                 onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.GetDisplayMessage()}}""));
         }}";
+    }
 
     private static string NamespaceDeclaration(RequiredPartialClassInfo g) =>
         string.IsNullOrEmpty(g.NameSpace) ? string.Empty : $"namespace {g.NameSpace};";
+
+    /// <summary>
+    /// Validates that the <c>[NotDefault]</c> and <c>[Trim]</c> attributes (if present) are
+    /// applied to a compatible <c>Required*</c> base. Emits a generator diagnostic when the
+    /// combination is invalid. Defense in depth — the same combinations are also flagged by
+    /// the matching analyzer rules in <c>Trellis.Analyzers</c>, but the generator must refuse
+    /// to emit broken code even if the analyzer is disabled or suppressed.
+    /// </summary>
+    /// <returns><c>true</c> when generation may proceed; <c>false</c> when generation must be skipped.</returns>
+    private static bool ValidateAttributeUsage(RequiredPartialClassInfo g, SourceProductionContext context)
+    {
+        var ok = true;
+
+        if (g.HasNotDefault && g.ClassBase == "RequiredBool")
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.NotDefaultOnRequiredBool,
+                    title: "[NotDefault] is not supported on RequiredBool",
+                    messageFormat: "Class '{0}' has [NotDefault] but inherits from RequiredBool. A bool that rejects false has only one constructible value, which is degenerate; express the constraint as a guard at the usage site instead.",
+                    category: "Trellis",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true),
+                location: null,
+                g.ClassName));
+            ok = false;
+        }
+
+        if (g.HasNotDefault && g.ClassBase == "RequiredEnum")
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.NotDefaultOnRequiredEnum,
+                    title: "[NotDefault] is not supported on RequiredEnum",
+                    messageFormat: "Class '{0}' has [NotDefault] but inherits from RequiredEnum. RequiredEnum is a smart-enum over declared string values; there is no CLR default(T) to reject. To disallow a specific member, override ValidateAdditional.",
+                    category: "Trellis",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true),
+                location: null,
+                g.ClassName));
+            ok = false;
+        }
+
+        if (g.HasTrim && g.ClassBase != "RequiredString")
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.TrimOnNonStringRequired,
+                    title: "[Trim] is only valid on RequiredString",
+                    messageFormat: "Class '{0}' has [Trim] but inherits from '{1}'. [Trim] is a string-only attribute; it has no meaning for non-string Required types.",
+                    category: "Trellis",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true),
+                location: null,
+                g.ClassName,
+                g.ClassBase));
+            ok = false;
+        }
+
+        return ok;
+    }
 
     private static string? GenerateStringMethods(RequiredPartialClassInfo g, SourceProductionContext context)
     {
@@ -563,13 +645,28 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be {g.MaxLength.Value} {"character" + (g.MaxLength.Value == 1 ? "" : "s")} or fewer."" }})));";
         }
 
+        // String validation pipeline, attribute-driven:
+        //   1. Null check (always emitted; consistent with the rest of the family).
+        //   2. [Trim] (only when present).
+        //   3. [NotDefault] empty-string rejection (only when present).
+        //   4. [StringLength] (operates on the post-Trim value).
+        //   5. ValidateAdditional consumer hook.
+        var trimStep = g.HasTrim
+            ? "normalized = normalized.Trim();"
+            : "";
+        var notDefaultStep = g.HasNotDefault
+            ? $@"
+    if (normalized.Length == 0)
+        return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));"
+            : "";
+
         return $@"
 
         /// <summary>
         /// Optional validation hook. Implement this partial method to add custom validation
         /// (e.g., regex patterns, format checks). Called after built-in validations pass.
         /// </summary>
-        /// <param name=""value"">The validated, trimmed string value.</param>
+        /// <param name=""value"">The validated string value (trimmed when [Trim] is applied).</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
         static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage);
@@ -585,11 +682,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            var notEmpty = value
-                .EnsureNotNullOrWhiteSpace(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
-            if (!notEmpty.TryGetValue(out var notEmptyValue))
-                return notEmpty.Map(str => new {g.ClassName}(str));
-            var normalized = notEmptyValue.Trim();{lengthChecks}
+            if (value is null)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+            var normalized = value;
+            {trimStep}{notDefaultStep}{lengthChecks}
             string? additionalError = null;
             ValidateAdditional(normalized, field, ref additionalError);
             if (additionalError is not null)
@@ -619,6 +715,21 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         var hasRange = g.RangeMin.HasValue && g.RangeMax.HasValue;
         var rangeMin = g.RangeMin.GetValueOrDefault();
         var rangeMax = g.RangeMax.GetValueOrDefault();
+
+        var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be zero.""";
+        var notDefaultIfCheck = g.HasNotDefault
+            ? $@"
+            if (value == 0)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})));"
+            : "";
+        var notDefaultNullableEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(x => x != 0, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+        var notDefaultParsedEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(_ => parsedInt != 0, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
 
         // Validate [Range] constraints are consistent
         if (hasRange && rangeMin > rangeMax)
@@ -666,7 +777,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             if (value < {rangeMin})
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
             if (value > {rangeMax})
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -681,7 +792,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var validated = valueOrNothing
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => x >= {rangeMin}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(x => x <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(x => x <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -701,7 +812,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }})))
                 .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -736,7 +847,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(int value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -749,7 +860,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -767,7 +878,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             int parsedInt = 0;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }})));
+                .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid integer."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -846,6 +957,21 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         var rangeMaxD = g.RangeDoubleMax ?? (double?)g.RangeMax;
         hasRange = hasRange || (g.RangeMin.HasValue && g.RangeMax.HasValue);
 
+        var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be zero.""";
+        var notDefaultIfCheck = g.HasNotDefault
+            ? $@"
+            if (value == 0m)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})));"
+            : "";
+        var notDefaultNullableEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(x => x != 0m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+        var notDefaultParsedEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(_ => parsedDecimal != 0m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+
         // Validate [Range] constraints are consistent
         if (hasRange && rangeMinD > rangeMaxD)
         {
@@ -911,7 +1037,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             if (value < {minStr}m)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
             if (value > {maxStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -926,7 +1052,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var validated = valueOrNothing
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => x >= {minStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(x => x <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(x => x <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -946,7 +1072,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }})))
                 .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -981,7 +1107,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(decimal value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -994,7 +1120,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1012,7 +1138,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             decimal parsedDecimal = 0m;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }})));
+                .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid decimal."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1089,6 +1215,21 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         var rangeLongMin = g.RangeLongMin.GetValueOrDefault();
         var rangeLongMax = g.RangeLongMax.GetValueOrDefault();
 
+        var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be zero.""";
+        var notDefaultIfCheck = g.HasNotDefault
+            ? $@"
+            if (value == 0L)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})));"
+            : "";
+        var notDefaultNullableEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(x => x != 0L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+        var notDefaultParsedEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(_ => parsedLong != 0L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+
         // Validate [Range] constraints are consistent
         if (hasRange && rangeLongMin > rangeLongMax)
         {
@@ -1135,7 +1276,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             if (value < {rangeLongMin}L)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
             if (value > {rangeLongMax}L)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -1150,7 +1291,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var validated = valueOrNothing
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => x >= {rangeLongMin}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1170,7 +1311,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }})))
                 .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1205,7 +1346,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public static Result<{g.ClassName}> TryCreate(long value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -1218,7 +1359,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1236,7 +1377,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             long parsedLong = 0;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }})));
+                .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid long."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1400,12 +1541,28 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.GetDisplayMessage()}}""));
         }}";
 
-    private static string GenerateDateTimeMethods(RequiredPartialClassInfo g) =>
-        $@"
+    private static string GenerateDateTimeMethods(RequiredPartialClassInfo g)
+    {
+        var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be DateTime.MinValue.""";
+        var notDefaultCheck = g.HasNotDefault
+            ? $@"
+            if (value == DateTime.MinValue)
+                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})));"
+            : "";
+        var notDefaultNullableEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(x => x != DateTime.MinValue, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+        var notDefaultParsedEnsure = g.HasNotDefault
+            ? $@"
+                .Ensure(_ => parsedDateTime != DateTime.MinValue, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = {notDefaultDetail} }})))"
+            : "";
+
+        return $@"
 
         /// <summary>
         /// Optional validation hook. Implement this partial method to add custom validation.
-        /// Called after built-in validations (null-check, MinValue check) pass.
+        /// Called after built-in validations pass.
         /// </summary>
         /// <param name=""value"">The validated DateTime value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
@@ -1416,15 +1573,13 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// Creates a validated instance from a DateTime.
         /// Required by IScalarValue interface for model binding and JSON deserialization.
         /// </summary>
-        /// <param name=""value"">The DateTime value to validate. Must not be <see cref=""DateTime.MinValue""/>.</param>
+        /// <param name=""value"">The DateTime value to validate.</param>
         /// <param name=""fieldName"">Optional field name for validation error messages.</param>
         /// <returns>Success with the value object, or Failure with validation errors.</returns>
         public static Result<{g.ClassName}> TryCreate(DateTime value, string? fieldName = null)
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (value == DateTime.MinValue)
-                return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+            var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultCheck}
             string? additionalError = null;
             ValidateAdditional(value, field, ref additionalError);
             if (additionalError is not null)
@@ -1437,8 +1592,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
-                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => x != DateTime.MinValue, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;
@@ -1453,11 +1607,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            DateTime parsedDateTime = DateTime.MinValue;
+            DateTime parsedDateTime = default;
             var validated = stringOrNull
                 .ToResult(() => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
-                .Ensure(x => DateTime.TryParse(x, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out parsedDateTime), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid date/time."" }})))
-                .Ensure(_ => parsedDateTime != DateTime.MinValue, _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
+                .Ensure(x => DateTime.TryParse(x, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out parsedDateTime), _ => new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid date/time."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;
@@ -1480,7 +1633,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            if (string.IsNullOrWhiteSpace(value))
+            if (value is null)
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
             if (!DateTime.TryParse(value, provider ?? System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
                 return Result.Fail<{g.ClassName}>(new Error.UnprocessableContent(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ""validation.error"") {{ Detail = ""Value must be a valid date/time."" }})));
@@ -1489,11 +1642,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
         /// <summary>
         /// Creates a validated instance from a DateTime. Throws if validation fails.
-        /// Use this for known-valid values in tests or with constants.
         /// </summary>
-        /// <param name=""value"">The DateTime value to validate.</param>
-        /// <returns>The validated value object.</returns>
-        /// <exception cref=""InvalidOperationException"">Thrown when validation fails.</exception>
         public static new {g.ClassName} Create(DateTime value)
         {{
             var result = TryCreate(value, null);
@@ -1504,11 +1653,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
         /// <summary>
         /// Creates a validated instance from a string by parsing it as a DateTime. Throws if validation or parsing fails.
-        /// Use this for known-valid date/time strings in tests or with constants.
         /// </summary>
-        /// <param name=""stringValue"">The string value to parse and validate.</param>
-        /// <returns>The validated value object.</returns>
-        /// <exception cref=""InvalidOperationException"">Thrown when validation or parsing fails.</exception>
         public static {g.ClassName} Create(string stringValue)
         {{
             var result = TryCreate(stringValue, null);
@@ -1516,6 +1661,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 onSuccess: created => created,
                 onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.GetDisplayMessage()}}""));
         }}";
+    }
 
     /// <summary>
     /// Extracts metadata from class declarations to determine which classes need code generation.
@@ -1632,7 +1778,28 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 }
             }
 
-            classToGenerate.Add(new RequiredPartialClassInfo(@namespace, className, @base, accessibility, maxLength, minLength, rangeMin, rangeMax, rangeLongMin, rangeLongMax, rangeDoubleMin, rangeDoubleMax, nestingParents, typePath));
+            // Read [NotDefault] and [Trim] attributes — apply across the Required family with
+            // per-base-type validity enforced separately (see TRLS040/TRLS041 generator diagnostics
+            // and the matching TRLS analyzer entries). We still harvest them on every base so the
+            // diagnostic emit step can see "presence on disallowed base" and fire.
+            bool hasNotDefault = false;
+            bool hasTrim = false;
+            foreach (var attr in classSymbol.GetAttributes())
+            {
+                if (attr.AttributeClass?.ContainingNamespace?.ToDisplayString() != "Trellis")
+                    continue;
+                switch (attr.AttributeClass?.Name)
+                {
+                    case "NotDefaultAttribute":
+                        hasNotDefault = true;
+                        break;
+                    case "TrimAttribute":
+                        hasTrim = true;
+                        break;
+                }
+            }
+
+            classToGenerate.Add(new RequiredPartialClassInfo(@namespace, className, @base, accessibility, maxLength, minLength, rangeMin, rangeMax, rangeLongMin, rangeLongMax, rangeDoubleMin, rangeDoubleMax, nestingParents, typePath, hasNotDefault, hasTrim));
         }
 
         return classToGenerate;

--- a/Trellis.Core/generator/RequiredPartialClassInfo.cs
+++ b/Trellis.Core/generator/RequiredPartialClassInfo.cs
@@ -139,6 +139,22 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     public readonly string TypePath;
 
     /// <summary>
+    /// Gets whether the target class is annotated with <c>[NotDefault]</c>.
+    /// When true, the generator emits a per-type "zero value" rejection check
+    /// (rejects <see cref="string.Empty"/> for strings, <c>0</c> for numerics,
+    /// <see cref="System.Guid.Empty"/> for GUIDs, <see cref="System.DateTime.MinValue"/> for
+    /// date-times). Invalid on <c>RequiredBool</c> and <c>RequiredEnum</c>.
+    /// </summary>
+    public readonly bool HasNotDefault;
+
+    /// <summary>
+    /// Gets whether the target class is annotated with <c>[Trim]</c>.
+    /// When true, the generator emits a trim of the input string before any other check.
+    /// Only valid on <c>RequiredString</c>-derived types.
+    /// </summary>
+    public readonly bool HasTrim;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="RequiredPartialClassInfo"/> class.
     /// </summary>
     /// <param name="nameSpace">The namespace of the partial class.</param>
@@ -155,6 +171,8 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// <param name="rangeDoubleMax">Optional maximum value from <c>[Range]</c> attribute for RequiredDecimal with fractional bounds.</param>
     /// <param name="nestingParents">Containing type declarations needed to emit nested generated types.</param>
     /// <param name="typePath">A unique namespace-qualified type path used for generated hint names.</param>
+    /// <param name="hasNotDefault">True when the target carries <c>[NotDefault]</c>.</param>
+    /// <param name="hasTrim">True when the target carries <c>[Trim]</c>.</param>
     public RequiredPartialClassInfo(
         string nameSpace,
         string className,
@@ -169,7 +187,9 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
         double? rangeDoubleMin = null,
         double? rangeDoubleMax = null,
         string[]? nestingParents = null,
-        string? typePath = null)
+        string? typePath = null,
+        bool hasNotDefault = false,
+        bool hasTrim = false)
     {
         NameSpace = nameSpace;
         ClassName = className;
@@ -185,6 +205,8 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
         RangeDoubleMax = rangeDoubleMax;
         NestingParents = nestingParents ?? [];
         TypePath = typePath ?? (string.IsNullOrEmpty(nameSpace) ? className : $"{nameSpace}.{className}");
+        HasNotDefault = hasNotDefault;
+        HasTrim = hasTrim;
     }
 
     public bool Equals(RequiredPartialClassInfo? other)
@@ -204,6 +226,8 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
             && RangeLongMax == other.RangeLongMax
             && RangeDoubleMin == other.RangeDoubleMin
             && RangeDoubleMax == other.RangeDoubleMax
+            && HasNotDefault == other.HasNotDefault
+            && HasTrim == other.HasTrim
             && TypePath == other.TypePath
             && NestingParents.SequenceEqual(other.NestingParents);
     }
@@ -227,6 +251,8 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
             hash = (hash * 31) + RangeLongMax.GetHashCode();
             hash = (hash * 31) + RangeDoubleMin.GetHashCode();
             hash = (hash * 31) + RangeDoubleMax.GetHashCode();
+            hash = (hash * 31) + HasNotDefault.GetHashCode();
+            hash = (hash * 31) + HasTrim.GetHashCode();
             hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(TypePath);
             return hash;
         }

--- a/Trellis.Core/generator/Trellis.Core.Generator.csproj
+++ b/Trellis.Core/generator/Trellis.Core.Generator.csproj
@@ -26,6 +26,10 @@
       <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
    </ItemGroup>
 
+   <ItemGroup>
+      <InternalsVisibleTo Include="Trellis.Core.Tests" />
+   </ItemGroup>
+
    <!--
       Force-disable PublishAot/PublishTrimmed inherited from a parent AOT-publishing project.
       Source generators target netstandard2.0 (mandated by Roslyn) and cannot satisfy the

--- a/Trellis.Core/src/Primitives/NotDefaultAttribute.cs
+++ b/Trellis.Core/src/Primitives/NotDefaultAttribute.cs
@@ -1,0 +1,89 @@
+﻿namespace Trellis;
+
+using System;
+
+/// <summary>
+/// Marks a partial <see cref="RequiredString{TSelf}"/> / <see cref="RequiredInt{TSelf}"/> /
+/// <see cref="RequiredLong{TSelf}"/> / <see cref="RequiredDecimal{TSelf}"/> /
+/// <see cref="RequiredGuid{TSelf}"/> / <see cref="RequiredDateTime{TSelf}"/> -derived class so
+/// the source generator emits an additional check that rejects the type's "zero value":
+/// <see cref="string.Empty"/> for strings, <c>0</c> for numerics,
+/// <see cref="Guid.Empty"/> for GUIDs, <see cref="DateTime.MinValue"/> for date-times.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default behavior of every <c>RequiredXxx&lt;T&gt;</c> base is to reject only <c>null</c>;
+/// the per-type "zero value" rejection is opt-in via this attribute. Mirrors the BCL
+/// <c>[NotNull]</c> / <c>[NotNullWhen]</c> naming pattern.
+/// </para>
+/// <para>
+/// The attribute name is shorthand for "reject this type's zero/sentinel value", not literally
+/// <c>default(T)</c> (which for <see cref="string"/> is <c>null</c>, not empty). The generator
+/// picks the rejection rule from the underlying primitive:
+/// <list type="bullet">
+///   <item><c>RequiredString&lt;T&gt;</c>: rejects <see cref="string.Empty"/>. When combined
+///     with <see cref="TrimAttribute"/>, the trim runs first, so whitespace-only input also
+///     becomes a rejection.</item>
+///   <item><c>RequiredInt&lt;T&gt;</c> / <c>RequiredLong&lt;T&gt;</c> / <c>RequiredDecimal&lt;T&gt;</c>:
+///     rejects <c>0</c>.</item>
+///   <item><c>RequiredGuid&lt;T&gt;</c>: rejects <see cref="Guid.Empty"/>.</item>
+///   <item><c>RequiredDateTime&lt;T&gt;</c>: rejects <see cref="DateTime.MinValue"/>.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Not supported on <c>RequiredBool&lt;T&gt;</c> (a bool that rejects <c>false</c> has only one
+/// constructible value, which is degenerate) or on <c>RequiredEnum&lt;T&gt;</c> (smart-enum
+/// members are always declared values; there is no CLR default to reject). The source generator
+/// emits a diagnostic for both invalid combinations, and the <c>TRLS</c> analyzer surfaces the
+/// same error in the IDE.
+/// </para>
+/// <para>
+/// Validation order in the generated <c>TryCreate</c>:
+/// <list type="number">
+///   <item>Null check (always).</item>
+///   <item><see cref="TrimAttribute"/> (string only; if present).</item>
+///   <item><see cref="NotDefaultAttribute"/> (if present).</item>
+///   <item><see cref="StringLengthAttribute"/> / <see cref="RangeAttribute"/> (if present).</item>
+///   <item>Consumer <c>ValidateAdditional</c> override.</item>
+/// </list>
+/// </para>
+/// </remarks>
+/// <example>
+/// Preserve today's "reject empty + whitespace" behavior on a string value object:
+/// <code>
+/// [Trim, NotDefault]
+/// public partial class FirstName : RequiredString&lt;FirstName&gt; { }
+///
+/// FirstName.TryCreate("John");      // Success
+/// FirstName.TryCreate("");          // Failure: "First Name cannot be empty."
+/// FirstName.TryCreate("   ");       // Failure: [Trim] -&gt; "" -&gt; [NotDefault]
+/// FirstName.TryCreate(" John ");    // Success: stored as "John"
+/// </code>
+/// </example>
+/// <example>
+/// Reject the zero ID on a numeric domain identifier:
+/// <code>
+/// [NotDefault]
+/// public partial class OrderNumber : RequiredInt&lt;OrderNumber&gt; { }
+///
+/// OrderNumber.TryCreate(0);   // Failure: "Order Number cannot be zero."
+/// OrderNumber.TryCreate(42);  // Success
+/// </code>
+/// </example>
+/// <example>
+/// Reject the empty GUID on an entity identifier:
+/// <code>
+/// [NotDefault]
+/// public partial class CustomerId : RequiredGuid&lt;CustomerId&gt; { }
+///
+/// CustomerId.TryCreate(Guid.Empty); // Failure: "Customer Id cannot be Guid.Empty."
+/// CustomerId.NewUniqueV7();         // Success
+/// </code>
+/// </example>
+/// <seealso cref="TrimAttribute"/>
+/// <seealso cref="StringLengthAttribute"/>
+/// <seealso cref="RangeAttribute"/>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class NotDefaultAttribute : Attribute
+{
+}

--- a/Trellis.Core/src/Primitives/RequiredDateTime.cs
+++ b/Trellis.Core/src/Primitives/RequiredDateTime.cs
@@ -1,8 +1,11 @@
 ﻿namespace Trellis;
 
 /// <summary>
-/// Base class for creating strongly-typed DateTime value objects that prevent primitive obsession for dates.
-/// Rejects <see cref="DateTime.MinValue"/> as the "empty" equivalent.
+/// Base class for creating strongly-typed DateTime value objects that prevent primitive
+/// obsession for dates. Rejects only <c>null</c> by default; <see cref="DateTime.MinValue"/>
+/// rejection is opt-in via the <see cref="NotDefaultAttribute"/> attribute. Recommended for
+/// any DateTime type used as an EF-mapped property to preserve the database invariant
+/// guarantee enforced by <c>TrellisScalarConverter</c> on rehydration.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/Trellis.Core/src/Primitives/RequiredDateTime.cs
+++ b/Trellis.Core/src/Primitives/RequiredDateTime.cs
@@ -9,18 +9,25 @@
 /// </summary>
 /// <remarks>
 /// <para>
-/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base for DateTime-based value objects
-/// with automatic validation that prevents default/MinValue dates. When used with the <c>partial</c> keyword,
+/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base
+/// for DateTime-based value objects. When used with the <c>partial</c> keyword,
 /// the PrimitiveValueObjectGenerator source generator automatically creates:
 /// <list type="bullet">
 /// <item><c>IScalarValue&lt;TSelf, DateTime&gt;</c> implementation for ASP.NET Core automatic validation</item>
 /// <item><c>TryCreate(DateTime)</c> - Factory method for DateTimes (required by IScalarValue)</item>
-/// <item><c>TryCreate(DateTime?, string?)</c> - Factory method with null/MinValue validation and custom field name</item>
+/// <item><c>TryCreate(DateTime?, string?)</c> - Factory method with null validation and custom field name</item>
 /// <item><c>TryCreate(string?, string?)</c> - Factory method for parsing strings with validation</item>
 /// <item><c>IParsable&lt;T&gt;</c> implementation (<c>Parse</c>, <c>TryParse</c>)</item>
 /// <item>JSON serialization support via <c>ParsableJsonConverter&lt;T&gt;</c></item>
 /// <item>Explicit cast operator from DateTime</item>
 /// <item>OpenTelemetry activity tracing</item>
+/// </list>
+/// </para>
+/// <para>
+/// Validation rules emitted by the source generator:
+/// <list type="bullet">
+/// <item><c>null</c> is always rejected with the per-type "cannot be empty." message.</item>
+/// <item>Apply <see cref="NotDefaultAttribute"/> to additionally reject <see cref="DateTime.MinValue"/> with the per-type "cannot be DateTime.MinValue." message. Recommended for any DateTime used as an EF-mapped property to preserve the database invariant guarantee enforced by <c>TrellisScalarConverter</c> on rehydration.</item>
 /// </list>
 /// </para>
 /// <para>
@@ -34,13 +41,24 @@
 /// </para>
 /// </remarks>
 /// <example>
-/// Creating a strongly-typed DateTime value object:
+/// Lenient default — only <c>null</c> is rejected:
 /// <code>
+/// public partial class EventTimestamp : RequiredDateTime&lt;EventTimestamp&gt; { }
+///
+/// var ok = EventTimestamp.TryCreate(DateTime.UtcNow);              // Success
+/// var min = EventTimestamp.TryCreate(DateTime.MinValue);           // Success (lenient)
+/// var nul = EventTimestamp.TryCreate((DateTime?)null);             // Failure
+/// </code>
+/// </example>
+/// <example>
+/// Strict opt-in — <see cref="DateTime.MinValue"/> rejected:
+/// <code>
+/// [NotDefault]
 /// public partial class OrderDate : RequiredDateTime&lt;OrderDate&gt; { }
 ///
-/// var result = OrderDate.TryCreate(DateTime.UtcNow);
-/// var fromString = OrderDate.TryCreate("2026-01-15T12:00:00Z");
-/// var invalid = OrderDate.TryCreate(DateTime.MinValue); // Failure
+/// var ok = OrderDate.TryCreate(DateTime.UtcNow);                   // Success
+/// var min = OrderDate.TryCreate(DateTime.MinValue);
+/// // Failure: "Order Date cannot be DateTime.MinValue."
 /// </code>
 /// </example>
 /// <seealso cref="ScalarValueObject{TSelf, T}"/>
@@ -51,7 +69,7 @@ public abstract class RequiredDateTime<TSelf> : ScalarValueObject<TSelf, DateTim
     /// <summary>
     /// Initializes a new instance of the <see cref="RequiredDateTime{TSelf}"/> class with the specified DateTime value.
     /// </summary>
-    /// <param name="value">The DateTime value. Must not be <see cref="DateTime.MinValue"/>.</param>
+    /// <param name="value">The DateTime value.</param>
     protected RequiredDateTime(DateTime value) : base(value)
     {
     }

--- a/Trellis.Core/src/Primitives/RequiredGuid.cs
+++ b/Trellis.Core/src/Primitives/RequiredGuid.cs
@@ -18,7 +18,7 @@
 /// <item><c>NewUniqueV4()</c> - Factory method for generating new unique Version 4 (random) identifiers</item>
 /// <item><c>NewUniqueV7()</c> - Factory method for generating new unique Version 7 (time-ordered) identifiers</item>
 /// <item><c>TryCreate(Guid)</c> - Factory method for non-nullable GUIDs (required by IScalarValue)</item>
-/// <item><c>TryCreate(Guid?, string?)</c> - Factory method with empty GUID validation and custom field name</item>
+/// <item><c>TryCreate(Guid?, string?)</c> - Factory method with null-only rejection by default (add <see cref="NotDefaultAttribute"/> for <see cref="Guid.Empty"/> rejection) and custom field name</item>
 /// <item><c>TryCreate(string?, string?)</c> - Factory method for parsing strings with validation</item>
 /// <item><c>IParsable&lt;T&gt;</c> implementation (<c>Parse</c>, <c>TryParse</c>)</item>
 /// <item>JSON serialization support via <c>ParsableJsonConverter&lt;T&gt;</c></item>
@@ -39,7 +39,7 @@
 /// Benefits over plain GUIDs:
 /// <list type="bullet">
 /// <item><strong>Type safety</strong>: Cannot accidentally use CustomerId where OrderId is expected</item>
-/// <item><strong>Validation</strong>: Prevents empty/default GUIDs at creation time</item>
+/// <item><strong>Validation</strong>: Prevents null at creation time; opt into <see cref="Guid.Empty"/> rejection with <c>[NotDefault]</c></item>
 /// <item><strong>Domain clarity</strong>: Makes code more self-documenting and expressive</item>
 /// <item><strong>Serialization</strong>: Consistent JSON and database representation</item>
 /// <item><strong>Factory methods</strong>: Clean API for creating new unique identifiers</item>
@@ -76,13 +76,15 @@
 /// 
 /// // Create from existing GUID with validation
 /// var result1 = CustomerId.TryCreate(existingGuid);
-/// // Returns: Success(CustomerId) if guid != Guid.Empty
-/// // Returns: Failure(Error.UnprocessableContent) if guid == Guid.Empty
-/// 
+/// // Default (no [NotDefault]): Success regardless of value, including Guid.Empty.
+/// // With [NotDefault] on CustomerId: Success when guid != Guid.Empty;
+/// // Failure("Customer Id cannot be Guid.Empty.") when guid == Guid.Empty.
+///
 /// // Create from string with validation
 /// var result2 = CustomerId.TryCreate("550e8400-e29b-41d4-a716-446655440000");
 /// // Returns: Success(CustomerId) if valid GUID format
-/// // Returns: Failure(Error.UnprocessableContent) if invalid format or empty GUID
+/// // Returns: Failure(Error.UnprocessableContent) if invalid format
+/// // (or, when [NotDefault] is applied, also Failure if the parsed GUID is Guid.Empty)
 /// 
 /// // With custom field name for validation errors
 /// var result3 = CustomerId.TryCreate(input, "customer.id");
@@ -120,7 +122,7 @@
 ///     [HttpGet("{id}")]
 ///     public async Task&lt;ActionResult&lt;Customer&gt;&gt; Get(CustomerId id) // Automatically validated!
 ///     {
-///         // If we reach here, 'id' is a valid, non-empty CustomerId
+///         // If we reach here, 'id' is a non-null CustomerId (and, with [NotDefault], non-Guid.Empty)
 ///         // Model binding validated it automatically
 ///         var customer = await _repository.GetByIdAsync(id);
 ///         return Ok(customer);
@@ -134,7 +136,7 @@
 ///     }
 /// }
 ///
-/// // Invalid GUID is rejected automatically:
+/// // Invalid GUID (with [NotDefault] on CustomerId) is rejected automatically:
 /// // GET /api/customers/00000000-0000-0000-0000-000000000000
 /// // Response: 422 Unprocessable Content
 /// // {
@@ -142,7 +144,7 @@
 /// //   "title": "One or more validation errors occurred.",
 /// //   "status": 422,
 /// //   "errors": {
-/// //     "id": ["Customer Id cannot be empty."]
+/// //     "id": ["Customer Id cannot be Guid.Empty."]
 /// //   }
 /// // }
 /// </code>
@@ -164,8 +166,8 @@
 /// // Request: GET /customers/550e8400-e29b-41d4-a716-446655440000
 /// // Response: { "customerId": "550e8400-e29b-41d4-a716-446655440000", "name": "John" }
 /// // 
-/// // Invalid GUID: GET /customers/00000000-0000-0000-0000-000000000000
-/// // Response: 422 Unprocessable Content with Error.UnprocessableContent
+/// // Invalid GUID (with [NotDefault] on CustomerId): GET /customers/00000000-0000-0000-0000-000000000000
+/// // Response: 422 Unprocessable Content with "Customer Id cannot be Guid.Empty." detail
 /// </code>
 /// </example>
 /// <example>
@@ -198,7 +200,7 @@ public abstract class RequiredGuid<TSelf> : ScalarValueObject<TSelf, Guid>
     /// <summary>
     /// Initializes a new instance of the <see cref="RequiredGuid{TSelf}"/> class with the specified GUID value.
     /// </summary>
-    /// <param name="value">The GUID value. Must not be <see cref="Guid.Empty"/>.</param>
+    /// <param name="value">The GUID value.</param>
     /// <remarks>
     /// <para>
     /// This constructor is protected and should be called by derived classes.

--- a/Trellis.Core/src/Primitives/RequiredGuid.cs
+++ b/Trellis.Core/src/Primitives/RequiredGuid.cs
@@ -136,7 +136,7 @@
 ///     }
 /// }
 ///
-/// // Invalid GUID (with [NotDefault] on CustomerId) is rejected automatically:
+/// // All-zero GUID (with [NotDefault] on CustomerId) is rejected as the sentinel value:
 /// // GET /api/customers/00000000-0000-0000-0000-000000000000
 /// // Response: 422 Unprocessable Content
 /// // {
@@ -166,7 +166,7 @@
 /// // Request: GET /customers/550e8400-e29b-41d4-a716-446655440000
 /// // Response: { "customerId": "550e8400-e29b-41d4-a716-446655440000", "name": "John" }
 /// // 
-/// // Invalid GUID (with [NotDefault] on CustomerId): GET /customers/00000000-0000-0000-0000-000000000000
+/// // All-zero GUID (rejected as the sentinel only when [NotDefault] is applied): GET /customers/00000000-0000-0000-0000-000000000000
 /// // Response: 422 Unprocessable Content with "Customer Id cannot be Guid.Empty." detail
 /// </code>
 /// </example>

--- a/Trellis.Core/src/Primitives/RequiredGuid.cs
+++ b/Trellis.Core/src/Primitives/RequiredGuid.cs
@@ -1,13 +1,17 @@
 ﻿namespace Trellis;
 
 /// <summary>
-/// Base class for creating strongly-typed GUID value objects that cannot have the default (empty) GUID value.
-/// Provides a foundation for entity identifiers and other domain concepts represented by GUIDs.
+/// Base class for creating strongly-typed GUID value objects. Rejects only <c>null</c> by
+/// default; <see cref="System.Guid.Empty"/> rejection is opt-in via the
+/// <see cref="NotDefaultAttribute"/> attribute. **Recommended for any GUID type used as an
+/// <c>Aggregate&lt;TId&gt;</c> / <c>Entity&lt;TId&gt;</c> ID or as an EF-mapped property** to
+/// preserve the database invariant guarantee enforced by <c>TrellisScalarConverter</c> on
+/// rehydration.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base for GUID-based value objects
-/// with automatic validation that prevents empty/default GUIDs. When used with the <c>partial</c> keyword,
+/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base for GUID-based value objects.
+/// When used with the <c>partial</c> keyword,
 /// the PrimitiveValueObjectGenerator source generator automatically creates:
 /// <list type="bullet">
 /// <item><c>IScalarValue&lt;TSelf, Guid&gt;</c> implementation for ASP.NET Core automatic validation</item>

--- a/Trellis.Core/src/Primitives/RequiredGuid.cs
+++ b/Trellis.Core/src/Primitives/RequiredGuid.cs
@@ -3,8 +3,8 @@
 /// <summary>
 /// Base class for creating strongly-typed GUID value objects. Rejects only <c>null</c> by
 /// default; <see cref="System.Guid.Empty"/> rejection is opt-in via the
-/// <see cref="NotDefaultAttribute"/> attribute. **Recommended for any GUID type used as an
-/// <c>Aggregate&lt;TId&gt;</c> / <c>Entity&lt;TId&gt;</c> ID or as an EF-mapped property** to
+/// <see cref="NotDefaultAttribute"/> attribute. Recommended for any GUID type used as an
+/// <c>Aggregate&lt;TId&gt;</c> / <c>Entity&lt;TId&gt;</c> ID or as an EF-mapped property to
 /// preserve the database invariant guarantee enforced by <c>TrellisScalarConverter</c> on
 /// rehydration.
 /// </summary>

--- a/Trellis.Core/src/Primitives/RequiredString.cs
+++ b/Trellis.Core/src/Primitives/RequiredString.cs
@@ -13,7 +13,7 @@
 /// <list type="bullet">
 /// <item><c>IScalarValue&lt;TSelf, string&gt;</c> implementation for ASP.NET Core automatic validation</item>
 /// <item><c>TryCreate(string)</c> - Factory method for non-nullable strings (required by IScalarValue)</item>
-/// <item><c>TryCreate(string?, string?)</c> - Factory method with null/empty/whitespace validation and custom field name</item>
+/// <item><c>TryCreate(string?, string?)</c> - Factory method with null-only rejection by default (add <see cref="NotDefaultAttribute"/> for empty rejection and <see cref="TrimAttribute"/> for trim) and custom field name</item>
 /// <item><c>IParsable&lt;T&gt;</c> implementation (<c>Parse</c>, <c>TryParse</c>)</item>
 /// <item>JSON serialization support via <c>ParsableJsonConverter&lt;T&gt;</c></item>
 /// <item>Explicit cast operator from string</item>
@@ -45,22 +45,34 @@
 /// Benefits over plain strings:
 /// <list type="bullet">
 /// <item><strong>Type safety</strong>: Cannot mix FirstName with LastName</item>
-/// <item><strong>Validation</strong>: Prevents null/empty strings at creation time</item>
+/// <item><strong>Validation</strong>: Prevents null at creation time; opt into empty / whitespace rejection with <c>[NotDefault]</c> / <c>[Trim]</c></item>
 /// <item><strong>Length constraints</strong>: Optional min/max length via <see cref="StringLengthAttribute"/></item>
 /// <item><strong>Domain clarity</strong>: Self-documenting code that expresses intent</item>
-/// <item><strong>Consistency</strong>: Centralized trimming and normalization</item>
+/// <item><strong>Consistency</strong>: Centralized normalization via opt-in attributes (<c>[Trim]</c>, <c>[NotDefault]</c>, <c>[StringLength]</c>) and the <c>ValidateAdditional</c> hook</item>
 /// <item><strong>Testability</strong>: Easy to test validation rules in isolation</item>
 /// </list>
 /// </para>
 /// </remarks>
 /// <example>
-/// Creating a strongly-typed name value object:
+/// Lenient default — only <c>null</c> is rejected:
 /// <code>
-/// // Define the value object (partial keyword enables source generation)
-/// public partial class FirstName : RequiredString&lt;FirstName&gt;
-/// {
-/// }
-/// 
+/// public partial class FirstName : RequiredString&lt;FirstName&gt; { }
+///
+/// FirstName.TryCreate("John");        // Success("John")
+/// FirstName.TryCreate("");            // Success("") — stored verbatim
+/// FirstName.TryCreate("   ");         // Success("   ") — whitespace preserved
+/// FirstName.TryCreate("  John  ");    // Success("  John  ") — no auto-trim
+/// FirstName.TryCreate(null);          // Failure: "First Name cannot be empty."
+/// </code>
+/// </example>
+/// <example>
+/// Strict opt-in equivalent to the pre-realignment defaults — apply <see cref="TrimAttribute"/>
+/// and <see cref="NotDefaultAttribute"/> together for the recommended default for any string
+/// mapped to a database column:
+/// <code>
+/// [Trim, NotDefault]
+/// public partial class FirstName : RequiredString&lt;FirstName&gt; { }
+///
 /// // The source generator automatically creates:
 /// // - IScalarValue&lt;FirstName, string&gt; interface implementation
 /// // - public static Result&lt;FirstName&gt; TryCreate(string value)
@@ -69,38 +81,29 @@
 /// // - public static bool TryParse(string? s, IFormatProvider? provider, out FirstName result)
 /// // - public static explicit operator FirstName(string value)
 /// // - private FirstName(string value) : base(value) { }
-/// 
-/// // Usage examples:
-/// 
-/// // Create with validation
-/// var result1 = FirstName.TryCreate("John");
-/// // Returns: Success(FirstName("John"))
-/// 
-/// var result2 = FirstName.TryCreate("");
-/// // Returns: Failure(Error.UnprocessableContent with detail "First Name cannot be empty.")
-/// 
-/// var result3 = FirstName.TryCreate(null);
-/// // Returns: Failure(Error.UnprocessableContent with detail "First Name cannot be empty.")
-/// 
-/// var result4 = FirstName.TryCreate("  John  ");
-/// // Returns: Success(FirstName("John")) - automatically trimmed
-/// 
+///
+/// FirstName.TryCreate("John");        // Success("John")
+/// FirstName.TryCreate("  John  ");    // Success("John") — trimmed
+/// FirstName.TryCreate("   ");         // Failure: trim → "" → [NotDefault]
+/// FirstName.TryCreate("");            // Failure: "First Name cannot be empty."
+/// FirstName.TryCreate(null);          // Failure: "First Name cannot be empty."
+///
 /// // With custom field name for validation errors
-/// var result5 = FirstName.TryCreate(input, "user.firstName");
+/// FirstName.TryCreate(input, "user.firstName");
 /// // Error field will be "user.firstName" instead of default "firstName"
-/// 
+///
 /// // Using in entity creation
 /// public class Person : Entity&lt;PersonId&gt;
 /// {
 ///     public FirstName FirstName { get; }
 ///     public LastName LastName { get; }
-///     
+///
 ///     public static Result&lt;Person&gt; Create(string firstName, string lastName) =>
 ///         FirstName.TryCreate(firstName)
 ///             .Combine(LastName.TryCreate(lastName))
 ///             .Map((first, last) => new Person(PersonId.NewUniqueV7(), first, last));
-///     
-///     private Person(PersonId id, FirstName firstName, LastName lastName) 
+///
+///     private Person(PersonId id, FirstName firstName, LastName lastName)
 ///         : base(id)
 ///     {
 ///         FirstName = firstName;
@@ -256,27 +259,30 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
     /// <summary>
     /// Initializes a new instance of the <see cref="RequiredString{TSelf}"/> class with the specified string value.
     /// </summary>
-    /// <param name="value">The string value. Must not be null or empty.</param>
+    /// <param name="value">The string value.</param>
     /// <remarks>
     /// <para>
     /// This constructor is protected and should be called by derived classes.
     /// When using the source generator (with <c>partial</c> keyword), a private constructor
-    /// is automatically generated that includes validation and trimming.
+    /// is automatically generated.
     /// </para>
     /// <para>
     /// Direct instantiation should be avoided. Instead, use the generated factory method:
     /// <list type="bullet">
-    /// <item><c>TryCreate(string?, string?)</c> - Create from string with validation and trimming</item>
+    /// <item><c>TryCreate(string?, string?)</c> - Create from string with validation</item>
     /// </list>
     /// </para>
     /// <para>
-    /// The generated TryCreate method automatically:
+    /// The generated <c>TryCreate</c> method always rejects <c>null</c> with
+    /// <c>"&lt;FieldName&gt; cannot be empty."</c>. Additional behavior is opt-in per attribute:
     /// <list type="bullet">
-    /// <item>Returns validation error for null values</item>
-    /// <item>Returns validation error for empty strings</item>
-    /// <item>Returns validation error for whitespace-only strings</item>
-    /// <item>Trims leading and trailing whitespace from valid strings</item>
+    /// <item><see cref="TrimAttribute"/> — trims leading and trailing whitespace before any subsequent check.</item>
+    /// <item><see cref="NotDefaultAttribute"/> — rejects <see cref="string.Empty"/> (operates on the post-trim value when <c>[Trim]</c> is also present).</item>
+    /// <item><see cref="StringLengthAttribute"/> — applies minimum and / or maximum length bounds; measures the post-trim value when <c>[Trim]</c> is present, the raw input otherwise.</item>
     /// </list>
+    /// Applying <c>[Trim, NotDefault]</c> together is the recommended setup for any string
+    /// mapped to a database column and recovers the pre-realignment "reject null + empty +
+    /// whitespace; auto-trim" default.
     /// </para>
     /// </remarks>
     protected RequiredString(string value) : base(value)

--- a/Trellis.Core/src/Primitives/RequiredString.cs
+++ b/Trellis.Core/src/Primitives/RequiredString.cs
@@ -1,14 +1,15 @@
 ﻿namespace Trellis;
 
 /// <summary>
-/// Base class for creating strongly-typed string value objects that cannot be null or empty.
-/// Provides a foundation for domain primitives like names, descriptions, codes, and other textual concepts.
+/// Base class for creating strongly-typed string value objects. Rejects only <c>null</c> by
+/// default; per-type sentinel rejection ("cannot be empty") and trimming are opt-in via the
+/// <see cref="NotDefaultAttribute"/> and <see cref="TrimAttribute"/> attributes.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base for string-based value objects
-/// with automatic validation that prevents null or empty strings. When used with the <c>partial</c> keyword,
-/// the PrimitiveValueObjectGenerator source generator automatically creates:
+/// This class extends <see cref="ScalarValueObject{TSelf, T}"/> to provide a specialized base for string-based value objects.
+/// When used with the <c>partial</c> keyword, the PrimitiveValueObjectGenerator source generator
+/// automatically creates:
 /// <list type="bullet">
 /// <item><c>IScalarValue&lt;TSelf, string&gt;</c> implementation for ASP.NET Core automatic validation</item>
 /// <item><c>TryCreate(string)</c> - Factory method for non-nullable strings (required by IScalarValue)</item>

--- a/Trellis.Core/src/Primitives/TrimAttribute.cs
+++ b/Trellis.Core/src/Primitives/TrimAttribute.cs
@@ -1,0 +1,51 @@
+﻿namespace Trellis;
+
+using System;
+
+/// <summary>
+/// Marks a partial <see cref="RequiredString{TSelf}"/>-derived class so the source generator
+/// trims the input string before any subsequent validation runs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Removed from the default <see cref="RequiredString{TSelf}"/> behavior (which previously
+/// always trimmed) so the type does exactly what its attributes declare and nothing more.
+/// Apply <c>[Trim]</c> when leading / trailing whitespace must be stripped before storage.
+/// </para>
+/// <para>
+/// Validation order in the generated <c>TryCreate</c>:
+/// <list type="number">
+///   <item>Null check (always).</item>
+///   <item><see cref="TrimAttribute"/> (if present).</item>
+///   <item><see cref="NotDefaultAttribute"/> (if present).</item>
+///   <item><see cref="StringLengthAttribute"/> (if present, measures the post-trim value).</item>
+///   <item>Consumer <c>ValidateAdditional</c> override.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <c>[Trim]</c> on its own (without <see cref="NotDefaultAttribute"/>) trims and stores the
+/// result verbatim, even if the result is <see cref="string.Empty"/>. Combine with
+/// <c>[NotDefault]</c> to reject empty / whitespace-only input — that is the recommended
+/// default for any string mapped to a database column.
+/// </para>
+/// <para>
+/// Not supported on non-string Required types (<c>RequiredInt</c>, <c>RequiredGuid</c>, etc.).
+/// The source generator emits a diagnostic and the <c>TRLS</c> analyzer surfaces the same
+/// error in the IDE.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Trim, NotDefault]
+/// public partial class FirstName : RequiredString&lt;FirstName&gt; { }
+///
+/// FirstName.TryCreate(" John ");  // Success: stored as "John"
+/// FirstName.TryCreate("   ");     // Failure: trim -&gt; "" -&gt; [NotDefault]
+/// </code>
+/// </example>
+/// <seealso cref="NotDefaultAttribute"/>
+/// <seealso cref="StringLengthAttribute"/>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class TrimAttribute : Attribute
+{
+}

--- a/Trellis.Core/tests/RequiredPartialClassInfoEqualityTests.cs
+++ b/Trellis.Core/tests/RequiredPartialClassInfoEqualityTests.cs
@@ -99,6 +99,101 @@ public class RequiredPartialClassInfoEqualityTests
         Make(classBase: "RequiredString", maxLength: 10).Equals(Make(classBase: "RequiredString", maxLength: 20)).Should().BeFalse();
 
     [Fact]
+    public void Differing_Accessibility_makes_infos_unequal() =>
+        Make(accessibility: "public").Equals(Make(accessibility: "internal")).Should().BeFalse();
+
+    [Fact]
+    public void Differing_MinLength_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredString", maxLength: 50, minLength: 1);
+        var b = Make(classBase: "RequiredString", maxLength: 50, minLength: 5);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeMin_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredInt", rangeMin: 1, rangeMax: 100);
+        var b = Make(classBase: "RequiredInt", rangeMin: 2, rangeMax: 100);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeMax_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredInt", rangeMin: 1, rangeMax: 100);
+        var b = Make(classBase: "RequiredInt", rangeMin: 1, rangeMax: 200);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeLongMin_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredLong", rangeLongMin: 1L, rangeLongMax: 100L);
+        var b = Make(classBase: "RequiredLong", rangeLongMin: 2L, rangeLongMax: 100L);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeLongMax_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredLong", rangeLongMin: 1L, rangeLongMax: 100L);
+        var b = Make(classBase: "RequiredLong", rangeLongMin: 1L, rangeLongMax: 200L);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeDoubleMin_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredDecimal", rangeDoubleMin: 0.5, rangeDoubleMax: 99.5);
+        var b = Make(classBase: "RequiredDecimal", rangeDoubleMin: 0.6, rangeDoubleMax: 99.5);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_RangeDoubleMax_makes_infos_unequal()
+    {
+        var a = Make(classBase: "RequiredDecimal", rangeDoubleMin: 0.5, rangeDoubleMax: 99.5);
+        var b = Make(classBase: "RequiredDecimal", rangeDoubleMin: 0.5, rangeDoubleMax: 100.0);
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_TypePath_makes_infos_unequal()
+    {
+        var a = Make(typePath: "MyApp.Inner.OrderId");
+        var b = Make(typePath: "MyApp.Outer.OrderId");
+        a.Equals(b).Should().BeFalse();
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_NestingParents_makes_infos_unequal()
+    {
+        // NestingParents is the only array-typed field; uses SequenceEqual in Equals.
+        // Both length-differs and element-differs must be detected.
+        var noParents = Make(nestingParents: []);
+        var oneParent = Make(nestingParents: ["public partial class Outer"]);
+        noParents.Equals(oneParent).Should().BeFalse();
+
+        var elementA = Make(nestingParents: ["public partial class Outer"]);
+        var elementB = Make(nestingParents: ["public partial class Container"]);
+        elementA.Equals(elementB).Should().BeFalse();
+
+        // Same content -> equal (content-based, not reference-based, equality)
+        var ref1 = Make(nestingParents: ["public partial class Outer", "public partial class Mid"]);
+        var ref2 = Make(nestingParents: ["public partial class Outer", "public partial class Mid"]);
+        ref1.Equals(ref2).Should().BeTrue();
+    }
+
+    [Fact]
     public void Equals_with_null_is_false() => Make().Equals(null).Should().BeFalse();
 
     [Fact]

--- a/Trellis.Core/tests/RequiredPartialClassInfoEqualityTests.cs
+++ b/Trellis.Core/tests/RequiredPartialClassInfoEqualityTests.cs
@@ -1,0 +1,136 @@
+﻿namespace Trellis.Core.Tests;
+
+using Trellis.PrimitiveValueObjectGenerator;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="RequiredPartialClassInfo"/>'s <see cref="object.Equals(object?)"/> and
+/// <see cref="object.GetHashCode"/> overrides. The class is the cache key into the incremental
+/// source-generator pipeline; if its equality fails to incorporate a new property, the generator
+/// will silently emit stale code when only that property changes. The <c>HasNotDefault</c> and
+/// <c>HasTrim</c> flags added by the POLA realignment must participate in both <c>Equals</c>
+/// and <c>GetHashCode</c>.
+/// </summary>
+public class RequiredPartialClassInfoEqualityTests
+{
+    private static RequiredPartialClassInfo Make(
+        string @namespace = "MyApp",
+        string className = "OrderId",
+        string classBase = "RequiredGuid",
+        string accessibility = "public",
+        int? maxLength = null,
+        int? minLength = null,
+        int? rangeMin = null,
+        int? rangeMax = null,
+        long? rangeLongMin = null,
+        long? rangeLongMax = null,
+        double? rangeDoubleMin = null,
+        double? rangeDoubleMax = null,
+        string[]? nestingParents = null,
+        string? typePath = null,
+        bool hasNotDefault = false,
+        bool hasTrim = false) =>
+        new(@namespace, className, classBase, accessibility, maxLength, minLength,
+            rangeMin, rangeMax, rangeLongMin, rangeLongMax, rangeDoubleMin, rangeDoubleMax,
+            nestingParents, typePath, hasNotDefault, hasTrim);
+
+    [Fact]
+    public void Identical_infos_are_equal_and_have_same_hash()
+    {
+        var a = Make();
+        var b = Make();
+        a.Equals(b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_HasNotDefault_makes_infos_unequal()
+    {
+        var lenient = Make(hasNotDefault: false);
+        var strict = Make(hasNotDefault: true);
+        lenient.Equals(strict).Should().BeFalse();
+        lenient.GetHashCode().Should().NotBe(strict.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_HasTrim_makes_infos_unequal()
+    {
+        var noTrim = Make(classBase: "RequiredString", hasTrim: false);
+        var withTrim = Make(classBase: "RequiredString", hasTrim: true);
+        noTrim.Equals(withTrim).Should().BeFalse();
+        noTrim.GetHashCode().Should().NotBe(withTrim.GetHashCode());
+    }
+
+    [Fact]
+    public void Adding_NotDefault_to_an_existing_class_changes_equality()
+    {
+        // The realistic incremental-generator scenario: the same partial class gains a
+        // [NotDefault] attribute. The pipeline must see this as a distinct info value or
+        // it will keep the stale generated output.
+        var before = Make(classBase: "RequiredGuid", hasNotDefault: false, hasTrim: false);
+        var after = Make(classBase: "RequiredGuid", hasNotDefault: true, hasTrim: false);
+        before.Equals(after).Should().BeFalse();
+        before.GetHashCode().Should().NotBe(after.GetHashCode());
+    }
+
+    [Fact]
+    public void Adding_Trim_to_an_existing_class_changes_equality()
+    {
+        var before = Make(classBase: "RequiredString", hasNotDefault: true, hasTrim: false);
+        var after = Make(classBase: "RequiredString", hasNotDefault: true, hasTrim: true);
+        before.Equals(after).Should().BeFalse();
+        before.GetHashCode().Should().NotBe(after.GetHashCode());
+    }
+
+    [Fact]
+    public void Differing_ClassName_makes_infos_unequal() =>
+        Make(className: "OrderId").Equals(Make(className: "CustomerId")).Should().BeFalse();
+
+    [Fact]
+    public void Differing_ClassBase_makes_infos_unequal() =>
+        Make(classBase: "RequiredGuid").Equals(Make(classBase: "RequiredString")).Should().BeFalse();
+
+    [Fact]
+    public void Differing_Namespace_makes_infos_unequal() =>
+        Make(@namespace: "MyApp").Equals(Make(@namespace: "OtherApp")).Should().BeFalse();
+
+    [Fact]
+    public void Differing_MaxLength_makes_infos_unequal() =>
+        Make(classBase: "RequiredString", maxLength: 10).Equals(Make(classBase: "RequiredString", maxLength: 20)).Should().BeFalse();
+
+    [Fact]
+    public void Equals_with_null_is_false() => Make().Equals(null).Should().BeFalse();
+
+    [Fact]
+    public void Equals_with_reference_is_true()
+    {
+        var info = Make();
+        info.Equals(info).Should().BeTrue();
+    }
+
+    [Fact]
+    public void All_flags_combination_round_trips_through_equality()
+    {
+        // Spot-check the 2x2 matrix of HasNotDefault x HasTrim.
+        var combos = new[]
+        {
+            (nd: false, t: false),
+            (nd: true,  t: false),
+            (nd: false, t: true),
+            (nd: true,  t: true),
+        };
+
+        for (int i = 0; i < combos.Length; i++)
+        {
+            for (int j = 0; j < combos.Length; j++)
+            {
+                var a = Make(classBase: "RequiredString", hasNotDefault: combos[i].nd, hasTrim: combos[i].t);
+                var b = Make(classBase: "RequiredString", hasNotDefault: combos[j].nd, hasTrim: combos[j].t);
+                if (i == j)
+                    a.Equals(b).Should().BeTrue();
+                else
+                    a.Equals(b).Should().BeFalse();
+            }
+        }
+    }
+}

--- a/Trellis.Core/tests/Trellis.Core.Tests.csproj
+++ b/Trellis.Core/tests/Trellis.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\src\Trellis.Core.csproj" />
+		<ProjectReference Include="..\generator\Trellis.Core.Generator.csproj" ReferenceOutputAssembly="true" OutputItemType="None" />
 		<ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
 	</ItemGroup>
 

--- a/Trellis.EntityFrameworkCore/tests/RequiredXxxRehydrationLenienceTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/RequiredXxxRehydrationLenienceTests.cs
@@ -1,0 +1,90 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using System;
+using Trellis;
+using Trellis.Testing;
+using Xunit;
+
+// Lenient and strict variants for the POLA realignment rehydration test.
+public partial class LenientEfGuid : RequiredGuid<LenientEfGuid> { }
+
+[NotDefault]
+public partial class StrictEfGuid : RequiredGuid<StrictEfGuid> { }
+
+public partial class LenientEfDateTime : RequiredDateTime<LenientEfDateTime> { }
+
+[NotDefault]
+public partial class StrictEfDateTime : RequiredDateTime<StrictEfDateTime> { }
+
+public partial class LenientEfString : RequiredString<LenientEfString> { }
+
+[Trim, NotDefault]
+public partial class StrictEfString : RequiredString<StrictEfString> { }
+
+/// <summary>
+/// Regression coverage for the POLA realignment EF read-path impact: <see cref="TrellisScalarConverter{TModel, TProvider}"/>
+/// calls <c>TryCreate</c> to materialize every row, so lenient-by-default Required types no longer
+/// throw <c>TrellisPersistenceMappingException</c> when a column legitimately contains the
+/// sentinel value (<c>Guid.Empty</c>, <c>DateTime.MinValue</c>, <c>""</c>). Strict types decorated
+/// with <c>[NotDefault]</c> retain the database-invariant guarantee.
+/// </summary>
+/// <remarks>
+/// Exercises the converter directly via <c>ValueConverter&lt;,&gt;.ConvertFromProvider</c> rather
+/// than spinning up a DbContext. The materialization path is the same in both cases — EF Core's
+/// query pipeline invokes the same delegate on every row read — so the converter-level assertion
+/// is equivalent to the round-trip check but does not require a backing database. This keeps the
+/// test compatible with the SQL-Server-less CI environment.
+/// </remarks>
+public class RequiredXxxRehydrationLenienceTests
+{
+    [Fact]
+    public void LenientGuidConverter_materializes_Guid_Empty_without_throwing()
+    {
+        var converter = new TrellisScalarConverter<LenientEfGuid, Guid>();
+        var materialized = (LenientEfGuid)converter.ConvertFromProvider(Guid.Empty)!;
+        materialized.Value.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void StrictGuidConverter_throws_TrellisPersistenceMappingException_on_Guid_Empty()
+    {
+        var converter = new TrellisScalarConverter<StrictEfGuid, Guid>();
+        Action act = () => _ = (StrictEfGuid)converter.ConvertFromProvider(Guid.Empty)!;
+        act.Should().Throw<TrellisPersistenceMappingException>()
+            .WithMessage("*Strict Ef Guid cannot be Guid.Empty*");
+    }
+
+    [Fact]
+    public void LenientDateTimeConverter_materializes_MinValue_without_throwing()
+    {
+        var converter = new TrellisScalarConverter<LenientEfDateTime, DateTime>();
+        var materialized = (LenientEfDateTime)converter.ConvertFromProvider(DateTime.MinValue)!;
+        materialized.Value.Should().Be(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void StrictDateTimeConverter_throws_on_MinValue()
+    {
+        var converter = new TrellisScalarConverter<StrictEfDateTime, DateTime>();
+        Action act = () => _ = (StrictEfDateTime)converter.ConvertFromProvider(DateTime.MinValue)!;
+        act.Should().Throw<TrellisPersistenceMappingException>()
+            .WithMessage("*Strict Ef Date Time cannot be DateTime.MinValue*");
+    }
+
+    [Fact]
+    public void LenientStringConverter_materializes_empty_string_without_throwing()
+    {
+        var converter = new TrellisScalarConverter<LenientEfString, string>();
+        var materialized = (LenientEfString)converter.ConvertFromProvider("")!;
+        materialized.Value.Should().Be("");
+    }
+
+    [Fact]
+    public void StrictStringConverter_throws_on_empty_string()
+    {
+        var converter = new TrellisScalarConverter<StrictEfString, string>();
+        Action act = () => _ = (StrictEfString)converter.ConvertFromProvider("")!;
+        act.Should().Throw<TrellisPersistenceMappingException>()
+            .WithMessage("*Strict Ef String cannot be empty*");
+    }
+}

--- a/Trellis.EntityFrameworkCore/tests/RequiredXxxRehydrationLenienceTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/RequiredXxxRehydrationLenienceTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using Trellis;
-using Trellis.Testing;
 using Xunit;
 
 // Lenient and strict variants for the POLA realignment rehydration test.

--- a/Trellis.Primitives/tests/CompositeRequiredStringFlowThroughTests.cs
+++ b/Trellis.Primitives/tests/CompositeRequiredStringFlowThroughTests.cs
@@ -1,0 +1,134 @@
+﻿namespace Trellis.Primitives.Tests;
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Trellis;
+using Trellis.Primitives;
+using Trellis.Testing;
+using Xunit;
+
+// --- Inner scalar value objects: one lenient, one strict ---
+
+public partial class FlowThroughLenientName : RequiredString<FlowThroughLenientName> { }
+
+[Trim, NotDefault]
+public partial class FlowThroughStrictName : RequiredString<FlowThroughStrictName> { }
+
+// --- Composite VO whose inner scalar is lenient ---
+
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<FlowThroughLenientComposite>))]
+public sealed class FlowThroughLenientComposite : ValueObject
+{
+    public FlowThroughLenientName Name { get; private set; } = null!;
+    public int Quantity { get; private set; }
+
+    private FlowThroughLenientComposite() { }
+    private FlowThroughLenientComposite(FlowThroughLenientName name, int quantity)
+    {
+        Name = name;
+        Quantity = quantity;
+    }
+
+    public static Result<FlowThroughLenientComposite> TryCreate(string name, int quantity, string? fieldName = null) =>
+        FlowThroughLenientName.TryCreate(name, "name")
+            .Map(n => new FlowThroughLenientComposite(n, quantity));
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Name.Value;
+        yield return Quantity;
+    }
+}
+
+// --- Composite VO whose inner scalar is strict ---
+
+[JsonConverter(typeof(CompositeValueObjectJsonConverter<FlowThroughStrictComposite>))]
+public sealed class FlowThroughStrictComposite : ValueObject
+{
+    public FlowThroughStrictName Name { get; private set; } = null!;
+    public int Quantity { get; private set; }
+
+    private FlowThroughStrictComposite() { }
+    private FlowThroughStrictComposite(FlowThroughStrictName name, int quantity)
+    {
+        Name = name;
+        Quantity = quantity;
+    }
+
+    public static Result<FlowThroughStrictComposite> TryCreate(string name, int quantity, string? fieldName = null) =>
+        FlowThroughStrictName.TryCreate(name, "name")
+            .Map(n => new FlowThroughStrictComposite(n, quantity));
+
+    protected override IEnumerable<IComparable?> GetEqualityComponents()
+    {
+        yield return Name.Value;
+        yield return Quantity;
+    }
+}
+
+/// <summary>
+/// Cross-cutting regression coverage: when a <see cref="CompositeValueObject{T}"/>-shaped
+/// type contains a <see cref="RequiredString{TSelf}"/> field, the composite's <c>TryCreate</c>
+/// delegates to the inner <c>TryCreate</c> — so the inner type's POLA-realigned validation
+/// flows through. Lenient inner types accept <c>""</c>; strict inner types (decorated with
+/// <c>[NotDefault]</c>) keep rejecting.
+/// </summary>
+/// <remarks>
+/// This is the composite-VO mirror of the EF rehydration test
+/// (<see cref="RequiredXxxRehydrationLenienceTests"/> in Trellis.EntityFrameworkCore.Tests):
+/// both prove that the realignment's "inner type decides" rule holds at every layer that
+/// invokes <c>TryCreate</c> on the inner scalar.
+/// </remarks>
+public class CompositeRequiredStringFlowThroughTests
+{
+    // ---- Direct TryCreate flow-through ----
+
+    [Fact]
+    public void Lenient_composite_TryCreate_accepts_empty_inner_string()
+    {
+        var result = FlowThroughLenientComposite.TryCreate("", 5);
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Name.Value.Should().Be("");
+    }
+
+    [Fact]
+    public void Strict_composite_TryCreate_rejects_empty_inner_string()
+    {
+        var result = FlowThroughStrictComposite.TryCreate("", 5);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Flow Through Strict Name cannot be empty.");
+    }
+
+    // ---- JSON deserialize flow-through ----
+
+    [Fact]
+    public void Lenient_composite_JSON_deserialize_accepts_empty_inner_string()
+    {
+        var json = "{\"name\":\"\",\"quantity\":5}";
+        var vo = JsonSerializer.Deserialize<FlowThroughLenientComposite>(json);
+        vo.Should().NotBeNull();
+        vo!.Name.Value.Should().Be("");
+        vo.Quantity.Should().Be(5);
+    }
+
+    [Fact]
+    public void Strict_composite_JSON_deserialize_rejects_empty_inner_string()
+    {
+        var json = "{\"name\":\"\",\"quantity\":5}";
+        Action act = () => JsonSerializer.Deserialize<FlowThroughStrictComposite>(json);
+        act.Should().Throw<TrellisJsonValidationException>()
+            .WithMessage("*Flow Through Strict Name cannot be empty*");
+    }
+
+    // ---- Non-sentinel happy paths to prove the composite still works ----
+
+    [Fact]
+    public void Lenient_composite_accepts_normal_string() =>
+        FlowThroughLenientComposite.TryCreate("Alice", 5).IsSuccess.Should().BeTrue();
+
+    [Fact]
+    public void Strict_composite_accepts_normal_string() =>
+        FlowThroughStrictComposite.TryCreate("Alice", 5).IsSuccess.Should().BeTrue();
+}

--- a/Trellis.Primitives/tests/RequiredDateTimeTests.cs
+++ b/Trellis.Primitives/tests/RequiredDateTimeTests.cs
@@ -3,10 +3,12 @@
 using System.Text.Json;
 using Trellis.Testing;
 
+[NotDefault]
 public partial class OrderDate : RequiredDateTime<OrderDate>
 {
 }
 
+[NotDefault]
 internal partial class InternalDate : RequiredDateTime<InternalDate>
 {
 }
@@ -42,7 +44,7 @@ public class RequiredDateTimeTests
         result.UnwrapError().Should().BeOfType<Error.UnprocessableContent>();
         var validation = (Error.UnprocessableContent)result.UnwrapError();
         validation.Fields[0].Field.Path.Should().Be("/orderDate");
-        validation.Fields[0].Detail.Should().Be("Order Date cannot be empty.");
+        validation.Fields[0].Detail.Should().Be("Order Date cannot be DateTime.MinValue.");
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredGuidTests.cs
+++ b/Trellis.Primitives/tests/RequiredGuidTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Trellis.Testing;
 using Xunit;
 
+[NotDefault]
 public partial class EmployeeId : RequiredGuid<EmployeeId>
 {
 }
@@ -20,7 +21,7 @@ public class RequiredGuidTests
         guidId1.UnwrapError().Should().BeOfType<Error.UnprocessableContent>();
         var validation = (Error.UnprocessableContent)guidId1.UnwrapError();
         validation.Fields[0].Field.Path.Should().Be("/employeeId");
-        validation.Fields[0].Detail.Should().Be("Employee Id cannot be empty.");
+        validation.Fields[0].Detail.Should().Be("Employee Id cannot be Guid.Empty.");
         validation.Fields[0].ReasonCode.Should().Be("validation.error");
     }
 
@@ -144,7 +145,7 @@ public class RequiredGuidTests
 
         // Assert
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("Failed to create EmployeeId:*Employee Id cannot be empty*");
+            .WithMessage("Failed to create EmployeeId:*Employee Id cannot be Guid.Empty*");
     }
 
     [Theory]
@@ -164,20 +165,29 @@ public class RequiredGuidTests
 
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("00000000-0000-0000-0000-000000000000")]
-    public void Cannot_create_RequiredGuid_from_empty_string(string? value)
+    [Fact]
+    public void Cannot_create_RequiredGuid_from_null_string()
     {
-        // Act
-        var myGuidResult = EmployeeId.TryCreate(value);
+        // Null string -> "cannot be empty" (the null-rejection message; consistent across the family).
+        var myGuidResult = EmployeeId.TryCreate((string?)null);
 
-        // Assert
         myGuidResult.IsFailure.Should().BeTrue();
-        myGuidResult.UnwrapError().Should().BeOfType<Error.UnprocessableContent>();
-        Error.UnprocessableContent ve = (Error.UnprocessableContent)myGuidResult.UnwrapError();
+        var ve = (Error.UnprocessableContent)myGuidResult.UnwrapError();
         ve.Fields[0].Field.Path.Should().Be("/employeeId");
         ve.Fields[0].Detail.Should().Be("Employee Id cannot be empty.");
+    }
+
+    [Fact]
+    public void Cannot_create_RequiredGuid_from_all_zero_string()
+    {
+        // "00000000-..." parses successfully into Guid.Empty, then the [NotDefault] check fires
+        // with the per-type "cannot be Guid.Empty." message — distinct from the null case above.
+        var myGuidResult = EmployeeId.TryCreate("00000000-0000-0000-0000-000000000000");
+
+        myGuidResult.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)myGuidResult.UnwrapError();
+        ve.Fields[0].Field.Path.Should().Be("/employeeId");
+        ve.Fields[0].Detail.Should().Be("Employee Id cannot be Guid.Empty.");
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredGuidValidateAdditionalTests.cs
+++ b/Trellis.Primitives/tests/RequiredGuidValidateAdditionalTests.cs
@@ -4,6 +4,7 @@ namespace Trellis.Primitives.Tests;
 /// <summary>
 /// RequiredGuid with custom validation — rejects Version 4 GUIDs (only allows V7).
 /// </summary>
+[NotDefault]
 public partial class V7OnlyId : RequiredGuid<V7OnlyId>
 {
     static partial void ValidateAdditional(Guid value, string fieldName, ref string? errorMessage)
@@ -17,6 +18,7 @@ public partial class V7OnlyId : RequiredGuid<V7OnlyId>
 /// <summary>
 /// RequiredGuid without ValidateAdditional — ensures the hook is optional.
 /// </summary>
+[NotDefault]
 public partial class PlainId : RequiredGuid<PlainId> { }
 
 /// <summary>

--- a/Trellis.Primitives/tests/RequiredNotDefaultAndTrimTests.cs
+++ b/Trellis.Primitives/tests/RequiredNotDefaultAndTrimTests.cs
@@ -19,6 +19,12 @@ public partial class LenientDecimal : RequiredDecimal<LenientDecimal> { }
 [NotDefault] public partial class StrictLong : RequiredLong<StrictLong> { }
 [NotDefault] public partial class StrictDecimal : RequiredDecimal<StrictDecimal> { }
 
+// Both [NotDefault] and [Range] — used to verify NotDefault runs before Range so a
+// zero input on a range-positive type surfaces the per-type message, not the range message.
+[NotDefault, Range(1, 100)] public partial class StrictRangedInt : RequiredInt<StrictRangedInt> { }
+[NotDefault, Range(1L, 100L)] public partial class StrictRangedLong : RequiredLong<StrictRangedLong> { }
+[NotDefault, Range(1, 100)] public partial class StrictRangedDecimal : RequiredDecimal<StrictRangedDecimal> { }
+
 [NotDefault] public partial class NoDefaultOnlyString : RequiredString<NoDefaultOnlyString> { }
 [Trim] public partial class TrimOnlyString : RequiredString<TrimOnlyString> { }
 [Trim, NotDefault] public partial class TrimAndNotDefaultString : RequiredString<TrimAndNotDefaultString> { }
@@ -148,6 +154,64 @@ public class RequiredNotDefaultAndTrimTests
         result.IsFailure.Should().BeTrue();
         var ve = (Error.UnprocessableContent)result.UnwrapError();
         ve.Fields[0].Detail.Should().Be("Strict Decimal cannot be zero.");
+    }
+
+    // ---------- Validation order: [NotDefault] runs BEFORE [Range] ----------
+
+    [Fact]
+    public void StrictRangedInt_zero_input_surfaces_NotDefault_message_not_Range()
+    {
+        // Without correct ordering the Range(1,100) check fires first ("must be at least 1.").
+        var result = StrictRangedInt.TryCreate(0);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Int cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictRangedInt_zero_input_via_nullable_overload_surfaces_NotDefault_message()
+    {
+        var result = StrictRangedInt.TryCreate((int?)0);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Int cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictRangedInt_zero_input_via_string_overload_surfaces_NotDefault_message()
+    {
+        var result = StrictRangedInt.TryCreate("0");
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Int cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictRangedLong_zero_surfaces_NotDefault_message()
+    {
+        var result = StrictRangedLong.TryCreate(0L);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Long cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictRangedDecimal_zero_surfaces_NotDefault_message()
+    {
+        var result = StrictRangedDecimal.TryCreate(0m);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Decimal cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictRangedInt_negative_input_still_surfaces_Range_message()
+    {
+        // Negative input is not the zero sentinel, so the Range check is the right one to fire.
+        var result = StrictRangedInt.TryCreate(-5);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Ranged Int must be at least 1.");
     }
 
     // Strict types still accept non-zero values

--- a/Trellis.Primitives/tests/RequiredNotDefaultAndTrimTests.cs
+++ b/Trellis.Primitives/tests/RequiredNotDefaultAndTrimTests.cs
@@ -1,0 +1,190 @@
+﻿namespace Trellis.Primitives.Tests;
+
+using System;
+using Trellis.Testing;
+using Xunit;
+
+// Lenient-default fixtures — no [NotDefault] / [Trim]. Document the new POLA behavior.
+public partial class LenientGuid : RequiredGuid<LenientGuid> { }
+public partial class LenientDateTime : RequiredDateTime<LenientDateTime> { }
+public partial class LenientString : RequiredString<LenientString> { }
+public partial class LenientInt : RequiredInt<LenientInt> { }
+public partial class LenientLong : RequiredLong<LenientLong> { }
+public partial class LenientDecimal : RequiredDecimal<LenientDecimal> { }
+
+// Strict (opt-in) fixtures with [NotDefault] / [Trim].
+[NotDefault] public partial class StrictGuid : RequiredGuid<StrictGuid> { }
+[NotDefault] public partial class StrictDateTime : RequiredDateTime<StrictDateTime> { }
+[NotDefault] public partial class StrictInt : RequiredInt<StrictInt> { }
+[NotDefault] public partial class StrictLong : RequiredLong<StrictLong> { }
+[NotDefault] public partial class StrictDecimal : RequiredDecimal<StrictDecimal> { }
+
+[NotDefault] public partial class NoDefaultOnlyString : RequiredString<NoDefaultOnlyString> { }
+[Trim] public partial class TrimOnlyString : RequiredString<TrimOnlyString> { }
+[Trim, NotDefault] public partial class TrimAndNotDefaultString : RequiredString<TrimAndNotDefaultString> { }
+
+/// <summary>
+/// POLA realignment behavior tests: undecorated RequiredXxx types reject only null;
+/// per-type sentinel rejection is opt-in via [NotDefault]. String trim is opt-in via [Trim].
+/// </summary>
+public class RequiredNotDefaultAndTrimTests
+{
+    // ---------- Lenient defaults: reject only null ----------
+
+    [Fact]
+    public void LenientGuid_accepts_Guid_Empty()
+    {
+        var result = LenientGuid.TryCreate(Guid.Empty);
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void LenientGuid_accepts_parsed_all_zero_string()
+    {
+        var result = LenientGuid.TryCreate("00000000-0000-0000-0000-000000000000");
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void LenientDateTime_accepts_MinValue()
+    {
+        var result = LenientDateTime.TryCreate(DateTime.MinValue);
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void LenientString_accepts_empty()
+    {
+        var result = LenientString.TryCreate("");
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be("");
+    }
+
+    [Fact]
+    public void LenientString_accepts_whitespace_verbatim_without_Trim()
+    {
+        var result = LenientString.TryCreate("  hi  ");
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be("  hi  ");
+    }
+
+    [Fact]
+    public void LenientInt_accepts_zero() => LenientInt.TryCreate(0).IsSuccess.Should().BeTrue();
+
+    [Fact]
+    public void LenientLong_accepts_zero() => LenientLong.TryCreate(0L).IsSuccess.Should().BeTrue();
+
+    [Fact]
+    public void LenientDecimal_accepts_zero() => LenientDecimal.TryCreate(0m).IsSuccess.Should().BeTrue();
+
+    // All lenient types still reject null
+    [Fact]
+    public void LenientGuid_rejects_null() => LenientGuid.TryCreate((Guid?)null).IsFailure.Should().BeTrue();
+
+    [Fact]
+    public void LenientInt_rejects_null() => LenientInt.TryCreate((int?)null).IsFailure.Should().BeTrue();
+
+    [Fact]
+    public void LenientString_rejects_null() => LenientString.TryCreate((string?)null).IsFailure.Should().BeTrue();
+
+    // ---------- [NotDefault] opt-in: reject the per-type zero value ----------
+
+    [Fact]
+    public void StrictGuid_rejects_Guid_Empty_with_per_type_message()
+    {
+        var result = StrictGuid.TryCreate(Guid.Empty);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Guid cannot be Guid.Empty.");
+    }
+
+    [Fact]
+    public void StrictGuid_rejects_parsed_all_zero_string_with_per_type_message()
+    {
+        // Critical regression test for the parse-overload sentinel disambiguation:
+        // "00000000-..." parses successfully, then the [NotDefault] ensure fires
+        // with the per-type "cannot be Guid.Empty." message — not the parse-failure
+        // "Guid should contain 32 digits..." message.
+        var result = StrictGuid.TryCreate("00000000-0000-0000-0000-000000000000");
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Guid cannot be Guid.Empty.");
+    }
+
+    [Fact]
+    public void StrictDateTime_rejects_MinValue_with_per_type_message()
+    {
+        var result = StrictDateTime.TryCreate(DateTime.MinValue);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Date Time cannot be DateTime.MinValue.");
+    }
+
+    [Fact]
+    public void StrictInt_rejects_zero_with_per_type_message()
+    {
+        var result = StrictInt.TryCreate(0);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Int cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictLong_rejects_zero_with_per_type_message()
+    {
+        var result = StrictLong.TryCreate(0L);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Long cannot be zero.");
+    }
+
+    [Fact]
+    public void StrictDecimal_rejects_zero_with_per_type_message()
+    {
+        var result = StrictDecimal.TryCreate(0m);
+        result.IsFailure.Should().BeTrue();
+        var ve = (Error.UnprocessableContent)result.UnwrapError();
+        ve.Fields[0].Detail.Should().Be("Strict Decimal cannot be zero.");
+    }
+
+    // Strict types still accept non-zero values
+    [Fact]
+    public void StrictGuid_accepts_non_empty() => StrictGuid.TryCreate(Guid.NewGuid()).IsSuccess.Should().BeTrue();
+
+    [Fact]
+    public void StrictInt_accepts_non_zero() => StrictInt.TryCreate(42).IsSuccess.Should().BeTrue();
+
+    // ---------- [Trim] / [NotDefault] string combinations ----------
+
+    [Fact]
+    public void NoDefaultOnlyString_rejects_empty_but_keeps_whitespace()
+    {
+        // [NotDefault] alone rejects exact "" but stores "   " verbatim because [Trim] is not applied.
+        NoDefaultOnlyString.TryCreate("").IsFailure.Should().BeTrue();
+        var ws = NoDefaultOnlyString.TryCreate("   ");
+        ws.IsSuccess.Should().BeTrue();
+        ws.Unwrap().Value.Should().Be("   ");
+    }
+
+    [Fact]
+    public void TrimOnlyString_trims_but_accepts_resulting_empty()
+    {
+        // [Trim] alone trims and accepts the (possibly empty) result.
+        var ws = TrimOnlyString.TryCreate("   ");
+        ws.IsSuccess.Should().BeTrue();
+        ws.Unwrap().Value.Should().Be("");
+        TrimOnlyString.TryCreate("  hello  ").Unwrap().Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void TrimAndNotDefaultString_trims_then_rejects_empty()
+    {
+        // Combined behavior recovers the pre-realignment RequiredString defaults.
+        TrimAndNotDefaultString.TryCreate("   ").IsFailure.Should().BeTrue();
+        TrimAndNotDefaultString.TryCreate("").IsFailure.Should().BeTrue();
+        TrimAndNotDefaultString.TryCreate("  John  ").Unwrap().Value.Should().Be("John");
+    }
+}

--- a/Trellis.Primitives/tests/RequiredStringLengthTests.cs
+++ b/Trellis.Primitives/tests/RequiredStringLengthTests.cs
@@ -6,7 +6,7 @@ using Trellis.Testing;
 /// <summary>
 /// Test value object with max length only.
 /// </summary>
-[StringLength(10)]
+[Trim, NotDefault, StringLength(10)]
 public partial class ShortCode : RequiredString<ShortCode>
 {
 }
@@ -14,7 +14,7 @@ public partial class ShortCode : RequiredString<ShortCode>
 /// <summary>
 /// Test value object with both min and max length.
 /// </summary>
-[StringLength(50, MinimumLength = 3)]
+[Trim, NotDefault, StringLength(50, MinimumLength = 3)]
 public partial class UserName : RequiredString<UserName>
 {
 }

--- a/Trellis.Primitives/tests/RequiredStringTests.cs
+++ b/Trellis.Primitives/tests/RequiredStringTests.cs
@@ -4,9 +4,11 @@ using System.Globalization;
 using System.Text.Json;
 using Trellis.Testing;
 
+[Trim, NotDefault]
 public partial class TrackingId : RequiredString<TrackingId>
 {
 }
+[Trim, NotDefault]
 internal partial class InternalTrackingId : RequiredString<InternalTrackingId>
 {
 }

--- a/Trellis.Primitives/tests/SourceGeneratedCreateMethodTests.cs
+++ b/Trellis.Primitives/tests/SourceGeneratedCreateMethodTests.cs
@@ -40,7 +40,7 @@ public class SourceGeneratedCreateMethodTests
 
         // Assert
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("Failed to create EmployeeId:*Employee Id cannot be empty*");
+            .WithMessage("Failed to create EmployeeId:*Employee Id cannot be Guid.Empty*");
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/ValidateAdditionalTests.cs
+++ b/Trellis.Primitives/tests/ValidateAdditionalTests.cs
@@ -8,7 +8,7 @@ using Trellis.Testing;
 /// <summary>
 /// RequiredString with regex pattern validation via ValidateAdditional.
 /// </summary>
-[StringLength(10)]
+[Trim, NotDefault, StringLength(10)]
 public partial class Sku : RequiredString<Sku>
 {
     static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage)
@@ -21,6 +21,7 @@ public partial class Sku : RequiredString<Sku>
 /// <summary>
 /// RequiredString without ValidateAdditional — ensures the hook is truly optional.
 /// </summary>
+[Trim, NotDefault]
 public partial class PlainName : RequiredString<PlainName> { }
 
 /// <summary>

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", "Maybe<T>", Maybe, MaybeInvariant, Error, Unit, "Page<T>", Page, Cursor, "EquatableArray<T>", EquatableArray, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, RepresentationMetadata, "WriteOutcome<T>", IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", "Maybe<T>", Maybe, MaybeInvariant, Error, Unit, "Page<T>", Page, Cursor, "EquatableArray<T>", EquatableArray, ResourceRef, EntityTagValue, RetryAfterValue, PreconditionKind, InputPointer, FieldViolation, RuleViolation, AuthChallenge, RepresentationMetadata, "WriteOutcome<T>", IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-05-06
 audience: [llm]
@@ -1679,7 +1679,24 @@ Marker subclass of `System.Text.Json.JsonException` thrown by Trellis JSON conve
 
 ## Primitive value object base classes
 
-These types ship in `Trellis.Core`. They are the building blocks for strongly-typed primitive value objects — derive a `partial class` from one of the `Required*<TSelf>` bases and the bundled `Trellis.Core.Generator` source generator emits the `TryCreate` / `Create` / `Parse` / `TryParse` / `JsonConverter` boilerplate. The validation attributes (`StringLengthAttribute`, `RangeAttribute`, `EnumValueAttribute`) attach declarative invariants that the generator wires into the generated validation. The concrete primitives that derive from these bases (`EmailAddress`, `Money`, etc.) live in `Trellis.Primitives` — see [trellis-api-primitives.md](trellis-api-primitives.md).
+These types ship in `Trellis.Core`. They are the building blocks for strongly-typed primitive value objects — derive a `partial class` from one of the `Required*<TSelf>` bases and the bundled `Trellis.Core.Generator` source generator emits the `TryCreate` / `Create` / `Parse` / `TryParse` / `JsonConverter` boilerplate. The validation attributes (`StringLengthAttribute`, `RangeAttribute`, `NotDefaultAttribute`, `TrimAttribute`, `EnumValueAttribute`) attach declarative invariants that the generator wires into the generated validation. The concrete primitives that derive from these bases (`EmailAddress`, `Money`, etc.) live in `Trellis.Primitives` — see [trellis-api-primitives.md](trellis-api-primitives.md).
+
+#### `Required*<TSelf>` default behavior and the `[NotDefault]` / `[Trim]` opt-ins
+
+Every `Required*<TSelf>` base now follows the same rule: **the generated `TryCreate` rejects only `null`**. Per-type "zero value" rejection (`""` for strings, `0` for numerics, `Guid.Empty`, `DateTime.MinValue`) is opt-in via `[NotDefault]`. String trim is opt-in via `[Trim]`. This realigns the family with `RequiredInt<TSelf>(0)` — which has always succeeded — and matches the Principle of Least Astonishment.
+
+| Base | Default (no attributes) rejects | Add `[NotDefault]` to also reject |
+|---|---|---|
+| `RequiredInt<TSelf>` / `RequiredLong<TSelf>` / `RequiredDecimal<TSelf>` | `null` | `0` (per-type message "cannot be zero.") |
+| `RequiredString<TSelf>` | `null` | `""` (after `[Trim]` if present; per-type message "cannot be empty.") |
+| `RequiredGuid<TSelf>` | `null` | `Guid.Empty` (per-type message "cannot be Guid.Empty.") |
+| `RequiredDateTime<TSelf>` | `null` | `DateTime.MinValue` (per-type message "cannot be DateTime.MinValue.") |
+| `RequiredBool<TSelf>` | `null` | **compile-time error** (TRLS040 — a bool that rejects `false` is degenerate). |
+| `RequiredEnum<TSelf>` | `null` and unknown member name | **compile-time error** (TRLS042 — smart-enum has no CLR default). |
+
+Generated `TryCreate` validation order: `null → [Trim] → [NotDefault] → [StringLength] / [Range] → ValidateAdditional`. With `[Trim]` absent, `[StringLength]` measures the raw input.
+
+The `[NotDefault]` rule also drives the EF Core `TrellisScalarConverter` read path: rows containing the per-type sentinel value materialize successfully for lenient types and throw `TrellisPersistenceMappingException` for strict types. Add `[NotDefault]` to any `RequiredGuid` / `RequiredDateTime` used as an `Aggregate<TId>` / `Entity<TId>` ID or as an EF-mapped property to keep the strict-on-rehydration guarantee.
 
 ### `RangeAttribute`
 
@@ -1713,6 +1730,32 @@ public sealed class StringLengthAttribute : Attribute
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public StringLengthAttribute(int maximumLength)` | `StringLengthAttribute` | Length metadata for `RequiredString<TSelf>`. |
+
+### `NotDefaultAttribute`
+
+```csharp
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class NotDefaultAttribute : Attribute
+```
+
+Marker attribute consumed at compile time by `Trellis.Core.Generator`. When present on a partial class derived from `RequiredString` / `RequiredInt` / `RequiredLong` / `RequiredDecimal` / `RequiredGuid` / `RequiredDateTime`, the generator emits an additional check that rejects the type's "zero value" (see the per-type behavior table at the top of this section). Not valid on `RequiredBool` (TRLS040) or `RequiredEnum` (TRLS042); the generator emits a compile-time error in those cases.
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public NotDefaultAttribute()` | `NotDefaultAttribute` | Marker only — no constructor arguments. |
+
+### `TrimAttribute`
+
+```csharp
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class TrimAttribute : Attribute
+```
+
+Marker attribute consumed at compile time by `Trellis.Core.Generator`. When present on a `RequiredString<TSelf>`-derived partial class, the generator emits `value.Trim()` before any subsequent check. Combine with `[NotDefault]` to recover the pre-realignment "reject null + empty + whitespace; trim" default — the recommended setup for any string mapped to a database column. Only valid on `RequiredString`; the generator emits TRLS041 if applied to any other Required base.
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public TrimAttribute()` | `TrimAttribute` | Marker only — no constructor arguments. |
 
 ### `EnumValueAttribute`
 
@@ -1943,7 +1986,7 @@ public static explicit operator TSelf(string value)
 static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: null/empty/whitespace rejection, trimming, optional `[StringLength]` checks.
+- Built-in validation: `null` rejection. Add `[NotDefault]` to also reject `""` (after `[Trim]` if present). `[StringLength]` operates on the post-`[Trim]` value when both are present, on the raw input otherwise.
 
 #### `RequiredGuid<TSelf>`
 
@@ -1962,7 +2005,7 @@ public static explicit operator TSelf(Guid value)
 static partial void ValidateAdditional(Guid value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `Guid.Empty` rejection.
+- Built-in validation: `null` rejection. Add `[NotDefault]` to also reject `Guid.Empty` (recommended for any GUID used as an `Aggregate<TId>` / `Entity<TId>` ID or EF-mapped property — see EF read-path note above).
 
 #### `RequiredInt<TSelf>`
 
@@ -1980,7 +2023,7 @@ public static explicit operator TSelf(int value)
 static partial void ValidateAdditional(int value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `null` rejection for nullable inputs, optional `[Range(int, int)]`.
+- Built-in validation: `null` rejection for nullable inputs, optional `[Range(int, int)]`. Add `[NotDefault]` to also reject `0`.
 
 #### `RequiredDecimal<TSelf>`
 
@@ -1998,7 +2041,7 @@ public static explicit operator TSelf(decimal value)
 static partial void ValidateAdditional(decimal value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `null` rejection for nullable inputs, optional `[Range(int, int)]` or `[Range(double, double)]`.
+- Built-in validation: `null` rejection for nullable inputs, optional `[Range(int, int)]` or `[Range(double, double)]`. Add `[NotDefault]` to also reject `0m`.
 - String parsing: the plain `TryCreate(string?, string?)` overload uses invariant culture; use the `IFormatProvider` overload for culture-aware decimal formats.
 
 #### `RequiredLong<TSelf>`
@@ -2017,7 +2060,7 @@ public static explicit operator TSelf(long value)
 static partial void ValidateAdditional(long value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `null` rejection for nullable inputs, optional `[Range(long, long)]`.
+- Built-in validation: `null` rejection for nullable inputs, optional `[Range(long, long)]`. Add `[NotDefault]` to also reject `0L`.
 
 #### `RequiredBool<TSelf>`
 
@@ -2034,7 +2077,7 @@ public static explicit operator TSelf(bool value)
 static partial void ValidateAdditional(bool value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `null` rejection for nullable inputs; `false` is valid.
+- Built-in validation: `null` rejection for nullable inputs; `false` is valid. `[NotDefault]` is not supported on `RequiredBool` (TRLS040 — a bool that rejects `false` would be degenerate).
 
 #### `RequiredDateTime<TSelf>`
 
@@ -2052,7 +2095,7 @@ public static explicit operator TSelf(DateTime value)
 static partial void ValidateAdditional(DateTime value, string fieldName, ref string? errorMessage)
 ```
 
-- Built-in validation: `DateTime.MinValue` rejection.
+- Built-in validation: `null` rejection. Add `[NotDefault]` to also reject `DateTime.MinValue` (recommended for any DateTime used as an EF-mapped property — see EF read-path note above).
 
 #### `RequiredEnum<TSelf>`
 


### PR DESCRIPTION
The `RequiredXxx<T>` family was asymmetric: `RequiredInt<T>(0)` succeeded but `RequiredString<T>("""")` failed, `RequiredGuid<T>(Guid.Empty)` failed, `RequiredDateTime<T>(DateTime.MinValue)` failed. Consumers reaching for one after the other got surprised.

Every `RequiredXxx<T>` base now follows the same rule: `TryCreate` rejects only `null`. Per-type ""zero value"" rejection (`""""` for strings, `0` for numerics, `Guid.Empty`, `DateTime.MinValue`) and string `Trim()` are opt-in via two new attributes `[NotDefault]` and `[Trim]` consumed at compile time by `Trellis.Core.Generator`. The generator emits the conditional checks per the validation order `null → [Trim] → [NotDefault] → [StringLength]/[Range] → ValidateAdditional`. Three new compile-time diagnostics (TRLS040, TRLS041, TRLS042) prevent invalid attribute combinations even when the matching analyzer rules are suppressed.

The full behavior matrix, including the EF `TrellisScalarConverter` rehydration impact, is in `CHANGELOG.md` and `docs/docfx_project/api_reference/trellis-api-core.md`.