### PR TITLE
Add IResult-aware FluentAssertions extension (BeSuccess / BeFailure / etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### `IResult`-aware FluentAssertions extension
+
+Tests asserting against members typed as the non-generic `IResult` interface — most commonly `IAuthorizeResource<TResource>.Authorize` and `IAuthorizeResourceVia<TOwner>.Authorize`, which both return `IResult` by contract — can now call `.Should().BeSuccess()` / `.BeFailureOfType<TError>()` / `.HaveErrorCode(...)` / `.HaveErrorDetail(...)` / `.HaveErrorDetailContaining(...)` directly without casting to `Result<Unit>`. New `IResultAssertions` mirrors the failure-side surface of the existing `ResultAssertions<TValue>`; `HaveValue` and equivalents are not offered because the non-generic interface carries no typed value. Concrete `Result<T>` continues to bind to the typed entry point — struct is more specific than the interface, so overload resolution prefers `Should<T>(this Result<T>)`.
+
 ### Fixed
 
 #### `Result<Page<T>>.ToHttpResponse` no longer silently drops `WithETag` / `WithLastModified` / `Vary` / `WithContentLanguage` / `WithContentLocation` / `EvaluatePreconditions`

--- a/Trellis.Testing/src/Assertions/IResultAssertions.cs
+++ b/Trellis.Testing/src/Assertions/IResultAssertions.cs
@@ -33,9 +33,12 @@ public static class IResultAssertionsExtensions
 {
     /// <summary>
     /// Returns an assertions object for fluent assertions on the non-generic
-    /// <see cref="IResult"/> interface.
+    /// <see cref="IResult"/> interface. Accepts <see langword="null"/> so that a null
+    /// receiver surfaces as a clean FluentAssertions failure ("Expected result to not be
+    /// &lt;null&gt;") rather than a <see cref="System.NullReferenceException"/> from the
+    /// first assertion call.
     /// </summary>
-    public static IResultAssertions Should(this IResult result) => new(result);
+    public static IResultAssertions Should(this IResult? result) => new(result);
 }
 
 /// <summary>
@@ -48,24 +51,33 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
     /// <summary>
     /// Initializes a new instance of the <see cref="IResultAssertions"/> class.
     /// </summary>
-    public IResultAssertions(IResult result) : base(result)
+    public IResultAssertions(IResult? result) : base(result!)
     {
     }
 
     /// <inheritdoc/>
     protected override string Identifier => "result";
 
+    private bool RequireNonNullSubject(string because, object[] becauseArgs) =>
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected {context:result} to not be <null>{reason}.");
+
     /// <summary>Asserts that the result is a success.</summary>
     public AndConstraint<IResultAssertions> BeSuccess(
         string because = "",
         params object[] becauseArgs)
     {
-        Subject.TryGetError(out var error);
-        Execute.Assertion
-            .BecauseOf(because, becauseArgs)
-            .ForCondition(Subject.IsSuccess)
-            .FailWith("Expected {context:result} to be success{reason}, but it failed with error: {0}",
-                error);
+        if (RequireNonNullSubject(because, becauseArgs))
+        {
+            Subject!.TryGetError(out var error);
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.IsSuccess)
+                .FailWith("Expected {context:result} to be success{reason}, but it failed with error: {0}",
+                    error);
+        }
 
         return new AndConstraint<IResultAssertions>(this);
     }
@@ -75,12 +87,17 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
         string because = "",
         params object[] becauseArgs)
     {
-        Execute.Assertion
-            .BecauseOf(because, becauseArgs)
-            .ForCondition(Subject.IsFailure)
-            .FailWith("Expected {context:result} to be failure{reason}, but it succeeded.");
+        Error? error = null;
+        if (RequireNonNullSubject(because, becauseArgs))
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject!.IsFailure)
+                .FailWith("Expected {context:result} to be failure{reason}, but it succeeded.");
 
-        Subject.TryGetError(out var error);
+            Subject.TryGetError(out error);
+        }
+
         return new AndWhichConstraint<IResultAssertions, Error>(this, error!);
     }
 
@@ -98,9 +115,12 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
         params object[] becauseArgs)
         where TError : Error
     {
+        if (!RequireNonNullSubject(because, becauseArgs))
+            return new AndWhichConstraint<IResultAssertions, TError>(this, (TError)default!);
+
         BeFailure(because, becauseArgs);
 
-        Subject.TryGetError(out var error);
+        Subject!.TryGetError(out var error);
         var matches = error is TError;
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
@@ -120,10 +140,12 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
         string because = "",
         params object[] becauseArgs)
     {
-        BeFailure(because, becauseArgs);
-
-        Subject.TryGetError(out var error);
-        error!.Code.Should().Be(expectedCode, because, becauseArgs);
+        if (RequireNonNullSubject(because, becauseArgs))
+        {
+            BeFailure(because, becauseArgs);
+            Subject!.TryGetError(out var error);
+            error!.Code.Should().Be(expectedCode, because, becauseArgs);
+        }
 
         return new AndConstraint<IResultAssertions>(this);
     }
@@ -134,10 +156,12 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
         string because = "",
         params object[] becauseArgs)
     {
-        BeFailure(because, becauseArgs);
-
-        Subject.TryGetError(out var error);
-        error!.Detail!.Should().Be(expectedDetail, because, becauseArgs);
+        if (RequireNonNullSubject(because, becauseArgs))
+        {
+            BeFailure(because, becauseArgs);
+            Subject!.TryGetError(out var error);
+            error!.Detail!.Should().Be(expectedDetail, because, becauseArgs);
+        }
 
         return new AndConstraint<IResultAssertions>(this);
     }
@@ -148,10 +172,12 @@ public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAsserti
         string because = "",
         params object[] becauseArgs)
     {
-        BeFailure(because, becauseArgs);
-
-        Subject.TryGetError(out var error);
-        error!.Detail!.Should().Contain(substring, because, becauseArgs);
+        if (RequireNonNullSubject(because, becauseArgs))
+        {
+            BeFailure(because, becauseArgs);
+            Subject!.TryGetError(out var error);
+            error!.Detail!.Should().Contain(substring, because, becauseArgs);
+        }
 
         return new AndConstraint<IResultAssertions>(this);
     }

--- a/Trellis.Testing/src/Assertions/IResultAssertions.cs
+++ b/Trellis.Testing/src/Assertions/IResultAssertions.cs
@@ -19,6 +19,16 @@ using FluentAssertions.Primitives;
 /// <c>Result&lt;T&gt;</c> is a struct, more specific than the <c>IResult</c> interface,
 /// so overload resolution prefers the typed extension at the call site.
 /// </remarks>
+/// <example>
+/// <para>
+/// Receivers statically typed as <see cref="IResult"/>, <see cref="IResult{TValue}"/>, or
+/// any other type that only satisfies the <see cref="IResult"/> contract bind to this
+/// non-generic entry point because the typed extension is only declared on the concrete
+/// <see cref="Result{TValue}"/> struct. Consumers holding <see cref="IResult{TValue}"/>
+/// who want <c>.HaveValue</c>-style typed assertions should narrow the receiver to a
+/// concrete <see cref="Result{TValue}"/> first.
+/// </para>
+/// </example>
 public static class IResultAssertionsExtensions
 {
     /// <summary>

--- a/Trellis.Testing/src/Assertions/IResultAssertions.cs
+++ b/Trellis.Testing/src/Assertions/IResultAssertions.cs
@@ -1,0 +1,154 @@
+﻿namespace Trellis.Testing;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+/// <summary>
+/// FluentAssertions extension for <see cref="IResult"/> (the non-generic Trellis result
+/// interface). Lets tests call <c>.Should().BeSuccess()</c> / <c>.Should().BeFailure()</c>
+/// against members typed as <c>IResult</c> — most commonly
+/// <see cref="Trellis.Authorization.IAuthorizeResource{TResource}.Authorize"/> and
+/// <see cref="Trellis.Authorization.IAuthorizeResourceVia{TOwner}.Authorize"/>, which both
+/// return <see cref="IResult"/> by contract.
+/// </summary>
+/// <remarks>
+/// The typed <see cref="ResultAssertions{TValue}"/> entry point continues to apply for
+/// concrete <see cref="Result{TValue}"/> values via the existing
+/// <see cref="ResultAssertionsExtensions.Should{TValue}(Result{TValue})"/> extension —
+/// <c>Result&lt;T&gt;</c> is a struct, more specific than the <c>IResult</c> interface,
+/// so overload resolution prefers the typed extension at the call site.
+/// </remarks>
+public static class IResultAssertionsExtensions
+{
+    /// <summary>
+    /// Returns an assertions object for fluent assertions on the non-generic
+    /// <see cref="IResult"/> interface.
+    /// </summary>
+    public static IResultAssertions Should(this IResult result) => new(result);
+}
+
+/// <summary>
+/// Contains assertion methods for the non-generic <see cref="IResult"/> interface. Mirrors
+/// the failure-side surface of <see cref="ResultAssertions{TValue}"/> (no success-value
+/// assertions exist because <see cref="IResult"/> carries no typed value).
+/// </summary>
+public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAssertions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IResultAssertions"/> class.
+    /// </summary>
+    public IResultAssertions(IResult result) : base(result)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override string Identifier => "result";
+
+    /// <summary>Asserts that the result is a success.</summary>
+    public AndConstraint<IResultAssertions> BeSuccess(
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Subject.TryGetError(out var error);
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject.IsSuccess)
+            .FailWith("Expected {context:result} to be success{reason}, but it failed with error: {0}",
+                error);
+
+        return new AndConstraint<IResultAssertions>(this);
+    }
+
+    /// <summary>Asserts that the result is a failure.</summary>
+    public AndWhichConstraint<IResultAssertions, Error> BeFailure(
+        string because = "",
+        params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject.IsFailure)
+            .FailWith("Expected {context:result} to be failure{reason}, but it succeeded.");
+
+        Subject.TryGetError(out var error);
+        return new AndWhichConstraint<IResultAssertions, Error>(this, error!);
+    }
+
+    /// <summary>Asserts that the result is a failure with a specific error type.</summary>
+    /// <typeparam name="TError">The expected error type.</typeparam>
+    /// <remarks>
+    /// Wrong-type behavior mirrors <see cref="ResultAssertions{TValue}.BeFailureOfType{TError}"/>:
+    /// without an active <see cref="AssertionScope"/> the assertion throws immediately;
+    /// with an active scope it records the failure and returns <c>default(TError)!</c> so
+    /// the scope's eventual <c>Dispose</c> surfaces the recorded assertion rather than a
+    /// chained <see cref="System.NullReferenceException"/>.
+    /// </remarks>
+    public AndWhichConstraint<IResultAssertions, TError> BeFailureOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        var matches = error is TError;
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(matches)
+            .FailWith("Expected {context:result} error to be of type {0}{reason}, but found {1}",
+                FormatErrorTypeName(typeof(TError)),
+                error is null ? null : FormatErrorTypeName(error.GetType()));
+
+        return new AndWhichConstraint<IResultAssertions, TError>(
+            this,
+            matches ? (TError)error! : default!);
+    }
+
+    /// <summary>Asserts that the failure has a specific error code.</summary>
+    public AndConstraint<IResultAssertions> HaveErrorCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error!.Code.Should().Be(expectedCode, because, becauseArgs);
+
+        return new AndConstraint<IResultAssertions>(this);
+    }
+
+    /// <summary>Asserts that the failure has a specific error detail.</summary>
+    public AndConstraint<IResultAssertions> HaveErrorDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error!.Detail!.Should().Be(expectedDetail, because, becauseArgs);
+
+        return new AndConstraint<IResultAssertions>(this);
+    }
+
+    /// <summary>Asserts that the failure error detail contains the specified substring.</summary>
+    public AndConstraint<IResultAssertions> HaveErrorDetailContaining(
+        string substring,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        BeFailure(because, becauseArgs);
+
+        Subject.TryGetError(out var error);
+        error!.Detail!.Should().Contain(substring, because, becauseArgs);
+
+        return new AndConstraint<IResultAssertions>(this);
+    }
+
+    private static string FormatErrorTypeName(System.Type t)
+    {
+        var declaring = t.DeclaringType;
+        return declaring is null ? t.Name : $"{declaring.Name}.{t.Name}";
+    }
+}

--- a/Trellis.Testing/tests/Assertions/IResultAssertionsTests.cs
+++ b/Trellis.Testing/tests/Assertions/IResultAssertionsTests.cs
@@ -119,4 +119,33 @@ public class IResultAssertionsTests
         var result = Result.Ok(42);
         result.Should().BeSuccess().Which.Should().Be(42);
     }
+
+    // Null-receiver guard — null IResult surfaces a clean assertion failure, not NRE
+
+    [Fact]
+    public void BeSuccess_on_null_receiver_fails_assertion_not_NRE()
+    {
+        IResult? result = null;
+        var act = () => result.Should().BeSuccess();
+        act.Should().Throw<Exception>()
+            .Which.Should().NotBeOfType<NullReferenceException>("null receiver must surface as a clean assertion failure");
+    }
+
+    [Fact]
+    public void BeFailure_on_null_receiver_fails_assertion_not_NRE()
+    {
+        IResult? result = null;
+        var act = () => result.Should().BeFailure();
+        act.Should().Throw<Exception>()
+            .Which.Should().NotBeOfType<NullReferenceException>();
+    }
+
+    [Fact]
+    public void BeFailureOfType_on_null_receiver_fails_assertion_not_NRE()
+    {
+        IResult? result = null;
+        var act = () => result.Should().BeFailureOfType<Error.Forbidden>();
+        act.Should().Throw<Exception>()
+            .Which.Should().NotBeOfType<NullReferenceException>();
+    }
 }

--- a/Trellis.Testing/tests/Assertions/IResultAssertionsTests.cs
+++ b/Trellis.Testing/tests/Assertions/IResultAssertionsTests.cs
@@ -1,0 +1,122 @@
+﻿namespace Trellis.Testing.Tests.Assertions;
+
+using System;
+
+/// <summary>
+/// Tests for <see cref="IResultAssertions"/> — the non-generic <see cref="IResult"/>
+/// assertion entry point. Motivating use case: assertions against the return value of
+/// <c>IAuthorizeResource&lt;T&gt;.Authorize</c> / <c>IAuthorizeResourceVia&lt;TOwner&gt;.Authorize</c>,
+/// which both return <see cref="IResult"/> by interface contract.
+/// </summary>
+public class IResultAssertionsTests
+{
+    // BeSuccess
+
+    [Fact]
+    public void BeSuccess_passes_when_result_is_success()
+    {
+        IResult result = Result.Ok();
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void BeSuccess_fails_when_result_is_failure()
+    {
+        IResult result = Result.Fail(new Error.NotFound(new ResourceRef("Resource", null)) { Detail = "Not found" });
+        var act = () => result.Should().BeSuccess();
+        act.Should().Throw<Exception>()
+            .WithMessage("*to be success*failed with error*");
+    }
+
+    // BeFailure
+
+    [Fact]
+    public void BeFailure_passes_when_result_is_failure()
+    {
+        IResult result = Result.Fail(new Error.Forbidden("documents.edit"));
+        result.Should().BeFailure();
+    }
+
+    [Fact]
+    public void BeFailure_fails_when_result_is_success()
+    {
+        IResult result = Result.Ok();
+        var act = () => result.Should().BeFailure();
+        act.Should().Throw<Exception>()
+            .WithMessage("*to be failure*succeeded*");
+    }
+
+    [Fact]
+    public void BeFailure_exposes_error_via_Which()
+    {
+        var err = new Error.Forbidden("documents.edit");
+        IResult result = Result.Fail(err);
+
+        result.Should().BeFailure().Which.Should().BeSameAs(err);
+    }
+
+    // BeFailureOfType<TError>
+
+    [Fact]
+    public void BeFailureOfType_passes_when_error_type_matches_and_returns_typed_error()
+    {
+        var err = new Error.Forbidden("documents.edit");
+        IResult result = Result.Fail(err);
+
+        var which = result.Should().BeFailureOfType<Error.Forbidden>().Which;
+        which.Should().BeSameAs(err);
+        which.PolicyId.Should().Be("documents.edit");
+    }
+
+    [Fact]
+    public void BeFailureOfType_fails_when_error_type_does_not_match()
+    {
+        IResult result = Result.Fail(new Error.Forbidden("documents.edit"));
+
+        var act = () => result.Should().BeFailureOfType<Error.NotFound>();
+        act.Should().Throw<Exception>()
+            .WithMessage("*to be of type*NotFound*found*Forbidden*");
+    }
+
+    // HaveErrorCode / HaveErrorDetail / HaveErrorDetailContaining
+
+    [Fact]
+    public void HaveErrorCode_passes_when_error_code_matches()
+    {
+        // Error.Forbidden overrides Code to PolicyId; gives a meaningful per-instance code.
+        IResult result = Result.Fail(new Error.Forbidden("documents.edit"));
+        result.Should().HaveErrorCode("documents.edit");
+    }
+
+    [Fact]
+    public void HaveErrorDetail_passes_when_detail_matches()
+    {
+        IResult result = Result.Fail(new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty)
+        {
+            Detail = "Invalid request"
+        });
+        result.Should().HaveErrorDetail("Invalid request");
+    }
+
+    [Fact]
+    public void HaveErrorDetailContaining_passes_when_detail_contains_substring()
+    {
+        IResult result = Result.Fail(new Error.UnprocessableContent(EquatableArray<FieldViolation>.Empty)
+        {
+            Detail = "User input is invalid"
+        });
+        result.Should().HaveErrorDetailContaining("invalid");
+    }
+
+    // Overload-resolution sanity check — concrete Result<T> still resolves to typed assertions
+
+    [Fact]
+    public void Concrete_ResultT_resolves_to_typed_assertions_not_IResultAssertions()
+    {
+        // If the IResult overload were preferred, this would compile but BeSuccess() would
+        // return AndConstraint instead of AndWhichConstraint<_, TValue>, so .Which.Should()
+        // would not type-check against int.
+        var result = Result.Ok(42);
+        result.Should().BeSuccess().Which.Should().Be(42);
+    }
+}

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -127,7 +127,7 @@ public static class IResultAssertionsExtensions
 
 Entry-point for assertions against members typed as the non-generic `IResult` interface — most commonly `IAuthorizeResource<TResource>.Authorize` and `IAuthorizeResourceVia<TOwner>.Authorize`, which both return `IResult` by contract. Mirrors the failure-side surface of `ResultAssertions<TValue>` (no `.HaveValue` because the non-generic interface carries no typed value).
 
-Overload resolution: a concrete `Result<T>` always binds to the typed `Should<T>(this Result<T>)` extension instead (struct is more specific than the `IResult` interface). The non-generic entry point fires only when the call-site type is `IResult`.
+Overload resolution: a concrete `Result<T>` always binds to the typed `Should<T>(this Result<T>)` extension instead (struct is more specific than the `IResult` interface). The non-generic entry point fires for any receiver statically typed as `IResult` — including `IResult<TValue>`, generic type parameters constrained to `IResult`, and custom concrete types implementing `IResult` — because no typed extension exists for those receivers. Consumers holding `IResult<TValue>` who want the typed `.HaveValue` surface should narrow the receiver to a concrete `Result<TValue>` first.
 
 ```csharp
 public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAssertions>

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Testing
 namespaces: [Trellis.Testing]
-types: ["FakeRepository<TAggregate, TId>", "FakeSharedResourceLoader<TResource, TId>", TestActorProvider, TestActorScope, "ResultAssertions<TValue>", ResultAssertionsExtensions, ResultAssertionsAsyncExtensions, "MaybeAssertions<T>", MaybeAssertionsExtensions, ErrorAssertions, ErrorAssertionsExtensions, ValidationErrorAssertions, ValidationErrorAssertionsExtensions, UnwrapExtensions, UnwrapFailedException, AggregateTestMutator]
+types: ["FakeRepository<TAggregate, TId>", "FakeSharedResourceLoader<TResource, TId>", TestActorProvider, TestActorScope, "ResultAssertions<TValue>", ResultAssertionsExtensions, ResultAssertionsAsyncExtensions, IResultAssertions, IResultAssertionsExtensions, "MaybeAssertions<T>", MaybeAssertionsExtensions, ErrorAssertions, ErrorAssertionsExtensions, ValidationErrorAssertions, ValidationErrorAssertionsExtensions, UnwrapExtensions, UnwrapFailedException, AggregateTestMutator]
 version: v3
 last_verified: 2026-05-06
 audience: [llm]
@@ -29,6 +29,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 | Assert a generic result succeeded | `result.Should().BeSuccess()` / `.HaveValue(...)` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
 | Assert a result failed with a specific error case | `result.Should().BeFailureOfType<TError>()` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
 | Assert error code/detail | `.HaveErrorCode(...)`, `.HaveErrorDetail(...)`, `.HaveErrorDetailContaining(...)` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
+| Assert against `IResult` (e.g., `IAuthorizeResource<T>.Authorize` return value) | `result.Should().BeSuccess()` / `.BeFailureOfType<TError>()` — same surface, no `.HaveValue` since the non-generic interface carries no typed value | [`IResultAssertions`](#iresultassertions) |
 | Extract success value in tests only | `result.Unwrap()` | [Usage notes](#usage-notes) |
 | Extract error in tests only | `result.UnwrapError()` | [Usage notes](#usage-notes) |
 | Provide an actor in handler tests | `TestActorProvider` | [`TestActorProvider`](#testactorprovider) |
@@ -108,6 +109,56 @@ public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, 
 
     public AndConstraint<ResultAssertions<TValue>> NotBe(
         Result<TValue> unexpected,
+        string because = "",
+        params object[] becauseArgs);
+}
+```
+
+#### `IResultAssertionsExtensions`
+
+```csharp
+public static class IResultAssertionsExtensions
+{
+    public static IResultAssertions Should(this IResult result);
+}
+```
+
+#### `IResultAssertions`
+
+Entry-point for assertions against members typed as the non-generic `IResult` interface — most commonly `IAuthorizeResource<TResource>.Authorize` and `IAuthorizeResourceVia<TOwner>.Authorize`, which both return `IResult` by contract. Mirrors the failure-side surface of `ResultAssertions<TValue>` (no `.HaveValue` because the non-generic interface carries no typed value).
+
+Overload resolution: a concrete `Result<T>` always binds to the typed `Should<T>(this Result<T>)` extension instead (struct is more specific than the `IResult` interface). The non-generic entry point fires only when the call-site type is `IResult`.
+
+```csharp
+public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAssertions>
+{
+    public IResultAssertions(IResult result);
+
+    public AndConstraint<IResultAssertions> BeSuccess(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<IResultAssertions, Error> BeFailure(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<IResultAssertions, TError> BeFailureOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+
+    public AndConstraint<IResultAssertions> HaveErrorCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<IResultAssertions> HaveErrorDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<IResultAssertions> HaveErrorDetailContaining(
+        string substring,
         string because = "",
         params object[] becauseArgs);
 }


### PR DESCRIPTION
Tests asserting against members typed as the non-generic `IResult` interface — most commonly `IAuthorizeResource<T>.Authorize` and `IAuthorizeResourceVia<TOwner>.Authorize`, which both return `IResult` by contract — previously had to cast the return value to `Result<Unit>` before the existing `.Should().BeSuccess()` / `.BeFailureOfType<TError>()` / `.HaveErrorCode(...)` / etc. became available. Surfaced in the 2026-04-30 lab.

New `IResultAssertions` mirrors the failure-side surface of the existing `ResultAssertions<TValue>`; `HaveValue` and equivalents are not offered because the non-generic interface carries no typed value. Concrete `Result<T>` continues to bind to the typed entry point at the call site — struct is more specific than the interface, so overload resolution prefers `Should<T>(this Result<T>)` without ambiguity. A sanity-check test pins that resolution.