### PR TITLE
docs(cookbook): remove Recipe 26 (version-aware projection in shared controller)

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -97,7 +97,6 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Return synchronous `Result` chains from `Task`/`ValueTask` APIs | [Recipe 2](#recipe-2--command--handler--fluentvalidation--ef-persistence), then `AsTask()` / `AsValueTask()` in [trellis-api-core.md](trellis-api-core.md) |
 | Create HTTP-oriented resource errors | Use `ResourceRef.For<TResource>(id)` from [trellis-api-core.md](trellis-api-core.md) |
 | Add a state transition | [Recipe 9](#recipe-9--state-machine-canfire--fire-pattern-with-fireresult) |
-| Add a multi-version controller where v2 adds new fields to existing responses | [Recipe 26](#recipe-26--version-aware-response-projection-in-a-shared-controller) |
 | Write handler/domain tests | [Recipe 10](#recipe-10--test-handler-test-using-trellistesting-shouldbe--unwraperror) |
 | Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
@@ -114,7 +113,6 @@ These rows route recurring LLM lab mistakes to the most relevant reference befor
 | State transitions on an aggregate | [Recipe 9](#recipe-9--state-machine-canfire--fire-pattern-with-fireresult), then [trellis-api-statemachine.md](trellis-api-statemachine.md#patterns-index) | Keep transition methods consistent and put domain mutation after `FireResult` succeeds. |
 | Cross-aggregate mutation such as cancel/return releasing stock | [Recipe 1](#recipe-1--crud-aggregate-ddd-value-objects--entity--repository-contract), [Recipe 2](#recipe-2--command--handler--fluentvalidation--ef-persistence), and [trellis-api-core.md](trellis-api-core.md#domain-driven-design) | The application handler orchestrates multiple aggregates; an aggregate mutates only itself. |
 | Single-loop mutate-as-you-validate over a collection of related aggregates (reserve stock per line item, etc.) | [Recipe 25](#recipe-25--two-pass-validate-then-mutate-over-a-collection-of-related-aggregates) | A later element's validation failure leaves earlier elements partially mutated in memory. Validate every fallible domain check across every participating aggregate before the first state-changing call. |
-| Multi-version controller where the response shape diverges between api-versions (v2 adds new fields; v1 must keep its original shape) | [Recipe 26](#recipe-26--version-aware-response-projection-in-a-shared-controller) | One controller, `[ApiVersion]` × N, a private `Project(T)` seam keyed on `HttpContext.RequestedApiVersion`. Scales better than per-version controller folders for the typical "v1 still works at v2; v2 adds a field" case. |
 | Result-returning ASP endpoints | [Recipe 4](#recipe-4--minimal-api-endpoint-wiring-resultt--httpresponseoptionsbuilder--tohttpresponse), [Recipe 5](#recipe-5--mvc-controller-using-asactionresult), then [trellis-api-asp.md](trellis-api-asp.md#patterns-index) | `AddTrellisAsp()` is required for Result-to-HTTP mapping; exception middleware is not the mapper. |
 | Failure-code OpenAPI metadata or `.http` examples | [trellis-api-asp.md](trellis-api-asp.md#endpoint-checklist-for-generated-apis), [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#api-failure-path-test-checklist) | Generated APIs need failure paths, not happy-path-only docs/tests. |
 | Resource authorization guards | [Recipe 7](#recipe-7--authorization-iactorprovider--iauthorize--resource-based-auth), then [trellis-api-authorization.md](trellis-api-authorization.md#patterns-index) | Use `Result.Ensure` for owner/admin boolean guards. |
@@ -2170,147 +2168,6 @@ public async Task Submit_with_one_unsatisfiable_line_does_not_reserve_any_stock(
 ```
 
 Together with the duplicate-product case (two lines for the same product whose summed quantity exceeds available stock), these are the two failure-mode tests that catch every form of this bug.
-
----
-
-## Recipe 26 — Version-aware response projection in a shared controller
-
-**Problem.** A service ships a v2 API that adds new fields to an existing response shape (e.g. v2 introduces `Returned` to `OrderStatus` plus two new fields `returnedAt` and `returnReason`), while v1 clients must keep seeing the v1 shape — no new fields, and a returned order projects back to `status: "Delivered"` so the v1 surface stays byte-identical to what it shipped before. The v1 endpoints stay accessible under both api-versions; only the genuinely new endpoint (e.g. `POST /api/orders/{id}/return`) is v2-only.
-
-Asp.Versioning gives you the routing primitives (`[ApiVersion]` per class, `[MapToApiVersion]` per action). What it does not give you is the *response-shape dispatch* — there is no `[MapToApiVersionResponseShape]` attribute. Authors who reach this point typically reinvent one of two patterns from first principles: split the controller into two version-folders and duplicate every action, or keep a single controller and write a private `Project(T)` helper that branches on the runtime-matched api-version. The duplication tax for two versions and ~10 shared endpoints is ~100 lines per controller, multiplied across every controller whose response shape diverged. The single-controller form ships ~10 lines total per controller plus one `Project(T)` helper.
-
-This recipe documents the single-controller form because it scales better and keeps the spec rule *"v1 endpoints remain accessible under both versions"* expressible as a class-level attribute set rather than as a cross-folder convention.
-
-### The shape
-
-```csharp
-using Asp.Versioning;
-using Asp.Versioning.Http;           // HttpContext.RequestedApiVersion extension
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
-using Trellis;
-using Trellis.Asp;
-using Trellis.Asp.ApiVersioning;
-
-[ApiController]
-[ApiVersion("2026-11-12")]                  // v1: all endpoints below are reachable here.
-[ApiVersion("2026-12-01")]                  // v2: same endpoints, plus the v2-only Return.
-[Produces("application/json")]
-[Route("api/[controller]")]
-public sealed class OrdersController(ISender sender) : ControllerBase
-{
-    // Shared by both versions — response shape branches on requested version.
-    [HttpGet("{id}", Name = "Orders_GetById")]
-    [ProducesResponseType(typeof(OrderResponseV1), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(OrderResponseV2), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public Task<ActionResult<object>> GetById(OrderId id, CancellationToken ct) =>
-        sender.Send(new GetOrderByIdQuery(id), ct).AsTask()
-            .ToHttpResponseAsync<Order, object>(
-                Project,
-                opts => opts.WithETag(o => EntityTagValue.Strong(o.ETag))
-                            .WithLastModified(o => o.LastModified)
-                            .EvaluatePreconditions())
-            .AsActionResultAsync<object>();
-
-    // v2-only action — Asp.Versioning emits 404 when called with ?api-version=2026-11-12.
-    [HttpPost("{id}/return")]
-    [Consumes("application/json")]
-    [MapToApiVersion("2026-12-01")]
-    [ProducesResponseType(typeof(OrderResponseV2), StatusCodes.Status200OK)]
-    public Task<ActionResult<object>> Return(
-        OrderId id,
-        [FromBody] ReturnOrderRequest request,
-        CancellationToken ct) =>
-        sender.Send(new ReturnOrderCommand(id, request.Reason), ct).AsTask()
-            .ToHttpResponseAsync<Order, object>(Project, opts => opts.WithETag(o => EntityTagValue.Strong(o.ETag)))
-            .AsActionResultAsync<object>();
-
-    // The single dispatch seam. One read of the matched version; one branch.
-    private object Project(Order order) =>
-        IsV2() ? OrderResponseV2.From(order) : OrderResponseV1.From(order);
-
-    private bool IsV2() =>
-        HttpContext.RequestedApiVersion()?.ToString() == "2026-12-01";
-}
-```
-
-The matched-version read uses the `HttpContext.RequestedApiVersion()` extension property shipped by `Asp.Versioning.Http`. This is the reader-agnostic primary signal — it reflects whatever `IApiVersionReader` is configured (query, header, media-type, URL segment, or a composite reader) and is what `Trellis.Asp.ApiVersioning`'s own runtime uses internally (see [`trellis-api-asp-apiversioning.md`](trellis-api-asp-apiversioning.md) for the full resolution order).
-
-### Why `ActionResult<object>`
-
-`ToHttpResponseAsync<TDomain, TBody>(projection, opts)` requires a closed `TBody`. When the body's runtime type depends on the matched version, the only closed type that fits both branches is `object`. The opts selectors stay typed against `Order` (so `WithETag(o => …)` retains compile-time access to `o.ETag` etc.) — only the *body* type degrades to `object`. STJ serialises by runtime type, so the wire shape is correct for both `OrderResponseV1` and `OrderResponseV2`.
-
-The visible cost is OpenAPI metadata: a per-action `[ProducesResponseType(typeof(...), StatusCodes.Status200OK)]` now appears once per response shape (two lines instead of one), so consumers reading the OpenAPI document still see both response schemas — but the per-action body type in the action's signature is `object`, not the specific DTO. Authors who need typed `ActionResult<TDto>` for downstream tooling that introspects the action signature (rather than the `[ProducesResponseType]` metadata) should fall back to the split-controller form below.
-
-### Spec rules this pattern satisfies
-
-The convergent multi-version rule set in real services breaks down into four checks every version-aware endpoint MUST satisfy. The shape above satisfies them in one go:
-
-- **v1 endpoints reachable at both versions.** Both `[ApiVersion]` attributes on the class; no `[MapToApiVersion]` on shared actions.
-- **v2-only endpoints unreachable at v1.** `[MapToApiVersion("2026-12-01")]` on the v2-only action; Asp.Versioning emits 404 when called with the wrong version (not 400, not 405).
-- **v1 response shape stable.** `OrderResponseV1.From(order)` never includes the v2-only fields, and projects the `Returned` enum case back to `"Delivered"` at the DTO seam — `v1 dto.Status = order.Status == OrderStatus.Returned ? "Delivered" : order.Status.Value`.
-- **Location headers round-trip the requested api-version.** `CreatedAtVersionedRoute(...)` on creation responses; for 200 OK responses with Location (e.g., the Return endpoint), build a `RouteValueDictionary` that includes the matched version:
-
-  ```csharp
-  var location = Url.RouteUrl(
-      "Orders_GetById",
-      new RouteValueDictionary
-      {
-          ["id"] = order.Id.Value,
-          ["api-version"] = HttpContext.RequestedApiVersion()?.ToString()
-      });
-  ```
-
-  The hyphenated `"api-version"` key cannot be expressed as an anonymous-object property, so `RouteValueDictionary` with string-indexer initialisation is the correct shape.
-
-### Anti-pattern → fix
-
-```csharp
-// ❌ Splitting into two controllers in version-named folders just to vary the response shape.
-//    Now every action exists twice: 10 endpoints × 2 versions = 20 action bodies; every Maps,
-//    every authorization attribute, every [ProducesResponseType] is duplicated.
-namespace MyService.Api.v2026_11_12.Controllers { public sealed class OrdersController { /* 10 actions */ } }
-namespace MyService.Api.v2026_12_01.Controllers { public sealed class OrdersController { /* same 10 actions, v2 shapes */ } }
-```
-
-```csharp
-// ✅ One controller, [ApiVersion(..)] × N, [MapToApiVersion(..)] only on truly v-specific actions,
-//    one Project(T) seam. ~10 lines of class-level attribute set instead of N×duplicate actions.
-[ApiController]
-[ApiVersion("2026-11-12"), ApiVersion("2026-12-01")]
-public sealed class OrdersController { /* 10 shared actions + 1 v2-only + Project(T) */ }
-```
-
-```csharp
-// ❌ Reading the matched version from the query string directly. Works today; silently
-//    breaks if a future consumer enables MediaType, Header, URL-segment, or composite readers.
-private string RequestedApiVersion() => HttpContext.Request.Query["api-version"].ToString();
-```
-
-```csharp
-// ✅ Use the Asp.Versioning extension; reader-agnostic, mirrors the framework's own resolution.
-private bool IsV2() =>
-    HttpContext.RequestedApiVersion()?.ToString() == "2026-12-01";
-```
-
-```csharp
-// ❌ Hand-rolling Location for 201 Created endpoints — Trellis already has the version-aware helper.
-HttpContext.Response.Headers["Location"] = $"/api/orders/{order.Id.Value}?api-version={requestedVersion}";
-```
-
-```csharp
-// ✅ Creation endpoints — CreatedAtVersionedRoute round-trips the requested api-version automatically.
-//    Use the single-id overload when the route has one parameter.
-opts => opts.CreatedAtVersionedRoute("Orders_GetById", o => o.Id)
-```
-
-### When to split into per-version controllers anyway
-
-The single-controller form trades type-safety on the action signature (`ActionResult<object>`) for compactness. If your downstream tooling (e.g. an OpenAPI generator that drives a strongly-typed client) introspects the action *signature* rather than the `[ProducesResponseType]` metadata, or if the bodies for the two versions diverge enough that branching becomes the bulk of the action body, split. The break-even point in practice is "≥ 3 response fields differ and ≥ 4 actions return that response": below that, the single-controller form is the lower-cost shape.
-
----
-
 ## Cross-references
 
 - [trellis-api-core.md](trellis-api-core.md#extension-class-catalog-full-signatures) — every `Result*Extensions(Async)` family with full signatures.


### PR DESCRIPTION
Recipe 26 documented a single-controller, version-aware projection pattern for the case where a v2 API adds new fields to an existing response shape. The ASP template now demonstrates namespace-based API versioning (one controller per version, copied when a new version is released) as the recommended pattern; the shared-controller projection approach is no longer the template's worldview.

Remove the recipe body plus the two cookbook lookup-table rows that pointed at it.

Companion to TrellisAspTemplate PR #43.