### PR TITLE
docs(core): document NullableExtensions + NullableExtensionsAsync ToResult* overloads

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -39,6 +39,7 @@ Use this table before searching the long type catalog.
 | Adapt an already-computed result to async APIs | `.AsTask()` / `.AsValueTask()` | [`ResultTaskAdapterExtensions`](#task-adapter-family--resulttaskadapterextensions) |
 | Model expected absence | `Maybe<T>`, `Maybe.From(value)`, `Maybe<T>.None` | [`Maybe<T>`](#public-readonly-struct-maybet-where-t--notnull) |
 | Convert absence to a domain failure | `maybe.ToResult(error)` / `maybe.ToResult(errorFactory)` | [`MaybeExtensions`](#maybeextensions) |
+| Convert a nullable reference / value to a domain failure (sync or async) | `obj.ToResult(error)` / `task.ToResultAsync(error)` / `valueTask.ToResultAsync(errorFactory)` — works on `T?` for both `class` and `struct`, plus `Task<T?>` and `ValueTask<T?>` | [`Nullable to Result`](#nullable-to-result--nullableextensions-nullableextensionsasync) |
 | Create HTTP-oriented domain errors | Closed `Error` cases plus `ResourceRef.For<TResource>(id)` | [`Error`](#public-abstract-record-error), [`Error Cases`](#error-cases-closed-adt) |
 | Page list responses | `new Page<T>(items, next, previous, requestedLimit, appliedLimit)` (or `Page.Empty<T>(...)` when there are no items), `Cursor` | [`Pagination`](#pagination) |
 | Model aggregates/entities/events | `Aggregate<TId>`, `Entity<TId>`, `IDomainEvent` | [`Domain-Driven Design`](#domain-driven-design) |
@@ -1232,6 +1233,41 @@ Project a `Result<T>` to a `Maybe<T>` (failure → `None`).
 
 ```csharp
 Maybe<Order> maybe = await repo.TryLoadAsync(id).ToMaybeAsync();
+```
+
+#### Nullable to Result — `NullableExtensions`, `NullableExtensionsAsync`
+
+Bridge a plain nullable value (`T?` for reference or value types) into the Result track. Mirrors `Maybe<T>.ToResult` for repositories that return raw nullables instead of `Maybe<T>`. The async overloads extend `Task<T?>` and `ValueTask<T?>` directly so you don't pay the `(await …).ToResult(error)` parenthesised-await burr — chain them like `BindAsync` / `EnsureAsync` / `MapAsync`.
+
+The `Func<Error>` overloads validate the factory **before** awaiting the receiver: a null `errorFactory` throws `ArgumentNullException` even when the source would have succeeded.
+
+**Sync — `NullableExtensions` (4 overloads)**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static Result<T> ToResult<T>(this T? nullable, Error error) where T : struct` | `Result<T>` | Value-type variant. `null` → `Fail(error)`; otherwise `Ok(nullable.Value)`. |
+| `public static Result<T> ToResult<T>(this T? nullable, Func<Error> errorFactory) where T : struct` | `Result<T>` | Value-type factory variant. Throws `ArgumentNullException` when `errorFactory` is `null`. |
+| `public static Result<T> ToResult<T>(this T? obj, Error error) where T : class` | `Result<T>` | Reference-type variant. |
+| `public static Result<T> ToResult<T>(this T? obj, Func<Error> errorFactory) where T : class` | `Result<T>` | Reference-type factory variant. |
+
+**Async — `NullableExtensionsAsync` (8 overloads)**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static Task<Result<T>> ToResultAsync<T>(this Task<T?> nullableTask, Error error) where T : struct` | `Task<Result<T>>` | `Task<T?>` value-type variant. |
+| `public static Task<Result<T>> ToResultAsync<T>(this Task<T?> nullableTask, Func<Error> errorFactory) where T : struct` | `Task<Result<T>>` | `Task<T?>` value-type factory variant. |
+| `public static Task<Result<T>> ToResultAsync<T>(this Task<T?> nullableTask, Error error) where T : class` | `Task<Result<T>>` | `Task<T?>` reference-type variant — the canonical "repo returns `Task<User?>`" bridge. |
+| `public static Task<Result<T>> ToResultAsync<T>(this Task<T?> nullableTask, Func<Error> errorFactory) where T : class` | `Task<Result<T>>` | `Task<T?>` reference-type factory variant. |
+| `public static ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> nullableTask, Error error) where T : struct` | `ValueTask<Result<T>>` | `ValueTask<T?>` value-type variant. |
+| `public static ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> nullableTask, Func<Error> errorFactory) where T : struct` | `ValueTask<Result<T>>` | `ValueTask<T?>` value-type factory variant. |
+| `public static ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> nullableTask, Error error) where T : class` | `ValueTask<Result<T>>` | `ValueTask<T?>` reference-type variant — the canonical "repo returns `ValueTask<Order?>`" bridge. |
+| `public static ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> nullableTask, Func<Error> errorFactory) where T : class` | `ValueTask<Result<T>>` | `ValueTask<T?>` reference-type factory variant. |
+
+```csharp
+// Repository returns ValueTask<Order?> — bridge into the Result track without (await ...).ToResult(...) parens.
+private ValueTask<Result<Order>> LoadOrderAsync(OrderId id, CancellationToken ct) =>
+    _orderRepository.FindByIdAsync(id, ct)
+        .ToResultAsync(new Error.NotFound(ResourceRef.For<Order>(id)));
 ```
 
 ---

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1237,9 +1237,9 @@ Maybe<Order> maybe = await repo.TryLoadAsync(id).ToMaybeAsync();
 
 #### Nullable to Result — `NullableExtensions`, `NullableExtensionsAsync`
 
-Bridge a plain nullable value (`T?` for reference or value types) into the Result track. Mirrors `Maybe<T>.ToResult` for repositories that return raw nullables instead of `Maybe<T>`. The async overloads extend `Task<T?>` and `ValueTask<T?>` directly so you don't pay the `(await …).ToResult(error)` parenthesised-await burr — chain them like `BindAsync` / `EnsureAsync` / `MapAsync`.
+Bridge a plain nullable value (`T?` for reference or value types) into the Result track. Mirrors `Maybe<T>.ToResult` for repositories that return raw nullables instead of `Maybe<T>`. The async overloads extend `Task<T?>` and `ValueTask<T?>` directly, so call sites can chain `.ToResultAsync(error)` onto a repository call without an intermediate `await` — matching the receiver pattern used by `BindAsync` / `EnsureAsync` / `MapAsync`.
 
-The `Func<Error>` overloads validate the factory **before** awaiting the receiver: a null `errorFactory` throws `ArgumentNullException` even when the source would have succeeded.
+The `Func<Error>` async overloads delegate to the sync `ToResult` after awaiting, so the `ArgumentNullException.ThrowIfNull(errorFactory)` check fires on the awaited continuation rather than synchronously. The thrown exception still surfaces from the returned `Task` / `ValueTask`. This intentionally differs from `MaybeExtensionsAsync.ToResultAsync(Func<Error>)`, which validates the factory before awaiting.
 
 **Sync — `NullableExtensions` (4 overloads)**
 
@@ -1264,7 +1264,8 @@ The `Func<Error>` overloads validate the factory **before** awaiting the receive
 | `public static ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> nullableTask, Func<Error> errorFactory) where T : class` | `ValueTask<Result<T>>` | `ValueTask<T?>` reference-type factory variant. |
 
 ```csharp
-// Repository returns ValueTask<Order?> — bridge into the Result track without (await ...).ToResult(...) parens.
+// Repository returns ValueTask<Order?>. ToResultAsync extends the task receiver
+// directly, so no intermediate await + sync ToResult call is required.
 private ValueTask<Result<Order>> LoadOrderAsync(OrderId id, CancellationToken ct) =>
     _orderRepository.FindByIdAsync(id, ct)
         .ToResultAsync(new Error.NotFound(ResourceRef.For<Order>(id)));


### PR DESCRIPTION
The 12 `ToResult*` / `ToResultAsync` overloads in `NullableExtensions` / `NullableExtensionsAsync` have **always shipped** in `Trellis.Core` (the `where T : class` async overloads since Feb 2026, the `ValueTask` variants since Dec 2025), but the `trellis-api-core.md` API reference only documented them as a single one-line catalog row ("Converts nullable reference/value types to `Result<T>`") with no signature table. The `MaybeExtensionsAsync` `ToResultAsync` overloads next door have a full signature table — that asymmetry misleads readers into thinking the `T?` / `Task<T?>` / `ValueTask<T?>` overloads don't exist.

## Triggered by

A false-positive feature request from `xavierjohn/BuberDinner` asking for the four `where T : class` async overloads. The consumer checked the API reference, saw only `Maybe<T>` async overloads documented, concluded the `T?` side didn't have async support, and filed a request to add them. Every shape they asked for **already exists** in `alpha.342`.

## What this PR adds

Two surgical additions to `docs/docfx_project/api_reference/trellis-api-core.md`:

### 1. Row in the top "Use this when" lookup table (line 42)

Gives readers a direct hit for "Convert a nullable reference / value to a domain failure (sync or async)" with the canonical `obj.ToResult(error)` / `task.ToResultAsync(error)` / `valueTask.ToResultAsync(errorFactory)` patterns plus an anchor link to the new detail section.

### 2. New `#### Nullable to Result — NullableExtensions, NullableExtensionsAsync` subsection (line 1238)

Immediately after the existing `#### ToMaybe` subsection in the extension catalog. Two signature tables:

- **`NullableExtensions`** (sync) — 4 overloads: `T : struct` + `T : class` × `Error` + `Func<Error>`
- **`NullableExtensionsAsync`** — all 8 overloads: `Task<T?>` + `ValueTask<T?>` × `T : struct` + `T : class` × `Error` + `Func<Error>`

Plus an end-to-end example showing the canonical "repo returns `ValueTask<Order?>`" → `.ToResultAsync(new Error.NotFound(...))` pattern that avoids the `(await ...).ToResult(...)` parenthesised-await burr the consumer was hitting.

## Scope

Pure documentation change — **no code edits**. `trellis-api-core.md` is the only API reference file mentioning these types (verified by repo-wide grep). Diff stat: `1 file changed, 36 insertions(+)`. File still UTF-8 BOM (editorconfig-compliant).
