### PR TITLE
docs(authorization): document token-pass-through microservices path in Recipe 7

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -506,6 +506,33 @@ services.AddResourceAuthorization(
 
 For the AOT-safe per-command registration shape (`AddResourceAuthorization<TMessage, TResource, TResponse>()`) and the equivalent `TrellisServiceBuilder.UseResourceAuthorization<TMessage, TResource, TResponse>()` slot, see [`trellis-api-servicedefaults.md`](trellis-api-servicedefaults.md#trellisservicebuilder). For multi-hop authorization (the resource the actor must own is reached via one or more navigation hops), see [Recipe 24](#recipe-24--indirect-multi-hop-resource-authorization).
 
+**Microservices.** The setup above works identically behind a reverse proxy / API gateway — the simplest microservices pattern is **token pass-through**: the gateway validates the incoming external JWT (Auth0 / Entra / Keycloak / etc.) and forwards it as-is, and each microservice configures `AddJwtBearer(o => o.Authority = "https://idp")` against the SAME external IDP. No new Trellis packages required.
+
+```csharp
+// Microservice composition — token pass-through path.
+// Gateway validated the JWT; this service validates again against the same IDP and
+// hydrates the Actor from the standard claims.
+builder.Services.AddAuthentication("Bearer").AddJwtBearer(o =>
+{
+    o.Authority = "https://your-idp.example";   // SAME IDP the gateway validated against
+    o.Audience = "your-service";                // pin per-service audience
+    o.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true, ValidIssuer = "https://your-idp.example",
+        ValidateAudience = true, ValidAudience = "your-service",
+        ValidateLifetime = true, RequireSignedTokens = true,
+        ClockSkew = TimeSpan.FromSeconds(30),
+    };
+});
+
+builder.Services.AddTrellis(o => o
+    .UseClaimsActorProvider(c => { c.ActorIdClaim = "sub"; c.PermissionsClaim = "permissions"; })
+    .UseResourceAuthorization()
+    .UseResourceAuthorization<UpdateOrderCommand, Order, Result<Unit>>());
+```
+
+This pattern works today with current Trellis. Choose it when the external IDP is stable, all microservices share the same trust root, and you don't need per-cluster permission projection or shorter-than-IDP token lifetimes. When those constraints matter, the roadmap will offer two additional opt-in patterns: **Trellis internal JWT** (gateway re-mints a fresh per-cluster JWT from the full resolved `Actor`; see `TrellisInternalJwtActorProvider` + `Trellis.Yarp` in the authorization-microservices article when it ships) and **OAuth2 token exchange / OBO** (use `Microsoft.Identity.Web`'s OBO support directly — Trellis does not ship a token-exchange helper). The three-way decision matrix is documented in the upcoming `authorization-microservices.md` article.
+
 ---
 
 ## Recipe 8 — EF Core: `MaybePropertyMapping` for nullable value objects


### PR DESCRIPTION
# Document the token-pass-through microservices path in Recipe 7

## Summary

Today's microservices users have to assemble "how do I do microservices with current Trellis" from package READMEs and the bundled actor-provider helpers. The roadmap's P3 (`TrellisInternalJwtActorProvider`) + P4 (`Trellis.Yarp`) work currently in progress could implicitly suggest microservices REQUIRE those new packages — they don't. The simplest microservices pattern, **token pass-through**, works today with current Trellis using `AddJwtBearer` + `UseClaimsActorProvider` (or any of the bundled actor providers) against the SAME external IDP both gateway and microservices validate against.

Recipe 7 (Authorization) gains a new "Microservices" subsection covering:

- The strict `AddJwtBearer` profile a microservice should use behind a gateway (`Authority`, `Audience`, full `ValidateIssuer/Audience/Lifetime`, `RequireSignedTokens`, tight `ClockSkew`).
- The matching `AddTrellis(...)` composition root with `UseClaimsActorProvider`.
- When to choose this path (external IDP stable, all services share trust root, no per-cluster permission projection needed).
- Forward-pointers to the two opt-in patterns the roadmap is building — **Trellis internal JWT** (P3 + P4) for per-cluster permission projection / shorter token lifetimes / gateway-side identity hydration, and **OAuth2 token exchange / OBO** via `Microsoft.Identity.Web` for enterprise multi-tenant SaaS — without misrepresenting either as required.

Also expands the P6 backlog item (consolidated `authorization-microservices.md` article, blocked on P4 E2E) to frame microservices auth as a **3-way choice** (Path A pass-through / Path B Trellis internal JWT / Path C OBO) with a decision matrix, so consumers pick by trade-off rather than defaulting to the Trellis-specific path. The microservices boundary (ADR-002 §5.6) applies to all three; the differences are only in HOW the resolved `Actor` crosses the gateway-to-microservice boundary. Backlog edit is outside the git repo.

## Files changed

| File | Change |
|---|---|
| `docs/docfx_project/api_reference/trellis-api-cookbook.md` | +27 lines — new "Microservices" subsection appended to Recipe 7 |

## Why this is a separate PR

Per the one-PR-at-a-time invariant, the doc clarification is independent of the in-progress P3 implementation and unblocks today's consumers without waiting on P3+P4. The P6 narrative article remains blocked on P4 E2E; this PR is the minimum-viable Recipe 7 update so today's users see the canonical pass-through pattern documented somewhere.

## Verification

| Gate | Result |
|---|---|
| `docfx docs/docfx_project/docfx.json` | builds clean (only the 2 benign `FailedToLoadAnalyzer` warnings the workflow already filters) |
| `pwsh ./docs/docfx_project/api_reference/audit-stale-docs.ps1` | clean |
| Local mirror of publish-docs v1 `Error.X(...)` factory gate | 0 hits |
| `dotnet build Trellis.slnx -c Release` | 0 warnings / 0 errors (TreatWarningsAsErrors=true) |
| `dotnet test Trellis.slnx -c Release --no-build` | 6,945 passed / 0 failed / 15 skipped (smoke check; no code changes) |
| BOM on `trellis-api-cookbook.md` | ✓ |

No code change. Doc-only PR.
