### PR TITLE
Fix dependabot build failure: add explicit checks/pull-requests write permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
     branches: [ main ]
 
+# Dependabot PRs run with a read-only GITHUB_TOKEN by default. The
+# EnricoMi/publish-unit-test-result-action step calls POST /check-runs
+# (needs `checks: write`) and may comment on PRs (`pull-requests: write`).
+# Without this explicit block, the action 403s on every dependabot PR
+# even when the build + tests themselves are green.
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an explicit workflow-level `permissions:` block to `.github/workflows/build.yml` so the `EnricoMi/publish-unit-test-result-action` step doesn't 403 on dependabot PRs.

## Why

PR #587 (and any future dependabot PR) fails on the **Publish Test Results** step with:

```
Request POST /repos/xavierjohn/Trellis/check-runs failed with 403: Forbidden
github.GithubException.GithubException: Resource not accessible by integration
```

Root cause: dependabot PRs run with a read-only `GITHUB_TOKEN` by default. The action needs `checks: write` to create a check run and `pull-requests: write` to comment on PRs. Without an explicit workflow-level `permissions:` block, both are denied.

## The fix

```yaml
permissions:
  contents: read
  checks: write
  pull-requests: write
```

Minimum needed:
- `contents: read` — `actions/checkout`
- `checks: write` — `EnricoMi/publish-unit-test-result-action` creates a check run
- `pull-requests: write` — `EnricoMi/publish-unit-test-result-action` comments on PRs

Non-dependabot `pull_request` events and `push` / `workflow_dispatch` events were already getting these permissions implicitly; this change is a no-op for them and a fix for dependabot.

## Scope

Only `build.yml` is affected. Surveyed the other workflows:

| Workflow | Triggers on PR? | Has GitHub-API write step? | Action needed |
|---|---|---|---|
| `build.yml` | yes (`pull_request`) | yes (publish test results) | **This fix** |
| `documentation.yml` | yes | yes (`peaceiris/actions-gh-pages`) but gated to `workflow_dispatch + main` | none |
| `codeql.yml` | no (push/schedule only) | yes (CodeQL) | none |
| `publish.yml` / `publish-alpha.yml` | no (`workflow_dispatch`) | yes (release) | none |

## After merge

Re-run PR #587's CI; the Publish Test Results step should now succeed. The 2 grouped github-actions bumps (codecov-action v5→v6, upload-artifact v6→v7) are both safe per the changelogs.