### PR TITLE
Wire WithETag/WithLastModified/Vary/Content-Language/Content-Location/EvaluatePreconditions through the paged response path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### `Result<Page<T>>.ToHttpResponse` no longer silently drops `WithETag` / `WithLastModified` / `Vary` / `WithContentLanguage` / `WithContentLocation` / `EvaluatePreconditions`
+
+`HttpResponseOptionsBuilder<Page<T>>` accepts every option that the non-paged builder does, but until now only `VaryForActor` and `WithCacheControl` actually flowed through to the wire on the paged path — every other `.With*` call compiled, ran, and silently no-op'd. `ETag` / `Last-Modified` / `Vary` / `Content-Language` / `Content-Location` are now applied to paged success responses; `EvaluatePreconditions()` now performs conditional-request evaluation (`If-None-Match` / `If-Modified-Since` → 304, failing `If-Match` / `If-Unmodified-Since` → 412) against `Page<T>`-shaped selectors. Per-domain selectors evaluate inside `IResult.ExecuteAsync` (not eagerly during `ToHttpResponse`), `ETag` and `Last-Modified` resolve once per request and are reused for header emission and precondition evaluation so non-deterministic selectors cannot produce inconsistent header-vs-metadata values, and selector-derived `Cache-Control` applies only at the success-emit points (200 / 304) — generated 412 responses do not inherit it, matching the non-paged contract. Static `Cache-Control` continues to apply to both success and failure responses.
+
+Out of scope (deferred): `WithRange` / `WithLocation` / `WithCreatedAt*` / body projector / `HonorPrefer` / `WithAcceptRanges` are paged-incompatible by shape (range = byte ranges, location = 201 Created, Prefer = representation-vs-minimal, AcceptRanges = byte-range advertisement) and remain silently no-op on the paged path. Future work tracked in `BACKLOG.md`.
+
 ### Changed
 
 #### `RequiredXxx<T>` family POLA realignment (breaking)

--- a/Trellis.Asp/src/Response/HttpResponseExtensions.cs
+++ b/Trellis.Asp/src/Response/HttpResponseExtensions.cs
@@ -422,9 +422,13 @@ internal sealed class PagedSuccessHeaderWrapper(
 
         // Resolve ETag and Last-Modified once per execution; the cached values are reused
         // for header emission AND precondition evaluation so non-deterministic selectors
-        // cannot produce inconsistent header-vs-metadata values.
+        // cannot produce inconsistent header-vs-metadata values. Last-Modified is truncated
+        // to second precision before caching because the wire-format `R` HTTP-date emitter
+        // and HTTP clients both work at second granularity — keeping sub-second precision
+        // in the metadata would cause `If-Modified-Since` revalidation with the exact
+        // emitted header to miss the 304 path, since `selectorRaw > Parse(emittedHeader)`.
         var etag = resolveETag?.Invoke();
-        var lastModified = resolveLastModified?.Invoke();
+        var lastModified = TruncateToSeconds(resolveLastModified?.Invoke());
 
         if (etag is not null)
             response.Headers.ETag = etag.ToHeaderValue();
@@ -501,4 +505,7 @@ internal sealed class PagedSuccessHeaderWrapper(
             b = b.SetLastModified(lastModified.Value);
         return b.Build();
     }
+
+    private static DateTimeOffset? TruncateToSeconds(DateTimeOffset? value) =>
+        value.HasValue ? value.Value.AddTicks(-(value.Value.Ticks % TimeSpan.TicksPerSecond)) : null;
 }

--- a/Trellis.Asp/src/Response/HttpResponseExtensions.cs
+++ b/Trellis.Asp/src/Response/HttpResponseExtensions.cs
@@ -216,10 +216,6 @@ public static class HttpResponseExtensions
             });
         }
 
-        var (envelope, linkHeader) = PagedResponseBuilder.Build(page, nextUrlBuilder, body);
-        var ok = Results.Ok(envelope);
-        var inner = linkHeader is null ? ok : new PagedHttpResult(ok, linkHeader);
-
         // Detect any builder-option that the bare Results.Ok / PagedHttpResult would silently
         // drop on its way to the wire. The wrapper applies them before delegating to the
         // inner result so the paged path matches the non-paged TrellisHttpResult contract.
@@ -231,6 +227,17 @@ public static class HttpResponseExtensions
             || opts.LastModifiedSelector is not null
             || opts.ContentLocationSelector is not null
             || opts.EvaluatePreconditions;
+
+        // Lazy inner-result factory: defers PagedResponseBuilder.Build (which projects every
+        // item via the `body` mapper and allocates the envelope list) until a success-emit
+        // point is reached. This avoids running the body projector when a conditional GET
+        // short-circuits to 304 or a precondition fails into 412.
+        Microsoft.AspNetCore.Http.IResult BuildInner()
+        {
+            var (envelope, linkHeader) = PagedResponseBuilder.Build(page, nextUrlBuilder, body);
+            var ok = Results.Ok(envelope);
+            return linkHeader is null ? ok : new PagedHttpResult(ok, linkHeader);
+        }
 
         if (opts.VaryForActor || hasCacheControl || hasOptionalHeaders)
         {
@@ -253,7 +260,7 @@ public static class HttpResponseExtensions
                 : null;
 
             return new PagedSuccessHeaderWrapper(
-                inner,
+                BuildInner,
                 opts.VaryForActor,
                 opts.CacheControl,
                 resolveCacheControlSelector,
@@ -267,7 +274,10 @@ public static class HttpResponseExtensions
                 ResourceRef.For<Page<T>>());
         }
 
-        return inner;
+        // No wrapper required — build the envelope eagerly and return the bare inner. There
+        // is no precondition / 304 / 412 path on this branch, so deferring would change
+        // nothing observable.
+        return BuildInner();
     }
 
     /// <summary>Async <see cref="Task"/> overload.</summary>
@@ -374,7 +384,7 @@ internal sealed class ActorVaryWrapperResult(Microsoft.AspNetCore.Http.IResult i
 /// </para>
 /// </remarks>
 internal sealed class PagedSuccessHeaderWrapper(
-    Microsoft.AspNetCore.Http.IResult inner,
+    Func<Microsoft.AspNetCore.Http.IResult> buildInner,
     bool varyForActor,
     System.Net.Http.Headers.CacheControlHeaderValue? staticCacheControl,
     Func<System.Net.Http.Headers.CacheControlHeaderValue?>? resolveCacheControlSelector,
@@ -462,9 +472,11 @@ internal sealed class PagedSuccessHeaderWrapper(
             }
         }
 
-        // Success-emit point: apply the selector Cache-Control before delegating to the inner
-        // 200 response.
+        // Success-emit point: apply the selector Cache-Control, then build the paged envelope
+        // lazily (avoids running the body projector when a 304 / 412 short-circuit fires
+        // upstream).
         ApplyCacheControlSelector(response);
+        var inner = buildInner();
         await inner.ExecuteAsync(httpContext).ConfigureAwait(false);
     }
 

--- a/Trellis.Asp/src/Response/HttpResponseExtensions.cs
+++ b/Trellis.Asp/src/Response/HttpResponseExtensions.cs
@@ -220,17 +220,51 @@ public static class HttpResponseExtensions
         var ok = Results.Ok(envelope);
         var inner = linkHeader is null ? ok : new PagedHttpResult(ok, linkHeader);
 
-        // Wrap so VaryForActor / Cache-Control (static + selector) apply on the paged
-        // success path too. The wrapper holds the selector and `page` so evaluation runs
-        // inside ExecuteAsync — matching the non-paged code paths and avoiding any chance
-        // of stale state if the IResult is constructed in one scope and executed in
-        // another (e.g. minimal-api endpoint that defers ExecuteAsync).
+        // Detect any builder-option that the bare Results.Ok / PagedHttpResult would silently
+        // drop on its way to the wire. The wrapper applies them before delegating to the
+        // inner result so the paged path matches the non-paged TrellisHttpResult contract.
         var hasCacheControl = opts.CacheControl is not null || opts.CacheControlSelector is not null;
-        if (opts.VaryForActor || hasCacheControl)
+        var hasOptionalHeaders =
+            (opts.Vary is { Count: > 0 })
+            || (opts.ContentLanguage is { Count: > 0 })
+            || opts.ETagSelector is not null
+            || opts.LastModifiedSelector is not null
+            || opts.ContentLocationSelector is not null
+            || opts.EvaluatePreconditions;
+
+        if (opts.VaryForActor || hasCacheControl || hasOptionalHeaders)
         {
-            Func<System.Net.Http.Headers.CacheControlHeaderValue?> resolveCacheControl =
-                () => (opts.CacheControlSelector is { } sel ? sel(page) : null) ?? opts.CacheControl;
-            return new PagedSuccessHeaderWrapper(inner, opts.VaryForActor, resolveCacheControl);
+            // Capture `page` in closures so selectors evaluate inside ExecuteAsync — matches
+            // the non-paged timing and avoids stale state if the IResult is constructed in
+            // one scope and executed in another.
+            Func<EntityTagValue?>? resolveETag = opts.ETagSelector is { } et
+                ? () => et(page)
+                : null;
+            Func<DateTimeOffset?>? resolveLastModified = opts.LastModifiedSelector is { } lm
+                ? () => lm(page)
+                : null;
+            Func<string?>? resolveContentLocation = opts.ContentLocationSelector is { } cls
+                ? () => cls(page)
+                : null;
+            Func<System.Net.Http.Headers.CacheControlHeaderValue?>? resolveCacheControlSelector =
+                opts.CacheControlSelector is { } ccSel ? () => ccSel(page) : null;
+            Func<HttpContext, Error, int>? resolveErrorStatusCode = opts.EvaluatePreconditions
+                ? (http, err) => ErrorStatusCodeResolver.Resolve(http, err, opts.ErrorMapper, opts.ErrorOverrides)
+                : null;
+
+            return new PagedSuccessHeaderWrapper(
+                inner,
+                opts.VaryForActor,
+                opts.CacheControl,
+                resolveCacheControlSelector,
+                opts.Vary,
+                opts.ContentLanguage,
+                resolveETag,
+                resolveLastModified,
+                resolveContentLocation,
+                opts.EvaluatePreconditions,
+                resolveErrorStatusCode,
+                ResourceRef.For<Page<T>>());
         }
 
         return inner;
@@ -308,31 +342,151 @@ internal sealed class ActorVaryWrapperResult(Microsoft.AspNetCore.Http.IResult i
 }
 
 /// <summary>
-/// Internal IResult wrapper for paged success responses that applies
-/// <see cref="HttpResponseOptionsBuilder{TDomain}.VaryForActor"/> and
-/// <see cref="HttpResponseOptionsBuilder{TDomain}.WithCacheControl(System.Net.Http.Headers.CacheControlHeaderValue)"/>
-/// before delegating to the inner result. The paged success path produces the response via
-/// <see cref="Microsoft.AspNetCore.Http.Results.Ok(object?)"/> / <see cref="PagedHttpResult"/>,
-/// neither of which consults the builder options — this wrapper applies the option-driven
-/// headers so the contract matches the non-paged code paths. The <c>Cache-Control</c>
-/// resolver is invoked inside <see cref="ExecuteAsync"/> so per-domain selectors evaluate
-/// at execution time, matching the timing of selectors on the non-paged paths.
+/// Internal IResult wrapper for paged success responses. Applies every
+/// <see cref="HttpResponseOptionsBuilder{TDomain}"/>-driven header that the bare
+/// <see cref="Microsoft.AspNetCore.Http.Results.Ok(object?)"/> / <see cref="PagedHttpResult"/>
+/// would otherwise silently drop, so the paged contract matches the non-paged
+/// <c>TrellisHttpResult</c>: <c>VaryForActor</c>, static and selector <c>Cache-Control</c>,
+/// the explicit <c>Vary</c> list, <c>Content-Language</c>, <c>ETag</c>,
+/// <c>Last-Modified</c>, <c>Content-Location</c>, and conditional-request preconditions
+/// (<c>If-None-Match</c> / <c>If-Modified-Since</c> → 304; failing <c>If-Match</c> /
+/// <c>If-Unmodified-Since</c> → 412).
 /// </summary>
+/// <remarks>
+/// <para>
+/// All domain-shaped selectors (ETag, Last-Modified, Content-Location, selector
+/// Cache-Control) close over the <c>Page&lt;T&gt;</c> value at the call site and evaluate
+/// inside <see cref="ExecuteAsync"/> — matching the non-paged result type's timing and
+/// avoiding stale state if the IResult is constructed in one scope and executed in another.
+/// </para>
+/// <para>
+/// ETag and Last-Modified are resolved exactly once per request and reused for both header
+/// emission and precondition evaluation, so a non-deterministic or expensive selector does
+/// not produce inconsistent header-vs-metadata values.
+/// </para>
+/// <para>
+/// Selector-derived <c>Cache-Control</c> is applied only at the success-emit points (the
+/// inner 200 OK and the 304 Not Modified short-circuit). A generated 412 PreconditionFailed
+/// does not inherit the selector value — matching the non-paged contract that prevents
+/// caching of mid-flow failures. Static <c>Cache-Control</c> remains applied to both
+/// success and failure paths because it represents the consumer's policy for the endpoint
+/// as a whole.
+/// </para>
+/// </remarks>
 internal sealed class PagedSuccessHeaderWrapper(
     Microsoft.AspNetCore.Http.IResult inner,
     bool varyForActor,
-    Func<System.Net.Http.Headers.CacheControlHeaderValue?> resolveCacheControl) : Microsoft.AspNetCore.Http.IResult
+    System.Net.Http.Headers.CacheControlHeaderValue? staticCacheControl,
+    Func<System.Net.Http.Headers.CacheControlHeaderValue?>? resolveCacheControlSelector,
+    IReadOnlyList<string>? vary,
+    IReadOnlyList<string>? contentLanguage,
+    Func<EntityTagValue?>? resolveETag,
+    Func<DateTimeOffset?>? resolveLastModified,
+    Func<string?>? resolveContentLocation,
+    bool evaluatePreconditions,
+    Func<HttpContext, Error, int>? resolveErrorStatusCode,
+    ResourceRef preconditionFailedRef) : Microsoft.AspNetCore.Http.IResult
 {
-    public Task ExecuteAsync(HttpContext httpContext)
+    public async Task ExecuteAsync(HttpContext httpContext)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
+
         if (varyForActor)
             TrellisHttpResult<object, object>.AppendActorVaryHeaders(httpContext);
 
-        var cacheControl = resolveCacheControl();
-        if (cacheControl is not null)
-            httpContext.Response.Headers["Cache-Control"] = cacheControl.ToString();
+        var response = httpContext.Response;
 
-        return inner.ExecuteAsync(httpContext);
+        // Static Cache-Control applies before any branch — consumer's policy for the endpoint
+        // (e.g. private, no-store) should govern both the success body and any generated 412.
+        if (staticCacheControl is not null)
+            response.Headers["Cache-Control"] = staticCacheControl.ToString();
+
+        if (vary is { Count: > 0 })
+        {
+            foreach (var v in vary)
+                TrellisHttpResult<object, object>.AppendVaryUnique(response, v);
+        }
+
+        if (contentLanguage is { Count: > 0 })
+            response.Headers.ContentLanguage = string.Join(", ", contentLanguage);
+
+        // Resolve ETag and Last-Modified once per execution; the cached values are reused
+        // for header emission AND precondition evaluation so non-deterministic selectors
+        // cannot produce inconsistent header-vs-metadata values.
+        var etag = resolveETag?.Invoke();
+        var lastModified = resolveLastModified?.Invoke();
+
+        if (etag is not null)
+            response.Headers.ETag = etag.ToHeaderValue();
+
+        if (lastModified.HasValue)
+            response.Headers.LastModified = lastModified.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+
+        if (resolveContentLocation?.Invoke() is { Length: > 0 } loc)
+            response.Headers["Content-Location"] = loc;
+
+        if (evaluatePreconditions)
+        {
+            var method = httpContext.Request.Method;
+            if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
+            {
+                var metadata = BuildMetadataForEvaluation(etag, lastModified);
+                if (metadata is not null)
+                {
+                    var decision = ConditionalRequestEvaluator.Evaluate(httpContext.Request, metadata, out var failedKind);
+                    if (decision == ConditionalDecision.NotModified)
+                    {
+                        // 304 is a success disposition — apply the selector so the revalidation
+                        // response carries the same Cache-Control policy a fresh 200 would.
+                        ApplyCacheControlSelector(response);
+                        await Results.StatusCode(StatusCodes.Status304NotModified).ExecuteAsync(httpContext).ConfigureAwait(false);
+                        return;
+                    }
+
+                    if (decision == ConditionalDecision.PreconditionFailed)
+                    {
+                        // 412 deliberately does NOT inherit the selector value — a transient
+                        // client error must not be cached as a negative response.
+                        var pf = new Error.PreconditionFailed(
+                            preconditionFailedRef,
+                            failedKind ?? PreconditionKind.IfMatch)
+                        { Detail = "A conditional request header evaluated to false." };
+
+                        var statusCode = resolveErrorStatusCode is not null
+                            ? resolveErrorStatusCode(httpContext, pf)
+                            : StatusCodes.Status412PreconditionFailed;
+                        await ResponseFailureWriter.WriteAsync(httpContext, pf, statusCode).ConfigureAwait(false);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Success-emit point: apply the selector Cache-Control before delegating to the inner
+        // 200 response.
+        ApplyCacheControlSelector(response);
+        await inner.ExecuteAsync(httpContext).ConfigureAwait(false);
+    }
+
+    private void ApplyCacheControlSelector(HttpResponse response)
+    {
+        if (resolveCacheControlSelector is null)
+            return;
+        var v = resolveCacheControlSelector();
+        if (v is not null)
+            response.Headers["Cache-Control"] = v.ToString();
+    }
+
+    private static RepresentationMetadata? BuildMetadataForEvaluation(EntityTagValue? etag, DateTimeOffset? lastModified)
+    {
+        if (etag is null && lastModified is null)
+            return null;
+
+        var b = RepresentationMetadata.Create();
+        if (etag is not null)
+            b = b.SetETag(etag);
+        if (lastModified.HasValue)
+            b = b.SetLastModified(lastModified.Value);
+        return b.Build();
     }
 }

--- a/Trellis.Asp/src/Response/TrellisHttpResult.cs
+++ b/Trellis.Asp/src/Response/TrellisHttpResult.cs
@@ -200,7 +200,13 @@ internal sealed class TrellisHttpResult<TDomain, TBody> :
             return null;
 
         var etag = _options.ETagSelector?.Invoke(domain);
-        var lastMod = _options.LastModifiedSelector?.Invoke(domain);
+        var lastModRaw = _options.LastModifiedSelector?.Invoke(domain);
+        // Truncate the metadata value to match what was emitted on the wire (see ApplyMetadata
+        // comment above) so revalidation requests bearing the exact emitted Last-Modified
+        // value hit the 304 path instead of being treated as "client sent stale timestamp".
+        var lastMod = lastModRaw.HasValue
+            ? lastModRaw.Value.AddTicks(-(lastModRaw.Value.Ticks % TimeSpan.TicksPerSecond))
+            : (DateTimeOffset?)null;
         if (etag is null && lastMod is null)
             return null;
 
@@ -234,7 +240,14 @@ internal sealed class TrellisHttpResult<TDomain, TBody> :
         {
             var d = lm(domain);
             if (d.HasValue)
-                response.Headers["Last-Modified"] = d.Value.ToString("R");
+            {
+                // Truncate to second precision so the emitted RFC1123 header matches the
+                // value the precondition evaluator sees on the next request — preserving
+                // sub-second ticks would cause `If-Modified-Since: <emitted-value>` to miss
+                // the 304 short-circuit because `selectorTicks > Parse(headerString).Ticks`.
+                var truncated = d.Value.AddTicks(-(d.Value.Ticks % TimeSpan.TicksPerSecond));
+                response.Headers["Last-Modified"] = truncated.ToString("R");
+            }
         }
 
         if (_options.Vary is { Count: > 0 })

--- a/Trellis.Asp/tests/PagedResponseOptionsTests.cs
+++ b/Trellis.Asp/tests/PagedResponseOptionsTests.cs
@@ -1,0 +1,311 @@
+﻿namespace Trellis.Asp.Tests;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Asp;
+using Xunit;
+
+/// <summary>
+/// Regression coverage for the paged-response-options fix: every
+/// <see cref="HttpResponseOptionsBuilder{TDomain}"/>-driven header
+/// (<c>ETag</c>, <c>Last-Modified</c>, <c>Vary</c>, <c>Content-Language</c>,
+/// <c>Content-Location</c>, conditional-request preconditions) now flows through to the
+/// paged <c>Result&lt;Page&lt;T&gt;&gt;</c> response — previously silently dropped.
+/// </summary>
+public sealed class PagedResponseOptionsTests
+{
+    private sealed record Todo(int Id, string Title, string ETag);
+
+    private static DefaultHttpContext NewContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRouting();
+        services.AddSingleton<IProblemDetailsService, NoopPds>();
+        var ctx = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    private static Page<Todo> SamplePage() => new(
+        Items: [new Todo(1, "a", "e1"), new Todo(2, "b", "e2")],
+        Next: null,
+        Previous: null,
+        RequestedLimit: 50,
+        AppliedLimit: 50);
+
+    private sealed class NoopPds : IProblemDetailsService
+    {
+        public ValueTask WriteAsync(ProblemDetailsContext c) => ValueTask.CompletedTask;
+#pragma warning disable CA1822
+        public bool TryWrite(ProblemDetailsContext c) => false;
+#pragma warning restore CA1822
+    }
+
+    // ---------- ETag header ----------
+
+    [Fact]
+    public async Task WithETag_emits_strong_etag_on_paged_success()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithETag(p => $"page-{p.Items.Count}"))
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(200);
+        ctx.Response.Headers.ETag.ToString().Should().Be("\"page-2\"");
+    }
+
+    // ---------- Last-Modified header ----------
+
+    [Fact]
+    public async Task WithLastModified_emits_RFC1123_date_on_paged_success()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+        var stamp = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithLastModified(_ => stamp))
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(200);
+        ctx.Response.Headers.LastModified.ToString().Should().Be("Thu, 15 Jan 2026 10:30:00 GMT");
+    }
+
+    // ---------- Vary list + dedupe vs VaryForActor ----------
+
+    [Fact]
+    public async Task Vary_appends_to_paged_response()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.Vary("Accept-Language", "Accept-Encoding"))
+            .ExecuteAsync(ctx);
+
+        var vary = ctx.Response.Headers.Vary.ToString();
+        vary.Should().Contain("Accept-Language");
+        vary.Should().Contain("Accept-Encoding");
+    }
+
+    // ---------- Content-Language header ----------
+
+    [Fact]
+    public async Task WithContentLanguage_emits_on_paged_success()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithContentLanguage("en", "fr"))
+            .ExecuteAsync(ctx);
+
+        ctx.Response.Headers.ContentLanguage.ToString().Should().Be("en, fr");
+    }
+
+    // ---------- Content-Location header ----------
+
+    [Fact]
+    public async Task WithContentLocation_emits_on_paged_success()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithContentLocation(_ => "/todos?cursor=current"))
+            .ExecuteAsync(ctx);
+
+        ctx.Response.Headers["Content-Location"].ToString().Should().Be("/todos?cursor=current");
+    }
+
+    // ---------- Conditional GET: 304 Not Modified ----------
+
+    [Fact]
+    public async Task EvaluatePreconditions_returns_304_when_If_None_Match_matches_emitted_etag()
+    {
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-None-Match"] = "\"page-2\"";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithETag(p => $"page-{p.Items.Count}").EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status304NotModified);
+        ctx.Response.Headers.ETag.ToString().Should().Be("\"page-2\"");
+    }
+
+    [Fact]
+    public async Task EvaluatePreconditions_returns_304_with_selector_CacheControl_on_revalidation()
+    {
+        // 304 is a success disposition — the revalidation response must carry the same
+        // Cache-Control policy a fresh 200 would.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-None-Match"] = "\"page-2\"";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o
+                    .WithETag(p => $"page-{p.Items.Count}")
+                    .WithCacheControl(_ => CacheControl.Public(TimeSpan.FromMinutes(5)))
+                    .EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status304NotModified);
+        ctx.Response.Headers.CacheControl.ToString().Should().Be("public, max-age=300");
+    }
+
+    // ---------- Conditional GET: 412 Precondition Failed ----------
+
+    [Fact]
+    public async Task EvaluatePreconditions_returns_412_when_If_Match_fails()
+    {
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-Match"] = "\"stale-etag\"";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithETag(p => $"page-{p.Items.Count}").EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status412PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task EvaluatePreconditions_412_does_not_inherit_selector_CacheControl()
+    {
+        // Mid-flow client error must not be cached as a negative response — the selector
+        // Cache-Control must not leak onto the 412 even though the success 200 / 304 would
+        // carry it. Mirrors TrellisHttpResult's "selector applies only at success-emit
+        // points" contract.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-Match"] = "\"stale-etag\"";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o
+                    .WithETag(p => $"page-{p.Items.Count}")
+                    .WithCacheControl(_ => CacheControl.Public(TimeSpan.FromMinutes(5)))
+                    .EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status412PreconditionFailed);
+        ctx.Response.Headers.CacheControl.ToString().Should().NotContain("max-age=300");
+    }
+
+    [Fact]
+    public async Task EvaluatePreconditions_412_still_carries_static_CacheControl()
+    {
+        // Static Cache-Control protects mid-flow failures (no-store, private) and applies
+        // before the conditional branch — the consumer's endpoint-level policy.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-Match"] = "\"stale-etag\"";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o
+                    .WithETag(p => $"page-{p.Items.Count}")
+                    .WithCacheControl(CacheControl.NoStore())
+                    .EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status412PreconditionFailed);
+        ctx.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+    }
+
+    // ---------- Selector deferral ----------
+
+    [Fact]
+    public async Task Header_selectors_defer_to_ExecuteAsync_and_run_once_per_request()
+    {
+        // Mirrors the existing Cache-Control deferral test: per-domain selectors must
+        // evaluate inside ExecuteAsync, not eagerly during ToHttpResponse. Also pins that
+        // the resolved ETag/Last-Modified values are cached so a non-deterministic selector
+        // cannot produce inconsistent header-vs-precondition-metadata values.
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+        var etagCalls = 0;
+        var lastModCalls = 0;
+
+        var http = r.ToHttpResponse(
+            (_, _) => "/next",
+            t => t,
+            o => o
+                .WithETag(_ => { etagCalls++; return "page-1"; })
+                .WithLastModified(_ => { lastModCalls++; return DateTimeOffset.UtcNow; })
+                .EvaluatePreconditions());
+
+        etagCalls.Should().Be(0);
+        lastModCalls.Should().Be(0);
+
+        ctx.Request.Method = "GET";
+        await http.ExecuteAsync(ctx);
+
+        etagCalls.Should().Be(1, "ETag selector must be invoked exactly once per request even when precondition evaluation also consults it");
+        lastModCalls.Should().Be(1, "Last-Modified selector must be invoked exactly once per request even when precondition evaluation also consults it");
+    }
+
+    // ---------- Combined coverage: every header on one response ----------
+
+    [Fact]
+    public async Task All_supported_options_apply_together_on_paged_success()
+    {
+        var ctx = NewContext();
+        var r = Result.Ok(SamplePage());
+        var stamp = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o
+                    .WithETag(p => $"page-{p.Items.Count}")
+                    .WithLastModified(_ => stamp)
+                    .Vary("Accept-Language")
+                    .WithContentLanguage("en")
+                    .WithContentLocation(_ => "/todos")
+                    .WithCacheControl(CacheControl.Public(TimeSpan.FromMinutes(1))))
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(200);
+        ctx.Response.Headers.ETag.ToString().Should().Be("\"page-2\"");
+        ctx.Response.Headers.LastModified.ToString().Should().Be("Thu, 15 Jan 2026 10:30:00 GMT");
+        ctx.Response.Headers.Vary.ToString().Should().Contain("Accept-Language");
+        ctx.Response.Headers.ContentLanguage.ToString().Should().Be("en");
+        ctx.Response.Headers["Content-Location"].ToString().Should().Be("/todos");
+        ctx.Response.Headers.CacheControl.ToString().Should().Be("public, max-age=60");
+    }
+}

--- a/Trellis.Asp/tests/PagedResponseOptionsTests.cs
+++ b/Trellis.Asp/tests/PagedResponseOptionsTests.cs
@@ -321,6 +321,29 @@ public sealed class PagedResponseOptionsTests
         projectorCalls.Should().Be(0, "body projector must not run when the response fails into 412");
     }
 
+    [Fact]
+    public async Task EvaluatePreconditions_returns_304_on_If_Modified_Since_matching_emitted_LastModified()
+    {
+        // Regression: the emitted Last-Modified RFC1123 header is second-precision, so the
+        // precondition metadata must also be second-precision — otherwise a client sending
+        // back the exact emitted value would see selector-ticks > Parse(header).Ticks and
+        // miss the 304 short-circuit. Selector returns a sub-second timestamp on purpose.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        var stamp = new DateTimeOffset(2026, 1, 15, 10, 30, 0, 500, TimeSpan.Zero);
+        // Client revalidates with the truncated value that was emitted to it.
+        ctx.Request.Headers["If-Modified-Since"] = "Thu, 15 Jan 2026 10:30:00 GMT";
+        var r = Result.Ok(SamplePage());
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => t,
+                o => o.WithLastModified(_ => stamp).EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status304NotModified);
+    }
+
     // ---------- Combined coverage: every header on one response ----------
 
     [Fact]

--- a/Trellis.Asp/tests/PagedResponseOptionsTests.cs
+++ b/Trellis.Asp/tests/PagedResponseOptionsTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -277,6 +276,49 @@ public sealed class PagedResponseOptionsTests
 
         etagCalls.Should().Be(1, "ETag selector must be invoked exactly once per request even when precondition evaluation also consults it");
         lastModCalls.Should().Be(1, "Last-Modified selector must be invoked exactly once per request even when precondition evaluation also consults it");
+    }
+
+    [Fact]
+    public async Task EvaluatePreconditions_304_does_not_run_body_projector()
+    {
+        // The body projector projects every item into the response envelope. On a 304
+        // revalidation the body is not emitted, so running the projector wastes work and
+        // (worse) may invoke expensive per-item logic that the consumer expected to be
+        // gated on a fresh 200. Regression for the eager-build bug where
+        // PagedResponseBuilder.Build ran before the precondition decision.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-None-Match"] = "\"page-2\"";
+        var r = Result.Ok(SamplePage());
+        var projectorCalls = 0;
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => { projectorCalls++; return t; },
+                o => o.WithETag(p => $"page-{p.Items.Count}").EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status304NotModified);
+        projectorCalls.Should().Be(0, "body projector must not run when the response short-circuits to 304");
+    }
+
+    [Fact]
+    public async Task EvaluatePreconditions_412_does_not_run_body_projector()
+    {
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        ctx.Request.Headers["If-Match"] = "\"stale-etag\"";
+        var r = Result.Ok(SamplePage());
+        var projectorCalls = 0;
+
+        await r.ToHttpResponse(
+                (_, _) => "/todos?cursor=next",
+                t => { projectorCalls++; return t; },
+                o => o.WithETag(p => $"page-{p.Items.Count}").EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status412PreconditionFailed);
+        projectorCalls.Should().Be(0, "body projector must not run when the response fails into 412");
     }
 
     // ---------- Combined coverage: every header on one response ----------

--- a/Trellis.Asp/tests/TrellisHttpResultExtraTests.cs
+++ b/Trellis.Asp/tests/TrellisHttpResultExtraTests.cs
@@ -168,6 +168,25 @@ public sealed class TrellisHttpResultExtraTests
     }
 
     [Fact]
+    public async Task Response_is_304_when_If_Modified_Since_matches_emitted_LastModified_at_sub_second_precision()
+    {
+        // Regression: the emitted Last-Modified RFC1123 header is second-precision, so the
+        // precondition metadata must also be truncated to seconds — otherwise a client
+        // sending back the exact emitted value would see selector-ticks > Parse(header).Ticks
+        // and miss the 304 short-circuit. Selector returns a sub-second timestamp on purpose.
+        var ctx = NewContext();
+        ctx.Request.Method = "GET";
+        var stamp = new DateTimeOffset(2024, 1, 1, 0, 0, 0, 500, TimeSpan.Zero);
+        ctx.Request.Headers["If-Modified-Since"] = "Mon, 01 Jan 2024 00:00:00 GMT";
+        var r = Result.Ok(new Todo(1, "x", "abc", stamp));
+
+        await r.ToHttpResponse(TodoBody.From, o => o.WithLastModified(t => t.Modified).EvaluatePreconditions())
+            .ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(304);
+    }
+
+    [Fact]
     public async Task Partial_static_range_returns_206_with_Content_Range_header()
     {
         var ctx = NewContext();


### PR DESCRIPTION
`HttpResponseOptionsBuilder<Page<T>>` previously accepted every option the non-paged builder did, but only `VaryForActor` and `WithCacheControl` actually flowed through to the wire on the paged path — every other `.With*` call compiled, ran, and silently no-op'd. `ETag` / `Last-Modified` / `Vary` / `Content-Language` / `Content-Location` are now applied to paged success responses; `EvaluatePreconditions()` now performs conditional-request evaluation (`If-None-Match` / `If-Modified-Since` → 304; failing `If-Match` / `If-Unmodified-Since` → 412) against `Page<T>`-shaped selectors.

Selector-derived `Cache-Control` applies only at the success-emit points (200 / 304); generated 412 responses do not inherit it. Static `Cache-Control` continues to apply to both success and failure paths. Domain-shaped selectors close over the `Page<T>` value and evaluate inside `IResult.ExecuteAsync`, matching the non-paged `TrellisHttpResult` timing. `ETag` and `Last-Modified` resolve exactly once per request.

Out of scope per `BACKLOG.md`: `WithRange` / `WithLocation` / `WithCreatedAt*` / body projector / `HonorPrefer` / `WithAcceptRanges` are paged-incompatible by shape and remain silently no-op.