### PR TITLE
Document Money / CurrencyCode validation as syntax-only

### DIFF
--- a/Trellis.Primitives/src/Primitives/CurrencyCode.cs
+++ b/Trellis.Primitives/src/Primitives/CurrencyCode.cs
@@ -10,20 +10,23 @@ using Trellis;
 /// <remarks>
 /// <b>Validation Rules (Opinionated):</b>
 /// <para>
-/// Valid codes are three ASCII letters (e.g., USD, EUR, GBP). Non-ASCII letters such as
-/// German umlauts, Greek, or Cyrillic are rejected. The stored value is uppercase.
+/// Valid codes are three ASCII letters (e.g., USD, EUR, GBP). Input is case-insensitive —
+/// <c>"usd"</c>, <c>"USD"</c>, and <c>"Usd"</c> all parse; the stored value is uppercase via
+/// <c>ToUpperInvariant()</c>. Non-ASCII letters such as German umlauts, Greek, or Cyrillic are
+/// rejected, and codes shorter or longer than three characters are rejected.
 /// </para>
 /// <para>
-/// <b>Scope of validation.</b> Only the ISO 4217 <i>format</i> (three uppercase ASCII letters)
-/// is enforced. The ISO 4217 <i>active-code list</i> is not consulted, so syntactically valid
+/// <b>Scope of validation.</b> Only the ISO 4217 <i>format</i> (three ASCII letters) is
+/// enforced. The ISO 4217 <i>active-code list</i> is not consulted, so syntactically valid
 /// but reserved or unassigned codes such as <c>XXX</c>, <c>XTS</c>, and <c>ZZZ</c> are accepted.
 /// Applications that need to restrict to currencies actually supported by a payment processor,
 /// reject ISO reserved/test codes, or otherwise impose a narrower policy should layer an
 /// allow-list at the application boundary.
 /// </para>
 /// <para>
-/// <b>If these rules don't fit your domain</b> (e.g., cryptocurrency codes like BTC, ETH),
-/// create your own CurrencyCode value object using the <see cref="ScalarValueObject{TSelf, T}"/> base class.
+/// <b>If these rules don't fit your domain</b> (e.g., cryptocurrency ticker symbols longer than
+/// three characters like <c>USDT</c>, <c>DOGE</c>, <c>MATIC</c>), create your own currency-code
+/// value object using the <see cref="ScalarValueObject{TSelf, T}"/> base class.
 /// </para>
 /// </remarks>
 [JsonConverter(typeof(ParsableJsonConverter<CurrencyCode>))]

--- a/Trellis.Primitives/src/Primitives/CurrencyCode.cs
+++ b/Trellis.Primitives/src/Primitives/CurrencyCode.cs
@@ -14,6 +14,14 @@ using Trellis;
 /// German umlauts, Greek, or Cyrillic are rejected. The stored value is uppercase.
 /// </para>
 /// <para>
+/// <b>Scope of validation.</b> Only the ISO 4217 <i>format</i> (three uppercase ASCII letters)
+/// is enforced. The ISO 4217 <i>active-code list</i> is not consulted, so syntactically valid
+/// but reserved or unassigned codes such as <c>XXX</c>, <c>XTS</c>, and <c>ZZZ</c> are accepted.
+/// Applications that need to restrict to currencies actually supported by a payment processor,
+/// reject ISO reserved/test codes, or otherwise impose a narrower policy should layer an
+/// allow-list at the application boundary.
+/// </para>
+/// <para>
 /// <b>If these rules don't fit your domain</b> (e.g., cryptocurrency codes like BTC, ETH),
 /// create your own CurrencyCode value object using the <see cref="ScalarValueObject{TSelf, T}"/> base class.
 /// </para>

--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -40,6 +40,15 @@ public class Money : ValueObject
     /// <summary>
     /// Creates a Money instance with the specified amount and currency code.
     /// </summary>
+    /// <remarks>
+    /// Currency validation is delegated to <see cref="CurrencyCode.TryCreate"/> and is
+    /// syntactic only (three uppercase ASCII letters per ISO 4217 format). The ISO 4217
+    /// active-code list is not enforced — values like <c>XXX</c>, <c>XTS</c>, or <c>ZZZ</c>
+    /// satisfy the format and will be accepted. Applications that need to restrict to a
+    /// specific set of currencies (e.g., those a payment processor supports, or excluding
+    /// ISO reserved/test codes) should layer an allow-list at the application boundary
+    /// before calling <see cref="TryCreate"/>.
+    /// </remarks>
     /// <param name="amount">The monetary amount.</param>
     /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD", "EUR").</param>
     /// <param name="fieldName">Optional field name for validation errors.</param>

--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -42,15 +42,16 @@ public class Money : ValueObject
     /// </summary>
     /// <remarks>
     /// Currency validation is delegated to <see cref="CurrencyCode.TryCreate"/> and is
-    /// syntactic only (three uppercase ASCII letters per ISO 4217 format). The ISO 4217
-    /// active-code list is not enforced — values like <c>XXX</c>, <c>XTS</c>, or <c>ZZZ</c>
-    /// satisfy the format and will be accepted. Applications that need to restrict to a
-    /// specific set of currencies (e.g., those a payment processor supports, or excluding
-    /// ISO reserved/test codes) should layer an allow-list at the application boundary
-    /// before calling <see cref="TryCreate"/>.
+    /// syntactic only (three ASCII letters per ISO 4217 format; input is case-insensitive,
+    /// stored uppercase via <c>ToUpperInvariant</c>). The ISO 4217 active-code list is not
+    /// enforced — values like <c>XXX</c>, <c>XTS</c>, or <c>ZZZ</c> satisfy the format and
+    /// will be accepted. Applications that need to restrict to a specific set of currencies
+    /// (e.g., those a payment processor supports, or excluding ISO reserved/test codes)
+    /// should layer an allow-list at the application boundary before calling
+    /// <see cref="TryCreate"/>.
     /// </remarks>
     /// <param name="amount">The monetary amount.</param>
-    /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD", "EUR").</param>
+    /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD", "EUR"); case-insensitive.</param>
     /// <param name="fieldName">Optional field name for validation errors.</param>
     /// <returns>Result containing the Money instance or validation errors.</returns>
     public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -128,7 +128,7 @@ public class CurrencyCode : ScalarValueObject<CurrencyCode, string>, IScalarValu
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<CurrencyCode> TryCreate(string? value, string? fieldName = null)` | `Result<CurrencyCode>` | Requires exactly three uppercase ASCII letters per ISO 4217 *format*. The ISO 4217 *active-code list* is not enforced — syntactically valid but reserved or unassigned codes such as `XXX`, `XTS`, `ZZZ` are accepted. Applications that need active-currency enforcement (e.g., payment processors that only support a subset, or excluding the ISO test/reserved codes) should layer an allow-list at the application boundary. |
+| `public static Result<CurrencyCode> TryCreate(string? value, string? fieldName = null)` | `Result<CurrencyCode>` | Requires exactly three ASCII letters per ISO 4217 *format*. Input is case-insensitive — `"usd"`, `"USD"`, and `"Usd"` are all accepted; the stored value is uppercase via `ToUpperInvariant()`. The ISO 4217 *active-code list* is not enforced — syntactically valid but reserved or unassigned codes such as `XXX`, `XTS`, `ZZZ` are accepted. Applications that need active-currency enforcement (e.g., payment processors that only support a subset, or excluding the ISO test/reserved codes) should layer an allow-list at the application boundary. |
 | `public static CurrencyCode Parse(string? s, IFormatProvider? provider)` | `CurrencyCode` | Throws `FormatException` on failure. |
 | `public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out CurrencyCode result)` | `bool` | Safe parse helper. |
 
@@ -262,7 +262,7 @@ public class Money : ValueObject
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts. Currency validation is delegated to [`CurrencyCode.TryCreate`](#currencycode) and is syntactic only — codes outside the ISO 4217 active list (`XXX`, `XTS`, `ZZZ`, etc.) are accepted because they satisfy the three-uppercase-ASCII-letter format. Layer an application-level allow-list when active-code enforcement is required. |
+| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts. Currency validation is delegated to [`CurrencyCode.TryCreate`](#currencycode) and is syntactic only — three ASCII letters (case-insensitive input; normalized to uppercase). Codes outside the ISO 4217 active list (`XXX`, `XTS`, `ZZZ`, etc.) are accepted because they satisfy the format. Layer an application-level allow-list when active-code enforcement is required. |
 | `public static Money Create(decimal amount, string currencyCode)` | `Money` | Throwing factory. |
 | `public Result<Money> Add(Money other)` | `Result<Money>` | Requires matching currencies. Throws `ArgumentNullException` when `other` is null. Returns `Error.UnprocessableContent` on currency mismatch or addition overflow. |
 | `public Result<Money> Subtract(Money other)` | `Result<Money>` | Requires matching currencies and non-negative result. Throws `ArgumentNullException` when `other` is null. |

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -128,7 +128,7 @@ public class CurrencyCode : ScalarValueObject<CurrencyCode, string>, IScalarValu
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<CurrencyCode> TryCreate(string? value, string? fieldName = null)` | `Result<CurrencyCode>` | Requires exactly three letters. |
+| `public static Result<CurrencyCode> TryCreate(string? value, string? fieldName = null)` | `Result<CurrencyCode>` | Requires exactly three uppercase ASCII letters per ISO 4217 *format*. The ISO 4217 *active-code list* is not enforced — syntactically valid but reserved or unassigned codes such as `XXX`, `XTS`, `ZZZ` are accepted. Applications that need active-currency enforcement (e.g., payment processors that only support a subset, or excluding the ISO test/reserved codes) should layer an allow-list at the application boundary. |
 | `public static CurrencyCode Parse(string? s, IFormatProvider? provider)` | `CurrencyCode` | Throws `FormatException` on failure. |
 | `public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out CurrencyCode result)` | `bool` | Safe parse helper. |
 
@@ -262,7 +262,7 @@ public class Money : ValueObject
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts and invalid currency codes. |
+| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts. Currency validation is delegated to [`CurrencyCode.TryCreate`](#currencycode) and is syntactic only — codes outside the ISO 4217 active list (`XXX`, `XTS`, `ZZZ`, etc.) are accepted because they satisfy the three-uppercase-ASCII-letter format. Layer an application-level allow-list when active-code enforcement is required. |
 | `public static Money Create(decimal amount, string currencyCode)` | `Money` | Throwing factory. |
 | `public Result<Money> Add(Money other)` | `Result<Money>` | Requires matching currencies. Throws `ArgumentNullException` when `other` is null. Returns `Error.UnprocessableContent` on currency mismatch or addition overflow. |
 | `public Result<Money> Subtract(Money other)` | `Result<Money>` | Requires matching currencies and non-negative result. Throws `ArgumentNullException` when `other` is null. |


### PR DESCRIPTION
## Issue

The `Money.TryCreate` API reference row says:

> "Rejects negative amounts and **invalid currency codes**."

The word "invalid" implies semantic validation (active ISO 4217 code), but the actual implementation delegates to `CurrencyCode.TryCreate`, which enforces only the format (three uppercase ASCII letters). Codes like `"XXX"`, `"XTS"`, `"ZZZ"` are reserved or test codes per the ISO 4217 active list but satisfy the format, so they pass.

A consumer reading the `Money` row reasonably assumes active-code enforcement. Tests written against that assumption fail; production code passing a UI-typed `"FOO"` silently accepts it.

## Fix

Doc-only clarification on three surfaces. No code or behavior change.

- `trellis-api-primitives.md` — rewrite the `Money.TryCreate` row to explicitly delegate to `CurrencyCode.TryCreate`, name the codes that slip through, and point at the application-level allow-list seam.
- `trellis-api-primitives.md` — tighten the `CurrencyCode.TryCreate` row from "Requires exactly three letters" to call out *format-only* vs *active-list* and name the same examples.
- `CurrencyCode` class `<remarks>` — add a "Scope of validation" paragraph mirroring the API reference text.
- `Money.TryCreate` XML — add a `<remarks>` block linking to `CurrencyCode.TryCreate` and naming the boundary.

Active-code enforcement remains out of scope: currency policies vary widely by consumer (payment processors typically support 30, not 165; crypto needs non-ISO codes; accounting needs historical codes), so Trellis stays out of the policy decision and exposes a layerable primitive.