### PR TITLE
Fix dotnet test commands in Examples docs to use --solution / --project

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -37,7 +37,7 @@ dotnet run --project SsoExample/SsoExample.csproj --launch-profile Development
 ## Run all sample tests
 
 ```bash
-dotnet test Trellis.slnx -c Release --filter "FullyQualifiedName~Examples"
+dotnet test --solution Trellis.slnx -c Release --filter "FullyQualifiedName~Examples"
 ```
 
 ## Conventions enforced across every sample

--- a/Examples/TestingPatterns/README.md
+++ b/Examples/TestingPatterns/README.md
@@ -22,7 +22,7 @@ runtime application — it is a sample of *how to test* code that uses Trellis.
 ## Run it
 
 ```pwsh
-dotnet test Examples/TestingPatterns/TestingPatterns.Tests.csproj
+dotnet test --project Examples/TestingPatterns/TestingPatterns.Tests.csproj
 ```
 
 ## Why this lives in `Examples/`


### PR DESCRIPTION
The current .NET SDK rejects the positional solution-path or project-path form for `dotnet test`:

    Specifying a solution for 'dotnet test' should be via '--solution'.
    Specifying a project for 'dotnet test' should be via '--project'.

Update the two example invocations in the Examples docs to use the switch form.