### PR TITLE
Add ErrorRetryExtensions for transport-neutral retry classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — retry classification
+
+- **`Trellis.Core`** — transport-neutral retry classification over the closed `Error` catalog: `RetryClassification` enum (`Transient`, `Permanent`, `FailFast`) and the static `ErrorRetryExtensions` class with `error.Classify()`, `error.IsTransient()`, `error.IsPermanent()`, `error.IsFailFast()`, and `error.GetRetryAdvice()`. `Classify` is exhaustive over all 12 `Error` cases. `Error.Aggregate` uses max-severity semantics over its inners; `GetRetryAdvice` returns `null` for `Error.Aggregate` by design. `Error.TransportFault` defaults to `Permanent` because every transport-specific payload shipped today (`HttpError.MethodNotAllowed`, `NotAcceptable`, `PreconditionFailed`, `ContentTooLarge`, `UnsupportedMediaType`, `RangeNotSatisfiable`, `PreconditionRequired`) is a caller-side error; retryable transient transport outcomes (HTTP 429, HTTP 503) are mapped at the boundary to `Error.RateLimited` / `Error.Unavailable` and never reach `Error.TransportFault`. Replaces hand-rolled `gatewayResult.Error is Error.Unavailable or Error.RateLimited` switches in worker loops, message consumers, and outbound-gateway clients.
+
 ### Added — pagination ergonomics
 
 - **`Trellis.Core`** — first-class cursor pagination primitives shared by every storage adapter and transport: `PageSize` (with `FromRequested` lenient parser and `TryCreate` strict parser), `Cursor` (opaque `readonly record struct`), `CursorCodec` (URL-safe base64 encode / `TryDecode<TKey>` returning `Result<TKey>` with `Error.InvalidInput.ForField(..., "cursor.malformed", ...)` on bad input), `Page<T>` (`Items`, `Next`, `Previous`, `RequestedLimit`, `AppliedLimit`, `WasCapped`, `DeliveredCount`), `Page<T>.Map<TOut>` (preserves cursors and limits across DTO projection), and `PageBuilder.FromOverFetch` (storage-agnostic over-fetch slicer for single-key and composite `(CreatedAt, Id)` seek). All AOT-friendly — no JSON, no reflection, no `Expression.Compile`.

--- a/Trellis.Core/NUGET_README.md
+++ b/Trellis.Core/NUGET_README.md
@@ -27,6 +27,7 @@ Result<string> email = Result.Ok("ada@example.com")
 - Build resource-aware HTTP errors tersely with `ResourceRef.For<TResource>(id)`.
 - Define custom `Required*<TSelf>` value objects with source-generated parsing, JSON conversion, and tracing support.
 - Persist staged state alongside a failure with `Result.FailAfterCommit<T>(error)` — opt-in for background-worker handlers that need a permanent-failure transition to commit even though the handler returns a failed result.
+- Classify `Error` values into `Transient` / `Permanent` / `FailFast` retry buckets with `error.Classify()` / `error.IsTransient()` / `error.GetRetryAdvice()` — transport-neutral helpers for worker, consumer, and outbound-gateway retry loops.
 
 ## `Result<T>` is not directly JSON-serializable
 

--- a/Trellis.Core/README.md
+++ b/Trellis.Core/README.md
@@ -27,6 +27,7 @@ Result<string> email = Result.Ok("ada@example.com")
 - Build resource-aware HTTP errors tersely with `ResourceRef.For<TResource>(id)`.
 - Define custom `Required*<TSelf>` value objects with source-generated parsing, JSON conversion, and tracing support.
 - Persist staged state alongside a failure with `Result.FailAfterCommit<T>(error)` — opt-in for background-worker handlers that need a permanent-failure transition to commit even though the handler returns a failed result.
+- Classify `Error` values into `Transient` / `Permanent` / `FailFast` retry buckets with `error.Classify()` / `error.IsTransient()` / `error.GetRetryAdvice()` — transport-neutral helpers for worker, consumer, and outbound-gateway retry loops.
 
 ## `Result<T>` is not directly JSON-serializable
 

--- a/Trellis.Core/src/Errors/ErrorRetryExtensions.cs
+++ b/Trellis.Core/src/Errors/ErrorRetryExtensions.cs
@@ -55,7 +55,7 @@ public static class ErrorRetryExtensions
     /// <item><term><see cref="Error.Unavailable"/></term><description><see cref="RetryClassification.Transient"/></description></item>
     /// <item><term><see cref="Error.RateLimited"/></term><description><see cref="RetryClassification.Transient"/></description></item>
     /// <item><term><see cref="Error.Unexpected"/></term><description><see cref="RetryClassification.Transient"/> — see below</description></item>
-    /// <item><term><see cref="Error.TransportFault"/></term><description><see cref="RetryClassification.Transient"/></description></item>
+    /// <item><term><see cref="Error.TransportFault"/></term><description><see cref="RetryClassification.Permanent"/> — see below</description></item>
     /// <item><term><see cref="Error.AuthenticationRequired"/></term><description><see cref="RetryClassification.FailFast"/></description></item>
     /// <item><term><see cref="Error.Forbidden"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
     /// <item><term><see cref="Error.InvalidInput"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
@@ -75,6 +75,20 @@ public static class ErrorRetryExtensions
     /// internal faults and surface deterministic failures as
     /// <see cref="Error.InvariantViolation"/>, <see cref="Error.InvalidInput"/>, or
     /// <see cref="Error.Conflict"/> instead. Consumers must still cap retries.
+    /// </para>
+    /// <para>
+    /// <b>Why <see cref="Error.TransportFault"/> is <see cref="RetryClassification.Permanent"/>.</b>
+    /// <see cref="ITransportFault"/> is opaque from <c>Trellis.Core</c>'s perspective; the
+    /// concrete payload is defined by transport-specific packages (for example
+    /// <c>HttpError</c> in <c>Trellis.Http.Abstractions</c>). The retryable transient
+    /// outcomes those transports produce (HTTP 429, HTTP 503, gRPC <c>UNAVAILABLE</c>) are
+    /// mapped at the boundary to <see cref="Error.RateLimited"/> and
+    /// <see cref="Error.Unavailable"/> — which carry <see cref="RetryAdvice"/> — and never
+    /// reach <see cref="Error.TransportFault"/>. Every <c>HttpError</c> case shipped today
+    /// (405, 406, 412, 413, 415, 416, 428) is a caller-side error that will not succeed by
+    /// waiting and retrying. Transport packages that surface their own retryable transient
+    /// faults via <see cref="Error.TransportFault"/> should provide a transport-aware
+    /// classification extension that overrides this default for those specific faults.
     /// </para>
     /// <para>
     /// <b>Why <see cref="Error.Conflict"/> is <see cref="RetryClassification.Permanent"/>.</b>
@@ -102,7 +116,7 @@ public static class ErrorRetryExtensions
             Error.Unavailable => RetryClassification.Transient,
             Error.RateLimited => RetryClassification.Transient,
             Error.Unexpected => RetryClassification.Transient,
-            Error.TransportFault => RetryClassification.Transient,
+            Error.TransportFault => RetryClassification.Permanent,
             Error.AuthenticationRequired => RetryClassification.FailFast,
             Error.Forbidden => RetryClassification.Permanent,
             Error.InvalidInput => RetryClassification.Permanent,

--- a/Trellis.Core/src/Errors/ErrorRetryExtensions.cs
+++ b/Trellis.Core/src/Errors/ErrorRetryExtensions.cs
@@ -1,0 +1,190 @@
+﻿namespace Trellis;
+
+/// <summary>
+/// Transport-neutral retry-classification helpers over the closed <see cref="Error"/>
+/// catalog. Lets workers, message consumers, and outbound-gateway callers ask "should I
+/// retry this, give up on this item, or halt the batch?" without hand-rolling parallel
+/// <c>switch</c> blocks against framework error types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Scope.</b> These helpers answer the generic "retry the same operation later"
+/// question. Domain-specific retry shapes (optimistic-concurrency reload-and-retry for
+/// <see cref="Error.Conflict"/>; INSERT-with-regenerated-natural-key retry for
+/// <c>SaveChangesWithRetryAsync</c>) require their own primitives because they have to
+/// mutate state before retrying. Consumers writing such loops should switch on the
+/// concrete <see cref="Error"/> shape directly, not call <see cref="Classify"/>.
+/// </para>
+/// <para>
+/// <b>Eventually-consistent reads.</b> <see cref="Error.NotFound"/> and
+/// <see cref="Error.Gone"/> default to <see cref="RetryClassification.Permanent"/>.
+/// Services whose reads are eventually consistent (read-your-own-writes against a
+/// replicated store, message consumers ahead of write replication) should override
+/// locally rather than expect the framework default to infer their model.
+/// </para>
+/// <para>
+/// <b>Override pattern.</b> Consumers that disagree with the default mapping for one or
+/// more cases should branch on the concrete shape first and only fall back to
+/// <see cref="Classify"/> for the cases they don't override:
+/// <code language="csharp">
+/// var classification = error switch
+/// {
+///     Error.Conflict c when c.ReasonCode == "concurrent_modification" =&gt; RetryClassification.Transient,
+///     _ =&gt; error.Classify(),
+/// };
+/// </code>
+/// </para>
+/// </remarks>
+public static class ErrorRetryExtensions
+{
+    /// <summary>
+    /// Classifies an <see cref="Error"/> using the framework's default transport-neutral
+    /// mapping. Use the result to decide whether the surrounding worker / consumer loop
+    /// should retry this item, give up on it, or halt the batch entirely.
+    /// </summary>
+    /// <param name="error">The error to classify.</param>
+    /// <returns>The default <see cref="RetryClassification"/> for <paramref name="error"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// <b>Default mapping</b> (every nested case of <see cref="Error"/> is enumerated;
+    /// the catalog is closed so the table is exhaustive at framework-publish time):
+    /// </para>
+    /// <list type="table">
+    /// <listheader><term>Error case</term><description>Classification</description></listheader>
+    /// <item><term><see cref="Error.Unavailable"/></term><description><see cref="RetryClassification.Transient"/></description></item>
+    /// <item><term><see cref="Error.RateLimited"/></term><description><see cref="RetryClassification.Transient"/></description></item>
+    /// <item><term><see cref="Error.Unexpected"/></term><description><see cref="RetryClassification.Transient"/> — see below</description></item>
+    /// <item><term><see cref="Error.TransportFault"/></term><description><see cref="RetryClassification.Transient"/></description></item>
+    /// <item><term><see cref="Error.AuthenticationRequired"/></term><description><see cref="RetryClassification.FailFast"/></description></item>
+    /// <item><term><see cref="Error.Forbidden"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
+    /// <item><term><see cref="Error.InvalidInput"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
+    /// <item><term><see cref="Error.InvariantViolation"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
+    /// <item><term><see cref="Error.NotFound"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
+    /// <item><term><see cref="Error.Gone"/></term><description><see cref="RetryClassification.Permanent"/></description></item>
+    /// <item><term><see cref="Error.Conflict"/></term><description><see cref="RetryClassification.Permanent"/> — see below</description></item>
+    /// <item><term><see cref="Error.Aggregate"/></term><description>Recursive max-severity: <see cref="RetryClassification.FailFast"/> if any inner classifies as <see cref="RetryClassification.FailFast"/>; otherwise <see cref="RetryClassification.Permanent"/> if any inner classifies as <see cref="RetryClassification.Permanent"/>; otherwise <see cref="RetryClassification.Transient"/>.</description></item>
+    /// </list>
+    /// <para>
+    /// <b>Why <see cref="Error.Unexpected"/> is <see cref="RetryClassification.Transient"/>.</b>
+    /// <see cref="Error.Unexpected"/> wraps unhandled exceptions and other "this should not
+    /// have happened" situations. A retry can hide a deterministic bug (the same code path
+    /// will throw again the next time), but it can also recover a transient failure (a
+    /// momentary serialization error, a stale connection). The default favours
+    /// availability: producers should reserve <see cref="Error.Unexpected"/> for unknown
+    /// internal faults and surface deterministic failures as
+    /// <see cref="Error.InvariantViolation"/>, <see cref="Error.InvalidInput"/>, or
+    /// <see cref="Error.Conflict"/> instead. Consumers must still cap retries.
+    /// </para>
+    /// <para>
+    /// <b>Why <see cref="Error.Conflict"/> is <see cref="RetryClassification.Permanent"/>.</b>
+    /// Resolving a 409-shaped conflict typically requires conflict-specific work (reload
+    /// the current rowversion, re-apply the change, regenerate a colliding natural key)
+    /// that a generic outer retry loop cannot perform. Domains that have a meaningful
+    /// retry strategy for a conflict should override locally as shown above, or use a
+    /// dedicated primitive like <c>DbContext.SaveChangesWithRetryAsync</c>.
+    /// </para>
+    /// <para>
+    /// <b>Aggregate semantics.</b> The aggregate classification answers "should I retry
+    /// the operation that produced this aggregate <em>as an indivisible unit</em>?" A
+    /// mixed aggregate of a permanent and a transient failure is classified
+    /// <see cref="RetryClassification.Permanent"/> because retrying the unit will not
+    /// change the permanent inner's outcome. Callers that need to retry the transient
+    /// parts independently must iterate over <see cref="Error.Aggregate.Errors"/> and
+    /// classify each inner separately.
+    /// </para>
+    /// </remarks>
+    public static RetryClassification Classify(this Error error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return error switch
+        {
+            Error.Unavailable => RetryClassification.Transient,
+            Error.RateLimited => RetryClassification.Transient,
+            Error.Unexpected => RetryClassification.Transient,
+            Error.TransportFault => RetryClassification.Transient,
+            Error.AuthenticationRequired => RetryClassification.FailFast,
+            Error.Forbidden => RetryClassification.Permanent,
+            Error.InvalidInput => RetryClassification.Permanent,
+            Error.InvariantViolation => RetryClassification.Permanent,
+            Error.NotFound => RetryClassification.Permanent,
+            Error.Gone => RetryClassification.Permanent,
+            Error.Conflict => RetryClassification.Permanent,
+            Error.Aggregate agg => ClassifyAggregate(agg),
+            _ => RetryClassification.Permanent,
+        };
+    }
+
+    /// <summary>
+    /// Convenience predicate equivalent to
+    /// <c><see cref="Classify"/>(error) == <see cref="RetryClassification.Transient"/></c>.
+    /// </summary>
+    /// <param name="error">The error to classify.</param>
+    /// <returns><see langword="true"/> if <paramref name="error"/> is classified as <see cref="RetryClassification.Transient"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is <see langword="null"/>.</exception>
+    public static bool IsTransient(this Error error) =>
+        Classify(error) == RetryClassification.Transient;
+
+    /// <summary>
+    /// Convenience predicate equivalent to
+    /// <c><see cref="Classify"/>(error) == <see cref="RetryClassification.Permanent"/></c>.
+    /// </summary>
+    /// <param name="error">The error to classify.</param>
+    /// <returns><see langword="true"/> if <paramref name="error"/> is classified as <see cref="RetryClassification.Permanent"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is <see langword="null"/>.</exception>
+    public static bool IsPermanent(this Error error) =>
+        Classify(error) == RetryClassification.Permanent;
+
+    /// <summary>
+    /// Convenience predicate equivalent to
+    /// <c><see cref="Classify"/>(error) == <see cref="RetryClassification.FailFast"/></c>.
+    /// </summary>
+    /// <param name="error">The error to classify.</param>
+    /// <returns><see langword="true"/> if <paramref name="error"/> is classified as <see cref="RetryClassification.FailFast"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is <see langword="null"/>.</exception>
+    public static bool IsFailFast(this Error error) =>
+        Classify(error) == RetryClassification.FailFast;
+
+    /// <summary>
+    /// Returns the <see cref="RetryAdvice"/> carried by the error, when the producer
+    /// supplied one. Currently only <see cref="Error.RateLimited"/> and
+    /// <see cref="Error.Unavailable"/> carry advice; all other cases (including
+    /// <see cref="Error.Aggregate"/>) return <see langword="null"/>.
+    /// </summary>
+    /// <param name="error">The error to inspect.</param>
+    /// <returns>The producer-supplied <see cref="RetryAdvice"/>, or <see langword="null"/> when none was supplied.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// <b>Aggregate returns <see langword="null"/> by design.</b> Returning advice from
+    /// the first transient inner would (a) contradict <see cref="Classify"/> when the
+    /// aggregate classifies as <see cref="RetryClassification.Permanent"/> or
+    /// <see cref="RetryClassification.FailFast"/>, and (b) silently under-wait when later
+    /// inners suggest a longer delay. Callers that want a per-inner retry policy should
+    /// iterate over <see cref="Error.Aggregate.Errors"/> and apply their own merge rule.
+    /// </para>
+    /// </remarks>
+    public static RetryAdvice? GetRetryAdvice(this Error error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return error switch
+        {
+            Error.RateLimited rl => rl.Retry,
+            Error.Unavailable un => un.Retry,
+            _ => null,
+        };
+    }
+
+    private static RetryClassification ClassifyAggregate(Error.Aggregate aggregate)
+    {
+        var max = RetryClassification.Transient;
+        foreach (var inner in aggregate.Errors)
+        {
+            var c = Classify(inner);
+            if (c > max) max = c;
+            if (max == RetryClassification.FailFast) break;
+        }
+
+        return max;
+    }
+}

--- a/Trellis.Core/src/Errors/RetryClassification.cs
+++ b/Trellis.Core/src/Errors/RetryClassification.cs
@@ -1,0 +1,42 @@
+﻿namespace Trellis;
+
+/// <summary>
+/// Transport-neutral classification of <see cref="Error"/> values for outer retry loops
+/// (background workers, message-broker consumers, outbound-gateway callers). Answers the
+/// question "given this failure, what should the surrounding job do next?" without
+/// committing to any specific transport or retry policy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three values are defined; the numeric ordering encodes severity so that
+/// <see cref="ErrorRetryExtensions.Classify(Error)"/> can use <c>max</c> semantics when
+/// classifying an <see cref="Error.Aggregate"/>:
+/// <see cref="Transient"/> &lt; <see cref="Permanent"/> &lt; <see cref="FailFast"/>.
+/// Consumers should treat the ordering as an implementation detail and prefer pattern
+/// matching on the enum members rather than numeric comparisons.
+/// </para>
+/// </remarks>
+public enum RetryClassification
+{
+    /// <summary>
+    /// Retrying the same operation later is likely to succeed. Honour any
+    /// <see cref="RetryAdvice"/> returned by
+    /// <see cref="ErrorRetryExtensions.GetRetryAdvice(Error)"/> when scheduling the retry;
+    /// fall back to the consumer's default backoff policy when no advice is present.
+    /// </summary>
+    Transient = 0,
+
+    /// <summary>
+    /// Retrying the same operation will not change the outcome. The caller should drop
+    /// this work item, surface the failure to its observability sink, and move on to the
+    /// next item.
+    /// </summary>
+    Permanent = 1,
+
+    /// <summary>
+    /// The failure cannot be recovered in-process and indicates a precondition for the
+    /// whole job is no longer met (e.g. credentials revoked). The caller should halt
+    /// the surrounding batch / consumer loop rather than process further items.
+    /// </summary>
+    FailFast = 2,
+}

--- a/Trellis.Core/tests/Errors/ErrorRetryExtensionsTests.cs
+++ b/Trellis.Core/tests/Errors/ErrorRetryExtensionsTests.cs
@@ -1,0 +1,312 @@
+﻿namespace Trellis.Core.Tests.Errors;
+
+using System.Linq;
+using System.Reflection;
+using Trellis.Testing;
+
+/// <summary>
+/// Tests for <see cref="ErrorRetryExtensions"/> and <see cref="RetryClassification"/>.
+/// Covers the default classification of every nested case of <see cref="Error"/>,
+/// aggregate max-severity semantics, retry-advice extraction, the predicate convenience
+/// helpers, null-argument handling, and a reflection-based exhaustiveness guard that
+/// fails when a new nested case of <see cref="Error"/> ships without an explicit
+/// classification.
+/// </summary>
+public class ErrorRetryExtensionsTests
+{
+    private static readonly ResourceRef SampleResource = ResourceRef.For<Sample>("id-1");
+
+    private sealed record Sample(string Id);
+
+    private sealed record SampleTransportFault(string Name) : ITransportFault;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Direct classification per Error case
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public static TheoryData<Error, RetryClassification> ClassificationCases() => new()
+    {
+        { new Error.Unavailable(), RetryClassification.Transient },
+        { new Error.RateLimited(), RetryClassification.Transient },
+        { new Error.Unexpected("unhandled_exception"), RetryClassification.Transient },
+        { new Error.TransportFault(new SampleTransportFault("http-timeout")), RetryClassification.Transient },
+        { new Error.AuthenticationRequired(), RetryClassification.FailFast },
+        { new Error.Forbidden("policy.deny"), RetryClassification.Permanent },
+        { Error.InvalidInput.ForField("name", "required"), RetryClassification.Permanent },
+        { new Error.InvariantViolation("order_must_have_items"), RetryClassification.Permanent },
+        { new Error.NotFound(SampleResource), RetryClassification.Permanent },
+        { new Error.Gone(SampleResource), RetryClassification.Permanent },
+        { new Error.Conflict(SampleResource, "duplicate_key"), RetryClassification.Permanent },
+    };
+
+    [Theory]
+    [MemberData(nameof(ClassificationCases))]
+    public void Classify_returns_expected_classification_for_each_error_case(
+        Error error, RetryClassification expected) =>
+        error.Classify().Should().Be(expected);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Aggregate classification: max-severity semantics
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Classify_aggregate_with_only_transient_inners_returns_transient()
+    {
+        var agg = new Error.Aggregate(
+            new Error.Unavailable(),
+            new Error.RateLimited(),
+            new Error.Unexpected("io"));
+
+        agg.Classify().Should().Be(RetryClassification.Transient);
+    }
+
+    [Fact]
+    public void Classify_aggregate_with_mixed_transient_and_permanent_returns_permanent()
+    {
+        var agg = new Error.Aggregate(
+            new Error.Unavailable(),
+            new Error.NotFound(SampleResource));
+
+        agg.Classify().Should().Be(RetryClassification.Permanent);
+    }
+
+    [Fact]
+    public void Classify_aggregate_with_any_failfast_inner_returns_failfast()
+    {
+        var agg = new Error.Aggregate(
+            new Error.Unavailable(),
+            new Error.AuthenticationRequired("Bearer"));
+
+        agg.Classify().Should().Be(RetryClassification.FailFast);
+    }
+
+    [Fact]
+    public void Classify_aggregate_with_failfast_and_permanent_inners_returns_failfast()
+    {
+        var agg = new Error.Aggregate(
+            new Error.NotFound(SampleResource),
+            new Error.AuthenticationRequired());
+
+        agg.Classify().Should().Be(RetryClassification.FailFast);
+    }
+
+    [Fact]
+    public void Classify_aggregate_with_only_permanent_inners_returns_permanent()
+    {
+        var agg = new Error.Aggregate(
+            new Error.NotFound(SampleResource),
+            new Error.Forbidden("policy.deny"));
+
+        agg.Classify().Should().Be(RetryClassification.Permanent);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Predicate helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsTransient_true_when_classification_is_transient()
+    {
+        new Error.Unavailable().IsTransient().Should().BeTrue();
+        new Error.NotFound(SampleResource).IsTransient().Should().BeFalse();
+        new Error.AuthenticationRequired().IsTransient().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPermanent_true_when_classification_is_permanent()
+    {
+        new Error.NotFound(SampleResource).IsPermanent().Should().BeTrue();
+        new Error.Unavailable().IsPermanent().Should().BeFalse();
+        new Error.AuthenticationRequired().IsPermanent().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsFailFast_true_when_classification_is_failfast()
+    {
+        new Error.AuthenticationRequired().IsFailFast().Should().BeTrue();
+        new Error.Unavailable().IsFailFast().Should().BeFalse();
+        new Error.NotFound(SampleResource).IsFailFast().Should().BeFalse();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GetRetryAdvice
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetRetryAdvice_returns_advice_supplied_by_RateLimited()
+    {
+        var advice = new RetryAdvice(After: TimeSpan.FromSeconds(30));
+
+        var error = new Error.RateLimited(advice);
+
+        error.GetRetryAdvice().Should().Be(advice);
+    }
+
+    [Fact]
+    public void GetRetryAdvice_returns_advice_supplied_by_Unavailable()
+    {
+        var at = DateTimeOffset.UtcNow.AddSeconds(15);
+        var advice = new RetryAdvice(At: at);
+
+        var error = new Error.Unavailable(ReasonCode: "db_unreachable", Retry: advice);
+
+        error.GetRetryAdvice().Should().Be(advice);
+    }
+
+    [Fact]
+    public void GetRetryAdvice_returns_null_when_RateLimited_has_no_advice() =>
+        new Error.RateLimited().GetRetryAdvice().Should().BeNull();
+
+    [Fact]
+    public void GetRetryAdvice_returns_null_when_Unavailable_has_no_advice() =>
+        new Error.Unavailable().GetRetryAdvice().Should().BeNull();
+
+    public static TheoryData<Error> NonAdviceCarryingCases() => new()
+    {
+        new Error.Unexpected("io"),
+        new Error.TransportFault(new SampleTransportFault("timeout")),
+        new Error.AuthenticationRequired(),
+        new Error.Forbidden("policy.deny"),
+        Error.InvalidInput.ForField("name", "required"),
+        new Error.InvariantViolation("rule"),
+        new Error.NotFound(SampleResource),
+        new Error.Gone(SampleResource),
+        new Error.Conflict(SampleResource, "duplicate_key"),
+    };
+
+    [Theory]
+    [MemberData(nameof(NonAdviceCarryingCases))]
+    public void GetRetryAdvice_returns_null_for_cases_that_do_not_carry_advice(Error error) =>
+        error.GetRetryAdvice().Should().BeNull();
+
+    [Fact]
+    public void GetRetryAdvice_returns_null_for_aggregate_even_when_inner_carries_advice()
+    {
+        // Aggregate intentionally returns null so callers cannot accidentally retry a
+        // Permanent or FailFast aggregate using an inner Transient's advice.
+        var advice = new RetryAdvice(After: TimeSpan.FromSeconds(30));
+        var agg = new Error.Aggregate(
+            new Error.NotFound(SampleResource),
+            new Error.RateLimited(advice));
+
+        agg.GetRetryAdvice().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetRetryAdvice_returns_null_for_aggregate_of_only_transient_inners()
+    {
+        // Even when every inner is Transient (so the aggregate classifies Transient),
+        // the helper deliberately returns null to force consumers to apply their own
+        // merge rule over potentially-conflicting inner hints.
+        var agg = new Error.Aggregate(
+            new Error.Unavailable(Retry: new RetryAdvice(After: TimeSpan.FromSeconds(1))),
+            new Error.RateLimited(new RetryAdvice(After: TimeSpan.FromMinutes(1))));
+
+        agg.GetRetryAdvice().Should().BeNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Null-argument handling
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Classify_throws_on_null()
+    {
+        var act = () => ErrorRetryExtensions.Classify(null!);
+
+        act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("error");
+    }
+
+    [Fact]
+    public void IsTransient_throws_on_null()
+    {
+        var act = () => ErrorRetryExtensions.IsTransient(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void IsPermanent_throws_on_null()
+    {
+        var act = () => ErrorRetryExtensions.IsPermanent(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void IsFailFast_throws_on_null()
+    {
+        var act = () => ErrorRetryExtensions.IsFailFast(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetRetryAdvice_throws_on_null()
+    {
+        var act = () => ErrorRetryExtensions.GetRetryAdvice(null!);
+
+        act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("error");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Enum severity ordering (relied on by aggregate max-semantics)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RetryClassification_numeric_ordering_encodes_severity_low_to_high()
+    {
+        // The ClassifyAggregate implementation relies on the ordering
+        // Transient (0) < Permanent (1) < FailFast (2). Pin it so a future re-ordering
+        // surfaces as a test failure rather than a silent semantic change.
+        ((int)RetryClassification.Transient).Should().Be(0);
+        ((int)RetryClassification.Permanent).Should().Be(1);
+        ((int)RetryClassification.FailFast).Should().Be(2);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Exhaustiveness guard — fails loudly when a new Error nested case is added
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Discovers every nested <c>sealed record</c> derived from <see cref="Error"/> via
+    /// reflection. If a new case is added to the closed catalog without updating
+    /// <see cref="ErrorRetryExtensions.Classify(Error)"/>, this test fails with the name
+    /// of the unhandled case so the author is forced to make an explicit decision.
+    /// Aggregate is excluded because it is covered by dedicated aggregate-semantics tests.
+    /// </summary>
+    [Fact]
+    public void Classify_handles_every_nested_Error_case_explicitly()
+    {
+        var nestedCases = typeof(Error)
+            .GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(Error).IsAssignableFrom(t))
+            .Where(t => t != typeof(Error.Aggregate))
+            .OrderBy(t => t.Name)
+            .ToArray();
+
+        nestedCases.Should().NotBeEmpty("the closed Error catalog must contain at least one case");
+
+        var expectedHandledCases = new[]
+        {
+            nameof(Error.AuthenticationRequired),
+            nameof(Error.Conflict),
+            nameof(Error.Forbidden),
+            nameof(Error.Gone),
+            nameof(Error.InvalidInput),
+            nameof(Error.InvariantViolation),
+            nameof(Error.NotFound),
+            nameof(Error.RateLimited),
+            nameof(Error.TransportFault),
+            nameof(Error.Unavailable),
+            nameof(Error.Unexpected),
+        };
+
+        nestedCases.Select(t => t.Name).Should().BeEquivalentTo(
+            expectedHandledCases,
+            "every non-Aggregate nested Error case must have an explicit classification in " +
+            "ErrorRetryExtensions.Classify (the fallback `_ => Permanent` is a safety net, not " +
+            "a substitute for an intentional mapping). Add the new case to the switch in " +
+            "ErrorRetryExtensions and to the expectedHandledCases list in this test.");
+    }
+}

--- a/Trellis.Core/tests/Errors/ErrorRetryExtensionsTests.cs
+++ b/Trellis.Core/tests/Errors/ErrorRetryExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ErrorRetryExtensionsTests
         { new Error.Unavailable(), RetryClassification.Transient },
         { new Error.RateLimited(), RetryClassification.Transient },
         { new Error.Unexpected("unhandled_exception"), RetryClassification.Transient },
-        { new Error.TransportFault(new SampleTransportFault("http-timeout")), RetryClassification.Transient },
+        { new Error.TransportFault(new SampleTransportFault("http-timeout")), RetryClassification.Permanent },
         { new Error.AuthenticationRequired(), RetryClassification.FailFast },
         { new Error.Forbidden("policy.deny"), RetryClassification.Permanent },
         { Error.InvalidInput.ForField("name", "required"), RetryClassification.Permanent },

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -553,9 +553,9 @@ HTTP-specific status codes, headers, and problem-details `type` tokens are not t
 
 | Error case | Classification |
 | --- | --- |
-| `Error.Unavailable`, `Error.RateLimited`, `Error.Unexpected`, `Error.TransportFault` | `Transient` |
+| `Error.Unavailable`, `Error.RateLimited`, `Error.Unexpected` | `Transient` |
 | `Error.AuthenticationRequired` | `FailFast` |
-| `Error.Forbidden`, `Error.InvalidInput`, `Error.InvariantViolation`, `Error.NotFound`, `Error.Gone`, `Error.Conflict` | `Permanent` |
+| `Error.Forbidden`, `Error.InvalidInput`, `Error.InvariantViolation`, `Error.NotFound`, `Error.Gone`, `Error.Conflict`, `Error.TransportFault` | `Permanent` |
 
 `Error.Aggregate` is classified by max-severity over its inner errors (the constructor flattens nested aggregates, so the inners are never themselves `Aggregate`): `FailFast` if any inner classifies as `FailFast`; otherwise `Permanent` if any inner classifies as `Permanent`; otherwise `Transient`. The rule answers "should I retry the operation that produced this aggregate **as an indivisible unit?**" — a mixed `Aggregate(Permanent, Transient)` is `Permanent` because retrying the unit will not change the permanent inner's outcome. Callers that want per-inner retry granularity must iterate over `agg.Errors` themselves.
 
@@ -564,6 +564,8 @@ HTTP-specific status codes, headers, and problem-details `type` tokens are not t
 **Conflict and eventually-consistent reads.** `Error.Conflict` defaults to `Permanent` because a generic outer retry loop cannot perform the conflict-specific work (rowversion reload, natural-key regeneration) that 409-shaped failures usually require. Domains with a meaningful conflict retry strategy should override locally — branch on the concrete shape first and only call `Classify()` in the fallback arm — or use a dedicated primitive such as `DbContext.SaveChangesWithRetryAsync` (see [trellis-api-efcore.md](trellis-api-efcore.md)). `Error.NotFound` and `Error.Gone` default to `Permanent`; services whose reads are eventually consistent should override the mapping locally rather than expect the framework default to infer their consistency model.
 
 **Why `Error.Unexpected` is `Transient`.** `Error.Unexpected` wraps unhandled exceptions and "this should not have happened" conditions. A retry can hide a deterministic bug or recover a momentary failure; the default favours availability. Producers should reserve `Error.Unexpected` for unknown internal faults and surface deterministic failures as `Error.InvariantViolation`, `Error.InvalidInput`, or `Error.Conflict` instead. Consumers must still cap retries.
+
+**Why `Error.TransportFault` is `Permanent`.** `ITransportFault` is opaque from `Trellis.Core`'s perspective; concrete payloads (such as `HttpError` in `Trellis.Http.Abstractions`) are defined by transport-specific packages. The retryable transient outcomes those transports produce (HTTP 429, HTTP 503, gRPC `UNAVAILABLE`) are mapped at the boundary to `Error.RateLimited` and `Error.Unavailable` — which carry `RetryAdvice` — and never reach `Error.TransportFault`. Every `HttpError` case shipped today (405, 406, 412, 413, 415, 416, 428) is a caller-side error that will not succeed by waiting and retrying. Transport packages that surface their own retryable transient faults via `Error.TransportFault` should provide a transport-aware classification extension that overrides this default for the specific faults that are genuinely retryable.
 
 #### Supporting types
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-05-06
 audience: [llm]
@@ -31,6 +31,7 @@ Use this table before searching the long type catalog.
 | Return success/failure without payload | `Result.Ok()` / `Result.Fail(error)` (returns `Result<Unit>`) | [`Result`](#public-static-partial-class-result) |
 | Return success/failure with payload | `Result.Ok(value)` / `Result.Fail<T>(error)` | [`Result<TValue>`](#public-readonly-struct-resulttvalue--iresulttvalue-iequatableresulttvalue-ifailurefactoryresulttvalue-ipersistonfailure) |
 | Fail but still persist staged work (worker pattern) | `Result.FailAfterCommit<T>(error)` / `Result.FailAfterCommit(error)` | [`Result`](#public-static-partial-class-result), [`IPersistOnFailure`](#public-interface-ipersistonfailure) |
+| Classify an `Error` for a worker/consumer retry loop | `error.Classify()` / `error.IsTransient()` / `error.IsPermanent()` / `error.IsFailFast()` / `error.GetRetryAdvice()` | [`Retry classification`](#retry-classification-errorretryextensions) |
 | Turn a boolean guard into a result | `Result.Ensure(condition, error)` or `.Ensure(...)` in a chain | [`Result`](#public-static-partial-class-result), [`Ensure family`](#ensure-family--ensureextensions-ensureextensionsasync-ensureallextensions-ensureallextensionsasync) |
 | Start independent async result-producing operations concurrently | `Result.ParallelAsync(...)`, then combine the returned tasks | [`Result`](#public-static-partial-class-result) |
 | Combine multiple validated *typed* fields into a tuple | static `Result.Combine<T1,T2>(Result<T1>, Result<T2>)` or instance `r1.Combine(r2)`, then `.Map(...)` | [`Combine family`](#combine-family--combineextensions-combineextensionsasync-combineerrorextensions) |
@@ -535,6 +536,34 @@ Domain code treats `ITransportFault` as opaque and does not inspect concrete tra
 `RetryAdvice` is a transport-neutral retry hint: `public readonly record struct RetryAdvice(TimeSpan? After = null, DateTimeOffset? At = null);`. `Error.RateLimited` and `Error.Unavailable` carry it so the boundary can emit `Retry-After` without teaching the domain about HTTP headers.
 
 HTTP-specific status codes, headers, and problem-details `type` tokens are not the domain's responsibility. See [trellis-api-asp.md](trellis-api-asp.md#trellisaspoptions) for the boundary mapping table.
+
+#### Retry classification (ErrorRetryExtensions)
+
+`ErrorRetryExtensions` (static class in the `Trellis` namespace) and the `RetryClassification` enum (`Transient = 0`, `Permanent = 1`, `FailFast = 2`) translate the closed `Error` catalog into the three decisions a worker, message-broker consumer, or outbound-gateway caller has to make on every failed item: retry, give up, or halt the batch.
+
+| Extension on `Error` | Returns | Purpose |
+| --- | --- | --- |
+| `RetryClassification Classify(this Error error)` | `RetryClassification` | Default mapping for every nested `Error` case. Throws `ArgumentNullException` on `null`. |
+| `bool IsTransient(this Error error)` | `bool` | Shorthand for `Classify(error) == RetryClassification.Transient`. |
+| `bool IsPermanent(this Error error)` | `bool` | Shorthand for `Classify(error) == RetryClassification.Permanent`. |
+| `bool IsFailFast(this Error error)` | `bool` | Shorthand for `Classify(error) == RetryClassification.FailFast`. |
+| `RetryAdvice? GetRetryAdvice(this Error error)` | `RetryAdvice?` | Returns advice carried by `Error.RateLimited` / `Error.Unavailable`. Returns `null` for every other case, including `Error.Aggregate` (intentional — see below). |
+
+**Default classification table.** Every non-aggregate nested case of `Error` is enumerated; the catalog is closed so the table is exhaustive at framework-publish time:
+
+| Error case | Classification |
+| --- | --- |
+| `Error.Unavailable`, `Error.RateLimited`, `Error.Unexpected`, `Error.TransportFault` | `Transient` |
+| `Error.AuthenticationRequired` | `FailFast` |
+| `Error.Forbidden`, `Error.InvalidInput`, `Error.InvariantViolation`, `Error.NotFound`, `Error.Gone`, `Error.Conflict` | `Permanent` |
+
+`Error.Aggregate` is classified by max-severity over its inner errors (the constructor flattens nested aggregates, so the inners are never themselves `Aggregate`): `FailFast` if any inner classifies as `FailFast`; otherwise `Permanent` if any inner classifies as `Permanent`; otherwise `Transient`. The rule answers "should I retry the operation that produced this aggregate **as an indivisible unit?**" — a mixed `Aggregate(Permanent, Transient)` is `Permanent` because retrying the unit will not change the permanent inner's outcome. Callers that want per-inner retry granularity must iterate over `agg.Errors` themselves.
+
+**`GetRetryAdvice` for `Error.Aggregate` always returns `null`.** Two reasons: (1) returning the first transient inner's advice would contradict `Classify` whenever the aggregate is `Permanent` or `FailFast`, and (2) under-waiting is order-dependent (a `RateLimited(1s)` followed by a `RateLimited(60s)` would suggest 1 s). Callers that want a merged hint must define their own policy over the inner errors.
+
+**Conflict and eventually-consistent reads.** `Error.Conflict` defaults to `Permanent` because a generic outer retry loop cannot perform the conflict-specific work (rowversion reload, natural-key regeneration) that 409-shaped failures usually require. Domains with a meaningful conflict retry strategy should override locally — branch on the concrete shape first and only call `Classify()` in the fallback arm — or use a dedicated primitive such as `DbContext.SaveChangesWithRetryAsync` (see [trellis-api-efcore.md](trellis-api-efcore.md)). `Error.NotFound` and `Error.Gone` default to `Permanent`; services whose reads are eventually consistent should override the mapping locally rather than expect the framework default to infer their consistency model.
+
+**Why `Error.Unexpected` is `Transient`.** `Error.Unexpected` wraps unhandled exceptions and "this should not have happened" conditions. A retry can hide a deterministic bug or recover a momentary failure; the default favours availability. Producers should reserve `Error.Unexpected` for unknown internal faults and surface deterministic failures as `Error.InvariantViolation`, `Error.InvalidInput`, or `Error.Conflict` instead. Consumers must still cap retries.
 
 #### Supporting types
 

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -702,7 +702,7 @@ public async ValueTask<Result<Reminder>> Handle(
 }
 ```
 
-`Error.IsTransient()` / `IsPermanent()` / `IsFailFast()` / `Classify()` (the `ErrorRetryExtensions` helpers in the `Trellis` namespace) is the canonical worker-side retry classifier. It covers `Error.Unavailable` and `Error.RateLimited` as transient, folds in `Error.Unexpected` (so an unanticipated exception in a downstream gateway doesn't permanently park the message), separates `Error.AuthenticationRequired` as fail-fast (halt the batch — not the same as a per-item permanent failure), and handles `Error.Aggregate` with max-severity semantics. The hand-written `is Error.Unavailable or Error.RateLimited` switch is incomplete on every axis and should not be repeated.
+The `ErrorRetryExtensions` helpers in the `Trellis` namespace (`Error.IsTransient()`, `IsPermanent()`, `IsFailFast()`, `Classify()`) are the canonical worker-side retry classifier. They cover `Error.Unavailable` and `Error.RateLimited` as transient, fold in `Error.Unexpected` (so an unanticipated exception in a downstream gateway doesn't permanently park the message), separate `Error.AuthenticationRequired` as fail-fast (halt the batch — not the same as a per-item permanent failure), and handle `Error.Aggregate` with max-severity semantics. The hand-written `is Error.Unavailable or Error.RateLimited` switch is incomplete on every axis and should not be repeated.
 
 Pipeline behavior at this point:
 

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -686,7 +686,7 @@ public async ValueTask<Result<Reminder>> Handle(
     }
 
     // Transient → ordinary failure: nothing persists, retry will re-enter the handler.
-    if (gatewayResult.Error is Error.Unavailable or Error.RateLimited)
+    if (gatewayResult.Error.IsTransient())
         return Result.Fail<Reminder>(gatewayResult.Error);
 
     // Permanent failure → mark the row and persist that decision alongside the failure outcome.
@@ -696,6 +696,8 @@ public async ValueTask<Result<Reminder>> Handle(
     return Result.FailAfterCommit<Reminder>(gatewayResult.Error);
 }
 ```
+
+`Error.IsTransient()` (and the sibling `IsPermanent()` / `IsFailFast()` / `Classify()` helpers in `Trellis.Core.ErrorRetryExtensions`) is the canonical worker-side retry classifier. It covers `Error.Unavailable` and `Error.RateLimited` as transient, but also folds in `Error.Unexpected` (so an unanticipated exception in a downstream gateway doesn't permanently park the message) and `Error.Aggregate` with max-severity semantics. The hand-written `is Error.Unavailable or Error.RateLimited` switch is incomplete on both axes and should not be repeated.
 
 Pipeline behavior at this point:
 

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -685,6 +685,11 @@ public async ValueTask<Result<Reminder>> Handle(
         return Result.Ok(reminder);
     }
 
+    // Fail-fast (e.g., AuthenticationRequired) → ordinary failure; nothing persists,
+    // and the caller halts the batch instead of treating the item as permanently failed.
+    if (gatewayResult.Error.IsFailFast())
+        return Result.Fail<Reminder>(gatewayResult.Error);
+
     // Transient → ordinary failure: nothing persists, retry will re-enter the handler.
     if (gatewayResult.Error.IsTransient())
         return Result.Fail<Reminder>(gatewayResult.Error);
@@ -697,7 +702,7 @@ public async ValueTask<Result<Reminder>> Handle(
 }
 ```
 
-`Error.IsTransient()` (and the sibling `IsPermanent()` / `IsFailFast()` / `Classify()` helpers in `Trellis.Core.ErrorRetryExtensions`) is the canonical worker-side retry classifier. It covers `Error.Unavailable` and `Error.RateLimited` as transient, but also folds in `Error.Unexpected` (so an unanticipated exception in a downstream gateway doesn't permanently park the message) and `Error.Aggregate` with max-severity semantics. The hand-written `is Error.Unavailable or Error.RateLimited` switch is incomplete on both axes and should not be repeated.
+`Error.IsTransient()` / `IsPermanent()` / `IsFailFast()` / `Classify()` (the `ErrorRetryExtensions` helpers in the `Trellis` namespace) is the canonical worker-side retry classifier. It covers `Error.Unavailable` and `Error.RateLimited` as transient, folds in `Error.Unexpected` (so an unanticipated exception in a downstream gateway doesn't permanently park the message), separates `Error.AuthenticationRequired` as fail-fast (halt the batch — not the same as a per-item permanent failure), and handles `Error.Aggregate` with max-severity semantics. The hand-written `is Error.Unavailable or Error.RateLimited` switch is incomplete on every axis and should not be repeated.
 
 Pipeline behavior at this point:
 


### PR DESCRIPTION
## Issue

Worker loops, message consumers, and outbound-gateway clients all need to decide whether a failed operation should be retried. Each call site currently re-derives that decision from a hand-rolled switch on `Error` cases, with inconsistent treatment of `Unexpected`, `Conflict`, `NotFound`, and `Aggregate`.

## Fix

A closed-ADT classifier in `Trellis.Core`:

- `RetryClassification` enum: `Transient`, `Permanent`, `FailFast`.
- `error.Classify()`  exhaustive switch over all 12 `Error` cases.
- `error.IsTransient()` / `IsPermanent()` / `IsFailFast()`  predicate sugar.
- `error.GetRetryAdvice()`  surfaces `RateLimited` / `Unavailable` advice as `RetryAdvice?`.

Design choices documented in the XML docs:

- `Aggregate` uses max-severity, so a single `FailFast` or `Permanent` member escalates the whole batch (correct for ""retry as a unit"").
- `GetRetryAdvice` returns `null` for `Aggregate` by design  picking one member's advice would silently under-wait.
- `Unexpected` maps to `Transient` so a single unanticipated exception doesn't permanently park a worker message. Callers that know a specific `Unexpected` is terminal override locally.
- `Conflict` / `NotFound` / `Gone` default to `Permanent` because the typical optimistic-concurrency and read-your-write resolutions are caller-specific.

A reflection-based exhaustiveness test fails if a new `Error` case ships without being added to the classifier, so the closed-ADT safety-net branch can never silently mis-classify a future case.

Closes #530