### PR TITLE
docs(cookbook): add Recipe 30 audit-methodology + cross-link Recipe 20 from Recipes 14 and 18

### DIFF
--- a/MIGRATION_v3.md
+++ b/MIGRATION_v3.md
@@ -812,3 +812,29 @@ If the comment body should accept `""` after trimming but still reject whitespac
 | TRLS051 | Error | `[AllowWhitespace]` on a non-string Required base |
 | TRLS052 | Error | `[NoTrim]` on a non-string Required base |
 | TRLS053 | Error | Contradictory combination, for example `[AllowZero]` + `[Positive]` |
+
+---
+
+## Appendix — Verifying behavior after upgrade
+
+After upgrading a Trellis package, several authoritative sources can answer "what does this version of the API actually do?" They are not equally trustworthy at any given moment. Use the highest tier first; fall through only when a tier leaves the question unanswered.
+
+1. **Published nuspec on nuget.org** — confirms what version of what package is actually installed. The lock for "what's in the binary you just restored."
+2. **Auto-deposited API ref docs in `.github/`** — every Trellis package packs a `trellis-api-<name>.md` reference file (declared via `<TrellisApiRefName>` in the `.csproj`). `Trellis.ApiReference.targets` copies the files into the consuming project's `.github/` directory at restore time. **This is the canonical surface that ships with the binary.** When a deposited doc and a source-tree snapshot disagree, the deposited doc is right.
+3. **Behavior probe via a one-off test** — write a single test that exercises the API in the shape your code uses it. Compiles against the actually-installed package; behavior is observable directly. Faster than reading source; conclusive when the doc reads ambiguously.
+4. **Framework source** — only when (1)–(3) leave a question unanswered. Local clones can lag the published package, especially during alpha development; treat as the source of last resort.
+
+### Concrete example — caught mistakes
+
+The methodology emerged from a real `FunctionalDdd 2.x → Trellis 3.0.0-alpha.337` migration where it caught two mistakes before they shipped:
+
+- **False-positive correctness regression**, caught at step (2). The author wrote up a "`RequiredString<T>` silently accepts empty strings — silent semantic change from v2.x" finding, drafted an upstream issue, and added `[NotDefault, Trim]` to six value objects to "preserve v2.x semantics." An audit pass against `.github/trellis-api-core.md` proved strict-by-default ships in alpha.337 — the attributes were vestigial no-ops (`TRLS046`, `TRLS047`). Issue retracted before filing. Without the auto-deposited docs this would have shipped as a public framework-team report carrying a false correctness claim.
+- **Real correctness bug**, also caught at step (2). Porting removed `Result<T>.Value` to inline `.Match(v => v, e => throw …)` for nested DTO conversion preserved the throwing semantic locally but surfaced as HTTP 500 instead of HTTP 422 with field violations. An audit of the cookbook against the actual API behavior found `TraverseAll` — the canonical accumulating combinator for exactly this pattern.
+
+### Why this order
+
+The published nuspec is the lock. The deposited refs are the framework's own claim about its current surface — shipped alongside the binary, versioned together, never out of sync with the installed package. A behavior probe verifies the binary directly without trusting any doc. The framework source is the last resort because it can drift from the published package during alpha development. Trellis ships `trellis-api-*.md` files with every package precisely so consumers don't need to clone the framework source to audit upgrades.
+
+### AI tooling note
+
+When an AI assistant proposes a Trellis pattern after an upgrade, point it at the `.github/trellis-api-*.md` files first. The deposited docs are the source of truth your AI tools and your CI both verify against — keeping consumer-side AI audits grounded against the framework's shipped surface rather than a search-engine cached generic answer.

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -104,7 +104,6 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
 | Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-composition-builder) |
-| Audit a Trellis package upgrade for behavior changes | [Recipe 30](#recipe-30--auditing-your-trellis-upgrade-against-the-deposited-api-refs) |
 
 ### Mistake-regression routing
 
@@ -2499,55 +2498,6 @@ app.MapPost("/payments", CreatePaymentAsync).WithMetadata(new IdempotentAttribut
 **Composition rules.** `services.AddTrellisIdempotency(...)` (or the builder slot `t.UseIdempotency(...)`) registers options + scope resolver + an internal marker; `services.AddInMemoryIdempotencyStore()` is a separate, explicit call so a dev-only in-memory store is never silently inherited into production. `app.UseTrellisIdempotency()` throws at startup if `AddTrellisIdempotency(...)` was not called. The `IIdempotencyStore` registration is also validated at startup when the container exposes `IServiceProviderIsService` (the default Microsoft.Extensions.DependencyInjection container does); on containers that do not expose it the missing-store failure surfaces as a per-request resolution error on the first opted-in request. The in-memory store is single-process only; multi-instance hosts need an EF-backed store (per-tenant table or shared with `Scope` as a discriminator column) that implements the same CAS contract. `MaxRequestBodyBytes` and `MaxResponseBodyBytes` are hard caps: exceeding the request cap returns `413 Payload Too Large` before any handler runs; exceeding the response cap aborts capture and records no snapshot (the next retry re-executes), so the cap should be set high enough to envelop the largest legitimate response from any opted-in endpoint. Endpoints that stream via `SendFileAsync` cannot be captured and are equivalent to exceeding the response cap — model those as non-idempotent or convert them to a buffered response.
 
 **Tests.** Use `Microsoft.AspNetCore.TestHost.TestServer` (the same harness pattern as Recipe 26) plus an `IIdempotencyStore` registered as a singleton (`InMemoryIdempotencyStore`) plus `TimeProvider` swapped for `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (from the `Microsoft.Extensions.TimeProvider.Testing` NuGet package). Drive the same `(key, body)` twice — assert the second call returns the captured status code, headers, and body byte-for-byte. Drive `(key, mutated-body)` — assert `422` and the original snapshot is still replayable. Advance `FakeTimeProvider` past `ReservationTimeout` to exercise the sweep + re-reserve path. The NuGet package is `Microsoft.Extensions.TimeProvider.Testing` (the namespace containing `FakeTimeProvider` is `Microsoft.Extensions.Time.Testing`); the test project should reference the package the same way `Trellis.Testing.Worker`'s harness does.
-
----
-
-## Recipe 30 — Auditing your Trellis upgrade against the deposited API refs
-
-**Problem.** You bumped `Trellis.Core` from `3.0.0-alpha.310` to `3.0.0-alpha.337` and need to know what behavior changed before re-running the suite blind. The published nuspec gives versions, not semantics. A local `git clone` of the framework source tree can lag the published package, especially during alpha development. A search-engine answer is two flips behind. What's the authoritative source to trust, in what order?
-
-**Cross-check order — use the highest tier first; fall through only when a tier leaves the question unanswered.**
-
-1. **Published nuspec on nuget.org** — confirms what version of what package is actually installed. The lock for "what's in the binary you just restored."
-2. **Auto-deposited API ref docs in `.github/`** — every Trellis package packs a `trellis-api-<name>.md` reference file (declared via `<TrellisApiRefName>` in the .csproj). `Trellis.ApiReference.targets` copies the files into the consuming project's `.github/` directory at restore time. **This is the canonical surface that ships with the binary.** When a deposited doc and a source-tree snapshot disagree, the deposited doc is right.
-3. **Behavior probe via a one-off test** — write a single test that exercises the API in the shape your code uses it. Compiles against the actually-installed package; behavior is observable directly. Faster than reading source; conclusive when the doc reads ambiguously.
-4. **Framework source** — only when (1)–(3) leave a question unanswered. Local clones can lag the published package; treat as the source of last resort during alpha development.
-
-**Concrete example.** From a real `FunctionalDdd 2.x → Trellis 3.0.0-alpha.337` migration:
-
-- **Mistake 1 — false-positive correctness regression**, caught at step (2). The author wrote up a "`RequiredString<T>` silently accepts empty strings — silent semantic change from v2.x" finding, drafted a GitHub issue, and added `[NotDefault, Trim]` to six value objects to "preserve v2.x semantics." An audit pass against `.github/trellis-api-core.md` proved strict-by-default ships in alpha.337 — the attributes were vestigial no-ops (`TRLS046`, `TRLS047`). Issue retracted before filing. Without the auto-deposited docs this would have shipped as a public framework-team report carrying a false tier-1 correctness claim.
-- **Mistake 2 — real correctness bug**, also caught at step (2). Porting removed `Result<T>.Value` to inline `.Match(v => v, e => throw …)` for nested DTO conversion preserved the throwing semantic locally but surfaced as HTTP 500 instead of HTTP 422 with field violations. The cookbook audit found [Recipe 20](#recipe-20--fail-fast-vs-accumulating-sequencetraverse-vs-sequencealltraverseall) (`TraverseAll`) — the canonical accumulating combinator for exactly this pattern.
-
-```csharp
-// Step 3 — behavior probes. One test per behavior, executed against the actually-installed package.
-[Fact]
-public void RequiredString_rejects_empty_string_by_default()
-{
-    // No [AllowEmpty] attribute — verifies the strict-by-default contract
-    // documented at .github/trellis-api-core.md.
-    var result = MySku.TryCreate(string.Empty);
-    result.Should().BeFailureOfType<Error.InvalidInput>();
-}
-
-[Fact]
-public void Nested_DTO_validation_accumulates_field_failures_via_TraverseAll()
-{
-    var rows = new[]
-    {
-        new CreateContactRow(Email: "bad-1", Name: "A"),
-        new CreateContactRow(Email: "bad-2", Name: "B"),
-    };
-
-    var result = rows.TraverseAll(row => EmailAddress.TryCreate(row.Email));
-
-    var failure = result.Should().BeFailureOfType<Error.InvalidInput>().Subject;
-    failure.Fields.Items.Should().HaveCount(2); // both rows surface, not just the first
-}
-```
-
-**Why this order works.** The published nuspec is the lock. The deposited refs are the framework's own claim about its current surface — shipped alongside the binary, versioned together, never out of sync with the installed package. A behavior probe verifies the binary directly without trusting any doc. The framework source is the last resort because it can drift from the published package during alpha development. Trellis ships `trellis-api-*.md` files with every package precisely so consumers don't need to clone the framework source to audit upgrades — the authoritative surface travels with the package.
-
-**AI tooling angle.** When an AI assistant proposes a Trellis pattern, point it at the `.github/trellis-api-*.md` files first. The deposited docs are the source of truth your AI tools and your CI both verify against — keeping consumer-side AI audits grounded against the framework's shipped surface rather than a search-engine cached generic answer.
 
 ---
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -104,6 +104,7 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
 | Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-composition-builder) |
+| Audit a Trellis package upgrade for behavior changes | [Recipe 30](#recipe-30--auditing-your-trellis-upgrade-against-the-deposited-api-refs) |
 
 ### Mistake-regression routing
 
@@ -1107,6 +1108,8 @@ The answer depends on whether the inner type is a **scalar** (single-primitive) 
 
 > **The same DTO pattern applies inside a composite VO.** If a *composite value object's interior* contains `Maybe<TPrimitive>` / arrays / collections, `CompositeValueObjectJsonConverter` rejects them too (see Recipe 13 §"Supported property shapes inside a composite VO"). Keep the composite VO clean as a domain type and declare a wire-shape DTO with nullable transports, then lift on inbound (`.AsMaybe()` / `Maybe.From(...)`) and project on outbound (`.AsNullable()`).
 
+> **Nested collections in DTOs need `TraverseAll`, not inline `.Match`.** When a DTO carries a list of items each of which becomes a value object — for example `IReadOnlyList<MenuSectionDto>` → `IReadOnlyList<MenuSection>` — use [Recipe 20](#recipe-20--fail-fast-vs-accumulating-sequencetraverse-vs-sequencealltraverseall) (`TraverseAll` / `SequenceAll`) to accumulate per-item validation failures into one `Error.InvalidInput`. Inlining `.Select(s => s.ToDomain().Match(c => c, e => throw …))` throws on the first invalid row and surfaces as HTTP 500 instead of HTTP 422 with per-field violations.
+
 ### Pattern A — scalar `Maybe<T>` directly on the DTO
 
 ```csharp
@@ -1420,6 +1423,8 @@ var command = Result.Combine(
         CustomerName.TryCreate(request.CustomerName, nameof(request.CustomerName)))
     .Map((email, customerName) => new CreateCustomerCommand(email, customerName));
 ```
+
+**Nested collections.** When `CreateCustomerRequest` carries a `List<AddressDto>` whose items each need to become value objects, the `Result.Combine` shape above doesn't generalize to the collection — use [Recipe 20](#recipe-20--fail-fast-vs-accumulating-sequencetraverse-vs-sequencealltraverseall) (`TraverseAll`) to validate every row and accumulate per-item failures into one `Error.InvalidInput`. Inlining `.Select(item => item.ToCommand().Match(c => c, e => throw …))` throws on the first invalid row and surfaces as HTTP 500 instead of HTTP 422 with field violations.
 
 ---
 
@@ -2494,6 +2499,55 @@ app.MapPost("/payments", CreatePaymentAsync).WithMetadata(new IdempotentAttribut
 **Composition rules.** `services.AddTrellisIdempotency(...)` (or the builder slot `t.UseIdempotency(...)`) registers options + scope resolver + an internal marker; `services.AddInMemoryIdempotencyStore()` is a separate, explicit call so a dev-only in-memory store is never silently inherited into production. `app.UseTrellisIdempotency()` throws at startup if `AddTrellisIdempotency(...)` was not called. The `IIdempotencyStore` registration is also validated at startup when the container exposes `IServiceProviderIsService` (the default Microsoft.Extensions.DependencyInjection container does); on containers that do not expose it the missing-store failure surfaces as a per-request resolution error on the first opted-in request. The in-memory store is single-process only; multi-instance hosts need an EF-backed store (per-tenant table or shared with `Scope` as a discriminator column) that implements the same CAS contract. `MaxRequestBodyBytes` and `MaxResponseBodyBytes` are hard caps: exceeding the request cap returns `413 Payload Too Large` before any handler runs; exceeding the response cap aborts capture and records no snapshot (the next retry re-executes), so the cap should be set high enough to envelop the largest legitimate response from any opted-in endpoint. Endpoints that stream via `SendFileAsync` cannot be captured and are equivalent to exceeding the response cap — model those as non-idempotent or convert them to a buffered response.
 
 **Tests.** Use `Microsoft.AspNetCore.TestHost.TestServer` (the same harness pattern as Recipe 26) plus an `IIdempotencyStore` registered as a singleton (`InMemoryIdempotencyStore`) plus `TimeProvider` swapped for `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (from the `Microsoft.Extensions.TimeProvider.Testing` NuGet package). Drive the same `(key, body)` twice — assert the second call returns the captured status code, headers, and body byte-for-byte. Drive `(key, mutated-body)` — assert `422` and the original snapshot is still replayable. Advance `FakeTimeProvider` past `ReservationTimeout` to exercise the sweep + re-reserve path. The NuGet package is `Microsoft.Extensions.TimeProvider.Testing` (the namespace containing `FakeTimeProvider` is `Microsoft.Extensions.Time.Testing`); the test project should reference the package the same way `Trellis.Testing.Worker`'s harness does.
+
+---
+
+## Recipe 30 — Auditing your Trellis upgrade against the deposited API refs
+
+**Problem.** You bumped `Trellis.Core` from `3.0.0-alpha.310` to `3.0.0-alpha.337` and need to know what behavior changed before re-running the suite blind. The published nuspec gives versions, not semantics. A local `git clone` of the framework source tree can lag the published package, especially during alpha development. A search-engine answer is two flips behind. What's the authoritative source to trust, in what order?
+
+**Cross-check order — use the highest tier first; fall through only when a tier leaves the question unanswered.**
+
+1. **Published nuspec on nuget.org** — confirms what version of what package is actually installed. The lock for "what's in the binary you just restored."
+2. **Auto-deposited API ref docs in `.github/`** — every Trellis package packs a `trellis-api-<name>.md` reference file (declared via `<TrellisApiRefName>` in the .csproj). `Trellis.ApiReference.targets` copies the files into the consuming project's `.github/` directory at restore time. **This is the canonical surface that ships with the binary.** When a deposited doc and a source-tree snapshot disagree, the deposited doc is right.
+3. **Behavior probe via a one-off test** — write a single test that exercises the API in the shape your code uses it. Compiles against the actually-installed package; behavior is observable directly. Faster than reading source; conclusive when the doc reads ambiguously.
+4. **Framework source** — only when (1)–(3) leave a question unanswered. Local clones can lag the published package; treat as the source of last resort during alpha development.
+
+**Concrete example.** From a real `FunctionalDdd 2.x → Trellis 3.0.0-alpha.337` migration:
+
+- **Mistake 1 — false-positive correctness regression**, caught at step (2). The author wrote up a "`RequiredString<T>` silently accepts empty strings — silent semantic change from v2.x" finding, drafted a GitHub issue, and added `[NotDefault, Trim]` to six value objects to "preserve v2.x semantics." An audit pass against `.github/trellis-api-core.md` proved strict-by-default ships in alpha.337 — the attributes were vestigial no-ops (`TRLS046`, `TRLS047`). Issue retracted before filing. Without the auto-deposited docs this would have shipped as a public framework-team report carrying a false tier-1 correctness claim.
+- **Mistake 2 — real correctness bug**, also caught at step (2). Porting removed `Result<T>.Value` to inline `.Match(v => v, e => throw …)` for nested DTO conversion preserved the throwing semantic locally but surfaced as HTTP 500 instead of HTTP 422 with field violations. The cookbook audit found [Recipe 20](#recipe-20--fail-fast-vs-accumulating-sequencetraverse-vs-sequencealltraverseall) (`TraverseAll`) — the canonical accumulating combinator for exactly this pattern.
+
+```csharp
+// Step 3 — behavior probes. One test per behavior, executed against the actually-installed package.
+[Fact]
+public void RequiredString_rejects_empty_string_by_default()
+{
+    // No [AllowEmpty] attribute — verifies the strict-by-default contract
+    // documented at .github/trellis-api-core.md.
+    var result = MySku.TryCreate(string.Empty);
+    result.Should().BeFailureOfType<Error.InvalidInput>();
+}
+
+[Fact]
+public void Nested_DTO_validation_accumulates_field_failures_via_TraverseAll()
+{
+    var rows = new[]
+    {
+        new CreateContactRow(Email: "bad-1", Name: "A"),
+        new CreateContactRow(Email: "bad-2", Name: "B"),
+    };
+
+    var result = rows.TraverseAll(row => EmailAddress.TryCreate(row.Email));
+
+    var failure = result.Should().BeFailureOfType<Error.InvalidInput>().Subject;
+    failure.Fields.Items.Should().HaveCount(2); // both rows surface, not just the first
+}
+```
+
+**Why this order works.** The published nuspec is the lock. The deposited refs are the framework's own claim about its current surface — shipped alongside the binary, versioned together, never out of sync with the installed package. A behavior probe verifies the binary directly without trusting any doc. The framework source is the last resort because it can drift from the published package during alpha development. Trellis ships `trellis-api-*.md` files with every package precisely so consumers don't need to clone the framework source to audit upgrades — the authoritative surface travels with the package.
+
+**AI tooling angle.** When an AI assistant proposes a Trellis pattern, point it at the `.github/trellis-api-*.md` files first. The deposited docs are the source of truth your AI tools and your CI both verify against — keeping consumer-side AI audits grounded against the framework's shipped surface rather than a search-engine cached generic answer.
 
 ---
 


### PR DESCRIPTION
Implements **backlog items 5 and 9** (External Migration Feedback — BuberDinner v3) from `backlog.md`.

## Item 5 — cross-link Recipe 20 (`TraverseAll`) from Recipes 14 and 18

The cookbook's Patterns Index lists Recipe 20 only under "fail-fast vs accumulating collection ops" — a phrase a developer working on DTO conversion won't search for. BuberDinner shipped a real correctness bug from this gap: nested DTO validation written as `.Select(s => s.ToCommand().Match(c => c, e => throw …))` surfaced as **HTTP 500** instead of **HTTP 422 with field violations**.

Adds one-line callouts:
- **Recipe 14** (optional fields): admonition pointing at Recipe 20 for nested-collection cases that don't fit the optional-field pattern.
- **Recipe 18** (DTO → command): paragraph pointing at Recipe 20 for the case where `Result.Combine` doesn't generalize to a collection of nested DTOs.

## Item 9 — new Recipe 30: audit-methodology

Codifies the 4-tier upgrade-audit methodology that emerged from the BuberDinner migration:

1. Published nuspec on nuget.org (the lock)
2. Auto-deposited API ref docs in `.github/` (the canonical surface)
3. Behavior probe via one-off test (verification against the actual binary)
4. Framework source (last resort — can drift during alpha development)

The methodology caught two real BuberDinner mistakes during the migration:
- A **false-positive tier-1 regression** ("`RequiredString<T>` silently accepts empty strings") — invalidated when `.github/trellis-api-core.md` proved strict-by-default ships in alpha.337 and the `[NotDefault, Trim]` attributes the author added were vestigial no-ops.
- A **real correctness bug** (nested DTO `.Match(v => v, e => throw …)` producing HTTP 500 instead of HTTP 422) — fixed by adopting Recipe 20.

Recipe 30 doubles as evidence for the docs-as-shipped-artifact positioning: the deposited refs ARE the source of truth, not the source tree.

Patterns Index updated with a Recipe 30 row.

## Verification

- `+54 / -0` insertions only; no existing recipe content modified.
- UTF-8 with BOM preserved (verified via `[System.IO.File]::ReadAllBytes` first-3-bytes check).
- All inline anchors point at valid existing or newly-added headings (verified manually against the cookbook's anchor-generation pattern).
- Pure documentation change — no compiled cookbook snippet (consistent with most cookbook recipes; only Recipes 1, 2, 13, 25 ship compile-checked snippets in `Examples/CookbookSnippets/`). No build/test required per repo convention.

## Source

- `backlog.md` (top-level repo file): see "External Migration Feedback — BuberDinner v3 (2026-06-04)" section.
- `../trellis-feedback.md` (Xavier's external migration report).
- Validation against framework source: `trellis-api-cookbook.md:90-107` (Patterns Index), `trellis-api-cookbook.md:1095, 1357, 1467` (Recipes 14, 18, 20 anchors), and the 2026-06-04 GPT-5.5 review of the validation.