### PR TITLE
Add pagination ergonomics helpers: PageSize, CursorCodec, PageBuilder, Page<T>.Map

### DIFF
--- a/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
+++ b/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
@@ -25,9 +25,9 @@ public sealed class ListOrdersHandler(AppDbContext db)
         {
             if (cursorToken.Length == 0)
                 return Result.Fail<Page<OrderListItem>>(
-                    Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed", "Cursor must not be empty."));
+                    Error.InvalidInput.ForField("cursor", "cursor.malformed", "Cursor must not be empty."));
 
-            var decoded = CursorCodec.TryDecode<System.Guid>(new Cursor(cursorToken), fieldName: nameof(query.Cursor));
+            var decoded = CursorCodec.TryDecode<System.Guid>(new Cursor(cursorToken), fieldName: "cursor");
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);

--- a/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
+++ b/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
@@ -9,42 +9,37 @@ using global::Mediator;
 using Microsoft.EntityFrameworkCore;
 using Trellis;
 
-public sealed record ListOrdersQuery(string? Cursor, int Limit) : IQuery<Result<Page<OrderListItem>>>;
+public sealed record ListOrdersQuery(string? Cursor, int? Limit) : IQuery<Result<Page<OrderListItem>>>;
 
 public sealed record OrderListItem(System.Guid Id, decimal Amount, string Currency);
 
 public sealed class ListOrdersHandler(AppDbContext db)
     : IQueryHandler<ListOrdersQuery, Result<Page<OrderListItem>>>
 {
-    private const int MaxLimit = 100;
-
     public async ValueTask<Result<Page<OrderListItem>>> Handle(ListOrdersQuery query, CancellationToken cancellationToken)
     {
-        var requested = query.Limit;
-        var applied = System.Math.Clamp(requested, 1, MaxLimit);
+        var pageSize = PageSize.FromRequested(query.Limit);
 
-        var orders = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+        System.Guid? afterId = null;
         if (query.Cursor is not null)
         {
-            if (!System.Guid.TryParseExact(query.Cursor, "N", out var cursorId))
-                return Result.Fail<Page<OrderListItem>>(
-                    Error.InvalidInput.ForField(nameof(query.Cursor), "Cursor is not a valid pagination token."));
-
-            orders = orders.Where(o => o.Id.Value > cursorId).OrderBy(o => o.Id);
+            var decoded = CursorCodec.TryDecode<System.Guid>(new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+            if (decoded.IsFailure)
+                return Result.Fail<Page<OrderListItem>>(decoded.Error!);
+            decoded.TryGetValue(out var id);
+            afterId = id;
         }
 
-        var rows = await orders.Take(applied + 1).ToListAsync(cancellationToken);
-        var hasNext = rows.Count > applied;
-        var items = rows.Take(applied)
-                          .Select(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value))
-                          .ToList();
+        var ordered = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+        var filtered = afterId is { } cursorId
+            ? ordered.Where(o => o.Id.Value > cursorId)
+            : (IQueryable<CookbookSnippets.Recipe01.Order>)ordered;
 
-        return Result.Ok(new Page<OrderListItem>(
-            Items: items,
-            Next: hasNext ? new Cursor(items[^1].Id.ToString("N")) : null,
-            Previous: query.Cursor is null ? null : new Cursor(query.Cursor),
-            RequestedLimit: requested,
-            AppliedLimit: applied));
+        var rows = await filtered.Take(pageSize.Applied + 1).ToListAsync(cancellationToken);
+
+        return Result.Ok(
+            PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value)
+                .Map(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value)));
     }
 }
 internal static class Recipe3PageSurface

--- a/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
+++ b/Examples/CookbookSnippets/Recipe03_PaginatedQuery.cs
@@ -21,9 +21,13 @@ public sealed class ListOrdersHandler(AppDbContext db)
         var pageSize = PageSize.FromRequested(query.Limit);
 
         System.Guid? afterId = null;
-        if (query.Cursor is not null)
+        if (query.Cursor is { } cursorToken)
         {
-            var decoded = CursorCodec.TryDecode<System.Guid>(new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+            if (cursorToken.Length == 0)
+                return Result.Fail<Page<OrderListItem>>(
+                    Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed", "Cursor must not be empty."));
+
+            var decoded = CursorCodec.TryDecode<System.Guid>(new Cursor(cursorToken), fieldName: nameof(query.Cursor));
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);

--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -46,13 +46,13 @@ Accept: application/json
 ### Replace the placeholder below with the value of `next.cursor` from the
 ### body (or just GET the URL from the `Link: <…>; rel="next"` header).
 ### (Under automated replay the placeholder is still sent verbatim, which is
-### rejected as 422 from Error.InvalidInput.ForRule("invalid_cursor") — same code path
-### as the dedicated malformed-cursor case below.)
+### rejected as 422 from Error.InvalidInput.ForField("cursor", "cursor.malformed") —
+### same code path as the dedicated malformed-cursor case below.)
 # @expect status: 422
 GET {{host}}/api/accounts?limit=5&cursor=REPLACE_WITH_NEXT_CURSOR
 Accept: application/json
 
-### List accounts — malformed cursor (422 from Error.InvalidInput.ForRule("invalid_cursor"))
+### List accounts — malformed cursor (422 from Error.InvalidInput.ForField("cursor", "cursor.malformed"))
 # @expect status: 422
 GET {{host}}/api/accounts?cursor=not-a-real-cursor
 Accept: application/json

--- a/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
+++ b/Examples/Showcase/src/Showcase.Application/Persistence/IAccountRepository.cs
@@ -65,80 +65,28 @@ public sealed class InMemoryAccountRepository : IAccountRepository
 
     public Result<Page<BankAccount>> GetPage(int limit, Cursor? cursor)
     {
-        var requestedLimit = limit <= 0 ? 10 : limit;
-        var appliedLimit = Math.Min(requestedLimit, ServerCap);
+        var pageSize = PageSize.FromRequested(limit <= 0 ? 10 : limit, max: ServerCap);
 
         Guid? afterId = null;
         if (cursor is { } c)
         {
-            if (!TryDecodeCursor(c, out var decoded))
-            {
-                return Result.Fail<Page<BankAccount>>(
-                    Error.InvalidInput.ForField("cursor", "invalid_cursor", "Cursor is not a recognized token."));
-            }
+            var decoded = CursorCodec.TryDecode<Guid>(c);
+            if (decoded.IsFailure)
+                return Result.Fail<Page<BankAccount>>(decoded.Error!);
 
-            afterId = decoded;
+            decoded.TryGetValue(out var id);
+            afterId = id;
         }
 
         lock (_gate)
         {
-            var ordered = _accounts.Values
+            var overFetched = _accounts.Values
                 .OrderBy(a => a.Id.Value)
                 .Where(a => afterId is not Guid g || a.Id.Value.CompareTo(g) > 0)
-                .Take(appliedLimit + 1)
+                .Take(pageSize.Applied + 1)
                 .ToList();
 
-            var hasMore = ordered.Count > appliedLimit;
-            var items = hasMore ? ordered.Take(appliedLimit).ToList() : ordered;
-            Cursor? next = hasMore && items.Count > 0
-                ? new Cursor(EncodeCursor(items[^1].Id.Value))
-                : null;
-
-            return Result.Ok(new Page<BankAccount>(
-                Items: items,
-                Next: next,
-                Previous: null,
-                RequestedLimit: requestedLimit,
-                AppliedLimit: appliedLimit));
+            return Result.Ok(PageBuilder.FromOverFetch(overFetched, pageSize, a => a.Id.Value));
         }
-    }
-
-    private static string EncodeCursor(Guid afterId)
-    {
-        var json = $"{{\"afterId\":\"{afterId}\"}}";
-        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
-        return Base64UrlEncode(bytes);
-    }
-
-    private static bool TryDecodeCursor(Cursor cursor, out Guid afterId)
-    {
-        afterId = default;
-        if (string.IsNullOrEmpty(cursor.Token))
-            return false;
-        try
-        {
-            var bytes = Base64UrlDecode(cursor.Token);
-            using var doc = System.Text.Json.JsonDocument.Parse(bytes);
-            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object) return false;
-            if (!doc.RootElement.TryGetProperty("afterId", out var prop)) return false;
-            return Guid.TryParse(prop.GetString(), out afterId);
-        }
-        catch (System.Text.Json.JsonException) { return false; }
-        catch (FormatException) { return false; }
-    }
-
-    private static string Base64UrlEncode(byte[] bytes) =>
-        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
-
-    private static byte[] Base64UrlDecode(string token)
-    {
-        var s = token.Replace('-', '+').Replace('_', '/');
-        switch (s.Length % 4)
-        {
-            case 2: s += "=="; break;
-            case 3: s += "="; break;
-        }
-
-        return Convert.FromBase64String(s);
     }
 }

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -1,0 +1,189 @@
+﻿namespace Trellis;
+
+using System;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Helpers that encode and decode opaque <see cref="Cursor"/> tokens for seek-style
+/// pagination. Two overloads pairs are provided: a single-key form for pure <c>Id</c>-keyed
+/// pagination (the simplest, matches single-column indexes), and a composite
+/// <c>(CreatedAt, Id)</c> form for stable time-ordered seeks across non-unique
+/// primary sort keys.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Wire format:</b> The token is URL-safe Base64 (RFC 4648 §5) of a UTF-8 string.
+/// For single-key cursors, the payload is the key's invariant-culture string form. For
+/// composite cursors, the payload is <c>"{createdAt:O}|{id}"</c> where the date is
+/// formatted with the round-trip <c>"O"</c> specifier in invariant culture. Decoding
+/// splits at the FIRST <c>|</c> only, so an Id that happens to contain a pipe character
+/// is still unambiguous.
+/// </para>
+/// <para>
+/// <b>AOT-friendly:</b> No JSON, no reflection. Encoding uses <see cref="Convert.ToBase64String(byte[])"/>
+/// followed by URL-safe substitution; decoding inverts the substitution and parses with
+/// <see cref="IParsable{TSelf}.Parse(string, IFormatProvider?)"/>.
+/// </para>
+/// <para>
+/// <b>Opacity, not anti-tamper:</b> Cursors are server-opaque to discourage clients from
+/// reverse-engineering the sort key, but the encoding is not signed. Services that need
+/// to defend against tampering must wrap or replace this codec with one that signs the
+/// payload; authorization filtering must always apply to the underlying query.
+/// </para>
+/// <para>
+/// <b>Supported TKey:</b> primitives such as <see cref="Guid"/>, <see cref="long"/>,
+/// <see cref="int"/>, and any <see cref="string"/> that survives the URL-safe base64
+/// round-trip. For Trellis value-object IDs (e.g. <c>RequiredGuid&lt;TSelf&gt;</c>),
+/// project to the underlying primitive (<c>.Value</c>) — the wrapper does not
+/// satisfy <see cref="ISpanFormattable"/>.
+/// </para>
+/// </remarks>
+public static class CursorCodec
+{
+    private const string DateFormat = "O";
+    private const char Separator = '|';
+
+    // ───── Single-key ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Encodes a single-key cursor for pure Id-based seek pagination.
+    /// </summary>
+    /// <typeparam name="TKey">The key type. Trellis primitives such as <see cref="Guid"/>,
+    /// <see cref="long"/>, <see cref="int"/>, and <see cref="string"/> are supported.</typeparam>
+    /// <param name="id">The Id of the boundary item.</param>
+    /// <returns>An opaque <see cref="Cursor"/> token.</returns>
+    public static Cursor Encode<TKey>(TKey id)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var payload = FormatInvariant(id);
+        return new Cursor(ToBase64Url(payload));
+    }
+
+    /// <summary>
+    /// Attempts to decode a single-key cursor.
+    /// </summary>
+    /// <typeparam name="TKey">The key type. Must implement <see cref="IParsable{TSelf}"/>.</typeparam>
+    /// <param name="cursor">The cursor to decode.</param>
+    /// <param name="fieldName">Optional field name for the failure error; defaults to <c>"cursor"</c>.</param>
+    /// <returns>
+    /// A <see cref="Result{TKey}"/> containing the decoded key on success or
+    /// <see cref="Error.InvalidInput"/> on a malformed token.
+    /// </returns>
+    public static Result<TKey> TryDecode<TKey>(Cursor cursor, string? fieldName = null)
+        where TKey : IParsable<TKey>
+    {
+        if (!TryFromBase64Url(cursor.Token, out var payload))
+            return Fail<TKey>(fieldName, "cursor.malformed", "Cursor is not a valid URL-safe base64 token.");
+
+        if (!TKey.TryParse(payload, CultureInfo.InvariantCulture, out var parsed) || parsed is null)
+            return Fail<TKey>(fieldName, "cursor.malformed", $"Cursor payload could not be parsed as {typeof(TKey).Name}.");
+
+        return Result.Ok(parsed);
+    }
+
+    // ───── Composite (CreatedAt, Id) ───────────────────────────────────────────
+
+    /// <summary>
+    /// Encodes a composite <c>(CreatedAt, Id)</c> cursor for stable time-ordered seek pagination.
+    /// </summary>
+    /// <typeparam name="TKey">The Id type. Trellis primitives such as <see cref="Guid"/>,
+    /// <see cref="long"/>, <see cref="int"/>, and <see cref="string"/> are supported.</typeparam>
+    /// <param name="createdAt">The creation timestamp of the boundary item.</param>
+    /// <param name="id">The Id of the boundary item, used as the secondary sort key.</param>
+    /// <returns>An opaque <see cref="Cursor"/> token.</returns>
+    public static Cursor Encode<TKey>(DateTimeOffset createdAt, TKey id)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var datePart = createdAt.ToString(DateFormat, CultureInfo.InvariantCulture);
+        var idPart = FormatInvariant(id);
+        var payload = string.Concat(datePart, Separator.ToString(), idPart);
+        return new Cursor(ToBase64Url(payload));
+    }
+
+    /// <summary>
+    /// Attempts to decode a composite <c>(CreatedAt, Id)</c> cursor.
+    /// </summary>
+    /// <typeparam name="TKey">The Id type. Must implement <see cref="IParsable{TSelf}"/>.</typeparam>
+    /// <param name="cursor">The cursor to decode.</param>
+    /// <param name="fieldName">Optional field name for the failure error; defaults to <c>"cursor"</c>.</param>
+    /// <returns>
+    /// A <see cref="Result{T}"/> containing the decoded <c>(CreatedAt, Id)</c> pair on success
+    /// or <see cref="Error.InvalidInput"/> on a malformed token.
+    /// </returns>
+    public static Result<(DateTimeOffset CreatedAt, TKey Id)> TryDecodeComposite<TKey>(
+        Cursor cursor, string? fieldName = null)
+        where TKey : IParsable<TKey>
+    {
+        if (!TryFromBase64Url(cursor.Token, out var payload))
+            return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", "Cursor is not a valid URL-safe base64 token.");
+
+        var pipe = payload.IndexOf(Separator, StringComparison.Ordinal);
+        if (pipe < 0)
+            return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", "Cursor payload is missing the composite separator.");
+
+        var datePart = payload.AsSpan(0, pipe);
+        var idPart = payload.AsSpan(pipe + 1);
+
+        if (!DateTimeOffset.TryParseExact(datePart, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var createdAt))
+            return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", "Cursor payload date segment could not be parsed.");
+
+        if (!TKey.TryParse(idPart.ToString(), CultureInfo.InvariantCulture, out var id) || id is null)
+            return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", $"Cursor payload id segment could not be parsed as {typeof(TKey).Name}.");
+
+        return Result.Ok((createdAt, id));
+    }
+
+    // ───── Internals ───────────────────────────────────────────────────────────
+
+    private static string FormatInvariant<TKey>(TKey id)
+        where TKey : notnull =>
+        id is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : id.ToString()!;
+
+    private static string ToBase64Url(string payload)
+    {
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        var standard = Convert.ToBase64String(bytes);
+        return standard.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+
+    private static bool TryFromBase64Url(string token, out string payload)
+    {
+        payload = string.Empty;
+        if (string.IsNullOrEmpty(token))
+            return false;
+
+        var standard = token.Replace('-', '+').Replace('_', '/');
+        switch (standard.Length % 4)
+        {
+            case 2: standard += "=="; break;
+            case 3: standard += "="; break;
+            case 1: return false;
+        }
+
+        try
+        {
+            var bytes = Convert.FromBase64String(standard);
+            payload = StrictUtf8.GetString(bytes);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    private static Result<T> Fail<T>(string? fieldName, string reasonCode, string detail) =>
+        Result.Fail<T>(Error.InvalidInput.ForField(fieldName ?? "cursor", reasonCode, detail));
+}

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 /// <summary>
 /// Helpers that encode and decode opaque <see cref="Cursor"/> tokens for seek-style
-/// pagination. Two overloads pairs are provided: a single-key form for pure <c>Id</c>-keyed
+/// pagination. Two overload pairs are provided: a single-key form for pure <c>Id</c>-keyed
 /// pagination (the simplest, matches single-column indexes), and a composite
 /// <c>(CreatedAt, Id)</c> form for stable time-ordered seeks across non-unique
 /// primary sort keys.
@@ -142,7 +142,14 @@ public static class CursorCodec
 
     private static string FormatInvariant<TKey>(TKey id)
         where TKey : notnull =>
-        id is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : id.ToString()!;
+        id switch
+        {
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+            string s => s,
+            _ => throw new NotSupportedException(
+                $"Cursor key type '{typeof(TKey).FullName}' must implement IFormattable or be string; " +
+                "a culture-sensitive ToString would break cursor round-trip.")
+        };
 
     private static string ToBase64Url(string payload)
     {

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -1,7 +1,6 @@
 ﻿namespace Trellis;
 
 using System;
-using System.Buffers.Text;
 using System.Globalization;
 using System.Text;
 

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -32,11 +32,28 @@ using System.Text;
 /// payload; authorization filtering must always apply to the underlying query.
 /// </para>
 /// <para>
-/// <b>Supported TKey:</b> primitives such as <see cref="Guid"/>, <see cref="long"/>,
-/// <see cref="int"/>, and any <see cref="string"/> that survives the URL-safe base64
-/// round-trip. For Trellis value-object IDs (e.g. <c>RequiredGuid&lt;TSelf&gt;</c>),
-/// project to the underlying primitive (<c>.Value</c>) — the wrapper does not
-/// satisfy <see cref="ISpanFormattable"/>.
+/// <b>Supported TKey:</b>
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <b>Encode</b> accepts any <c>TKey</c> that implements
+///     <see cref="IFormattable"/> (so it can be formatted in
+///     <see cref="System.Globalization.CultureInfo.InvariantCulture"/>) or that is a
+///     <see cref="string"/>.
+///   </description></item>
+///   <item><description>
+///     <b>TryDecode</b> additionally requires <c>TKey</c> to
+///     implement <see cref="IParsable{TSelf}"/>.
+///   </description></item>
+/// </list>
+/// <para>
+/// .NET primitives such as <see cref="Guid"/>, <see cref="long"/>, <see cref="int"/>,
+/// and <see cref="string"/> satisfy both. Trellis source-generated value-object wrappers
+/// (e.g. <c>partial class CustomerId : RequiredGuid&lt;CustomerId&gt;</c>) inherit
+/// <see cref="IFormattable"/> from <c>ScalarValueObject</c> and gain <see cref="IParsable{TSelf}"/>
+/// from the source generator, so they round-trip through the codec directly. Hand-written
+/// value objects that do not implement <see cref="IParsable{TSelf}"/> must project to the
+/// underlying primitive (<c>.Value</c>) for cursors.
 /// </para>
 /// </remarks>
 public static class CursorCodec
@@ -102,6 +119,8 @@ public static class CursorCodec
     /// <param name="createdAt">The creation timestamp of the boundary item.</param>
     /// <param name="id">The Id of the boundary item, used as the secondary sort key.</param>
     /// <returns>An opaque <see cref="Cursor"/> token.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="id"/> formats to an empty invariant-culture string (for example, an empty <see cref="string"/> key).</exception>
     public static Cursor Encode<TKey>(DateTimeOffset createdAt, TKey id)
         where TKey : notnull
     {
@@ -109,6 +128,8 @@ public static class CursorCodec
 
         var datePart = createdAt.ToString(DateFormat, CultureInfo.InvariantCulture);
         var idPart = FormatInvariant(id);
+        if (idPart.Length == 0)
+            throw new ArgumentException("Cursor key formatted to an empty payload; supply a non-empty key.", nameof(id));
         var payload = string.Concat(datePart, SeparatorString, idPart);
         return new Cursor(ToBase64Url(payload));
     }

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -23,7 +23,7 @@ using System.Text;
 /// <para>
 /// <b>AOT-friendly:</b> No JSON, no reflection. Encoding uses <see cref="Convert.ToBase64String(byte[])"/>
 /// followed by URL-safe substitution; decoding inverts the substitution and parses with
-/// <see cref="IParsable{TSelf}.Parse(string, IFormatProvider?)"/>.
+/// <see cref="IParsable{TSelf}.TryParse(string, IFormatProvider, out TSelf)"/>.
 /// </para>
 /// <para>
 /// <b>Opacity, not anti-tamper:</b> Cursors are server-opaque to discourage clients from
@@ -75,6 +75,9 @@ public static class CursorCodec
     public static Result<TKey> TryDecode<TKey>(Cursor cursor, string? fieldName = null)
         where TKey : IParsable<TKey>
     {
+        if (cursor.Equals(default(Cursor)))
+            return Fail<TKey>(fieldName, "cursor.malformed", "Cursor is default-constructed and has no token.");
+
         if (!TryFromBase64Url(cursor.Token, out var payload))
             return Fail<TKey>(fieldName, "cursor.malformed", "Cursor is not a valid URL-safe base64 token.");
 
@@ -119,6 +122,9 @@ public static class CursorCodec
         Cursor cursor, string? fieldName = null)
         where TKey : IParsable<TKey>
     {
+        if (cursor.Equals(default(Cursor)))
+            return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", "Cursor is default-constructed and has no token.");
+
         if (!TryFromBase64Url(cursor.Token, out var payload))
             return Fail<(DateTimeOffset, TKey)>(fieldName, "cursor.malformed", "Cursor is not a valid URL-safe base64 token.");
 

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -54,12 +54,16 @@ public static class CursorCodec
     /// <see cref="long"/>, <see cref="int"/>, and <see cref="string"/> are supported.</typeparam>
     /// <param name="id">The Id of the boundary item.</param>
     /// <returns>An opaque <see cref="Cursor"/> token.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="id"/> formats to an empty invariant-culture string (for example, an empty <see cref="string"/> key).</exception>
     public static Cursor Encode<TKey>(TKey id)
         where TKey : notnull
     {
         ArgumentNullException.ThrowIfNull(id);
 
         var payload = FormatInvariant(id);
+        if (payload.Length == 0)
+            throw new ArgumentException("Cursor key formatted to an empty payload; supply a non-empty key.", nameof(id));
         return new Cursor(ToBase64Url(payload));
     }
 

--- a/Trellis.Core/src/Pagination/CursorCodec.cs
+++ b/Trellis.Core/src/Pagination/CursorCodec.cs
@@ -43,6 +43,7 @@ public static class CursorCodec
 {
     private const string DateFormat = "O";
     private const char Separator = '|';
+    private const string SeparatorString = "|";
 
     // ───── Single-key ──────────────────────────────────────────────────────────
 
@@ -104,7 +105,7 @@ public static class CursorCodec
 
         var datePart = createdAt.ToString(DateFormat, CultureInfo.InvariantCulture);
         var idPart = FormatInvariant(id);
-        var payload = string.Concat(datePart, Separator.ToString(), idPart);
+        var payload = string.Concat(datePart, SeparatorString, idPart);
         return new Cursor(ToBase64Url(payload));
     }
 

--- a/Trellis.Core/src/Pagination/Page.cs
+++ b/Trellis.Core/src/Pagination/Page.cs
@@ -33,6 +33,7 @@ public readonly record struct Page<T>
 
     /// <summary>Constructs a validated page. Use <see cref="Page.Empty{T}(int, int)"/> for empty pages.</summary>
     /// <exception cref="ArgumentNullException"><paramref name="Items"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">A supplied cursor equals <c>default(Cursor)</c> (which has no token).</exception>
     /// <exception cref="ArgumentOutOfRangeException">A limit is non-positive, or <paramref name="AppliedLimit"/> exceeds <paramref name="RequestedLimit"/>.</exception>
     public Page(
         IReadOnlyList<T> Items,
@@ -42,6 +43,10 @@ public readonly record struct Page<T>
         int AppliedLimit)
     {
         ArgumentNullException.ThrowIfNull(Items);
+        if (Next is { } nextValue && nextValue.Equals(default(Cursor)))
+            throw new ArgumentException("Next cursor must not be default(Cursor) — use null to signal absence.", nameof(Next));
+        if (Previous is { } previousValue && previousValue.Equals(default(Cursor)))
+            throw new ArgumentException("Previous cursor must not be default(Cursor) — use null to signal absence.", nameof(Previous));
         if (RequestedLimit <= 0)
             throw new ArgumentOutOfRangeException(nameof(RequestedLimit), "Limit must be positive.");
         if (AppliedLimit <= 0)

--- a/Trellis.Core/src/Pagination/Page.cs
+++ b/Trellis.Core/src/Pagination/Page.cs
@@ -84,6 +84,27 @@ public readonly record struct Page<T>
 
     /// <summary>True when the server applied a smaller limit than the client requested.</summary>
     public bool WasCapped => AppliedLimit < RequestedLimit;
+
+    /// <summary>
+    /// Projects each item to a new type, preserving cursors and limits. Useful when a
+    /// repository wants to return <c>Page&lt;Dto&gt;</c> instead of <c>Page&lt;Entity&gt;</c>
+    /// without re-running the cursor/limit ceremony.
+    /// </summary>
+    /// <typeparam name="TOut">The projected item type.</typeparam>
+    /// <param name="selector">The projection. Required.</param>
+    /// <returns>A new <see cref="Page{TOut}"/> with the same cursors and limits.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <c>null</c>.</exception>
+    public Page<TOut> Map<TOut>(Func<T, TOut> selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var sourceItems = Items;
+        var projected = new TOut[sourceItems.Count];
+        for (var i = 0; i < sourceItems.Count; i++)
+            projected[i] = selector(sourceItems[i]);
+
+        return new Page<TOut>(projected, Next, Previous, RequestedLimit, AppliedLimit);
+    }
 }
 
 /// <summary>

--- a/Trellis.Core/src/Pagination/Page.cs
+++ b/Trellis.Core/src/Pagination/Page.cs
@@ -99,11 +99,11 @@ public readonly record struct Page<T>
         ArgumentNullException.ThrowIfNull(selector);
 
         var sourceItems = Items;
-        var projected = new TOut[sourceItems.Count];
+        var builder = ImmutableArray.CreateBuilder<TOut>(sourceItems.Count);
         for (var i = 0; i < sourceItems.Count; i++)
-            projected[i] = selector(sourceItems[i]);
+            builder.Add(selector(sourceItems[i]));
 
-        return new Page<TOut>(projected, Next, Previous, RequestedLimit, AppliedLimit);
+        return new Page<TOut>(builder.MoveToImmutable(), Next, Previous, RequestedLimit, AppliedLimit);
     }
 }
 

--- a/Trellis.Core/src/Pagination/PageBuilder.cs
+++ b/Trellis.Core/src/Pagination/PageBuilder.cs
@@ -45,6 +45,7 @@ public static class PageBuilder
     {
         ArgumentNullException.ThrowIfNull(overFetched);
         ArgumentNullException.ThrowIfNull(idSelector);
+        EnsureValidated(pageSize);
 
         if (overFetched.Count <= pageSize.Applied)
             return new Page<T>(MaterializeAll(overFetched), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
@@ -77,6 +78,7 @@ public static class PageBuilder
         ArgumentNullException.ThrowIfNull(overFetched);
         ArgumentNullException.ThrowIfNull(createdAtSelector);
         ArgumentNullException.ThrowIfNull(idSelector);
+        EnsureValidated(pageSize);
 
         if (overFetched.Count <= pageSize.Applied)
             return new Page<T>(MaterializeAll(overFetched), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
@@ -85,6 +87,17 @@ public static class PageBuilder
         var lastKept = kept[pageSize.Applied - 1];
         var next = CursorCodec.Encode(createdAtSelector(lastKept), idSelector(lastKept));
         return new Page<T>(kept, next, Previous: null, pageSize.Requested, pageSize.Applied);
+    }
+
+    private static void EnsureValidated(PageSize pageSize)
+    {
+        // PageSize is a struct, so callers can sidestep its constructor with default(PageSize).
+        // Refuse the zero-shape so the next-cursor logic (which indexes kept[Applied - 1])
+        // cannot reach a negative index.
+        if (pageSize.Requested <= 0 || pageSize.Applied <= 0 || pageSize.Applied > pageSize.Requested)
+            throw new ArgumentOutOfRangeException(
+                nameof(pageSize),
+                "PageSize must be a validated instance with Requested > 0, Applied > 0, and Applied <= Requested.");
     }
 
     private static ImmutableArray<T> MaterializeAll<T>(IReadOnlyList<T> source)

--- a/Trellis.Core/src/Pagination/PageBuilder.cs
+++ b/Trellis.Core/src/Pagination/PageBuilder.cs
@@ -1,0 +1,95 @@
+﻿namespace Trellis;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Storage-agnostic helper that turns an over-fetched list into a <see cref="Page{T}"/>
+/// with the correct <c>Next</c> cursor. Works with any data source — EF Core, Dapper,
+/// Cosmos, gRPC, in-memory — as long as the caller has already executed an
+/// <c>OrderBy(...).Take(pageSize.Applied + 1)</c> query against a stable sort key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Forward-only.</b> <see cref="Page{T}.Previous"/> is always <c>null</c>. Trellis
+/// does not yet ship a reverse-seek API; emitting a previous cursor that the existing
+/// next-URL builder would walk forward from would re-fetch the current page rather
+/// than the page before it.
+/// </para>
+/// <para>
+/// <b>Selector contract.</b> The selectors passed to <c>FromOverFetch</c> MUST match
+/// the sort keys used in the upstream query. Mismatched selectors produce semantically
+/// wrong cursors — the boundary item that the cursor points at will not be the one
+/// the next query would seek past.
+/// </para>
+/// </remarks>
+public static class PageBuilder
+{
+    /// <summary>
+    /// Builds a <see cref="Page{T}"/> from a single-key over-fetched list. The caller
+    /// should have asked the data source for <c>pageSize.Applied + 1</c> rows ordered
+    /// by the same key returned by <paramref name="idSelector"/>.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <typeparam name="TKey">The Id type used for cursoring.</typeparam>
+    /// <param name="overFetched">The over-fetched list (at most <c>pageSize.Applied + 1</c> items).</param>
+    /// <param name="pageSize">The validated page-size pair.</param>
+    /// <param name="idSelector">A selector that returns the cursor key from a row. Must match the upstream <c>OrderBy</c>.</param>
+    /// <returns>A <see cref="Page{T}"/> with at most <c>pageSize.Applied</c> items and the appropriate next cursor.</returns>
+    public static Page<T> FromOverFetch<T, TKey>(
+        IReadOnlyList<T> overFetched,
+        PageSize pageSize,
+        Func<T, TKey> idSelector)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(overFetched);
+        ArgumentNullException.ThrowIfNull(idSelector);
+
+        if (overFetched.Count <= pageSize.Applied)
+            return new Page<T>(overFetched.ToArray(), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
+
+        var kept = new T[pageSize.Applied];
+        for (var i = 0; i < pageSize.Applied; i++)
+            kept[i] = overFetched[i];
+
+        var lastKept = kept[pageSize.Applied - 1];
+        var next = CursorCodec.Encode(idSelector(lastKept));
+        return new Page<T>(kept, next, Previous: null, pageSize.Requested, pageSize.Applied);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="Page{T}"/> from a composite-key over-fetched list. The caller
+    /// should have asked the data source for <c>pageSize.Applied + 1</c> rows ordered by
+    /// <c>(CreatedAt, Id)</c> — the same keys returned by the selectors below.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <typeparam name="TKey">The Id type used as the secondary sort key.</typeparam>
+    /// <param name="overFetched">The over-fetched list (at most <c>pageSize.Applied + 1</c> items).</param>
+    /// <param name="pageSize">The validated page-size pair.</param>
+    /// <param name="createdAtSelector">A selector that returns the primary sort key from a row. Must match the upstream <c>OrderBy</c>.</param>
+    /// <param name="idSelector">A selector that returns the secondary sort key from a row. Must match the upstream <c>ThenBy</c>.</param>
+    /// <returns>A <see cref="Page{T}"/> with at most <c>pageSize.Applied</c> items and the appropriate next cursor.</returns>
+    public static Page<T> FromOverFetch<T, TKey>(
+        IReadOnlyList<T> overFetched,
+        PageSize pageSize,
+        Func<T, DateTimeOffset> createdAtSelector,
+        Func<T, TKey> idSelector)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(overFetched);
+        ArgumentNullException.ThrowIfNull(createdAtSelector);
+        ArgumentNullException.ThrowIfNull(idSelector);
+
+        if (overFetched.Count <= pageSize.Applied)
+            return new Page<T>(overFetched.ToArray(), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
+
+        var kept = new T[pageSize.Applied];
+        for (var i = 0; i < pageSize.Applied; i++)
+            kept[i] = overFetched[i];
+
+        var lastKept = kept[pageSize.Applied - 1];
+        var next = CursorCodec.Encode(createdAtSelector(lastKept), idSelector(lastKept));
+        return new Page<T>(kept, next, Previous: null, pageSize.Requested, pageSize.Applied);
+    }
+}

--- a/Trellis.Core/src/Pagination/PageBuilder.cs
+++ b/Trellis.Core/src/Pagination/PageBuilder.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 
 /// <summary>
 /// Storage-agnostic helper that turns an over-fetched list into a <see cref="Page{T}"/>
@@ -47,12 +47,9 @@ public static class PageBuilder
         ArgumentNullException.ThrowIfNull(idSelector);
 
         if (overFetched.Count <= pageSize.Applied)
-            return new Page<T>(overFetched.ToArray(), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
+            return new Page<T>(MaterializeAll(overFetched), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
 
-        var kept = new T[pageSize.Applied];
-        for (var i = 0; i < pageSize.Applied; i++)
-            kept[i] = overFetched[i];
-
+        var kept = MaterializePrefix(overFetched, pageSize.Applied);
         var lastKept = kept[pageSize.Applied - 1];
         var next = CursorCodec.Encode(idSelector(lastKept));
         return new Page<T>(kept, next, Previous: null, pageSize.Requested, pageSize.Applied);
@@ -82,14 +79,27 @@ public static class PageBuilder
         ArgumentNullException.ThrowIfNull(idSelector);
 
         if (overFetched.Count <= pageSize.Applied)
-            return new Page<T>(overFetched.ToArray(), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
+            return new Page<T>(MaterializeAll(overFetched), Next: null, Previous: null, pageSize.Requested, pageSize.Applied);
 
-        var kept = new T[pageSize.Applied];
-        for (var i = 0; i < pageSize.Applied; i++)
-            kept[i] = overFetched[i];
-
+        var kept = MaterializePrefix(overFetched, pageSize.Applied);
         var lastKept = kept[pageSize.Applied - 1];
         var next = CursorCodec.Encode(createdAtSelector(lastKept), idSelector(lastKept));
         return new Page<T>(kept, next, Previous: null, pageSize.Requested, pageSize.Applied);
+    }
+
+    private static ImmutableArray<T> MaterializeAll<T>(IReadOnlyList<T> source)
+    {
+        var builder = ImmutableArray.CreateBuilder<T>(source.Count);
+        for (var i = 0; i < source.Count; i++)
+            builder.Add(source[i]);
+        return builder.MoveToImmutable();
+    }
+
+    private static ImmutableArray<T> MaterializePrefix<T>(IReadOnlyList<T> source, int count)
+    {
+        var builder = ImmutableArray.CreateBuilder<T>(count);
+        for (var i = 0; i < count; i++)
+            builder.Add(source[i]);
+        return builder.MoveToImmutable();
     }
 }

--- a/Trellis.Core/src/Pagination/PageSize.cs
+++ b/Trellis.Core/src/Pagination/PageSize.cs
@@ -60,13 +60,15 @@ public readonly record struct PageSize
     }
 
     /// <summary>
-    /// Lenient factory: returns <see cref="Default"/> when <paramref name="requested"/> is
-    /// <c>null</c> or non-positive; otherwise preserves <paramref name="requested"/> verbatim
-    /// and clamps <see cref="Applied"/> to <paramref name="max"/>. Cap visibility survives.
+    /// Lenient factory: when <paramref name="requested"/> is <c>null</c> or non-positive,
+    /// returns a <see cref="PageSize"/> with <see cref="Requested"/> = <see cref="Default"/>
+    /// and <see cref="Applied"/> = <c>min(Default, max)</c>. Otherwise preserves
+    /// <paramref name="requested"/> verbatim and clamps <see cref="Applied"/> to
+    /// <paramref name="max"/>. Cap visibility (<see cref="WasCapped"/>) survives in both branches.
     /// </summary>
     /// <param name="requested">The client-requested limit (e.g. from a query string).</param>
     /// <param name="max">The server-side maximum. Defaults to <see cref="Max"/>.</param>
-    /// <returns>A <see cref="PageSize"/> with <c>Requested</c> kept verbatim and <c>Applied = min(Requested, max)</c>.</returns>
+    /// <returns>A <see cref="PageSize"/> with <c>Requested</c> kept verbatim (or <see cref="Default"/> for null/non-positive input) and <c>Applied = min(Requested, max)</c>.</returns>
     public static PageSize FromRequested(int? requested, int max = Max)
     {
         if (max <= 0)

--- a/Trellis.Core/src/Pagination/PageSize.cs
+++ b/Trellis.Core/src/Pagination/PageSize.cs
@@ -33,10 +33,10 @@ public readonly record struct PageSize
     /// <summary>The framework-default maximum page size. Callers may override per call via <see cref="FromRequested(int?, int)"/> or <see cref="TryCreate(int?, int, string?)"/>.</summary>
     public const int Max = 100;
 
-    /// <summary>The limit the client requested. Always positive.</summary>
+    /// <summary>The limit the client requested. Positive for validated instances; <c>default(PageSize)</c> yields zero and should not be observed in well-formed code.</summary>
     public int Requested { get; }
 
-    /// <summary>The limit the server actually applied. Always positive and never greater than <see cref="Requested"/>.</summary>
+    /// <summary>The limit the server actually applied. Positive for validated instances and never greater than <see cref="Requested"/>; <c>default(PageSize)</c> yields zero.</summary>
     public int Applied { get; }
 
     /// <summary>True when the server applied a smaller limit than the client requested.</summary>
@@ -81,10 +81,13 @@ public readonly record struct PageSize
     }
 
     /// <summary>
-    /// Strict factory: returns <see cref="Default"/> when <paramref name="requested"/> is
-    /// <c>null</c>; returns <see cref="Error.InvalidInput"/> when <paramref name="requested"/>
-    /// is non-positive or exceeds <paramref name="max"/>. Use when the API contract treats
-    /// out-of-range as a client error rather than a soft cap.
+    /// Strict factory: when <paramref name="requested"/> is <c>null</c>, returns a
+    /// <see cref="PageSize"/> with <see cref="Requested"/> set to <see cref="Default"/> and
+    /// <see cref="Applied"/> clamped to <c>min(Default, max)</c> — the same shape
+    /// <see cref="FromRequested(int?, int)"/> uses for the null case. Returns
+    /// <see cref="Error.InvalidInput"/> when <paramref name="requested"/> is non-positive
+    /// or exceeds <paramref name="max"/>. Use when the API contract treats out-of-range as
+    /// a client error rather than a soft cap.
     /// </summary>
     /// <param name="requested">The client-requested limit.</param>
     /// <param name="max">The server-side maximum. Defaults to <see cref="Max"/>.</param>

--- a/Trellis.Core/src/Pagination/PageSize.cs
+++ b/Trellis.Core/src/Pagination/PageSize.cs
@@ -1,0 +1,112 @@
+﻿namespace Trellis;
+
+using System;
+
+/// <summary>
+/// A request/applied limit pair carrying both the limit the client asked for and the
+/// limit the server actually applied (after server-side capping). Bridges raw user
+/// input directly into <see cref="Page{T}"/>'s <c>RequestedLimit</c> /
+/// <c>AppliedLimit</c> invariants so cap visibility (<c>WasCapped</c>) survives
+/// end-to-end.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a struct, not a <c>ScalarValueObject&lt;,&gt;</c>?</b> <see cref="PageSize"/> is
+/// not a scalar domain value — it is a protocol-level pair (requested versus applied).
+/// Modeling it as a scalar would force callers to track <c>Requested</c> separately,
+/// defeating the very cap visibility <see cref="Page{T}"/> was designed to surface.
+/// </para>
+/// <para>
+/// <b>Clamping vs. rejecting:</b> <see cref="FromRequested(int?, int)"/> clamps
+/// <see cref="Applied"/> down to the server cap while preserving <see cref="Requested"/>
+/// verbatim — this is the lenient mode that keeps <see cref="WasCapped"/> observable.
+/// <see cref="TryCreate(int?, int, string?)"/> is the strict counterpart that rejects
+/// out-of-range requests with <see cref="Error.InvalidInput"/>; use it when the API
+/// contract treats over-cap as a client error rather than a soft cap.
+/// </para>
+/// </remarks>
+public readonly record struct PageSize
+{
+    /// <summary>The default page size used when the client supplies no value.</summary>
+    public const int Default = 50;
+
+    /// <summary>The framework-default maximum page size. Callers may override per call via <see cref="FromRequested(int?, int)"/> or <see cref="TryCreate(int?, int, string?)"/>.</summary>
+    public const int Max = 100;
+
+    /// <summary>The limit the client requested. Always positive.</summary>
+    public int Requested { get; }
+
+    /// <summary>The limit the server actually applied. Always positive and never greater than <see cref="Requested"/>.</summary>
+    public int Applied { get; }
+
+    /// <summary>True when the server applied a smaller limit than the client requested.</summary>
+    public bool WasCapped => Applied < Requested;
+
+    /// <summary>Constructs a validated page size.</summary>
+    /// <param name="requested">The limit the client requested. Must be positive.</param>
+    /// <param name="applied">The limit the server applied. Must be positive and not greater than <paramref name="requested"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="requested"/> or <paramref name="applied"/> is non-positive, or <paramref name="applied"/> exceeds <paramref name="requested"/>.</exception>
+    public PageSize(int requested, int applied)
+    {
+        if (requested <= 0)
+            throw new ArgumentOutOfRangeException(nameof(requested), "Requested limit must be positive.");
+        if (applied <= 0)
+            throw new ArgumentOutOfRangeException(nameof(applied), "Applied limit must be positive.");
+        if (applied > requested)
+            throw new ArgumentOutOfRangeException(nameof(applied), "Applied limit cannot exceed requested limit.");
+
+        Requested = requested;
+        Applied = applied;
+    }
+
+    /// <summary>
+    /// Lenient factory: returns <see cref="Default"/> when <paramref name="requested"/> is
+    /// <c>null</c> or non-positive; otherwise preserves <paramref name="requested"/> verbatim
+    /// and clamps <see cref="Applied"/> to <paramref name="max"/>. Cap visibility survives.
+    /// </summary>
+    /// <param name="requested">The client-requested limit (e.g. from a query string).</param>
+    /// <param name="max">The server-side maximum. Defaults to <see cref="Max"/>.</param>
+    /// <returns>A <see cref="PageSize"/> with <c>Requested</c> kept verbatim and <c>Applied = min(Requested, max)</c>.</returns>
+    public static PageSize FromRequested(int? requested, int max = Max)
+    {
+        if (max <= 0)
+            throw new ArgumentOutOfRangeException(nameof(max), "Max must be positive.");
+
+        if (requested is null || requested.Value <= 0)
+            return new PageSize(Default, Math.Min(Default, max));
+
+        var req = requested.Value;
+        var applied = Math.Min(req, max);
+        return new PageSize(req, applied);
+    }
+
+    /// <summary>
+    /// Strict factory: returns <see cref="Default"/> when <paramref name="requested"/> is
+    /// <c>null</c>; returns <see cref="Error.InvalidInput"/> when <paramref name="requested"/>
+    /// is non-positive or exceeds <paramref name="max"/>. Use when the API contract treats
+    /// out-of-range as a client error rather than a soft cap.
+    /// </summary>
+    /// <param name="requested">The client-requested limit.</param>
+    /// <param name="max">The server-side maximum. Defaults to <see cref="Max"/>.</param>
+    /// <param name="fieldName">Optional field name for the error; defaults to <c>"pageSize"</c>.</param>
+    public static Result<PageSize> TryCreate(int? requested, int max = Max, string? fieldName = null)
+    {
+        if (max <= 0)
+            throw new ArgumentOutOfRangeException(nameof(max), "Max must be positive.");
+
+        var field = fieldName ?? "pageSize";
+
+        if (requested is null)
+            return Result.Ok(new PageSize(Default, Math.Min(Default, max)));
+
+        var req = requested.Value;
+        if (req <= 0)
+            return Result.Fail<PageSize>(
+                Error.InvalidInput.ForField(field, "page_size.out_of_range", $"{field} must be positive."));
+        if (req > max)
+            return Result.Fail<PageSize>(
+                Error.InvalidInput.ForField(field, "page_size.out_of_range", $"{field} must be at most {max}."));
+
+        return Result.Ok(new PageSize(req, req));
+    }
+}

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -112,6 +112,18 @@ public class CursorCodecTests
     }
 
     [Fact]
+    public void Single_key_rejects_empty_string_id()
+    {
+        // FormatInvariant("") yields an empty payload, which would in turn cause
+        // the Cursor ctor to throw with a confusing "token" message. The codec
+        // should reject the input up front against the right parameter name.
+        var act = () => CursorCodec.Encode("");
+
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("id");
+    }
+
+    [Fact]
     public void Single_key_rejects_default_cursor_without_throwing()
     {
         // default(Cursor) bypasses the validated constructor; reading Token throws

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -1,0 +1,242 @@
+﻿namespace Trellis.Core.Tests.Pagination;
+
+using System;
+using System.Globalization;
+using System.Threading;
+
+/// <summary>
+/// Unit tests for the <see cref="CursorCodec"/> helpers that encode and decode opaque
+/// <see cref="Cursor"/> tokens for single-key and composite <c>(CreatedAt, Id)</c>
+/// pagination.
+/// </summary>
+public class CursorCodecTests
+{
+    // ───── Single-key encode/decode ────────────────────────────────────────────
+
+    [Fact]
+    public void Single_key_round_trips_guid()
+    {
+        var id = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        var cursor = CursorCodec.Encode(id);
+        var decoded = CursorCodec.TryDecode<Guid>(cursor);
+
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var parsed).Should().BeTrue();
+        parsed.Should().Be(id);
+    }
+
+    [Fact]
+    public void Single_key_round_trips_long()
+    {
+        var cursor = CursorCodec.Encode(42L);
+        var decoded = CursorCodec.TryDecode<long>(cursor);
+
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var parsed).Should().BeTrue();
+        parsed.Should().Be(42L);
+    }
+
+    [Fact]
+    public void Single_key_round_trips_int()
+    {
+        var cursor = CursorCodec.Encode(1234);
+        var decoded = CursorCodec.TryDecode<int>(cursor);
+
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var parsed).Should().BeTrue();
+        parsed.Should().Be(1234);
+    }
+
+    [Fact]
+    public void Single_key_fails_on_malformed_base64()
+    {
+        var bogus = new Cursor("!!!not base64!!!");
+
+        var decoded = CursorCodec.TryDecode<Guid>(bogus);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Single_key_fails_when_payload_unparseable_for_target_key()
+    {
+        var bogus = CursorCodec.Encode("not-a-guid");
+
+        var decoded = CursorCodec.TryDecode<Guid>(bogus);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Single_key_fails_when_payload_bytes_are_invalid_utf8()
+    {
+        // 0xC0 0x80 is overlong-encoded NUL — a classic invalid UTF-8 sequence
+        // that lenient decoders silently turn into replacement characters.
+        // We want the codec to reject such cursors instead of admitting them
+        // as the literal string "��".
+        var standard = Convert.ToBase64String(new byte[] { 0xC0, 0x80 });
+        var urlSafe = standard.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        var bogus = new Cursor(urlSafe);
+
+        var decoded = CursorCodec.TryDecode<string>(bogus);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Single_key_propagates_field_name_into_error()
+    {
+        var bogus = new Cursor("!!!malformed!!!");
+
+        var decoded = CursorCodec.TryDecode<Guid>(bogus, fieldName: "after");
+
+        decoded.IsFailure.Should().BeTrue();
+        var invalid = decoded.Error.Should().BeOfType<Error.InvalidInput>().Subject;
+        invalid.Fields.Items.Should().Contain(f => f.Field.ToString().Contains("after"));
+    }
+
+    // ───── Composite (CreatedAt, Id) encode/decode ─────────────────────────────
+
+    [Fact]
+    public void Composite_round_trips_datetimeoffset_and_guid()
+    {
+        var createdAt = new DateTimeOffset(2026, 5, 22, 14, 30, 12, TimeSpan.FromHours(-7))
+            .AddTicks(1234567);
+        var id = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        var cursor = CursorCodec.Encode(createdAt, id);
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(cursor);
+
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var pair).Should().BeTrue();
+        pair.CreatedAt.Should().Be(createdAt);
+        pair.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public void Composite_uses_invariant_culture_across_thread_culture_change()
+    {
+        // Verifies the codec is culture-neutral. fr-FR formats decimals with comma rather
+        // than dot; if the codec accidentally used the current culture, the round-trip
+        // would parse the dot-formatted ticks back incorrectly.
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            var createdAt = new DateTimeOffset(2026, 5, 22, 14, 30, 12, TimeSpan.FromHours(-7))
+                .AddTicks(1234567);
+            var id = Guid.NewGuid();
+
+            var cursor = CursorCodec.Encode(createdAt, id);
+            var decoded = CursorCodec.TryDecodeComposite<Guid>(cursor);
+
+            decoded.IsSuccess.Should().BeTrue();
+            decoded.TryGetValue(out var pair).Should().BeTrue();
+            pair.CreatedAt.Should().Be(createdAt);
+            pair.Id.Should().Be(id);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void Composite_fails_on_malformed_base64()
+    {
+        var bogus = new Cursor("not base64 at all");
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(bogus);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Composite_fails_when_separator_missing()
+    {
+        // Encode something that is valid base64url but contains no '|' delimiter.
+        var noPipe = CursorCodec.Encode("2026-05-22T14:30:12Z and the id"); // single-key form, no pipe
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(noPipe);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Composite_fails_when_date_unparseable()
+    {
+        // Manually craft a bad composite payload: bogus date, valid guid.
+        var raw = "not-a-date|550e8400-e29b-41d4-a716-446655440000";
+        var b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(raw))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        var cursor = new Cursor(b64);
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(cursor);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Composite_fails_when_key_unparseable_for_target_type()
+    {
+        var raw = "2026-05-22T14:30:12.1234567-07:00|not-a-guid";
+        var b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(raw))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        var cursor = new Cursor(b64);
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(cursor);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void Composite_splits_at_first_pipe_only()
+    {
+        // Defensive: even if a hypothetical TKey serialized with embedded '|', the date
+        // segment is unambiguous because we split at the FIRST '|' only. Here we encode
+        // (date, "abc|def") and decode as string to verify the split semantics.
+        var createdAt = new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero);
+        var id = "abc|def";
+
+        var cursor = CursorCodec.Encode(createdAt, id);
+        var decoded = CursorCodec.TryDecodeComposite<string>(cursor);
+
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var pair).Should().BeTrue();
+        pair.CreatedAt.Should().Be(createdAt);
+        pair.Id.Should().Be("abc|def");
+    }
+
+    [Fact]
+    public void Composite_propagates_field_name_into_error()
+    {
+        var bogus = new Cursor("!!!malformed!!!");
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(bogus, fieldName: "after");
+
+        decoded.IsFailure.Should().BeTrue();
+        var invalid = decoded.Error.Should().BeOfType<Error.InvalidInput>().Subject;
+        invalid.Fields.Items.Should().Contain(f => f.Field.ToString().Contains("after"));
+    }
+
+    [Fact]
+    public void Encoded_cursor_token_is_url_safe_base64()
+    {
+        var id = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        var cursor = CursorCodec.Encode(id);
+
+        // URL-safe base64: '-' and '_' instead of '+' and '/', no padding.
+        cursor.Token.Should().NotContain("+");
+        cursor.Token.Should().NotContain("/");
+        cursor.Token.Should().NotContain("=");
+    }
+}

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -143,6 +143,17 @@ public class CursorCodecTests
     // ───── Composite (CreatedAt, Id) encode/decode ─────────────────────────────
 
     [Fact]
+    public void Composite_rejects_empty_string_id()
+    {
+        // Symmetric with single-key Encode("") — composite must not silently produce
+        // a "{date}|" payload that round-trips to an unparseable id for most TKey.
+        var act = () => CursorCodec.Encode(DateTimeOffset.UtcNow, "");
+
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("id");
+    }
+
+    [Fact]
     public void Composite_round_trips_datetimeoffset_and_guid()
     {
         var createdAt = new DateTimeOffset(2026, 5, 22, 14, 30, 12, TimeSpan.FromHours(-7))

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -98,6 +98,24 @@ public class CursorCodecTests
         invalid.Fields.Items.Should().Contain(f => f.Field.ToString().Contains("after"));
     }
 
+    [Fact]
+    public void Single_key_encode_rejects_non_formattable_non_string_key()
+    {
+        // A custom type that is neither IFormattable nor string. Without an invariant-culture
+        // formatting contract, encoding could emit a culture-sensitive token that decode then
+        // fails to parse — we want a clear, immediate NotSupportedException instead.
+        var key = new NonFormattableKey();
+
+        var act = () => CursorCodec.Encode(key);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    private sealed class NonFormattableKey
+    {
+        public override string ToString() => "anything";
+    }
+
     // ───── Composite (CreatedAt, Id) encode/decode ─────────────────────────────
 
     [Fact]

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -111,6 +111,18 @@ public class CursorCodecTests
         act.Should().Throw<NotSupportedException>();
     }
 
+    [Fact]
+    public void Single_key_rejects_default_cursor_without_throwing()
+    {
+        // default(Cursor) bypasses the validated constructor; reading Token throws
+        // InvalidOperationException. The Try* contract says no exceptions reach the
+        // caller, so the codec must surface this as Error.InvalidInput.
+        var decoded = CursorCodec.TryDecode<Guid>(default);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
     private sealed class NonFormattableKey
     {
         public override string ToString() => "anything";
@@ -230,6 +242,18 @@ public class CursorCodecTests
         decoded.TryGetValue(out var pair).Should().BeTrue();
         pair.CreatedAt.Should().Be(createdAt);
         pair.Id.Should().Be("abc|def");
+    }
+
+    [Fact]
+    public void Composite_rejects_default_cursor_without_throwing()
+    {
+        // Mirror of Single_key_rejects_default_cursor_without_throwing for the
+        // composite overload — the Try* contract must never let a default(Cursor)
+        // turn into an InvalidOperationException from Cursor.Token.
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(default);
+
+        decoded.IsFailure.Should().BeTrue();
+        decoded.Error.Should().BeOfType<Error.InvalidInput>();
     }
 
     [Fact]

--- a/Trellis.Core/tests/Pagination/CursorCodecTests.cs
+++ b/Trellis.Core/tests/Pagination/CursorCodecTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Globalization;
-using System.Threading;
 
 /// <summary>
 /// Unit tests for the <see cref="CursorCodec"/> helpers that encode and decode opaque

--- a/Trellis.Core/tests/Pagination/PageBuilderTests.cs
+++ b/Trellis.Core/tests/Pagination/PageBuilderTests.cs
@@ -1,0 +1,185 @@
+﻿namespace Trellis.Core.Tests.Pagination;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public sealed class PageBuilderTests
+{
+    private sealed record Row(Guid Id, DateTimeOffset CreatedAt, string Name);
+
+    // ───── Single-key over-fetch ───────────────────────────────────────────────
+
+    [Fact]
+    public void Single_key_under_fill_returns_no_next_cursor()
+    {
+        var pageSize = PageSize.FromRequested(10);
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "b"),
+        };
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+
+        page.Items.Count.Should().Be(2);
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+        page.RequestedLimit.Should().Be(10);
+        page.AppliedLimit.Should().Be(10);
+    }
+
+    [Fact]
+    public void Single_key_exact_fill_returns_no_next_cursor()
+    {
+        var pageSize = PageSize.FromRequested(3);
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "b"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "c"),
+        };
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+
+        page.Items.Count.Should().Be(3);
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+    }
+
+    [Fact]
+    public void Single_key_over_fill_returns_next_cursor_from_last_kept_item()
+    {
+        var pageSize = PageSize.FromRequested(3);
+        var lastKeptId = Guid.NewGuid();
+        var sentinelId = Guid.NewGuid();
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "b"),
+            new(lastKeptId, DateTimeOffset.UtcNow, "c"),
+            new(sentinelId, DateTimeOffset.UtcNow, "d"),
+        };
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+
+        page.Items.Count.Should().Be(3);
+        page.Next.Should().NotBeNull();
+        page.Previous.Should().BeNull();
+
+        var decoded = CursorCodec.TryDecode<Guid>(page.Next!.Value);
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var decodedId).Should().BeTrue();
+        decodedId.Should().Be(lastKeptId);
+    }
+
+    [Fact]
+    public void Single_key_empty_list_returns_empty_page()
+    {
+        var pageSize = PageSize.FromRequested(50);
+        var fetched = new List<Row>();
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+
+        page.Items.Count.Should().Be(0);
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+    }
+
+    [Fact]
+    public void Single_key_preserves_was_capped_in_page()
+    {
+        var pageSize = PageSize.FromRequested(1000); // requested=1000, applied=100 (Max)
+        var fetched = Enumerable.Range(0, 101) // applied + 1
+            .Select(_ => new Row(Guid.NewGuid(), DateTimeOffset.UtcNow, "x"))
+            .ToList();
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+
+        page.Items.Count.Should().Be(100);
+        page.RequestedLimit.Should().Be(1000);
+        page.AppliedLimit.Should().Be(100);
+        page.WasCapped.Should().BeTrue();
+        page.Next.Should().NotBeNull();
+    }
+
+    // ───── Composite over-fetch ────────────────────────────────────────────────
+
+    [Fact]
+    public void Composite_under_fill_returns_no_next_cursor()
+    {
+        var pageSize = PageSize.FromRequested(10);
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(-2), "a"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(-1), "b"),
+        };
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.CreatedAt, r => r.Id);
+
+        page.Items.Count.Should().Be(2);
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+    }
+
+    [Fact]
+    public void Composite_over_fill_returns_next_cursor_from_last_kept_item()
+    {
+        var pageSize = PageSize.FromRequested(2);
+        var lastKeptCreated = new DateTimeOffset(2026, 5, 22, 14, 30, 12, TimeSpan.Zero);
+        var lastKeptId = Guid.NewGuid();
+        var sentinelCreated = lastKeptCreated.AddSeconds(1);
+        var sentinelId = Guid.NewGuid();
+
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(-10), "a"),
+            new(lastKeptId, lastKeptCreated, "b"),
+            new(sentinelId, sentinelCreated, "c"),
+        };
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.CreatedAt, r => r.Id);
+
+        page.Items.Count.Should().Be(2);
+        page.Next.Should().NotBeNull();
+        page.Previous.Should().BeNull();
+
+        var decoded = CursorCodec.TryDecodeComposite<Guid>(page.Next!.Value);
+        decoded.IsSuccess.Should().BeTrue();
+        decoded.TryGetValue(out var pair).Should().BeTrue();
+        pair.CreatedAt.Should().Be(lastKeptCreated);
+        pair.Id.Should().Be(lastKeptId);
+    }
+
+    [Fact]
+    public void Composite_empty_list_returns_empty_page()
+    {
+        var pageSize = PageSize.FromRequested(25);
+        var fetched = new List<Row>();
+
+        var page = PageBuilder.FromOverFetch(fetched, pageSize, r => r.CreatedAt, r => r.Id);
+
+        page.Items.Count.Should().Be(0);
+        page.Next.Should().BeNull();
+        page.Previous.Should().BeNull();
+    }
+
+    [Fact]
+    public void Previous_is_always_null_forward_only()
+    {
+        var pageSize = PageSize.FromRequested(3);
+        var fetched = new List<Row>
+        {
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "b"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "c"),
+            new(Guid.NewGuid(), DateTimeOffset.UtcNow, "d"),
+        };
+
+        var single = PageBuilder.FromOverFetch(fetched, pageSize, r => r.Id);
+        var composite = PageBuilder.FromOverFetch(fetched, pageSize, r => r.CreatedAt, r => r.Id);
+
+        single.Previous.Should().BeNull();
+        composite.Previous.Should().BeNull();
+    }
+}

--- a/Trellis.Core/tests/Pagination/PageBuilderTests.cs
+++ b/Trellis.Core/tests/Pagination/PageBuilderTests.cs
@@ -182,4 +182,26 @@ public sealed class PageBuilderTests
         single.Previous.Should().BeNull();
         composite.Previous.Should().BeNull();
     }
+
+    // ───── Defensive validation ────────────────────────────────────────────────
+
+    [Fact]
+    public void Single_key_rejects_default_pageSize()
+    {
+        var fetched = new List<Row> { new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a") };
+
+        var act = () => PageBuilder.FromOverFetch(fetched, default(PageSize), r => r.Id);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("pageSize");
+    }
+
+    [Fact]
+    public void Composite_rejects_default_pageSize()
+    {
+        var fetched = new List<Row> { new(Guid.NewGuid(), DateTimeOffset.UtcNow, "a") };
+
+        var act = () => PageBuilder.FromOverFetch(fetched, default(PageSize), r => r.CreatedAt, r => r.Id);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("pageSize");
+    }
 }

--- a/Trellis.Core/tests/Pagination/PageMapTests.cs
+++ b/Trellis.Core/tests/Pagination/PageMapTests.cs
@@ -1,0 +1,71 @@
+﻿namespace Trellis.Core.Tests.Pagination;
+
+using System;
+using System.Linq;
+
+public sealed class PageMapTests
+{
+    private sealed record Source(int N);
+    private sealed record Dest(string Label);
+
+    [Fact]
+    public void Map_projects_items_and_preserves_cursors_and_limits()
+    {
+        var next = new Cursor("next-token");
+        var prev = new Cursor("prev-token");
+        var source = new Page<Source>(
+            new Source[] { new(1), new(2), new(3) },
+            next, prev, RequestedLimit: 50, AppliedLimit: 10);
+
+        var mapped = source.Map(s => new Dest($"v{s.N}"));
+
+        mapped.Items.Should().HaveCount(3);
+        mapped.Items.Select(d => d.Label).Should().Equal("v1", "v2", "v3");
+        mapped.Next.Should().Be(next);
+        mapped.Previous.Should().Be(prev);
+        mapped.RequestedLimit.Should().Be(50);
+        mapped.AppliedLimit.Should().Be(10);
+        mapped.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Map_on_empty_page_returns_empty_page_with_same_limits()
+    {
+        var source = Page.Empty<Source>(requestedLimit: 25, appliedLimit: 25);
+
+        var mapped = source.Map(s => new Dest($"v{s.N}"));
+
+        mapped.Items.Should().BeEmpty();
+        mapped.Next.Should().BeNull();
+        mapped.Previous.Should().BeNull();
+        mapped.RequestedLimit.Should().Be(25);
+        mapped.AppliedLimit.Should().Be(25);
+        mapped.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Map_preserves_null_next_and_previous()
+    {
+        var source = new Page<Source>(
+            new Source[] { new(7) },
+            Next: null, Previous: null, RequestedLimit: 10, AppliedLimit: 10);
+
+        var mapped = source.Map(s => new Dest($"v{s.N}"));
+
+        mapped.Next.Should().BeNull();
+        mapped.Previous.Should().BeNull();
+        mapped.Items.Single().Label.Should().Be("v7");
+    }
+
+    [Fact]
+    public void Map_throws_when_selector_is_null()
+    {
+        var source = new Page<Source>(
+            new Source[] { new(1) },
+            Next: null, Previous: null, RequestedLimit: 10, AppliedLimit: 10);
+
+        var act = () => source.Map<Dest>(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Trellis.Core/tests/Pagination/PageMapTests.cs
+++ b/Trellis.Core/tests/Pagination/PageMapTests.cs
@@ -9,6 +9,36 @@ public sealed class PageMapTests
     private sealed record Dest(string Label);
 
     [Fact]
+    public void Constructor_rejects_default_cursor_for_next()
+    {
+        // default(Cursor) is a Cursor whose Token getter throws. Letting it through
+        // the constructor would create a Page that explodes in HTTP projection.
+        var act = () => new Page<int>(
+            Items: Array.Empty<int>(),
+            Next: default(Cursor),
+            Previous: null,
+            RequestedLimit: 10,
+            AppliedLimit: 10);
+
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("Next");
+    }
+
+    [Fact]
+    public void Constructor_rejects_default_cursor_for_previous()
+    {
+        var act = () => new Page<int>(
+            Items: Array.Empty<int>(),
+            Next: null,
+            Previous: default(Cursor),
+            RequestedLimit: 10,
+            AppliedLimit: 10);
+
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("Previous");
+    }
+
+    [Fact]
     public void Map_projects_items_and_preserves_cursors_and_limits()
     {
         var next = new Cursor("next-token");

--- a/Trellis.Core/tests/Pagination/PageSizeTests.cs
+++ b/Trellis.Core/tests/Pagination/PageSizeTests.cs
@@ -233,6 +233,19 @@ public class PageSizeTests
     }
 
     [Fact]
+    public void FromRequested_with_null_clamps_default_to_smaller_max()
+    {
+        // When max < Default, FromRequested(null) returns Requested=Default but
+        // Applied is clamped down to max so WasCapped is observable. Documented
+        // shape that TryCreate(null, max) mirrors.
+        var size = PageSize.FromRequested(null, max: 10);
+
+        size.Requested.Should().Be(PageSize.Default);
+        size.Applied.Should().Be(10);
+        size.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
     public void TryCreate_with_null_clamps_default_to_smaller_max()
     {
         // When max < Default, TryCreate(null) returns Requested=Default but Applied=max.

--- a/Trellis.Core/tests/Pagination/PageSizeTests.cs
+++ b/Trellis.Core/tests/Pagination/PageSizeTests.cs
@@ -1,0 +1,214 @@
+﻿namespace Trellis.Core.Tests.Pagination;
+
+using System;
+
+/// <summary>
+/// Unit tests for the <see cref="PageSize"/> request/applied pair carrying both the
+/// limit the client asked for and the limit the server actually applied.
+/// </summary>
+public class PageSizeTests
+{
+    [Fact]
+    public void Constants_have_sensible_defaults()
+    {
+        PageSize.Default.Should().Be(50);
+        PageSize.Max.Should().Be(100);
+    }
+
+    [Fact]
+    public void Constructor_round_trips_valid_values()
+    {
+        var size = new PageSize(requested: 25, applied: 10);
+
+        size.Requested.Should().Be(25);
+        size.Applied.Should().Be(10);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_rejects_non_positive_requested(int requested)
+    {
+        var act = () => new PageSize(requested, 1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(requested));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_rejects_non_positive_applied(int applied)
+    {
+        var act = () => new PageSize(10, applied);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(applied));
+    }
+
+    [Fact]
+    public void Constructor_rejects_applied_greater_than_requested()
+    {
+        var act = () => new PageSize(requested: 5, applied: 10);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("applied");
+    }
+
+    [Fact]
+    public void WasCapped_true_when_applied_less_than_requested()
+    {
+        var size = new PageSize(requested: 100, applied: 50);
+
+        size.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WasCapped_false_when_applied_equals_requested()
+    {
+        var size = new PageSize(requested: 50, applied: 50);
+
+        size.WasCapped.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-1000)]
+    public void FromRequested_returns_default_when_requested_is_null_or_non_positive(int? requested)
+    {
+        var size = PageSize.FromRequested(requested);
+
+        size.Requested.Should().Be(PageSize.Default);
+        size.Applied.Should().Be(PageSize.Default);
+        size.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromRequested_preserves_requested_verbatim_when_capped_by_max()
+    {
+        // Critical: WasCapped must remain observable. Clamping Requested would destroy it.
+        var size = PageSize.FromRequested(1000);
+
+        size.Requested.Should().Be(1000);
+        size.Applied.Should().Be(PageSize.Max);
+        size.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromRequested_under_max_returns_unchanged_applied()
+    {
+        var size = PageSize.FromRequested(25);
+
+        size.Requested.Should().Be(25);
+        size.Applied.Should().Be(25);
+        size.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromRequested_respects_custom_max_parameter()
+    {
+        var size = PageSize.FromRequested(20, max: 5);
+
+        size.Requested.Should().Be(20);
+        size.Applied.Should().Be(5);
+        size.WasCapped.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromRequested_with_custom_max_does_not_cap_when_under()
+    {
+        var size = PageSize.FromRequested(3, max: 5);
+
+        size.Requested.Should().Be(3);
+        size.Applied.Should().Be(3);
+        size.WasCapped.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCreate_returns_success_for_valid_requested()
+    {
+        var result = PageSize.TryCreate(50);
+
+        result.IsSuccess.Should().BeTrue();
+        result.TryGetValue(out var size).Should().BeTrue();
+        size.Requested.Should().Be(50);
+        size.Applied.Should().Be(50);
+    }
+
+    [Fact]
+    public void TryCreate_returns_default_when_requested_is_null()
+    {
+        var result = PageSize.TryCreate(null);
+
+        result.IsSuccess.Should().BeTrue();
+        result.TryGetValue(out var size).Should().BeTrue();
+        size.Requested.Should().Be(PageSize.Default);
+        size.Applied.Should().Be(PageSize.Default);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void TryCreate_fails_when_requested_is_non_positive(int requested)
+    {
+        var result = PageSize.TryCreate(requested);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void TryCreate_fails_when_requested_exceeds_max()
+    {
+        var result = PageSize.TryCreate(101);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void TryCreate_strict_does_not_clamp()
+    {
+        // FromRequested clamps; TryCreate rejects. That distinction is the whole point.
+        var result = PageSize.TryCreate(1000);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryCreate_respects_custom_max()
+    {
+        PageSize.TryCreate(5, max: 5).IsSuccess.Should().BeTrue();
+        PageSize.TryCreate(6, max: 5).IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryCreate_propagates_field_name_into_error()
+    {
+        var result = PageSize.TryCreate(1000, fieldName: "limit");
+
+        result.IsFailure.Should().BeTrue();
+        var invalid = result.Error.Should().BeOfType<Error.InvalidInput>().Subject;
+        invalid.Fields.Items.Should().Contain(f => f.Field.ToString().Contains("limit"));
+    }
+
+    [Fact]
+    public void Equality_treats_records_with_same_values_as_equal()
+    {
+        var a = new PageSize(50, 50);
+        var b = new PageSize(50, 50);
+
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Composes_into_Page_constructor_without_violation()
+    {
+        var size = PageSize.FromRequested(200);
+        var page = new Page<int>([1, 2, 3], Next: null, Previous: null, RequestedLimit: size.Requested, AppliedLimit: size.Applied);
+
+        page.RequestedLimit.Should().Be(200);
+        page.AppliedLimit.Should().Be(PageSize.Max);
+        page.WasCapped.Should().BeTrue();
+    }
+}

--- a/Trellis.Core/tests/Pagination/PageSizeTests.cs
+++ b/Trellis.Core/tests/Pagination/PageSizeTests.cs
@@ -211,4 +211,38 @@ public class PageSizeTests
         page.AppliedLimit.Should().Be(PageSize.Max);
         page.WasCapped.Should().BeTrue();
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FromRequested_throws_when_max_is_non_positive(int max)
+    {
+        var act = () => PageSize.FromRequested(10, max);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(max));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void TryCreate_throws_when_max_is_non_positive(int max)
+    {
+        var act = () => PageSize.TryCreate(10, max);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(max));
+    }
+
+    [Fact]
+    public void TryCreate_with_null_clamps_default_to_smaller_max()
+    {
+        // When max < Default, TryCreate(null) returns Requested=Default but Applied=max.
+        // Documented behaviour: mirrors FromRequested(null, max).
+        var result = PageSize.TryCreate(null, max: 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.TryGetValue(out var size).Should().BeTrue();
+        size.Requested.Should().Be(PageSize.Default);
+        size.Applied.Should().Be(10);
+        size.WasCapped.Should().BeTrue();
+    }
 }

--- a/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
@@ -350,7 +350,7 @@ Phase 2 deliverable PR (`PR-PAGE`) — status:
 3. ⬜ Demote `PartialContentResult` collection overloads to `[Obsolete]`.
 4. ✅ Showcase paginates `GET /api/accounts/` end-to-end on both Minimal API and MVC hosts (server cap of 5; client requests 10; follow `Link rel="next"` / body cursor to drain). Integration tests cover both hosts.
 5. ⬜ OpenAPI schema transformer that surfaces the `Link` response header for any operation returning `Page<T>`.
-6. ⬜ Recipe doc: `docs/docfx_project/articles/pagination.md`.
+6. ✅ Recipe doc: `docs/docfx_project/articles/pagination.md`.
 
 ### 0.7.5 Implication for §0.6 (non-web consumers)
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -334,9 +334,9 @@ public sealed class ListOrdersHandler(AppDbContext db)
         {
             if (cursorToken.Length == 0)
                 return Result.Fail<Page<OrderListItem>>(
-                    Error.InvalidInput.ForField(nameof(q.Cursor), "cursor.malformed", "Cursor must not be empty."));
+                    Error.InvalidInput.ForField("cursor", "cursor.malformed", "Cursor must not be empty."));
 
-            var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: nameof(q.Cursor));
+            var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: "cursor");
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -330,9 +330,13 @@ public sealed class ListOrdersHandler(AppDbContext db)
         var pageSize = PageSize.FromRequested(q.Limit);
 
         Guid? afterId = null;
-        if (q.Cursor is not null)
+        if (q.Cursor is { } cursorToken)
         {
-            var decoded = CursorCodec.TryDecode<Guid>(new Cursor(q.Cursor), fieldName: nameof(q.Cursor));
+            if (cursorToken.Length == 0)
+                return Result.Fail<Page<OrderListItem>>(
+                    Error.InvalidInput.ForField(nameof(q.Cursor), "cursor.malformed", "Cursor must not be empty."));
+
+            var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: nameof(q.Cursor));
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -318,48 +318,44 @@ public static class OrdersDi
 using Trellis;
 
 // Paging cursor and limit are protocol/query-string controls validated at the transport seam.
-public sealed record ListOrdersQuery(string? Cursor, int Limit) : IQuery<Result<Page<OrderListItem>>>;
+public sealed record ListOrdersQuery(string? Cursor, int? Limit) : IQuery<Result<Page<OrderListItem>>>;
 
 public sealed record OrderListItem(Guid Id, decimal Amount, string Currency);
 
 public sealed class ListOrdersHandler(AppDbContext db)
     : IQueryHandler<ListOrdersQuery, Result<Page<OrderListItem>>>
 {
-    private const int MaxLimit = 100;
-
     public async ValueTask<Result<Page<OrderListItem>>> Handle(ListOrdersQuery q, CancellationToken ct)
     {
-        var requested = q.Limit;
-        var applied   = Math.Clamp(requested, 1, MaxLimit);
+        var pageSize = PageSize.FromRequested(q.Limit);
 
-        Guid afterId = Guid.Empty;
-        if (q.Cursor is not null && !Guid.TryParseExact(q.Cursor, "N", out afterId))
-            return Result.Fail<Page<OrderListItem>>(
-                Error.InvalidInput.ForField("cursor", "cursor.malformed", "Cursor is not a valid opaque token."));
+        Guid? afterId = null;
+        if (q.Cursor is not null)
+        {
+            var decoded = CursorCodec.TryDecode<Guid>(new Cursor(q.Cursor), fieldName: nameof(q.Cursor));
+            if (decoded.IsFailure)
+                return Result.Fail<Page<OrderListItem>>(decoded.Error!);
+            decoded.TryGetValue(out var id);
+            afterId = id;
+        }
 
         var query = db.Orders.AsNoTracking().OrderBy(o => o.Id);
-        if (q.Cursor is not null)
-            query = query.Where(o => o.Id.Value > afterId);
+        var filtered = afterId is { } cursorId
+            ? query.Where(o => o.Id.Value > cursorId)
+            : (IQueryable<Order>)query;
 
-        var rows = await query.Take(applied + 1).ToListAsync(ct);
-        var hasNext = rows.Count > applied;
-        var items   = rows.Take(applied)
-                          .Select(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value))
-                          .ToList();
+        var rows = await filtered.Take(pageSize.Applied + 1).ToListAsync(ct);
 
-        return Result.Ok(new Page<OrderListItem>(
-            Items: items,
-            Next: hasNext ? new Cursor(items[^1].Id.ToString("N")) : null,
-            Previous: q.Cursor is null ? null : new Cursor(q.Cursor),
-            RequestedLimit: requested,
-            AppliedLimit: applied));
+        return Result.Ok(
+            PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value)
+                .Map(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value)));
     }
 }
 ```
 
-**What it shows.** `Page<T>` is a `readonly record struct`; instances always carry positive limits and a non-null `Items`. `WasCapped` becomes `true` automatically when the server clamped the limit. Use `Page.Empty<T>(req, app)` for the empty case rather than `default(Page<T>)`.
+**What it shows.** `PageSize.FromRequested` is the canonical lenient parser: `null` or non-positive limits collapse to `PageSize.Default`, and `Applied` is clamped to `PageSize.Max` while `Requested` is preserved verbatim so `WasCapped` round-trips through the wire envelope. `CursorCodec.TryDecode<TKey>` parses an opaque token into a typed key (returning `Error.InvalidInput` on a malformed cursor) — value-object IDs are accommodated by projecting to the underlying primitive (`.Value`). `PageBuilder.FromOverFetch` slices the over-fetched list and emits the next cursor from the last kept row; `Previous` is always `null` (forward-only) until Trellis ships a reverse-seek API. `Page<T>.Map` projects to a DTO without re-running the cursor or limit ceremony.
 
-> **Cursor parsing must be ROP, not throwing.** `Guid.Parse(q.Cursor)` would throw on malformed input and escape the handler as a 500. Use `Guid.TryParseExact(..., "N", out var)` and return `Result.Fail<T>(Error.InvalidInput.ForField("cursor", ...))` so a bad cursor surfaces as a clean 422, not a stack trace. Apply the same shape (TryParse -> `Result` failure) for any opaque-token format you adopt.
+> **Cursor parsing must be ROP, not throwing.** Hand-rolling `Guid.Parse(cursor)` would throw on malformed input and escape the handler as a 500. `CursorCodec.TryDecode<TKey>` returns `Result.Fail` with `Error.InvalidInput` (reason code `cursor.malformed`) so a bad cursor surfaces as a clean 422, not a stack trace.
 
 ---
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1293,7 +1293,7 @@ public static class CursorCodec
 
 | Member | Description |
 | --- | --- |
-| `Encode<TKey>(TKey)` | Single-key cursor: URL-safe base64 of the key's invariant-culture string form. Supported keys include `Guid`, `long`, `int`, and `string` (without embedded `&#124;` for composite use). Project Trellis value-object IDs to their underlying primitive (`.Value`) before calling. |
+| `Encode<TKey>(TKey)` | Single-key cursor: URL-safe base64 of the key's invariant-culture string form. Supported keys include `Guid`, `long`, `int`, and `string`. Project Trellis value-object IDs to their underlying primitive (`.Value`) before calling. |
 | `TryDecode<TKey>(Cursor, string?)` | Inverse of the single-key `Encode`. Returns `Error.InvalidInput` (reason code `cursor.malformed`, field `fieldName ?? "cursor"`) on malformed base64 or unparseable payload. |
 | `Encode<TKey>(DateTimeOffset, TKey)` | Composite cursor for stable time-ordered seek: URL-safe base64 of `"{createdAt:O}&#124;{id}"` in invariant culture. |
 | `TryDecodeComposite<TKey>` | Inverse of the composite `Encode`. Splits at the **first** `&#124;` only, so an Id that happens to contain a pipe is still unambiguous. |
@@ -1336,9 +1336,13 @@ public async Task<Result<Page<OrderListItem>>> Handle(ListOrdersQuery query, Can
     var pageSize = PageSize.FromRequested(query.Limit);
 
     Guid? afterId = null;
-    if (query.Cursor is not null)
+    if (query.Cursor is { } cursorToken)
     {
-        var decoded = CursorCodec.TryDecode<Guid>(new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+        if (cursorToken.Length == 0)
+            return Result.Fail<Page<OrderListItem>>(
+                Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed", "Cursor must not be empty."));
+
+        var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: nameof(query.Cursor));
         if (decoded.IsFailure)
             return Result.Fail<Page<OrderListItem>>(decoded.Error!);
         decoded.TryGetValue(out var id);

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, Unit, "Page<T>", Page, Cursor, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-05-06
 audience: [llm]
@@ -1268,7 +1268,7 @@ public readonly record struct PageSize
 | `PageSize(int, int)` | Validated constructor. Throws `ArgumentOutOfRangeException` when either limit is non-positive or when `applied > requested`. |
 | `Requested` / `Applied` | The pair the caller asked for and the value the server actually used. Composes directly with `Page<T>` so `WasCapped` round-trips through the wire envelope. |
 | `WasCapped` | `true` when `Applied < Requested`. |
-| `FromRequested(int?, int)` | Lenient parser. Returns `Default` when `requested` is `null` or non-positive; clamps `Applied` to `max` but **preserves `Requested` verbatim** so cap visibility survives. |
+| `FromRequested(int?, int)` | Lenient parser. When `requested` is `null` or non-positive, returns `Requested = Default` and `Applied = min(Default, max)` (so a custom `max < Default` still clamps `Applied` and surfaces as `WasCapped`). When `requested` is positive, preserves it verbatim and clamps `Applied` to `max`. |
 | `TryCreate(int?, int, string?)` | Strict parser. Returns `Result.Fail<PageSize>` with `Error.InvalidInput` on a non-positive or out-of-range value; uses `fieldName ?? "pageSize"` for the field violation. |
 
 ### `public static class CursorCodec`

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1234,17 +1234,127 @@ Non-generic factory companion (mirrors the `Result` / `Result<T>` split — keep
 | --- | --- | --- |
 | `public static Page<T> Empty<T>(int requestedLimit, int appliedLimit)` | `Page<T>` | An empty page (no items, no cursors) for the supplied limits. |
 
+### `Page<T>.Map<TOut>`
+
+```csharp
+public Page<TOut> Map<TOut>(Func<T, TOut> selector);
+```
+
+| Member | Description |
+| --- | --- |
+| `Map<TOut>(Func<T, TOut>)` | Projects each item to a new type, preserving `Next`, `Previous`, `RequestedLimit`, and `AppliedLimit`. Throws `ArgumentNullException` when `selector` is null. Use to return `Page<Dto>` from a repository call that yielded `Page<Entity>` without re-running the cursor/limit ceremony. |
+
+### `public readonly record struct PageSize`
+
+```csharp
+public readonly record struct PageSize
+{
+    public const int Default = 50;
+    public const int Max = 100;
+
+    public PageSize(int requested, int applied);   // validates: requested > 0, applied > 0, applied <= requested
+    public int  Requested { get; }
+    public int  Applied   { get; }
+    public bool WasCapped { get; }
+
+    public static PageSize FromRequested(int? requested, int max = Max);
+    public static Result<PageSize> TryCreate(int? requested, int max = Max, string? fieldName = null);
+}
+```
+
+| Member | Description |
+| --- | --- |
+| `Default` / `Max` | Convention constants. `Default = 50` is used when the client doesn't supply a limit; `Max = 100` is the server-side ceiling. |
+| `PageSize(int, int)` | Validated constructor. Throws `ArgumentOutOfRangeException` when either limit is non-positive or when `applied > requested`. |
+| `Requested` / `Applied` | The pair the caller asked for and the value the server actually used. Composes directly with `Page<T>` so `WasCapped` round-trips through the wire envelope. |
+| `WasCapped` | `true` when `Applied < Requested`. |
+| `FromRequested(int?, int)` | Lenient parser. Returns `Default` when `requested` is `null` or non-positive; clamps `Applied` to `max` but **preserves `Requested` verbatim** so cap visibility survives. |
+| `TryCreate(int?, int, string?)` | Strict parser. Returns `Result.Fail<PageSize>` with `Error.InvalidInput` on a non-positive or out-of-range value; uses `fieldName ?? "pageSize"` for the field violation. |
+
+### `public static class CursorCodec`
+
+```csharp
+public static class CursorCodec
+{
+    public static Cursor Encode<TKey>(TKey id)
+        where TKey : notnull;
+
+    public static Result<TKey> TryDecode<TKey>(Cursor cursor, string? fieldName = null)
+        where TKey : IParsable<TKey>;
+
+    public static Cursor Encode<TKey>(DateTimeOffset createdAt, TKey id)
+        where TKey : notnull;
+
+    public static Result<(DateTimeOffset CreatedAt, TKey Id)> TryDecodeComposite<TKey>(
+        Cursor cursor, string? fieldName = null)
+        where TKey : IParsable<TKey>;
+}
+```
+
+| Member | Description |
+| --- | --- |
+| `Encode<TKey>(TKey)` | Single-key cursor: URL-safe base64 of the key's invariant-culture string form. Supported keys include `Guid`, `long`, `int`, and `string` (without embedded `&#124;` for composite use). Project Trellis value-object IDs to their underlying primitive (`.Value`) before calling. |
+| `TryDecode<TKey>(Cursor, string?)` | Inverse of the single-key `Encode`. Returns `Error.InvalidInput` (reason code `cursor.malformed`, field `fieldName ?? "cursor"`) on malformed base64 or unparseable payload. |
+| `Encode<TKey>(DateTimeOffset, TKey)` | Composite cursor for stable time-ordered seek: URL-safe base64 of `"{createdAt:O}&#124;{id}"` in invariant culture. |
+| `TryDecodeComposite<TKey>` | Inverse of the composite `Encode`. Splits at the **first** `&#124;` only, so an Id that happens to contain a pipe is still unambiguous. |
+
+**Opacity, not anti-tamper.** Cursors are server-opaque so that clients don't reverse-engineer the sort key, but the encoding is **not** signed. Services that need to defend against tampering must wrap or replace this codec with a signed variant; authorization filtering must always apply to the underlying query.
+
+**AOT-friendly.** No JSON, no reflection. The codec only uses `Convert.ToBase64String`, URL-safe substitution, and `IParsable<TKey>.TryParse` with `CultureInfo.InvariantCulture`.
+
+### `public static class PageBuilder`
+
+```csharp
+public static class PageBuilder
+{
+    public static Page<T> FromOverFetch<T, TKey>(
+        IReadOnlyList<T> overFetched,
+        PageSize pageSize,
+        Func<T, TKey> idSelector)
+        where TKey : notnull;
+
+    public static Page<T> FromOverFetch<T, TKey>(
+        IReadOnlyList<T> overFetched,
+        PageSize pageSize,
+        Func<T, DateTimeOffset> createdAtSelector,
+        Func<T, TKey> idSelector)
+        where TKey : notnull;
+}
+```
+
+Storage-agnostic over-fetch slicer. The caller asks the data source for `pageSize.Applied + 1` rows ordered by the same key(s) returned by the selectors; `FromOverFetch` keeps the first `pageSize.Applied` rows, emits a `Next` cursor from the **last kept** item via `CursorCodec`, and returns a validated `Page<T>`. Works with EF Core, Dapper, Cosmos, gRPC, or in-memory sources alike.
+
+**Forward-only.** `Previous` is always `null`. Trellis does not yet ship a reverse-seek API; emitting a previous cursor that the forward URL builder would walk would re-fetch the current page rather than the page before it.
+
+**Selector contract.** The selectors passed to `FromOverFetch` MUST match the sort keys used in the upstream query. Mismatched selectors produce semantically wrong cursors — the boundary item the cursor points at will not be the one the next query would seek past.
+
 **Wire shape.** `Trellis.Asp` projects `Page<T>` to `200 OK` with a JSON body envelope and a co-emitted `Link` header (RFC 8288). See `HttpResponseExtensions.ToHttpResponse` for the `Result<Page<T>>` overload. Trellis intentionally does **not** use `206 Partial Content` for collection pagination — RFC 9110 §14 was designed for byte-range transfer and lacks proxy/CDN support for collection ranges.
 
 ```csharp
-public Task<Result<Page<Order>>> List(string? cursorToken, int limit, CancellationToken ct) =>
-    repo.ListAsync(cursorToken is null ? null : new Cursor(cursorToken), limit, ct)
-        .MapAsync(rows => new Page<Order>(
-            Items: rows.Items,
-            Next: rows.HasMore ? new Cursor(rows.NextToken!) : null,
-            Previous: rows.PrevToken is null ? null : new Cursor(rows.PrevToken),
-            RequestedLimit: limit,
-            AppliedLimit: Math.Min(limit, MaxLimit)));
+public async Task<Result<Page<OrderListItem>>> Handle(ListOrdersQuery query, CancellationToken ct)
+{
+    var pageSize = PageSize.FromRequested(query.Limit);
+
+    Guid? afterId = null;
+    if (query.Cursor is not null)
+    {
+        var decoded = CursorCodec.TryDecode<Guid>(new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+        if (decoded.IsFailure)
+            return Result.Fail<Page<OrderListItem>>(decoded.Error!);
+        decoded.TryGetValue(out var id);
+        afterId = id;
+    }
+
+    var rows = await db.Orders.AsNoTracking()
+        .OrderBy(o => o.Id)
+        .Where(o => afterId == null || o.Id.Value > afterId)
+        .Take(pageSize.Applied + 1)
+        .ToListAsync(ct);
+
+    return Result.Ok(
+        PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value)
+            .Map(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value)));
+}
 ```
 
 ---

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1340,20 +1340,21 @@ public async Task<Result<Page<OrderListItem>>> Handle(ListOrdersQuery query, Can
     {
         if (cursorToken.Length == 0)
             return Result.Fail<Page<OrderListItem>>(
-                Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed", "Cursor must not be empty."));
+                Error.InvalidInput.ForField("cursor", "cursor.malformed", "Cursor must not be empty."));
 
-        var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: nameof(query.Cursor));
+        var decoded = CursorCodec.TryDecode<Guid>(new Cursor(cursorToken), fieldName: "cursor");
         if (decoded.IsFailure)
             return Result.Fail<Page<OrderListItem>>(decoded.Error!);
         decoded.TryGetValue(out var id);
         afterId = id;
     }
 
-    var rows = await db.Orders.AsNoTracking()
-        .OrderBy(o => o.Id)
-        .Where(o => afterId == null || o.Id.Value > afterId)
-        .Take(pageSize.Applied + 1)
-        .ToListAsync(ct);
+    var ordered = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+    var filtered = afterId is { } cursorId
+        ? ordered.Where(o => o.Id.Value > cursorId)
+        : (IQueryable<Order>)ordered;
+
+    var rows = await filtered.Take(pageSize.Applied + 1).ToListAsync(ct);
 
     return Result.Ok(
         PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value)

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -33,7 +33,7 @@ Graph, OData v4, GitHub, Stripe, and most other modern APIs.
 
 ## The building blocks
 
-All four types live in the `Trellis` namespace under `Trellis.Core`.
+All the pagination primitives live in the `Trellis` namespace under `Trellis.Core`.
 
 | Type | Purpose |
 | --- | --- |
@@ -67,10 +67,15 @@ public sealed class ListOrdersHandler(AppDbContext db)
         var pageSize = PageSize.FromRequested(query.Limit);
 
         Guid? afterId = null;
-        if (query.Cursor is not null)
+        if (query.Cursor is { } cursorToken)
         {
+            if (cursorToken.Length == 0)
+                return Result.Fail<Page<OrderListItem>>(
+                    Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed",
+                        "Cursor must not be empty."));
+
             var decoded = CursorCodec.TryDecode<Guid>(
-                new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+                new Cursor(cursorToken), fieldName: nameof(query.Cursor));
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -71,11 +71,11 @@ public sealed class ListOrdersHandler(AppDbContext db)
         {
             if (cursorToken.Length == 0)
                 return Result.Fail<Page<OrderListItem>>(
-                    Error.InvalidInput.ForField(nameof(query.Cursor), "cursor.malformed",
+                    Error.InvalidInput.ForField("cursor", "cursor.malformed",
                         "Cursor must not be empty."));
 
             var decoded = CursorCodec.TryDecode<Guid>(
-                new Cursor(cursorToken), fieldName: nameof(query.Cursor));
+                new Cursor(cursorToken), fieldName: "cursor");
             if (decoded.IsFailure)
                 return Result.Fail<Page<OrderListItem>>(decoded.Error!);
             decoded.TryGetValue(out var id);
@@ -214,11 +214,12 @@ responsibility is to fetch `pageSize.Applied + 1` rows ordered by the same key
 the selector returns:
 
 ```csharp
-var rows = await db.Orders.AsNoTracking()
-    .OrderBy(o => o.Id)
-    .Where(o => afterId == null || o.Id.Value > afterId)
-    .Take(pageSize.Applied + 1)
-    .ToListAsync(ct);
+var ordered = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+var filtered = afterId is { } cursorId
+    ? ordered.Where(o => o.Id.Value > cursorId)
+    : (IQueryable<Order>)ordered;
+
+var rows = await filtered.Take(pageSize.Applied + 1).ToListAsync(ct);
 
 var page = PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value);
 ```

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -1,0 +1,295 @@
+---
+title: Pagination
+package: Trellis.Core
+topics: [pagination, cursors, asp, results]
+related_api_reference: [trellis-api-core.md, trellis-api-asp.md]
+last_verified: 2026-05-22
+audience: [developer]
+---
+# Pagination
+
+Trellis ships cursor-based pagination as a first-class primitive. The data model
+lives in `Trellis.Core` and is transport-agnostic; the HTTP projection lives in
+`Trellis.Asp` and co-emits a JSON body envelope together with an RFC 8288 `Link`
+header so both LLM consumers (which read the JSON they already parsed) and
+RFC-aware crawlers / gateways (which follow the `Link: <…>; rel="next"` header)
+are served from the same response.
+
+This article walks through the building blocks, the canonical query-handler
+shape, and the trade-offs the design makes deliberately.
+
+## Why cursor-based, not offset-based?
+
+Offset pagination (`?page=3&pageSize=25`) re-counts the source on every request
+and breaks under inserts and deletes — the row that was at index 75 when the
+client fetched page 3 is at a different index by the time the client asks for
+page 4, producing skipped or duplicated items. Cursor-based pagination encodes a
+*position* (an Id, or a `(CreatedAt, Id)` pair) into an opaque token that the
+client echoes back. Each follow-up request is an O(log n) index seek, not an
+O(offset) scan; results are stable across concurrent writes.
+
+Trellis follows the body-envelope-with-cursor convention used by Microsoft
+Graph, OData v4, GitHub, Stripe, and most other modern APIs.
+
+## The building blocks
+
+All four types live in the `Trellis` namespace under `Trellis.Core`.
+
+| Type | Purpose |
+| --- | --- |
+| `Cursor` | Opaque continuation token (a `readonly record struct` over a `string Token`). |
+| `Page<T>` | Validated `readonly record struct` carrying `Items`, `Next`, `Previous`, `RequestedLimit`, `AppliedLimit`. |
+| `PageSize` | Pair of `Requested` + `Applied` limits with `WasCapped`; canonical parser is `PageSize.FromRequested(int?, int max)`. |
+| `CursorCodec` | Static encoder/decoder for single-key (`Id`) and composite (`CreatedAt, Id`) cursors. |
+| `PageBuilder` | Storage-agnostic over-fetch slicer that turns `applied + 1` rows into a validated `Page<T>` with the correct `Next` cursor. |
+| `Page<T>.Map<TOut>` | Instance method that projects items while preserving cursors and limits. |
+
+## The canonical query-handler shape
+
+A query handler that takes a `Cursor?` and an `int?` limit, applies the server
+cap, decodes the cursor, executes the seek query, slices the over-fetched list,
+and projects to a DTO — all without leaking exceptions:
+
+```csharp
+using Trellis;
+
+public sealed record ListOrdersQuery(string? Cursor, int? Limit)
+    : IQuery<Result<Page<OrderListItem>>>;
+
+public sealed record OrderListItem(Guid Id, decimal Amount, string Currency);
+
+public sealed class ListOrdersHandler(AppDbContext db)
+    : IQueryHandler<ListOrdersQuery, Result<Page<OrderListItem>>>
+{
+    public async ValueTask<Result<Page<OrderListItem>>> Handle(
+        ListOrdersQuery query, CancellationToken ct)
+    {
+        var pageSize = PageSize.FromRequested(query.Limit);
+
+        Guid? afterId = null;
+        if (query.Cursor is not null)
+        {
+            var decoded = CursorCodec.TryDecode<Guid>(
+                new Cursor(query.Cursor), fieldName: nameof(query.Cursor));
+            if (decoded.IsFailure)
+                return Result.Fail<Page<OrderListItem>>(decoded.Error!);
+            decoded.TryGetValue(out var id);
+            afterId = id;
+        }
+
+        var ordered = db.Orders.AsNoTracking().OrderBy(o => o.Id);
+        var filtered = afterId is { } cursorId
+            ? ordered.Where(o => o.Id.Value > cursorId)
+            : (IQueryable<Order>)ordered;
+
+        var rows = await filtered.Take(pageSize.Applied + 1).ToListAsync(ct);
+
+        return Result.Ok(
+            PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value)
+                .Map(o => new OrderListItem(o.Id.Value, o.Total.Amount, o.Total.Currency.Value)));
+    }
+}
+```
+
+The endpoint then maps `Result<Page<T>>` to the HTTP wire:
+
+```csharp
+app.MapGet("/orders", async (
+    string? cursor, int? limit, IMediator mediator, HttpContext http,
+    LinkGenerator links, CancellationToken ct) =>
+{
+    return (await mediator.Send(new ListOrdersQuery(cursor, limit), ct))
+        .ToHttpResponse(
+            nextUrlBuilder: (c, applied) =>
+                links.GetUriByName(http, "ListOrders",
+                    values: new { cursor = c.Token, limit = applied })
+                ?? throw new InvalidOperationException("Route 'ListOrders' not registered."),
+            body: page => new { items = page.Items, next = page.Next, previous = page.Previous,
+                                  requestedLimit = page.RequestedLimit, appliedLimit = page.AppliedLimit,
+                                  deliveredCount = page.DeliveredCount, wasCapped = page.WasCapped });
+}).WithName("ListOrders");
+```
+
+`Trellis.Asp` co-emits the `Link: <…>; rel="next"` header automatically from the
+`nextUrlBuilder` delegate, so both the JSON body and the header are sourced from
+a single function — there is no way for the two to drift.
+
+## `PageSize.FromRequested` — lenient by default, strict on demand
+
+Pagination parameters arrive at the transport seam; they are not domain
+invariants. `PageSize.FromRequested` is the lenient parser used in the example
+above:
+
+* `null` or a non-positive value collapses to `PageSize.Default` (50).
+* Values larger than `max` (defaults to `PageSize.Max` = 100) are clamped:
+  `Applied` becomes `max`, but `Requested` is preserved **verbatim** so the
+  caller's `WasCapped` observation survives the round-trip.
+
+```csharp
+PageSize.FromRequested(null);        // (Default, Default)  — WasCapped = false
+PageSize.FromRequested(0);           // (Default, Default)  — WasCapped = false
+PageSize.FromRequested(20);          // (20, 20)            — WasCapped = false
+PageSize.FromRequested(1000);        // (1000, 100)         — WasCapped = true
+PageSize.FromRequested(20, max: 5);  // (20, 5)             — WasCapped = true
+```
+
+When a request must be **rejected** rather than silently clamped, use
+`PageSize.TryCreate`:
+
+```csharp
+PageSize.TryCreate(1000)
+    .Match(
+        ok: size => /* ... */,
+        fail: err => Result.Fail<Page<Order>>(err));
+```
+
+`TryCreate` returns `Result.Fail<PageSize>` with `Error.InvalidInput` (field =
+`fieldName ?? "pageSize"`, reason code `"page_size.out_of_range"`) on any
+non-positive value or any value greater than `max`. Pick whichever fits your
+contract; both compose cleanly with `Page<T>`.
+
+## Cursors — opaque by design, not anti-tamper
+
+`Cursor` is just a wrapper over a string token. The encoding is `CursorCodec`'s
+business and is intentionally **not** part of the public surface:
+
+* **Single-key:** URL-safe base64 of the key's invariant-culture string form.
+* **Composite:** URL-safe base64 of `"{createdAt:O}|{id}"` in invariant culture.
+  Decoding splits at the **first** `|`, so an Id that happens to contain a pipe
+  remains unambiguous.
+
+The codec is AOT-friendly: no JSON, no reflection, no `Expression.Compile`. It
+uses `Convert.ToBase64String`, URL-safe substitution (`+`→`-`, `/`→`_`, drop
+`=` padding), and `IParsable<TKey>.TryParse` with `CultureInfo.InvariantCulture`.
+
+**Cursors are opaque so that clients don't reverse-engineer the sort key, but
+the encoding is not signed.** Services that need to defend against tampering
+must wrap or replace the codec with a signed variant; authorization filtering
+must always apply to the underlying query.
+
+### Trellis value-object IDs
+
+The generic constraint accepts any `notnull` key, and decoding requires
+`IParsable<TKey>`. Trellis value-object IDs (e.g. `OrderId : RequiredGuid<OrderId>`)
+do not directly satisfy `IParsable<TSelf>` for their underlying primitive, so
+the canonical pattern is to project to `.Value` at the boundary:
+
+```csharp
+// encode
+CursorCodec.Encode(order.Id.Value)            // .Value : Guid
+
+// decode (and rewrap)
+var decoded = CursorCodec.TryDecode<Guid>(cursor);
+return decoded.Bind(g =>
+    OrderId.TryCreate(g)
+        .MapError(_ => Error.InvalidInput.ForField("cursor", "cursor.malformed",
+                                                    "Cursor payload is not a valid OrderId.")));
+```
+
+This keeps the wire format tight (raw Guid string) and the domain type-safe
+(`OrderId` everywhere on the inside).
+
+## `PageBuilder.FromOverFetch` — the over-fetch idiom
+
+The "ask for one more than you need" idiom is how seek-style pagination
+discovers whether another page exists:
+
+```text
+applied = 25
+fetched = 26    →  page has Next     (kept = first 25; cursor from items[24])
+fetched = 25    →  page has no Next  (under-fill; this is the last page)
+fetched = 0     →  empty page        (under-fill; both cursors null)
+```
+
+`PageBuilder.FromOverFetch` encodes that logic once. The caller's only
+responsibility is to fetch `pageSize.Applied + 1` rows ordered by the same key
+the selector returns:
+
+```csharp
+var rows = await db.Orders.AsNoTracking()
+    .OrderBy(o => o.Id)
+    .Where(o => afterId == null || o.Id.Value > afterId)
+    .Take(pageSize.Applied + 1)
+    .ToListAsync(ct);
+
+var page = PageBuilder.FromOverFetch(rows, pageSize, o => o.Id.Value);
+```
+
+For stable time-ordered seek (rows with non-unique primary sort keys, e.g.
+events at the same millisecond), use the composite overload:
+
+```csharp
+var rows = await db.Events.AsNoTracking()
+    .OrderBy(e => e.CreatedAt).ThenBy(e => e.Id)
+    .Where(e => /* cursor predicate on (CreatedAt, Id) */)
+    .Take(pageSize.Applied + 1)
+    .ToListAsync(ct);
+
+var page = PageBuilder.FromOverFetch(rows, pageSize,
+    createdAtSelector: e => e.CreatedAt,
+    idSelector: e => e.Id.Value);
+```
+
+> **Selector contract.** The selectors passed to `FromOverFetch` must match the
+> sort keys used in the upstream query. Mismatched selectors produce
+> semantically wrong cursors — the boundary item the cursor points at will not
+> be the one the next query would seek past.
+
+### Forward-only by design
+
+`Page<T>.Previous` is always `null` from `PageBuilder`. Trellis does not yet
+ship a reverse-seek API, and re-running the `nextUrlBuilder` against an echoed
+"incoming" cursor would walk **forward** from that point — re-fetching the same
+page rather than the page before it. Until a real reverse-seek API exists,
+forward-only is the only correct behavior. Clients that need to go back navigate
+through their own request history.
+
+## `Page<T>.Map` — projecting to DTOs
+
+Repositories typically yield `Page<Entity>`; HTTP wire types are usually DTOs.
+`Page<T>.Map<TOut>` projects each item and preserves the cursors and limits in
+one call:
+
+```csharp
+Page<Order> entities = await repo.ListAsync(pageSize, cursor, ct);
+Page<OrderDto> response = entities.Map(o => new OrderDto(o.Id.Value, o.Total));
+```
+
+`Next`, `Previous`, `RequestedLimit`, `AppliedLimit`, and therefore `WasCapped`
+all survive the projection. Use it freely at the application/transport boundary.
+
+## ROP, not exceptions — what fails how
+
+| Failure | Result | Wire |
+| --- | --- | --- |
+| Malformed cursor token (bad base64, bad payload) | `Error.InvalidInput.ForField("cursor", "cursor.malformed", …)` | `422 Unprocessable Content` |
+| Out-of-range `limit` via `PageSize.TryCreate` | `Error.InvalidInput.ForField("pageSize", "page_size.out_of_range", …)` | `422 Unprocessable Content` |
+| Storage/timeout/connectivity | Whatever your repository chooses to surface (often `Error.Unavailable`) | `503` / `500` per `Trellis.Asp` mapping |
+| Success | `Result.Ok(page)` | `200 OK` + body envelope + `Link` header |
+
+No throw on any cursor or limit input — every failure surfaces as
+`Result.Fail<Page<T>>` and is mapped to a Problem Details response by
+`Trellis.Asp`. There is no path from a malformed query string to a 500.
+
+## Anti-patterns to avoid
+
+* **Hand-rolling base64 + JSON cursors.** `CursorCodec` already exists and is
+  AOT-safe; rolling your own duplicates the codec, drifts on culture handling,
+  and makes mistakes around `+`/`-` / `/`/`_` substitution and padding. Use the
+  codec; if you need signing, wrap it.
+* **Throwing on a bad cursor.** A malformed cursor is invalid client input, not
+  an exceptional condition. Throw a 500 and you've lost the audit trail and the
+  Problem Details body. Always return `Result.Fail<Page<T>>`.
+* **Returning items larger than the cap without `WasCapped`.** Clients can't
+  tell when the server clamped if `Requested` is rewritten to `Applied`. Use
+  `PageSize.FromRequested` (which preserves `Requested` verbatim) so the cap is
+  observable.
+* **`Items.Take(applied)` after the fact.** That works but loses the chance to
+  detect under-fill cleanly. `PageBuilder.FromOverFetch` separates the
+  "over-fetch + slice" concern from the rest of the handler.
+
+## See also
+
+* API reference: [Trellis.Core pagination types](../api_reference/trellis-api-core.md#pagination)
+* Cookbook: [Recipe 3 — Query handler returning Page<T>](../api_reference/trellis-api-cookbook.md#recipe-3--query-handler-returning-paget-paginated-list-with-cursor)
+* ADR-002 §0.7.4 — Pagination wire shape (RFC 8288 over RFC 9110 §14)

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -155,8 +155,11 @@ contract; both compose cleanly with `Page<T>`.
 
 ## Cursors — opaque by design, not anti-tamper
 
-`Cursor` is just a wrapper over a string token. The encoding is `CursorCodec`'s
-business and is intentionally **not** part of the public surface:
+`Cursor` is just a wrapper over a string token. The encoding format is
+`CursorCodec`'s business: clients must treat the token as opaque and never
+parse it. The codec itself is part of the public API so services can wrap or
+replace it (for example, to add HMAC signing) without changing the wire
+shape clients echo back:
 
 * **Single-key:** URL-safe base64 of the key's invariant-culture string form.
 * **Composite:** URL-safe base64 of `"{createdAt:O}|{id}"` in invariant culture.

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -292,4 +292,3 @@ No throw on any cursor or limit input — every failure surfaces as
 
 * API reference: [Trellis.Core pagination types](../api_reference/trellis-api-core.md#pagination)
 * Cookbook: [Recipe 3 — Query handler returning Page<T>](../api_reference/trellis-api-cookbook.md#recipe-3--query-handler-returning-paget-paginated-list-with-cursor)
-* ADR-002 §0.7.4 — Pagination wire shape (RFC 8288 over RFC 9110 §14)

--- a/docs/docfx_project/articles/pagination.md
+++ b/docs/docfx_project/articles/pagination.md
@@ -125,17 +125,20 @@ Pagination parameters arrive at the transport seam; they are not domain
 invariants. `PageSize.FromRequested` is the lenient parser used in the example
 above:
 
-* `null` or a non-positive value collapses to `PageSize.Default` (50).
+* `null` or a non-positive value collapses to `Requested = PageSize.Default`
+  (50). `Applied` is `min(Default, max)`, so when a custom `max < Default` is
+  supplied, `Applied` is clamped down further and `WasCapped` is observable.
 * Values larger than `max` (defaults to `PageSize.Max` = 100) are clamped:
   `Applied` becomes `max`, but `Requested` is preserved **verbatim** so the
   caller's `WasCapped` observation survives the round-trip.
 
 ```csharp
-PageSize.FromRequested(null);        // (Default, Default)  — WasCapped = false
-PageSize.FromRequested(0);           // (Default, Default)  — WasCapped = false
-PageSize.FromRequested(20);          // (20, 20)            — WasCapped = false
-PageSize.FromRequested(1000);        // (1000, 100)         — WasCapped = true
-PageSize.FromRequested(20, max: 5);  // (20, 5)             — WasCapped = true
+PageSize.FromRequested(null);            // (Default, Default)  — WasCapped = false
+PageSize.FromRequested(null, max: 5);    // (Default, 5)        — WasCapped = true
+PageSize.FromRequested(0);               // (Default, Default)  — WasCapped = false
+PageSize.FromRequested(20);              // (20, 20)            — WasCapped = false
+PageSize.FromRequested(1000);            // (1000, 100)         — WasCapped = true
+PageSize.FromRequested(20, max: 5);      // (20, 5)             — WasCapped = true
 ```
 
 When a request must be **rejected** rather than silently clamped, use
@@ -144,8 +147,8 @@ When a request must be **rejected** rather than silently clamped, use
 ```csharp
 PageSize.TryCreate(1000)
     .Match(
-        ok: size => /* ... */,
-        fail: err => Result.Fail<Page<Order>>(err));
+        onSuccess: size => /* ... */,
+        onFailure: err => Result.Fail<Page<Order>>(err));
 ```
 
 `TryCreate` returns `Result.Fail<PageSize>` with `Error.InvalidInput` (field =
@@ -190,7 +193,7 @@ CursorCodec.Encode(order.Id.Value)            // .Value : Guid
 var decoded = CursorCodec.TryDecode<Guid>(cursor);
 return decoded.Bind(g =>
     OrderId.TryCreate(g)
-        .MapError(_ => Error.InvalidInput.ForField("cursor", "cursor.malformed",
+        .MapOnFailure(_ => Error.InvalidInput.ForField("cursor", "cursor.malformed",
                                                     "Cursor payload is not a valid OrderId.")));
 ```
 

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -52,6 +52,8 @@
     href: integration.md
   - name: ASP.NET Core
     href: integration-aspnet.md
+  - name: Pagination
+    href: pagination.md
   - name: Single Sign-On (Google, Microsoft, OIDC)
     href: integration-sso.md
   - name: ASP.NET Core Authorization


### PR DESCRIPTION
The existing `Trellis.Core` pagination story (`Cursor` + `Page<T>`) leaves every consumer to hand-roll the same three things: clamping a requested page size to a server-side cap, encoding/decoding opaque cursors, and slicing an over-fetched buffer into a page-plus-next-cursor. The Showcase example demonstrated this with ~57 lines of inline JSON-in-base64 codec and hand-rolled clamping; Cookbook Recipe 3 repeated the pattern.

### What this adds

Four small additions to `Trellis.Core`:

- **`PageSize`** — validated record struct with `Default = 50` / `Max = 100`, a lenient `FromRequested` (clamps `Applied`, preserves `Requested` verbatim so `WasCapped` survives the wire envelope), and a strict `TryCreate` that returns `Result.Fail<PageSize>` on out-of-range input.
- **`CursorCodec`** — AOT-friendly static helper with single-key and composite `(CreatedAt, Id)` overloads. URL-safe base64 over the invariant-culture string form of the key (or `"{createdAt:O}|{id}"` for composites). Decode uses a throwing UTF-8 decoder so malformed payloads are rejected rather than silently turned into replacement characters. Failures return `Error.InvalidInput` with reason code `cursor.malformed`.
- **`PageBuilder`** — storage-agnostic over-fetch slicer. Caller fetches `Applied + 1` rows; `FromOverFetch` returns the existing `Page<T>` with the next cursor emitted from the last kept item. Forward-only (`Previous = null`) until Trellis has a real reverse-seek API.
- **`Page<T>.Map<TOut>`** — projects items while preserving `Next`, `Previous`, `RequestedLimit`, and `AppliedLimit`, so repositories can return `Page<DTO>` from `Page<Entity>` without losing cap visibility.

### Dogfooding

- `Examples/Showcase` `InMemoryAccountRepository.GetPage` rewritten using the new helpers (~57 lines → ~22, JSON-in-base64 codec deleted).
- `Examples/CookbookSnippets/Recipe03_PaginatedQuery` and Cookbook Recipe 3 rewritten to teach the canonical pattern.

### Docs

- New `docs/docfx_project/articles/pagination.md` (the recipe doc that closes ADR-002 §0.7.4 open item #6, now ticked off).
- Extended core API reference with `PageSize` / `CursorCodec` / `PageBuilder` / `Page<T>.Map` sections.

### Out of scope (deferred)

- `Trellis.EntityFrameworkCore` `ToPageAsync<T,TKey>` extension — value-object IDs plus generic key comparison need their own TDD spike across providers.
- OpenAPI `Link`-header schema transformer (ADR-002 §0.7.4 #5).
- `[Obsolete]` on byte-range collection overloads (ADR-002 §0.7.4 #3).