### PR TITLE
Run docs workflow on manual dispatch only

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,17 +2,6 @@
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'docs/**'
-      - '**/*.cs'
-      - '.github/workflows/documentation.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-      - '**/*.cs'
-      - '.github/workflows/documentation.yml'
 
 jobs:
   publish-docs:
@@ -139,14 +128,10 @@ jobs:
         echo "Documentation build successful"
 
     - name: Deploy to GitHub Pages
-      # Manual-only publish to gh-pages, restricted to main:
-      #
-      # * The doc build above runs on every PR/push to main as the quality gate
-      #   (warnings-as-errors catches link/xref/bookmark drift).
-      # * Deployment happens ONLY when the workflow is dispatched manually
-      #   AND the dispatch ref is main — so a manual run on a topic branch
-      #   never publishes that branch's _site to gh-pages.
-      if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+      # Branch guard: even though the workflow only runs on manual dispatch,
+      # restrict deployment to dispatches from main so dispatching the workflow
+      # against a topic branch never publishes that branch's _site to gh-pages.
+      if: github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

The `Publish documentation.` workflow had three triggers: `workflow_dispatch`, `pull_request` (paths `docs/**`, `**/*.cs`, the workflow file), and `push` to `main` (same paths). The deploy step was already manual-only via `if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'` — the `gh-pages` branch last updated on 2026-05-02 and the deploy step on today's `#526` merge run shows status `skipped`.

The build half, however, ran on every qualifying PR and `main` push as a doc-drift quality gate (docfx warnings-as-errors + stale `Error.X` factory detection + stale current-facing docs audit). Combined with the workflow being named `Publish documentation.`, the repeated green runs in the Actions tab read as "publication is happening automatically".

## Fix

Removes the `push` and `pull_request` triggers. The workflow now runs only when manually dispatched. The deploy step's branch guard is retained (`github.ref == 'refs/heads/main'`) so dispatching from a topic branch still never publishes that branch's `_site` to `gh-pages`; the now-redundant `github.event_name == 'workflow_dispatch'` check is dropped from the if: condition.

Trade-off: doc-drift (broken xrefs, stale `Error.X` factory refs, missing bookmark targets) no longer fails CI on PRs — it only surfaces when someone manually dispatches the workflow. Authors who want a local preflight can run `docfx docs/docfx_project/docfx.json` and `./docs/docfx_project/api_reference/audit-stale-docs.ps1` locally before merging doc-touching changes.