### PR TITLE
Document owner-by-id authorization quick-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation — owner-by-id authorization quick-start
+
+- **`docs/docfx_project/api_reference/trellis-api-authorization.md`** — new "Owner check in 8 lines — copy this" section at the top of the document, before the Patterns Index. Names the canonical owner-on-loaded-resource pattern (`IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>` so the framework reuses `SharedResourceLoaderById<TResource, TId>`) and shows the complete 16-line setup. The Patterns Index gains a top-of-table row pointing back at the quick-start.
+- **`docs/docfx_project/api_reference/trellis-api-cookbook.md`** — Recipe 7 reordered so the canonical owner case appears first (with explanatory comments naming it as "the 90% case"), then the static-permission gate. Recipe 24's decision matrix gains an explicit "Owner-by-id check on the command's resource (the 90% case)" row at the top so consumers debugging an authorization path land on the simplest match first.
+
 ### Documentation — `FailAfterCommit` composition anti-pattern
 
 - **`Trellis.Core`** — `Result.FailAfterCommit<T>(error)` XML remarks now explicitly call out that the helper is a *leaf* worker-handler operation and must not be threaded through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync`. The `PersistOnFailure` flag OR-accumulates onto aggregated failures, which silently commits the staged permanent-failure mutation alongside any other legs' outcomes — almost never what the handler author intended. The new guidance directs authors to restructure such handlers so the aggregating step runs to its terminal outcome first and `FailAfterCommit` is invoked as a terminal step (or in a follow-up command).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation — owner-by-id authorization quick-start
 
-- **`docs/docfx_project/api_reference/trellis-api-authorization.md`** — new "Owner check in 8 lines — copy this" section at the top of the document, before the Patterns Index. Names the canonical owner-on-loaded-resource pattern (`IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>` so the framework reuses `SharedResourceLoaderById<TResource, TId>`) and shows the complete 16-line setup. The Patterns Index gains a top-of-table row pointing back at the quick-start.
+- **`docs/docfx_project/api_reference/trellis-api-authorization.md`** — new "Owner check quick-start — copy this" section at the top of the document, before the Patterns Index. Names the canonical owner-on-loaded-resource pattern (`IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>` so the framework reuses `SharedResourceLoaderById<TResource, TId>`) and shows the complete copy-paste setup. The Patterns Index gains a top-of-table row pointing back at the quick-start.
 - **`docs/docfx_project/api_reference/trellis-api-cookbook.md`** — Recipe 7 reordered so the canonical owner case appears first (with explanatory comments naming it as "the 90% case"), then the static-permission gate. Recipe 24's decision matrix gains an explicit "Owner-by-id check on the command's resource (the 90% case)" row at the top so consumers debugging an authorization path land on the simplest match first.
 
 ### Documentation — `FailAfterCommit` composition anti-pattern

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -23,10 +23,45 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 - You are implementing static permission authorization through `IAuthorize`.
 - You are implementing resource-based authorization through `IAuthorizeResource<TResource>` and want the canonical guard shape.
 
+## Owner check in 8 lines — copy this
+
+The 90% case is "the command's resource id is loaded, and the actor must be the owner (or hold an admin permission)." For that shape, implement two interfaces — `IAuthorizeResource<TResource>` for the owner check and `IIdentifyResource<TResource, TId>` so the framework reuses the shared `SharedResourceLoaderById<TResource, TId>` instead of requiring a per-command loader.
+
+```csharp
+using Trellis;
+using Trellis.Authorization;
+
+public sealed record CancelOrderCommand(OrderId OrderId)
+    : ICommand<Result<Unit>>,
+      IAuthorizeResource<Order>,
+      IIdentifyResource<Order, OrderId>
+{
+    public OrderId GetResourceId() => OrderId;
+
+    public IResult Authorize(Actor actor, Order resource) =>
+        resource.OwnerId == actor.Id || actor.HasPermission("orders:admin")
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("orders.owner", ResourceRef.For<Order>(OrderId)));
+}
+
+// DI (composition root):
+services.AddResourceAuthorization<CancelOrderCommand, Order, Result<Unit>>();
+// One per command — AOT-safe; or use the assembly-scanning overload.
+```
+
+That's it. The mediator pipeline:
+
+1. resolves the actor via the registered `IActorProvider`,
+2. loads the `Order` by `OrderId` via the shared `SharedResourceLoaderById<Order, OrderId>` (auto-registered when the command implements `IIdentifyResource<Order, OrderId>`),
+3. calls `Authorize(actor, order)`.
+
+For multi-hop authorization (the resource the actor must own is reached via one or more navigation hops, including the cricket "actor owns home OR away team" shape), use `IAuthorizeResourceVia<TOwner>` with `IIdentifyRelatedResource[s]<TRelated, TId>` along the path — see cookbook [Recipe 24](trellis-api-cookbook.md#recipe-24--indirect-multi-hop-resource-authorization).
+
 ## Patterns Index
 
 | Goal | Canonical API / pattern | See |
 |---|---|---|
+| **Owner check on the command's resource (the 90% case)** | Implement `IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>`; the framework loads via `SharedResourceLoaderById<TResource, TId>` and calls `Authorize(actor, resource)` | [Owner check in 8 lines](#owner-check-in-8-lines--copy-this) |
 | Represent the current user/service | `Actor` | [`Actor`](#actor) |
 | Check granted permissions with explicit deny override | `actor.HasPermission(...)`, `HasAllPermissions(...)`, `HasAnyPermission(...)` | [`Actor`](#actor) |
 | Resolve actor for a request/message | `IActorProvider.GetCurrentActorAsync(...)` | [`IActorProvider`](#iactorprovider) |

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -23,7 +23,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md) — recipes using t
 - You are implementing static permission authorization through `IAuthorize`.
 - You are implementing resource-based authorization through `IAuthorizeResource<TResource>` and want the canonical guard shape.
 
-## Owner check in 8 lines — copy this
+## Owner check quick-start — copy this
 
 The 90% case is "the command's resource id is loaded, and the actor must be the owner (or hold an admin permission)." For that shape, implement two interfaces — `IAuthorizeResource<TResource>` for the owner check and `IIdentifyResource<TResource, TId>` so the framework reuses the shared `SharedResourceLoaderById<TResource, TId>` instead of requiring a per-command loader.
 
@@ -41,7 +41,9 @@ public sealed record CancelOrderCommand(OrderId OrderId)
     public IResult Authorize(Actor actor, Order resource) =>
         resource.OwnerId == actor.Id || actor.HasPermission("orders:admin")
             ? Result.Ok()
-            : Result.Fail(new Error.Forbidden("orders.owner", ResourceRef.For<Order>(OrderId)));
+            : Result.Fail(new Error.Forbidden(
+                PolicyId: "orders.owner",
+                Resource: ResourceRef.For<Order>(OrderId)));
 }
 
 // DI (composition root):
@@ -61,7 +63,7 @@ For multi-hop authorization (the resource the actor must own is reached via one 
 
 | Goal | Canonical API / pattern | See |
 |---|---|---|
-| **Owner check on the command's resource (the 90% case)** | Implement `IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>`; the framework loads via `SharedResourceLoaderById<TResource, TId>` and calls `Authorize(actor, resource)` | [Owner check in 8 lines](#owner-check-in-8-lines--copy-this) |
+| **Owner check on the command's resource (the 90% case)** | Implement `IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>`; the framework loads via `SharedResourceLoaderById<TResource, TId>` and calls `Authorize(actor, resource)` | [Owner check quick-start](#owner-check-quick-start--copy-this) |
 | Represent the current user/service | `Actor` | [`Actor`](#actor) |
 | Check granted permissions with explicit deny override | `actor.HasPermission(...)`, `HasAllPermissions(...)`, `HasAnyPermission(...)` | [`Actor`](#actor) |
 | Resolve actor for a request/message | `IActorProvider.GetCurrentActorAsync(...)` | [`IActorProvider`](#iactorprovider) |

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -446,7 +446,7 @@ app.MapGet("/blobs/{id:guid}", async (Guid id, IBlobRepository repo, Cancellatio
 
 ## Recipe 7 — Authorization: `IActorProvider` + `IAuthorize` + resource-based auth
 
-**Problem.** Static (permission) authorization on a delete command, plus resource-based ownership check on an update command — all via the mediator pipeline.
+**Problem.** Resource-based ownership check on an update command (the 90% case) plus a static permission gate on a delete command, all via the mediator pipeline.
 
 ```csharp
 using Trellis;
@@ -454,11 +454,9 @@ using Trellis.Asp.Authorization;
 using Trellis.Authorization;
 using Trellis.Primitives;
 
-public sealed record DeleteOrderCommand(OrderId OrderId) : ICommand<Result<Unit>>, IAuthorize
-{
-    public IReadOnlyList<string> RequiredPermissions => ["orders:delete"];
-}
-
+// CANONICAL OWNER CHECK — the 90% case. Implement IAuthorizeResource<TResource> for the
+// owner rule and IIdentifyResource<TResource, TId> so the framework reuses the shared
+// SharedResourceLoaderById<TResource, TId> instead of requiring a per-command loader.
 public sealed record UpdateOrderCommand(OrderId OrderId, Money NewTotal)
     : ICommand<Result<Unit>>, IAuthorizeResource<Order>, IIdentifyResource<Order, OrderId>
 {
@@ -471,6 +469,14 @@ public sealed record UpdateOrderCommand(OrderId OrderId, Money NewTotal)
         resource.OwnerId == actor.Id || actor.Permissions.Contains("orders:write")
             ? Result.Ok()
             : Result.Fail(new Error.Forbidden(PolicyId: "orders.owner", Resource: ResourceRef.For<Order>(OrderId)));
+}
+
+// Static permission gate (no resource load needed): every actor with the named permission
+// can run the command. Use IAuthorize when the authorization decision does not depend on
+// any resource state.
+public sealed record DeleteOrderCommand(OrderId OrderId) : ICommand<Result<Unit>>, IAuthorize
+{
+    public IReadOnlyList<string> RequiredPermissions => ["orders:delete"];
 }
 
 // DI wiring
@@ -488,7 +494,9 @@ services.AddResourceAuthorization(
     typeof(OrderResourceLoader).Assembly);      // ACL assembly (IResourceLoader<,> implementations)
 ```
 
-**What it shows.** `IAuthorize` enforces an AND-permission gate via `AuthorizationBehavior<,>`. `IAuthorizeResource<TResource>` runs *after* `IResourceLoader<TMessage, TResource>` produces the loaded resource, then calls `Authorize(actor, resource)`. Combining `IAuthorizeResource<TResource>` with `IIdentifyResource<TResource, TId>` lets the framework reuse the shared `SharedResourceLoaderById<TResource, TId>` instead of requiring a per-command loader.
+**What it shows.** Lead with `IAuthorizeResource<TResource>` + `IIdentifyResource<TResource, TId>` for the owner-on-loaded-resource case — that pair covers most domain authorization decisions, and the framework wires up `SharedResourceLoaderById<TResource, TId>` automatically so no per-command loader is needed. Fall back to `IAuthorize` for static permission gates that do not require a resource load. `IAuthorizeResource<TResource>` runs *after* the resource loader produces the loaded resource, then calls `Authorize(actor, resource)`; `IAuthorize` enforces an AND-permission gate via `AuthorizationBehavior<,>` before the handler runs.
+
+For the AOT-safe per-command registration shape (`AddResourceAuthorization<TMessage, TResource, TResponse>()`) and the equivalent `TrellisServiceBuilder.UseResourceAuthorization<TMessage, TResource, TResponse>()` slot, see [`trellis-api-servicedefaults.md`](trellis-api-servicedefaults.md#trellisservicebuilder). For multi-hop authorization (the resource the actor must own is reached via one or more navigation hops), see [Recipe 24](#recipe-24--indirect-multi-hop-resource-authorization).
 
 ---
 
@@ -1830,7 +1838,8 @@ The naive workaround is a per-handler ownership guard (e.g. cricket's old `Match
 
 | Scenario | Recipe |
 |---|---|
-| Authorize against the resource the command identifies | `IAuthorizeResource<T>` (Recipe 7) |
+| **Owner-by-id check on the command's resource (the 90% case)** | `IAuthorizeResource<T>` + `IIdentifyResource<T, TId>` → framework reuses `SharedResourceLoaderById<T, TId>` (Recipe 7) |
+| Authorize against the resource the command identifies (custom loader) | `IAuthorizeResource<T>` + custom `IResourceLoader<TMessage, T>` (Recipe 7) |
 | Authorize against a single related resource one FK hop away | `IAuthorizeResourceVia<TOwner>` + `IIdentifyRelatedResource<TOwner, TOwnerId>` on the leaf |
 | Authorize against a set of related resources (cricket fan-out, OR-ownership) | `IAuthorizeResourceVia<TOwner>` + `IIdentifyRelatedResources<TOwner, TOwnerId>` on the leaf |
 | Authorize against a resource at the end of a chain (`Match → Team → Tournament`) | `IAuthorizeResourceVia<TFinalOwner>` + `IIdentifyRelatedResource<,>` declared on each intermediate entity |


### PR DESCRIPTION
Documentation-only follow-up to PR-2c's verdict on the original `add-authorization-lite` design ask. Surfaces the canonical owner-on-loaded-resource pattern (`IAuthorizeResource<T>` + `IIdentifyResource<T,TId>` so the framework reuses `SharedResourceLoaderById<T,TId>`) so first-time readers land on the simplest match instead of wading through the six-interface table.

## Why docs-only

The original reviewer's ask was to add a new `OwnerResourceAuthorization<TCommand, TResource, TId>` base class for the 90% case. On reflection I rejected that:

- The complaint is *discoverability*, not architecture. Adding a SIXTH auth surface (alongside `IAuthorize`, `IAuthorizeResource`, `IAuthorizeResourceVia`, `IIdentifyResource`, `IIdentifyRelatedResource`, `IIdentifyRelatedResources`) makes the framework harder to reason about, especially for AI-native consumers.
- A new base would couple Authorize logic to the class, losing composability with `IAuthorize` permission gates.
- Recipe 7 already shows the canonical pattern in ~10 lines; the discoverability problem is that the cookbook table led with "static permission gate" and Recipe 7 itself opened with `DeleteOrderCommand : IAuthorize` before the owner case.

The fix: reorder the existing material so the owner case is first, name it clearly, and add a top-of-table pointer.

## What changed

- **`docs/docfx_project/api_reference/trellis-api-authorization.md`** — new "Owner check in 8 lines — copy this" section between the "Use this file when" list and the "Patterns Index" table. Shows the complete 16-line `UpdateOrderCommand` shape with both `IAuthorizeResource<Order>` and `IIdentifyResource<Order, OrderId>`, the typed `AddResourceAuthorization<...>()` registration call (AOT-safe), and the three-step pipeline explanation. The Patterns Index gains a top-of-table row pointing back at the quick-start.
- **`docs/docfx_project/api_reference/trellis-api-cookbook.md`** — Recipe 7 reordered so the owner case appears first (with explanatory comments naming it "the canonical owner check — the 90% case"); the static permission gate (`DeleteOrderCommand : IAuthorize`) follows as a contrast. Recipe 24's decision matrix gains an explicit "Owner-by-id check on the command's resource (the 90% case)" row at the top.
- **`CHANGELOG.md`** — new `[Unreleased]` documentation entry.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors.
- No code changes → no test churn.
- No new API surface, no analyzer.