### PR TITLE
Document Acl-layer provider-specific column mapping for EF Core

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -295,6 +295,8 @@ public sealed class EntityTimestampInterceptor : SaveChangesInterceptor
 | `public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)` | `InterceptionResult<int>` | Sets `CreatedAt` and `LastModified` for added entities, sets `LastModified` for modified entities, and also updates `LastModified` on unchanged aggregate roots when loaded dependents are added, modified, or deleted. |
 | `public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)` | `ValueTask<InterceptionResult<int>>` | Async equivalent of `SavingChanges`; includes unchanged aggregate-root promotion when loaded dependents change. |
 
+> **Note:** `EntityTimestampInterceptor` writes the CLR property values, but the column mapping for the stored representation is still the Acl's responsibility. See [Provider-specific column mapping](#provider-specific-column-mapping) when a provider cannot translate `DateTimeOffset` (or any other CLR type) on `CreatedAt` / `LastModified`.
+
 ### `MaybeQueryableExtensions`
 
 ```csharp
@@ -724,6 +726,48 @@ using Trellis.EntityFrameworkCore;
 IReadOnlyList<MaybePropertyMapping> mappings = db.GetMaybePropertyMappings();
 string debug = db.ToMaybeMappingDebugString();
 ```
+
+### Provider-specific column mapping
+
+The Acl layer owns storage-provider compatibility for every persisted column — **including columns Trellis writes via interceptors**, such as `CreatedAt`, `LastModified`, `ETag`, and any property inherited from `Aggregate<TId>` or `Entity<TId>`. `ApplyTrellisConventions(...)` (and its source-generated equivalent `ApplyTrellisConventionsFor<TContext>()`) defines the domain-to-EF shape for Trellis-known types, but it does not make every CLR type natively queryable, sortable, or projectable on every storage provider.
+
+When a provider rejects a translated operation on one of these properties — for example a runtime translation exception of the shape *"`<Provider>` does not support expressions of type 'X' in ORDER BY clauses"*, or a comparison/predicate translation failure — the layer-correct fix is to register a `ValueConverter` on the affected property in `DbContext.OnModelCreating(...)` **after** `base.OnModelCreating(modelBuilder)`. Trellis stays provider-agnostic on purpose; provider quirks are absorbed in the Acl.
+
+Manual `Property(...).HasConversion(...)` is **discouraged** when it duplicates Trellis-supported value-object conventions (those are handled by `ApplyTrellisConventions`), but **appropriate** when it adapts an already-mapped property to a provider-specific storage or query capability that Trellis intentionally leaves to the Acl. If the offending CLR type round-trips losslessly through a sortable/comparable scalar (`string`, `long`, `decimal`), use that as the converter target.
+
+```csharp
+using System;
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+// Example: SQLite cannot ORDER BY DateTimeOffset. Convert the framework-written
+// audit columns to ISO-8601 TEXT so server-side ordering on CreatedAt /
+// LastModified works without materializing the result set first.
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        var dtoConverter = new ValueConverter<DateTimeOffset, string>(
+            v => v.UtcDateTime.ToString("O", CultureInfo.InvariantCulture),
+            v => DateTimeOffset.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var name in new[] { "CreatedAt", "LastModified" })
+            {
+                var property = entityType.FindProperty(name);
+                if (property?.ClrType == typeof(DateTimeOffset))
+                    property.SetValueConverter(dtoConverter);
+            }
+        }
+    }
+}
+```
+
+The same pattern applies to other CLR-type / provider mismatches — for example `decimal` on a provider that only supports `double`, or a value object on a document store that cannot project nested types. Identify a sortable/comparable scalar that preserves the value, register the converter in the Acl, and keep the repository query server-side rather than falling back to `ToListAsync()` + in-memory ordering.
 
 ## Cross-references
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -748,10 +748,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 // NOTE: This converter normalizes every value to UTC on write. Round-trips
 // preserve the instant but read back with Offset == TimeSpan.Zero, not the
 // original offset. That trade-off is intentional for audit columns written by
-// EntityTimestampInterceptor (which always writes DateTimeOffset.UtcNow) and
-// is required for correct cross-row ordering when writes may come from clients
-// in different timezones. Do not reuse this converter for columns where the
-// original DateTimeOffset.Offset is semantically required.
+// EntityTimestampInterceptor (which always writes a UTC DateTimeOffset via
+// TimeProvider.GetUtcNow()) and is required for correct cross-row ordering
+// when writes may come from clients in different timezones. Do not reuse this
+// converter for columns where the original DateTimeOffset.Offset is
+// semantically required.
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -733,7 +733,7 @@ The Acl layer owns storage-provider compatibility for every persisted column —
 
 When a provider rejects a translated operation on one of these properties — for example a runtime translation exception of the shape *"`<Provider>` does not support expressions of type 'X' in ORDER BY clauses"*, or a comparison/predicate translation failure — the layer-correct fix is to register a `ValueConverter` on the affected property in `DbContext.OnModelCreating(...)` **after** `base.OnModelCreating(modelBuilder)`. Trellis stays provider-agnostic on purpose; provider quirks are absorbed in the Acl.
 
-Manual `Property(...).HasConversion(...)` is **discouraged** when it duplicates Trellis-supported value-object conventions (those are handled by `ApplyTrellisConventions`), but **appropriate** when it adapts an already-mapped property to a provider-specific storage or query capability that Trellis intentionally leaves to the Acl. If the offending CLR type round-trips losslessly through a sortable/comparable scalar (`string`, `long`, `decimal`), use that as the converter target.
+Manual `Property(...).HasConversion(...)` is **discouraged** when it duplicates Trellis-supported value-object conventions (those are handled by `ApplyTrellisConventions`), but **appropriate** when it adapts an already-mapped property to a provider-specific storage or query capability that Trellis intentionally leaves to the Acl. Choose a converter target that preserves the property's intended semantic and is sortable/comparable on the provider — for instant-only audit columns like `CreatedAt` / `LastModified`, a UTC-normalized scalar (ISO-8601 text or Unix-epoch `long`) preserves the instant and sorts correctly across rows written from different timezones; for columns where the original `DateTimeOffset.Offset` carries semantic meaning, that normalization is the wrong choice and you should pick a different storage shape (a side column for the offset, or a provider with native `datetimeoffset` support).
 
 ```csharp
 using System;
@@ -742,8 +742,16 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 // Example: SQLite cannot ORDER BY DateTimeOffset. Convert the framework-written
-// audit columns to ISO-8601 TEXT so server-side ordering on CreatedAt /
+// audit columns to UTC ISO-8601 TEXT so server-side ordering on CreatedAt /
 // LastModified works without materializing the result set first.
+//
+// NOTE: This converter normalizes every value to UTC on write. Round-trips
+// preserve the instant but read back with Offset == TimeSpan.Zero, not the
+// original offset. That trade-off is intentional for audit columns written by
+// EntityTimestampInterceptor (which always writes DateTimeOffset.UtcNow) and
+// is required for correct cross-row ordering when writes may come from clients
+// in different timezones. Do not reuse this converter for columns where the
+// original DateTimeOffset.Offset is semantically required.
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
Provider-translation failures on framework-written audit columns (`CreatedAt`, `LastModified`) had no documented fix path. The reference implied the Acl should not override Trellis conventions, which led consumers toward materialize-then-sort workarounds when SQLite rejected `ORDER BY` on `DateTimeOffset`.

Adds a new "Provider-specific column mapping" section to `trellis-api-efcore` that names the Acl as the owner of storage-provider compatibility for every persisted column (including framework-written ones), prescribes registering a `ValueConverter` in `OnModelCreating` after `base.OnModelCreating`, gives a `DateTimeOffset` -> ISO-8601 worked example, and cross-references from the `EntityTimestampInterceptor` section.