### PR TITLE
feat(core): add Result<T>.GetValueOrThrow + cookbook Recipe 30 (persistence rehydration)

### DIFF
--- a/Trellis.Core/src/Result/Extensions/GetValueOrThrow.cs
+++ b/Trellis.Core/src/Result/Extensions/GetValueOrThrow.cs
@@ -1,0 +1,104 @@
+﻿namespace Trellis;
+
+using System.Diagnostics;
+
+/// <summary>
+/// Production-safe throwing terminal extraction for <see cref="Result{T}"/>, intended for the
+/// narrow case where a failure represents a broken invariant the caller cannot act on —
+/// typically the persistence DTO → entity rehydration seam, where write-path validation
+/// guarantees the row is valid and any <c>TryCreate</c> failure on read indicates database
+/// corruption or migration drift.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <see cref="Maybe{T}.GetValueOrThrow(string?)"/> for symmetric ergonomics across
+/// the two ROP types: an explicit, named "this throws" contract gated by the verb in the
+/// method name, not an ambient property accessor (<c>Result&lt;T&gt;.Value</c> was removed in
+/// v3 because the ambient accessor was the primary cause of unsafe value access).
+/// </para>
+/// <para>
+/// Prefer <c>TryGetValue</c>, <c>Match</c>, <c>Bind</c>, <c>GetValueOrDefault</c>, or
+/// destructuring for normal Result-track flow. <see cref="GetValueOrThrow{TValue}(Result{TValue}, string?)"/>
+/// is the escape hatch for trust-boundary crossings where failure means
+/// "the world is not as expected" — not for request validation where the caller should
+/// surface a typed <c>Error.InvalidInput</c> on the Result track.
+/// </para>
+/// <para>
+/// Cookbook Recipe 30 covers the persistence-rehydration use case end to end, including the
+/// decision criteria for picking this throwing pattern versus a <c>Result&lt;TEntity&gt;</c>
+/// end-to-end shape for legacy / corruptible data paths.
+/// </para>
+/// </remarks>
+[DebuggerStepThrough]
+public static class GetValueOrThrowExtensions
+{
+    /// <summary>
+    /// Returns the success value, or throws <see cref="InvalidOperationException"/> if the
+    /// result is a failure. This is a terminal operator that exits the Result railway.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="result">The result to extract a value from.</param>
+    /// <param name="errorMessage">
+    /// Optional custom exception message used when the result is a failure. When
+    /// <see langword="null"/>, a default message is synthesized from
+    /// <c>typeof(<typeparamref name="TValue"/>).Name</c>, <see cref="Error.Code"/>, and
+    /// <see cref="Error.GetDisplayMessage"/>.
+    /// </param>
+    /// <returns>The success value.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="result"/> is a failure.</exception>
+    public static TValue GetValueOrThrow<TValue>(this Result<TValue> result, string? errorMessage = null) =>
+        result.TryGetValue(out var value)
+            ? value
+            : throw new InvalidOperationException(errorMessage ?? BuildDefaultMessage<TValue>(result.Error!));
+
+    /// <summary>
+    /// Awaits the task and returns the success value, or throws
+    /// <see cref="InvalidOperationException"/> if the result is a failure. This is a terminal
+    /// operator that exits the Result railway.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="resultTask">The task producing the result to extract a value from.</param>
+    /// <param name="errorMessage">
+    /// Optional custom exception message used when the result is a failure. When
+    /// <see langword="null"/>, a default message is synthesized from
+    /// <c>typeof(<typeparamref name="TValue"/>).Name</c>, <see cref="Error.Code"/>, and
+    /// <see cref="Error.GetDisplayMessage"/>.
+    /// </param>
+    /// <returns>The success value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="resultTask"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the awaited result is a failure.</exception>
+    public static async Task<TValue> GetValueOrThrowAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        string? errorMessage = null)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrThrow(errorMessage);
+    }
+
+    /// <summary>
+    /// Awaits the value-task and returns the success value, or throws
+    /// <see cref="InvalidOperationException"/> if the result is a failure. This is a terminal
+    /// operator that exits the Result railway.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="resultTask">The value-task producing the result to extract a value from.</param>
+    /// <param name="errorMessage">
+    /// Optional custom exception message used when the result is a failure. When
+    /// <see langword="null"/>, a default message is synthesized from
+    /// <c>typeof(<typeparamref name="TValue"/>).Name</c>, <see cref="Error.Code"/>, and
+    /// <see cref="Error.GetDisplayMessage"/>.
+    /// </param>
+    /// <returns>The success value.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the awaited result is a failure.</exception>
+    public static async ValueTask<TValue> GetValueOrThrowAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        string? errorMessage = null)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrThrow(errorMessage);
+    }
+
+    private static string BuildDefaultMessage<TValue>(Error error) =>
+        $"Result<{typeof(TValue).Name}> was a failure. Error: [{error.Code}] {error.GetDisplayMessage()}";
+}

--- a/Trellis.Core/tests/Results/Extensions/GetValueOrThrowTests.cs
+++ b/Trellis.Core/tests/Results/Extensions/GetValueOrThrowTests.cs
@@ -1,0 +1,186 @@
+﻿namespace Trellis.Core.Tests.Results.Extensions;
+
+using Trellis.Testing;
+
+/// <summary>
+/// Tests for <see cref="GetValueOrThrowExtensions"/> — the production-safe throwing extractor for
+/// trust-boundary crossings where a failed result represents a broken invariant the caller
+/// cannot act on (typically persistence DTO → entity rehydration). Mirrors
+/// <see cref="Maybe{T}.GetValueOrThrow(string?)"/> for ergonomic symmetry between the two ROP types.
+/// </summary>
+public class GetValueOrThrowTests
+{
+    #region Sync — Result<T>.GetValueOrThrow
+
+    [Fact]
+    public void GetValueOrThrow_Success_returns_value()
+    {
+        var sut = Result.Ok(42);
+
+        var value = sut.GetValueOrThrow();
+
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Success_with_custom_message_returns_value_and_does_not_throw()
+    {
+        var sut = Result.Ok("hello");
+
+        var value = sut.GetValueOrThrow("custom message that should not appear");
+
+        value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Success_with_null_reference_value_returns_null()
+    {
+        // Result.Ok<string?>(null!) is unusual but legal: the contract is "return what's there".
+        var sut = Result.Ok<string?>(null);
+
+        var value = sut.GetValueOrThrow();
+
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Failure_throws_InvalidOperationException()
+    {
+        var sut = Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42")));
+
+        var act = () => sut.GetValueOrThrow();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Failure_default_message_includes_TValue_name_and_Error_code()
+    {
+        var sut = Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42")));
+
+        var act = () => sut.GetValueOrThrow();
+
+        // Default message format: "Result<{TValue}> was a failure. Error: [{Code}] {DisplayMessage}"
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Int32*not-found*");
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Failure_with_custom_errorMessage_throws_with_that_exact_message()
+    {
+        var sut = Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42")));
+
+        var act = () => sut.GetValueOrThrow("Reconstructing User 42 from DB row");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Reconstructing User 42 from DB row");
+    }
+
+    [Fact]
+    public void GetValueOrThrow_default_Result_throws()
+    {
+        // default(Result<T>) is a typed failure carrying the shared "default_initialized" sentinel
+        // (TRLS019). Verify GetValueOrThrow surfaces it rather than returning default(TValue).
+        Result<string> sut = default;
+
+        var act = () => sut.GetValueOrThrow();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*default_initialized*");
+    }
+
+    [Fact]
+    public void GetValueOrThrow_Failure_with_Detail_renders_Detail_in_default_message()
+    {
+        var sut = Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42"))
+            { Detail = "User 42 has been purged." });
+
+        var act = () => sut.GetValueOrThrow();
+
+        // GetDisplayMessage() prefers Detail over Code template when Detail is set.
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*User 42 has been purged.*");
+    }
+
+    #endregion
+
+    #region Async — Task<Result<T>>.GetValueOrThrowAsync
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_Task_Success_returns_value()
+    {
+        var sut = Task.FromResult(Result.Ok(42));
+
+        var value = await sut.GetValueOrThrowAsync();
+
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_Task_Failure_throws_InvalidOperationException()
+    {
+        var sut = Task.FromResult(Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42"))));
+
+        var act = () => sut.GetValueOrThrowAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_Task_Failure_with_custom_message_uses_it_verbatim()
+    {
+        var sut = Task.FromResult(Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42"))));
+
+        var act = () => sut.GetValueOrThrowAsync("Reconstructing User 42 from DB row");
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Be("Reconstructing User 42 from DB row");
+    }
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_Task_null_resultTask_throws_ArgumentNullException()
+    {
+        Task<Result<int>>? sut = null;
+
+        var act = () => sut!.GetValueOrThrowAsync();
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region Async — ValueTask<Result<T>>.GetValueOrThrowAsync
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_ValueTask_Success_returns_value()
+    {
+        var sut = ValueTask.FromResult(Result.Ok(42));
+
+        var value = await sut.GetValueOrThrowAsync();
+
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_ValueTask_Failure_throws_InvalidOperationException()
+    {
+        var sut = ValueTask.FromResult(Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42"))));
+
+        var act = async () => await sut.GetValueOrThrowAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GetValueOrThrowAsync_ValueTask_Failure_with_custom_message_uses_it_verbatim()
+    {
+        var sut = ValueTask.FromResult(Result.Fail<int>(new Error.NotFound(ResourceRef.For("User", "42"))));
+
+        var act = async () => await sut.GetValueOrThrowAsync("Reconstructing User 42");
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Be("Reconstructing User 42");
+    }
+
+    #endregion
+}

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -2542,7 +2542,7 @@ public sealed class UserRepository(AppDbContext db) : IUserRepository
 }
 ```
 
-`GetValueOrThrow` throws `InvalidOperationException` whose message names the offending row. The exception bubbles through `ExceptionBehavior` and surfaces as `Error.Unexpected("unhandled_exception", faultId)` to the wire (HTTP 500), with the full message in operator-side logs — exactly the shape for "this should never have happened."
+`GetValueOrThrow` throws `InvalidOperationException` whose message names the offending row. The exception bubbles through `ExceptionBehavior` and surfaces as `new Error.Unexpected("unhandled_exception", faultId)` to the wire (HTTP 500), with the full message in operator-side logs — exactly the shape for "this should never have happened."
 
 **Why not `Trellis.Testing.Unwrap()`?** `Unwrap()` is a test-only helper (see [Recipe 18](#recipe-18--dto-primitives-to-value-object-command-no-test-only-unwrap)). Production code that uses it mixes test and production seams and is harder to grep for than a named-verb extractor. `GetValueOrThrow` ships in `Trellis.Core` and the verb in the name makes the failure mode explicit at every call site.
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -104,6 +104,7 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Define domain events | [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) |
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
 | Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-composition-builder) |
+| Rehydrate an entity from a database row (fail-loud vs Result-track) | [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track) |
 
 ### Mistake-regression routing
 
@@ -2498,6 +2499,130 @@ app.MapPost("/payments", CreatePaymentAsync).WithMetadata(new IdempotentAttribut
 **Composition rules.** `services.AddTrellisIdempotency(...)` (or the builder slot `t.UseIdempotency(...)`) registers options + scope resolver + an internal marker; `services.AddInMemoryIdempotencyStore()` is a separate, explicit call so a dev-only in-memory store is never silently inherited into production. `app.UseTrellisIdempotency()` throws at startup if `AddTrellisIdempotency(...)` was not called. The `IIdempotencyStore` registration is also validated at startup when the container exposes `IServiceProviderIsService` (the default Microsoft.Extensions.DependencyInjection container does); on containers that do not expose it the missing-store failure surfaces as a per-request resolution error on the first opted-in request. The in-memory store is single-process only; multi-instance hosts need an EF-backed store (per-tenant table or shared with `Scope` as a discriminator column) that implements the same CAS contract. `MaxRequestBodyBytes` and `MaxResponseBodyBytes` are hard caps: exceeding the request cap returns `413 Payload Too Large` before any handler runs; exceeding the response cap aborts capture and records no snapshot (the next retry re-executes), so the cap should be set high enough to envelop the largest legitimate response from any opted-in endpoint. Endpoints that stream via `SendFileAsync` cannot be captured and are equivalent to exceeding the response cap — model those as non-idempotent or convert them to a buffered response.
 
 **Tests.** Use `Microsoft.AspNetCore.TestHost.TestServer` (the same harness pattern as Recipe 26) plus an `IIdempotencyStore` registered as a singleton (`InMemoryIdempotencyStore`) plus `TimeProvider` swapped for `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (from the `Microsoft.Extensions.TimeProvider.Testing` NuGet package). Drive the same `(key, body)` twice — assert the second call returns the captured status code, headers, and body byte-for-byte. Drive `(key, mutated-body)` — assert `422` and the original snapshot is still replayable. Advance `FakeTimeProvider` past `ReservationTimeout` to exercise the sweep + re-reserve path. The NuGet package is `Microsoft.Extensions.TimeProvider.Testing` (the namespace containing `FakeTimeProvider` is `Microsoft.Extensions.Time.Testing`); the test project should reference the package the same way `Trellis.Testing.Worker`'s harness does.
+
+---
+
+## Recipe 30 — Rehydrating entities from persistence: fail-loud vs Result-track
+
+**Problem.** A repository loads a row from the database and needs to reconstruct a domain entity whose value-object fields each have `TryCreate(...) → Result<TVO>`. Recipe 18 covers the inbound direction (request DTO → command, with `Result.Combine + Map`). The inverse direction — DB row → entity — has a different failure semantic:
+
+- **Inbound** is *untrusted* input — every `TryCreate` failure is a legitimate validation response and must surface as `Error.InvalidInput` on the Result track so the caller can fix the request.
+- **Outbound** is *trusted* input — the row was written through the same `TryCreate` chain (write-path validation). A `TryCreate` failure on read means the row predates the validation rule (legacy data), the rule changed since (migration drift), or the database was tampered with — none of which the *application caller* can fix.
+
+Picking the right rehydration shape depends on which trust model applies to that specific aggregate.
+
+### Pattern A — fail-loud rehydration (the 90% case)
+
+When write-path validation is guaranteed (`TryCreate` enforced at every insert + update + migration backfill), a `TryCreate` failure on read is an operator bug. Use `Result<T>.GetValueOrThrow(string? errorMessage)` so the failure is loud, immediate, and names the offending row:
+
+```csharp
+using Trellis;
+
+public sealed class UserRepository(AppDbContext db) : IUserRepository
+{
+    public async Task<Result<User>> FindByIdAsync(UserId id, CancellationToken ct)
+    {
+        var row = await db.UserRows.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id.Value, ct);
+        if (row is null)
+            return Result.Fail<User>(new Error.NotFound(ResourceRef.For<User>(id)));
+
+        // Write-path TryCreate guarantees these are valid. A failure here is database
+        // corruption / migration drift; throw to fail loud rather than surface a
+        // "validation" failure to the application layer (which cannot act on it).
+        var user = User.TryCreate(
+            UserId.TryCreate(row.Id).GetValueOrThrow($"Corrupt User.Id in row {row.Id}"),
+            FirstName.TryCreate(row.FirstName).GetValueOrThrow($"Corrupt User.FirstName in row {row.Id}"),
+            LastName.TryCreate(row.LastName).GetValueOrThrow($"Corrupt User.LastName in row {row.Id}"),
+            EmailAddress.TryCreate(row.Email).GetValueOrThrow($"Corrupt User.Email in row {row.Id}"))
+            .GetValueOrThrow($"Corrupt User aggregate for row {row.Id}");
+
+        return Result.Ok(user);
+    }
+}
+```
+
+`GetValueOrThrow` throws `InvalidOperationException` whose message names the offending row. The exception bubbles through `ExceptionBehavior` and surfaces as `Error.Unexpected("unhandled_exception", faultId)` to the wire (HTTP 500), with the full message in operator-side logs — exactly the shape for "this should never have happened."
+
+**Why not `Trellis.Testing.Unwrap()`?** `Unwrap()` is a test-only helper (see [Recipe 18](#recipe-18--dto-primitives-to-value-object-command-no-test-only-unwrap)). Production code that uses it mixes test and production seams and is harder to grep for than a named-verb extractor. `GetValueOrThrow` ships in `Trellis.Core` and the verb in the name makes the failure mode explicit at every call site.
+
+### Pattern B — Result-track end-to-end (the legacy-data case)
+
+When write-path validation cannot be guaranteed — the table predates the current rules, an external migration imports rows from a third-party system, or the column may contain genuinely corruptible data — keep the failure on the Result track and let the application layer decide:
+
+```csharp
+public sealed class LegacyContactRepository(AppDbContext db) : ILegacyContactRepository
+{
+    public async Task<Result<Contact>> FindByIdAsync(ContactId id, CancellationToken ct)
+    {
+        var row = await db.ContactRows.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id.Value, ct);
+        if (row is null)
+            return Result.Fail<Contact>(new Error.NotFound(ResourceRef.For<Contact>(id)));
+
+        // Imported from a v1 system without our current TryCreate constraints; surface
+        // the per-field failures so the application can DLQ the row, request a fix-up
+        // from the data owner, or retry after the source system is corrected.
+        return Result.Combine(
+                ContactId.TryCreate(row.Id, "Id"),
+                FirstName.TryCreate(row.FirstName, "FirstName"),
+                EmailAddress.TryCreate(row.Email, "Email"))
+            .Bind((cid, firstName, email) => Contact.TryCreate(cid, firstName, email));
+    }
+}
+```
+
+The application layer then matches on the typed failure:
+
+```csharp
+var result = await repo.FindByIdAsync(id, ct);
+return result.Match(
+    onSuccess: contact => Ok(ContactResponse.From(contact)),
+    onFailure: err => err switch
+    {
+        Error.NotFound       => NotFound(),
+        Error.InvalidInput i => UnprocessableEntity(i.Fields), // row is invalid — surface why
+        _                    => Problem(),
+    });
+```
+
+### Choosing between A and B
+
+| Indicator | Pattern A (fail-loud) | Pattern B (Result-track) |
+|---|---|---|
+| Write path goes through `TryCreate`? | Yes | No (raw insert / external import / pre-validation legacy table) |
+| Schema migrations preserve invariants? | Yes (every column-add ships a backfill that satisfies `TryCreate`) | No (some columns may have legacy values) |
+| Who fixes a failure? | Operator (it's a bug — read the log, fix the data, redeploy) | Application / user (the data is genuinely invalid; surface and let them correct it) |
+| Wire shape on failure | HTTP 500 (`Error.Unexpected`) | HTTP 422 (`Error.InvalidInput`) or domain-specific |
+
+If you don't have one clear answer for a given aggregate, default to **Pattern A** — it's the higher-leverage shape because the failure is operator-actionable, and it matches the write-path invariants you're already enforcing at the API seam.
+
+**Anti-pattern → fix.**
+
+```csharp
+// ❌ Wrong — Trellis.Testing.Unwrap() in production code. Mixes test and production seams;
+//   harder to grep for than a named-verb extraction; the test-only contract is documented
+//   at Recipe 18.
+var user = User.TryCreate(
+    UserId.TryCreate(row.Id).Unwrap(),
+    EmailAddress.TryCreate(row.Email).Unwrap()).Unwrap();
+return Result.Ok(user);
+
+// ❌ Wrong — inline .Match(v => v, e => throw …). 50+ characters of ceremony at every call
+//   site; obscures intent; every codebase reinvents its own exception type and message format.
+var user = User.TryCreate(
+    UserId.TryCreate(row.Id).Match(v => v, e => throw new InvalidOperationException(e.ToString())),
+    EmailAddress.TryCreate(row.Email).Match(v => v, e => throw new InvalidOperationException(e.ToString())))
+    .Match(v => v, e => throw new InvalidOperationException(e.ToString()));
+return Result.Ok(user);
+
+// ✅ Correct — GetValueOrThrow with a row-identifying message at each seam.
+var user = User.TryCreate(
+    UserId.TryCreate(row.Id).GetValueOrThrow($"Corrupt User.Id in row {row.Id}"),
+    EmailAddress.TryCreate(row.Email).GetValueOrThrow($"Corrupt User.Email in row {row.Id}"))
+    .GetValueOrThrow($"Corrupt User aggregate for row {row.Id}");
+return Result.Ok(user);
+```
 
 ---
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -44,6 +44,7 @@ Use this table before searching the long type catalog.
 | Model aggregates/entities/events | `Aggregate<TId>`, `Entity<TId>`, `IDomainEvent` | [`Domain-Driven Design`](#domain-driven-design) |
 | Move reusable query predicates out of repositories | `Specification<T>` | [`Specification<T>`](#specificationt) |
 | Define custom required value objects | `partial class X : RequiredString<X>` / `RequiredGuid<X>` / other `Required*` bases | [`Primitive value object base classes`](#primitive-value-object-base-classes) |
+| Extract a success value or throw at a trust boundary (DTO → entity rehydration, JSON deserialization) | `result.GetValueOrThrow($"context message")` / `GetValueOrThrowAsync(...)` | [`GetValueOrThrowExtensions`](#extension-class-catalog-full-signatures) (entry in the extension catalog), [cookbook Recipe 30](trellis-api-cookbook.md#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track) |
 
 ## Canonical async handler skeleton
 
@@ -840,6 +841,7 @@ The result API contains a large generated extension surface. Exact public famili
 | `DiscardExtensions`, `DiscardTaskExtensions`, `DiscardValueTaskExtensions` | Drops the `Result<T>` value entirely (returns `void`/`Task`/`ValueTask`) for intentional fire-and-forget pipelines |
 | `EnsureExtensions`, `EnsureExtensionsAsync`, `EnsureAllExtensions`, `EnsureAllExtensionsAsync` | Predicate-based validation on successful values; includes collection-wide validation |
 | `GetValueOrDefaultExtensions` | Non-throwing value fallback helpers |
+| `GetValueOrThrowExtensions` | Production-safe throwing extractor for trust-boundary crossings (DTO → entity rehydration, JSON deserialization). Mirrors `Maybe<T>.GetValueOrThrow(string?)`; throws `InvalidOperationException` on failure. Sync + `Task<Result<T>>` + `ValueTask<Result<T>>` overloads. See cookbook Recipe 30. |
 | `ResultLinqExtensions`, `ResultLinqExtensionsTaskAsync`, `ResultLinqExtensionsTaskLeftAsync`, `ResultLinqExtensionsTaskRightAsync`, `ResultLinqExtensionsValueTaskAsync`, `ResultLinqExtensionsValueTaskLeftAsync`, `ResultLinqExtensionsValueTaskRightAsync` | LINQ query syntax support via `Select`/`SelectMany`/`Where` for `Result<T>`, `Task<Result<T>>` and `ValueTask<Result<T>>` (mixed sync/async sources and continuations) |
 | `MapExtensions`, `MapExtensionsAsync`, `MapIfExtensions`, `MapOnFailureExtensions` | Success-path mapping, conditional mapping, and failure remapping; tuple overloads generated for arities 2-9 |
 | `MatchExtensions`, `MatchExtensionsAsync`, `MatchTupleExtensions`, `MatchTupleExtensionsAsync` | Terminal branching for normal and tuple results. (The previous `MatchErrorExtensions` API was removed — use `result.Match(_ => ..., e => e switch { Error.NotFound nf => ..., ... })` against the closed catalog.) |


### PR DESCRIPTION
Implements **backlog Items 3 + 6** (External Migration Feedback — BuberDinner v3) from `backlog.md`.

## Item 3 — `Result<T>.GetValueOrThrow` extension

V3 correctly removed `Result<T>.Value` (the ambient accessor was the primary cause of unsafe value access — see `Trellis.Core/src/Result/Result{TValue}.cs:163-168`). The only existing escape hatch on `Result<T>` is `GetValueOrDefault(Func<Error, TValue>)`, which works for the persistence-rehydration case but carries no explicit "throws" signal and forces every consumer to invent their own exception type and message format. BuberDinner shipped a 30+-call-site local `UnwrapOrThrow` helper.

Adds `GetValueOrThrowExtensions` with three overloads:

```csharp
public static TValue GetValueOrThrow<TValue>(
    this Result<TValue> result, string? errorMessage = null);

public static async Task<TValue> GetValueOrThrowAsync<TValue>(
    this Task<Result<TValue>> resultTask, string? errorMessage = null);

public static async ValueTask<TValue> GetValueOrThrowAsync<TValue>(
    this ValueTask<Result<TValue>> resultTask, string? errorMessage = null);
```

Mirrors `Maybe<T>.GetValueOrThrow(string? errorMessage = null)` at `Trellis.Core/src/Maybe/Maybe{T}.cs:102` for ergonomic symmetry: same name, same parameter shape (`errorMessage`, not "context"), same exception type (`InvalidOperationException`). Name explicitly chosen over `UnwrapOrThrow` because `Unwrap()` lives in `Trellis.Testing` as a documented test-only helper (cookbook Recipe 18) — using the same verb in production would mix test and production seams.

Default exception message (when `errorMessage` is null) synthesizes from `typeof(TValue).Name` plus the underlying `Error`:

```text
Result<{TValue}> was a failure. Error: [{Code}] {DisplayMessage}
```

Matches the synthesis pattern in `Trellis.Testing.UnwrapExtensions`.

## Item 6 — Cookbook Recipe 30 (persistence rehydration)

New recipe documenting the two valid shapes for DB-row → entity reconstruction:

| Pattern | When to use | Wire shape on failure |
|---|---|---|
| **A — fail-loud** (the 90% case) | Write-path `TryCreate` guarantees every column is valid; a failure on read is database corruption or migration drift. | HTTP 500 (`Error.Unexpected`) via `ExceptionBehavior`, with the row-identifying message in operator logs. |
| **B — Result-track end-to-end** | Write path cannot guarantee invariants (legacy table, external import, corruptible data). | HTTP 422 (`Error.InvalidInput`) or domain-specific. |

Recipe includes a decision table (write-path through `TryCreate`?, who fixes a failure?, wire shape on failure?) and the standard anti-pattern → fix block calling out `Trellis.Testing.Unwrap()` and inline `.Match(v => v, e => throw …)` as the wrong shapes.

Patterns-Index row added: "Rehydrate an entity from a database row (fail-loud vs Result-track)" → Recipe 30.

## Docs

- `trellis-api-core.md` Patterns Index — row for "Extract a success value or throw at a trust boundary (DTO → entity rehydration, JSON deserialization)" pointing at the extension catalog + Recipe 30.
- `trellis-api-core.md` extension catalog — new row for `GetValueOrThrowExtensions` alongside the existing `GetValueOrDefault` entry. (No separate full-signature subsection — same precedent as `GetValueOrDefault`, which is also catalog-only.)

## Verification

- **15 new unit tests** in `Trellis.Core.Tests/Results/Extensions/GetValueOrThrowTests.cs` covering sync + `Task` + `ValueTask` success/failure paths, custom-message-verbatim, default-message-synthesis-includes-Code-and-Display, `default(Result<T>)` sentinel failure, null-reference `Ok` value, null-receiver `ArgumentNullException` guard on the `Task` overload, and `Detail` rendering in the default message via `GetDisplayMessage`.

Test runs:

| Package | Total | Pass | Fail | Skipped |
|---|---|---|---|---|
| `Trellis.Core.Tests` | 2,232 (+15) | 2,232 | 0 | 0 |
| `Trellis.Testing.Tests` | 204 | 204 | 0 | 0 |
| `Trellis.Asp.Tests` | 1,362 | 1,362 | 0 | 0 |
| `Trellis.Mediator.Tests` | 253 | 253 | 0 | 0 |
| `Trellis.EntityFrameworkCore.Tests` | 483 | 468 | 0 | 15 (LocalDB unavailable in this env) |

## Code review

GPT-5.5 code-review pass: found one bug in Recipe 30's Pattern A example where `User.TryCreate(...).GetValueOrThrow(...)` returns `User` but the method signature is `Task<Result<User>>`. Fixed by extracting to `var user` and wrapping the return in `Result.Ok(user)`. Same shape applied to the three anti-pattern / fix snippets for consistency. No other issues.

## Source

- `backlog.md` § "External Migration Feedback — BuberDinner v3 (2026-06-04)" Items 3 + 6.
- `../trellis-feedback.md` Items 3 + 6 (Xavier's external migration report).
- User design decisions (2026-06-04, GPT-5.5 review): name `GetValueOrThrow` over `UnwrapOrThrow` (Maybe parity); Recipe 30 presents both patterns (not just fail-loud) to avoid re-introducing Recipe 18's anti-pattern in the wrong direction.
