### PR TITLE
Document FailAfterCommit composition anti-pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation — `FailAfterCommit` composition anti-pattern
+
+- **`Trellis.Core`** — `Result.FailAfterCommit<T>(error)` XML remarks now explicitly call out that the helper is a *leaf* worker-handler operation and must not be threaded through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync`. The `PersistOnFailure` flag OR-accumulates onto aggregated failures, which silently commits the staged permanent-failure mutation alongside any other legs' outcomes — almost never what the handler author intended. The new guidance directs authors to restructure such handlers so the aggregating step runs to its terminal outcome first and `FailAfterCommit` is invoked as a terminal step (or in a follow-up command).
+- **`docs/docfx_project/api_reference/trellis-api-anti-patterns.md`** — new "Result.FailAfterCommit composed with aggregating operators" entry with a WRONG / FIX gallery example.
+- **`docs/docfx_project/api_reference/trellis-api-core.md`** — IPersistOnFailure section gains an "Anti-pattern" subsection pointing at the new anti-pattern entry, plus the existing pipeline-composition table.
+
 ### Added — Silent-403 diagnostics and `NestedJsonPathClaimsActorProvider`
 
 - **`Trellis.Asp`** — `ClaimsActorProvider` now emits two startup-diagnostics log entries (each throttled to fire at most once per application lifetime) that surface the silent-403 footgun caused by mis-configured nested-JSON identity-provider claims (Auth0 `app_metadata.roles`, Azure B2C `extension_*`, some Okta token shapes): **EventId 2** (Warning) fires when the configured `PermissionsClaim` resolves to zero entries on an authenticated identity that carries other claims; **EventId 3** (Error) fires when the configured claim resolves to a single value that parses as a JSON object or array. The diagnostics name the configured claim, list a sample of present claim types, and recommend `NestedJsonPathClaimsActorProvider`.

--- a/Trellis.Core/src/Result/Result.cs
+++ b/Trellis.Core/src/Result/Result.cs
@@ -81,6 +81,19 @@ public static partial class Result
     /// without an upstream source (e.g., <c>Ensure</c> evaluating <c>false</c> on a previously
     /// successful value, <c>EnsureNotNull</c>'s value-was-null branch) do <em>not</em> set the flag.
     /// </para>
+    /// <para>
+    /// <strong>Do not compose <c>FailAfterCommit</c> with aggregating operators.</strong>
+    /// <c>FailAfterCommit</c> is a <em>leaf</em> worker-handler operation: it converts a single
+    /// aggregate's transient external rejection into a persisted <c>permanently_failed</c> state
+    /// and returns. Threading that result through <c>Combine</c>, <c>TraverseAll</c>,
+    /// <c>SequenceAll</c>, or <c>WhenAllAsync</c> — composing it with the outcomes of other,
+    /// independent operations — is outside the supported pattern. The OR-accumulated flag will
+    /// then commit the staged permanent-failure mutation alongside whatever the other legs
+    /// produced, which is unlikely to match the handler author's intent. Restructure such
+    /// handlers so the aggregating step runs to its terminal outcome first and
+    /// <c>FailAfterCommit</c> is invoked at the end (or in a follow-up command), never as a
+    /// leg inside a multi-aggregate composition.
+    /// </para>
     /// </remarks>
     public static Result<TValue> FailAfterCommit<TValue>(Error error)
     {

--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -265,3 +265,47 @@ public sealed partial class Address : ValueObject
 ```
 
 > Severity: Error. When TRLS038 fires, the generator skips source generation for that type.
+
+## (No analyzer) — `Result.FailAfterCommit` composed with aggregating operators
+
+Not an analyzer-flagged rule (no diagnostic ID), but a recurring shape that the FailAfterCommit XML doc cautions against. `Result.FailAfterCommit<TValue>(error)` is a **leaf** worker-handler operation: it converts a single aggregate's transient external rejection into a persisted `permanently_failed` state and returns. Threading that result through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync` OR-accumulates the `PersistOnFailure` flag onto the aggregated failure — `TransactionalCommandBehavior` then commits the staged permanent-failure mutation alongside whatever the other legs produced, which is almost never what the handler author intended.
+
+```csharp
+// WRONG — FailAfterCommit composed with Combine: the staged permanent-failure mutation
+// commits alongside the validation-failure leg, even though the validation failure was
+// the deciding factor.
+public async Task<Result<OrderOutcome>> Handle(ProcessOrderCommand cmd, CancellationToken ct)
+{
+    Result<Unit> stagePermanentFailure = await MarkOrderAsPermanentlyFailedAsync(cmd.OrderId, ct);
+    // ↑ returns Result.FailAfterCommit(new Error.Unavailable(...))
+
+    Result<int> independentRule = Result.Fail<int>(
+        Error.InvalidInput.ForRule("downstream_limit_exceeded", "Customer is over quota."));
+
+    return stagePermanentFailure
+        .Combine(independentRule)
+        .Map((_, _) => new OrderOutcome(/* ... */));
+    // ↑ aggregated Error contains BOTH inner errors AND carries PersistOnFailure = true,
+    //   so TransactionalCommandBehavior commits the permanently_failed mutation.
+}
+
+// FIX — Treat FailAfterCommit as a terminal step. Run the aggregating composition to its
+// own terminal outcome first, THEN decide whether to invoke FailAfterCommit (typically in
+// a separate command or at the end of the handler with no further composition).
+public async Task<Result<OrderOutcome>> Handle(ProcessOrderCommand cmd, CancellationToken ct)
+{
+    Result<int> independentRule = Result.Fail<int>(
+        Error.InvalidInput.ForRule("downstream_limit_exceeded", "Customer is over quota."));
+
+    if (independentRule.IsFailure)
+        return Result.Fail<OrderOutcome>(independentRule.Error!);
+
+    // Now decide whether the external state warrants a persisted permanent-failure record.
+    // No composition with other legs — FailAfterCommit is the leaf.
+    return (await MarkOrderAsPermanentlyFailedAsync(cmd.OrderId, ct))
+        .Map(_ => new OrderOutcome(/* ... */));
+}
+```
+
+> Severity: Documentation only — no analyzer fires. The intent of `FailAfterCommit` is durable persistence of a permanent-failure state on a single aggregate; aggregating it across legs reaches outside that intent and produces partial commits the consumer rarely wants.
+

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -266,6 +266,12 @@ Opt-in marker carried by result types whose **failure** outcome should still tri
 | `TransactionalCommandBehavior` (`Trellis.EntityFrameworkCore`) | Commits staged changes on success **or** persist-on-failure. Commit error on a persist-on-failure outcome replaces the handler error in the returned response. |
 | `DomainEventDispatchBehavior` (`Trellis.Mediator`) | Treats persist-on-failure as failure: events are **not** dispatched. Events the handler raised on aggregates remain on those in-memory instances and are discarded with the request scope — they are not a durable retry buffer. Model post-failure side effects via an outbox row or a dedicated follow-up command. |
 
+#### Anti-pattern — composing `FailAfterCommit` with aggregating operators
+
+`Result.FailAfterCommit<T>(error)` is a **leaf** worker-handler operation: it converts a single aggregate's transient external rejection into a persisted `permanently_failed` state and returns. Threading that result through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync` OR-accumulates the `PersistOnFailure` flag onto the aggregated failure — `TransactionalCommandBehavior` then commits the staged permanent-failure mutation alongside whatever the other legs produced, which is almost never what the handler author intended.
+
+**Restructure** such handlers so the aggregating step runs to its terminal outcome first and `FailAfterCommit` is invoked at the end (or in a follow-up command), never as a leg inside a multi-aggregate composition. See [`trellis-api-anti-patterns.md`](trellis-api-anti-patterns.md#no-analyzer--resultfailaftercommit-composed-with-aggregating-operators) for the WRONG / FIX gallery entry.
+
 ---
 
 ### `public readonly struct Result<TValue> : IResult<TValue>, IEquatable<Result<TValue>>, IFailureFactory<Result<TValue>>, IPersistOnFailure`


### PR DESCRIPTION
Documentation-only follow-up to PR-2b's verdict on the original `add-persist-on-failure-seam` design ask. Adds explicit guidance — to the existing `Result.FailAfterCommit` XML remarks, the anti-pattern gallery, and `trellis-api-core.md` — that `FailAfterCommit` is a leaf worker-handler operation and must not be threaded through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync`.

## Why docs-only

The original reviewer's option set was: (A) breaking `WorkerOutcome<T>` sum-type rewrite; (B) add `WithoutPersistOnFailure()` seam operator + analyzer; or (C) AND-accumulate the persist-on-failure flag instead of OR-accumulating.

After re-reading the existing 53-line `Result.cs` XML doc on `FailAfterCommit`, none of (A)-(C) is the right response:

- (A) over-corrects — the documented worker-handler pattern is sound and widely used.
- (B) only helps developers who already know they need the seam — same discoverability gap as today.
- (C) inverts a documented semantic (intentional persistence by any opted-in leg) that the framework deliberately chose.

The reporter's repro mixes `FailAfterCommit` (a single-aggregate leaf operation) with `Combine` (a multi-leg composition). That composition isn't a documented or recommended pattern — the doc explicitly names ONE canonical use case. The right fix is to *tell authors how to structure code* rather than warn them post-hoc with an operator or analyzer.

## What changed

- `Trellis.Core/src/Result/Result.cs` — appended a paragraph to the `FailAfterCommit` XML remarks block calling out the composition restriction.
- `docs/docfx_project/api_reference/trellis-api-anti-patterns.md` — new "Result.FailAfterCommit composed with aggregating operators" entry with a WRONG / FIX example showing how to restructure the handler.
- `docs/docfx_project/api_reference/trellis-api-core.md` — `IPersistOnFailure` section gains an "Anti-pattern" subsection pointing at the new gallery entry.
- `CHANGELOG.md` — new `[Unreleased]` documentation entry.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors (XML doc validates).
- No code changes → no test churn; existing tests still pass.
- No diagnostic, no analyzer, no API surface change.