### PR TITLE
chore(deps): prune 6 unused PackageVersion pins from Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.0-rc.1" />
     <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
@@ -35,12 +32,10 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Stateless" Version="5.20.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.14.14" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
     <PackageVersion Include="T4.Build" Version="0.2.5" />
   </ItemGroup>
   <!-- Test -->
@@ -51,7 +46,6 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="Xunit.DependencyInjection" Version="11.1.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
   </ItemGroup>


### PR DESCRIPTION
Removes 6 dead `PackageVersion` entries from `Directory.Packages.props` that no `.csproj` actually consumes via `PackageReference`.

## Why these are truly dead

`CentralPackageTransitivePinningEnabled` is **NOT** set in this repo (only `ManagePackageVersionsCentrally=true`), so a `PackageVersion` without a matching `PackageReference` is a true no-op — it doesn't even constrain transitive versions.

Verified by inspecting `Examples/SsoExample/obj/project.assets.json`: JwtBearer 10.0.8 pulls `Microsoft.IdentityModel.JsonWebTokens 8.0.1` and `Microsoft.IdentityModel.Tokens 8.0.1` transitively — **ignoring** the `8.19.1` pins these lines were claiming. Confirms the pins were dead weight.

## Pins removed

| Package | Why it's dead |
|---|---|
| `Microsoft.IdentityModel.JsonWebTokens` 8.19.1 | Was for the carved-out internal-JWT minter (now in `xavierjohn/Trellis.Microservices`). No remaining direct consumer in this repo. SsoExample picks up 8.0.1 transitively from JwtBearer anyway. |
| `Microsoft.IdentityModel.Tokens` 8.19.1 | Same as above. |
| `Yarp.ReverseProxy` 2.3.0 | Was for `Trellis.Yarp`; carved out in #585. |
| `OpenTelemetry.Extensions.Hosting` 1.15.3 | No remaining `.csproj` consumer. |
| `System.Drawing.Common` 9.0.0 | No remaining `.csproj` consumer (likely historical). |
| `Xunit.DependencyInjection` 11.1.1 | No remaining `.csproj` consumer. |

## Verification

- `dotnet restore Trellis.slnx` → succeeded
- `dotnet build Trellis.slnx -c Release` → **0 warnings, 0 errors**
- `dotnet test Trellis.slnx -c Release --no-build` → **6,945 passed / 0 failed / 15 skipped** (identical to pre-cleanup; confirms zero impact)

File still has UTF-8 BOM per `.editorconfig` `charset = utf-8-bom` rule.

## Diff stat

`Directory.Packages.props | 6 ------ — 1 file changed, 6 deletions(-)`

Pure deletion, no formatting churn.
