### PR TITLE
docs: drop dangling ADR-002 §5.3 reference; rename cookbook GetByIdAsync to FindByIdAsync

### DIFF
--- a/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
@@ -881,7 +881,7 @@ The current explicit resource-authorization model is load-bearing and AI-correct
 - `IAuthorize` marker interface on messages — kept (rejecting v1's "delete it; attributes are sufficient"). The marker is what the pipeline behavior dispatches on.
 - `IAuthorizeResource<TResource>` — declares "this message authorizes against a resource of type T".
 - `IIdentifyResource<TMessage, TId>` — extracts the resource id from the message.
-- `IResourceLoader<TId, TResource>` — loads the resource (with caching).
+- `IResourceLoader<TMessage, TResource>` — loads the resource.
 - `[Authorize(Permissions = ...)]` attribute as syntactic sugar over `IAuthorize` for the simple permission-check case.
 
 **Layering is the right framing** (per critique): attributes provide the simple ergonomic path; the explicit interfaces remain for resource-aware auth. We do not delete the explicit model.

--- a/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
@@ -863,7 +863,7 @@ Keep as a thin package providing pipeline behaviors. The canonical pipeline (out
 2. `TracingBehavior` — OpenTelemetry spans.
 3. `LoggingBehavior` — structured logs with duration and outcome.
 4. `AuthorizationBehavior` — checks `[Authorize]` permissions via `IActorProvider`.
-5. `ResourceAuthorizationBehavior` — *opt-in*; checks `IAuthorizeResource<T>` with loader caching (see §5.3). Inserted by `AddResourceAuthorization(...)` immediately before `ValidationBehavior` so the loaded resource is checked once per request.
+5. `ResourceAuthorizationBehavior` — *opt-in*; checks `IAuthorizeResource<T>`. Inserted by `AddResourceAuthorization(...)` immediately before `ValidationBehavior` so the loaded resource is checked once per request.
 6. `ValidationBehavior` — **unified validation stage**. Runs `IValidate.Validate()` when the message implements it AND every `IMessageValidator<TMessage>` registered in DI for the message, aggregating `Error.UnprocessableContent` failures (both `Fields` and `Rules`) into a single response. **External validation sources plug in here through `IMessageValidator<TMessage>` instead of occupying their own pipeline slot** — in particular, `Trellis.FluentValidation` contributes a `FluentValidationMessageValidatorAdapter<TMessage>` registered by `AddTrellisFluentValidation()`. Empty `UnprocessableContent` failures still short-circuit; calling `AddTrellisFluentValidation()` is idempotent.
 7. `TransactionalCommandBehavior` — *opt-in*; lives in `Trellis.EntityFrameworkCore`. Wraps commands in `IUnitOfWork.CommitAsync`. Opt in via `AddTrellisUnitOfWork<TContext>()` after all other behavior registrations so it lands innermost (closest to the handler).
 

--- a/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
+++ b/docs/docfx_project/adr/ADR-002-v2-redesign-plan.md
@@ -876,15 +876,15 @@ The Trellis-owned dispatcher is a **Phase 7** opt-in (see §15), behind a separa
 ### 5.2 `Trellis.Authorization` — actor + resource auth retained explicitly
 
 The current explicit resource-authorization model is load-bearing and AI-correctness-positive. **Keep** the contracts:
-- `IActor` / `Actor` record (already good).
+- `Actor` — sealed class with `ActorId` typed identifier, permissions, forbidden permissions, and ABAC attributes (identity-based equality).
 - `IActorProvider` — single abstraction users implement.
 - `IAuthorize` marker interface on messages — kept (rejecting v1's "delete it; attributes are sufficient"). The marker is what the pipeline behavior dispatches on.
 - `IAuthorizeResource<TResource>` — declares "this message authorizes against a resource of type T".
-- `IIdentifyResource<TMessage, TId>` — extracts the resource id from the message.
+- `IAuthorizeResourceVia<TOwner>` — declares "this message authorizes against an owner reached by navigation from the resource" (multi-hop ownership).
+- `IIdentifyResource<TResource, TId>` — extracts the resource id from the message.
 - `IResourceLoader<TMessage, TResource>` — loads the resource.
-- `[Authorize(Permissions = ...)]` attribute as syntactic sugar over `IAuthorize` for the simple permission-check case.
 
-**Layering is the right framing** (per critique): attributes provide the simple ergonomic path; the explicit interfaces remain for resource-aware auth. We do not delete the explicit model.
+**Explicit interfaces are the right framing** (per critique): `IAuthorize.RequiredPermissions` is the simple permission-gate path (no attribute layer); `IAuthorizeResource<TResource>` and `IAuthorizeResourceVia<TOwner>` provide resource-aware auth. We do not delete the explicit model in favor of attributes.
 
 **`Trellis.FluentValidation` stays as a separate, opt-in package** (consistent with §2 row 9 and the "no forced third-party transitive dependencies" principle). The `ValidationBehavior` in `Trellis.Mediator` discovers FluentValidation validators *only when* `Trellis.FluentValidation` is referenced — the discovery happens via a typed extension method on `IServiceCollection` that the FluentValidation package contributes (`AddTrellisFluentValidation()`). Consumers who do not install `Trellis.FluentValidation` get the `IValidate.Validate()` path only. The 3 standalone extension methods (`ToResult`, `ValidateToResult`, `ValidateToResultAsync`) remain in `Trellis.FluentValidation` for use outside the pipeline. **No folding.**
 

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -396,14 +396,14 @@ public sealed record CancelOrderCommand(OrderId OrderId)
 
 public interface IOrderRepository
 {
-    Task<Maybe<Order>> GetByIdAsync(OrderId id, CancellationToken ct);
+    Task<Maybe<Order>> FindByIdAsync(OrderId id, CancellationToken ct);
 }
 
 public sealed class OrderResourceLoader(IOrderRepository repo)
     : SharedResourceLoaderById<Order, OrderId>
 {
     public override async Task<Result<Order>> GetByIdAsync(OrderId id, CancellationToken ct) =>
-        (await repo.GetByIdAsync(id, ct)).ToResult(new Error.NotFound(ResourceRef.For<Order>(id)));
+        (await repo.FindByIdAsync(id, ct)).ToResult(new Error.NotFound(ResourceRef.For<Order>(id)));
 }
 ```
 


### PR DESCRIPTION
Two surgical doc-only fixes ahead of the v4 typed-accessor + microservices auth roadmap captured in `backlog.md`.

## Changes

- **`docs/docfx_project/adr/ADR-002-v2-redesign-plan.md` (§5.1, line 866)** — Remove the dangling `with loader caching (see §5.3)` parenthetical. §5.3 was never written; the v4 typed-accessor work will land the real §5.3 covering mutation-ready handoff.

- **`docs/docfx_project/api_reference/trellis-api-authorization.md` (lines 397–406)** — Rename cookbook `IOrderRepository.GetByIdAsync(...) → Task<Maybe<Order>>` to `FindByIdAsync` to match the framework's `Get*` (→ `Result<T>`) / `Find*` (→ `Maybe<T>`) naming convention documented in `integration-ef.md:515` and `integration-testing.md:219`. Loader override's own `GetByIdAsync` returning `Result<T>` correctly stays — that's the canonical `SharedResourceLoaderById<T, TId>` method name and follows the `Get*`/`Result` convention. Loader body updated to call `repo.FindByIdAsync` and lift to `Result<T>` via `.ToResult(new Error.NotFound(...))`.

## Verification (local CI mirror)

| Gate | Source | Result |
|---|---|---|
| Stale v1 `Error.X(...)` factory references | `documentation.yml` | PASS |
| Stale current-facing docs (`audit-stale-docs.ps1`) | `documentation.yml` | PASS |
| `dotnet restore && dotnet build -c Release` | `build.yml` + `documentation.yml` | 0 warn / 0 err (64s) |
| `docfx docs/docfx_project/docfx.json` | `documentation.yml` | Clean; `_site` produced (126s) |
| `dotnet test --no-build -c Release --filter-not-trait "Category=Integration"` | `build.yml` | 6,867 passed / 0 failed / 15 skipped |

No code changed; build/test included for parity with CI.