### PR TITLE
Stop emitting empty .snupkg files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,10 +61,11 @@
     <!-- Release hygiene (ga-07) -->
     <!-- DotNet.ReproducibleBuilds bundles Microsoft.SourceLink.GitHub and sets
          Deterministic, ContinuousIntegrationBuild (under CI), EmbedUntrackedSources.
-         The properties below cover what it does NOT enable by default. -->
+         The properties below cover what it does NOT enable by default.
+         DebugType=embedded puts the PDB inside the DLL, so symbols travel with
+         the binary and there is nothing left to ship in a .snupkg — symbol
+         packages are intentionally disabled. -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -30,14 +30,6 @@
 
     <!-- Disable documentation requirement for analyzer project -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-
-    <!--
-      Analyzer-only package: the .dll ships under analyzers/dotnet/cs (see ItemGroup below)
-      with IncludeBuildOutput=false, so there is nothing under lib/ to symbolicate. Disable
-      symbol-package generation; otherwise SDK 10.0.203 fails with NU5017 ("Cannot create a
-      package that has no dependencies nor content") when producing the empty .snupkg.
-    -->
-    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->

--- a/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
@@ -1266,7 +1266,7 @@ Every framework `.nupkg` produced by Phases 1a–5a satisfies the following befo
 |---|---|---|
 | **Determinism** | `<Deterministic>true</Deterministic>` + `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` set in `Directory.Build.props` | CI verifies bit-identical `.nupkg` across two clean builds of the same SHA |
 | **SourceLink** | `Microsoft.SourceLink.GitHub` referenced; `<PublishRepositoryUrl>true</PublishRepositoryUrl>`, `<EmbedUntrackedSources>true</EmbedUntrackedSources>` | CI fails if any package lacks SourceLink metadata |
-| **Symbols** | `<IncludeSymbols>true</IncludeSymbols>` + `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` | `.snupkg` published to symbol server alongside `.nupkg` |
+| **Symbols** | `<DebugType>embedded</DebugType>` (default from `DotNet.ReproducibleBuilds`) embeds the PDB inside the DLL, which ships inside each `.nupkg`. No separate `.snupkg` is produced. | `dotnet pack` emits a `.nupkg` only; consumers get step-into debugging via the embedded PDB + SourceLink without a symbol-server roundtrip |
 | **Strong naming** | All runtime assemblies signed with the `Trellis.snk` key (already in repo for v1) | CI fails if any output assembly is unsigned |
 | **AOT / trim** | `<IsAotCompatible>true</IsAotCompatible>` + `<IsTrimmable>true</IsTrimmable>` per §12.6 | CI builds a trimmed/AOT test harness and fails on any IL2026/IL2070/IL3050 warning |
 | **Public API tracking** | `Microsoft.CodeAnalysis.PublicApiAnalyzers` with `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` per package | CI fails on undocumented public-API additions/removals |


### PR DESCRIPTION
## Issue

`dotnet pack` was producing an empty `.snupkg` (~2 KB manifest, no PDB content) for every project alongside each `.nupkg`. The symbol packages had nothing useful in them because `DotNet.ReproducibleBuilds` sets `DebugType=embedded`, which already puts each PDB inside its DLL — and therefore inside the `.nupkg`. The two `.snupkg`-generating properties (`IncludeSymbols=true` and `SymbolPackageFormat=snupkg`) and the embedded-PDB baseline are mutually exclusive; only one of them gets to carry the symbols.

These properties were introduced together with the other GA release-hygiene flags in 7a72bbdd without the embedded-PDB conflict being noticed.

## Fix

Removes `IncludeSymbols` and `SymbolPackageFormat` from `Directory.Build.props`. Embedded PDBs and SourceLink metadata continue to ship inside every `.nupkg` via `PublishRepositoryUrl=true`, `EmbedUntrackedSources=true`, and the embedded `DebugType` default. Consumers still get step-into debugging without a symbol-server roundtrip.

Verified by repacking `Trellis.Core`: `bin\Release` now contains only `Trellis.Core.3.0.0-alpha.303.nupkg` (no companion `.snupkg`), and the `.nupkg` size is unchanged from prior builds — confirming the embedded PDB was always doing the real work.