### PR TITLE
Unify validation error keys on camelCase (FluentValidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — FluentValidation validation-error keys are now camelCase
+
+`JsonPointerNormalizer.ToJsonPointer(...)` now lower-camelCases each name segment, so
+FluentValidation-derived validation error keys match the camelCase JSON wire and the rest of
+Trellis's validation field names (the seam's `Required*.TryCreate(value, fieldName)` and the ASP
+scalar-binding path already camelCase). For example, `Address.PostCode` now normalizes to
+`/address/postCode` (was `/Address/PostCode`) and `Items[0].Sku` to `/items/0/sku`. Indexer
+segments are unchanged. Tests or clients asserting on the previous PascalCase FluentValidation
+field keys need updating.
+
 ### Removed — Microservice trust-boundary code carved out to `xavierjohn/Trellis.Microservices` (BREAKING)
 
 This release completes the carve-out of all microservice trust-boundary code (gateway-side JWT minting + consumer-side actor hydration + shared contract constants) into the separate [`xavierjohn/Trellis.Microservices`](https://github.com/xavierjohn/Trellis.Microservices) repository. The carve-out consolidates security-tier code under one CODEOWNERS surface, eliminates the gateway/consumer contract-literal duplication (now via the new `Trellis.Microservices.Abstractions` package), and lets the microservices packages evolve on an independent release cadence from the core framework.

--- a/Examples/Showcase/README.md
+++ b/Examples/Showcase/README.md
@@ -23,7 +23,7 @@ the two hosting styles side-by-side over a single, identical contract.
 | `Trellis.Asp.ToHttpResponseAsync(...)` mapping (Minimal API) | `Showcase.MinimalApi/Endpoints/*` |
 | **Mediator pipeline** (`AddMediator` + `AddTrellisBehaviors`) | `Showcase.MinimalApi/Program.cs` |
 | **`IValidate` + FluentValidation composition** in one `ValidationBehavior` stage | `Showcase.Application/Features/SubmitBatchTransfers/*` |
-| **JSON Pointer normalization** for FluentValidation nested (`/Metadata/Reference`) and indexer (`/Lines/0/Memo`) paths (translated to MVC `Metadata.Reference` / `Lines[0].Memo` on the wire by `Trellis.Asp`) | `Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersValidator.cs` |
+| **JSON Pointer normalization** for FluentValidation nested (`/metadata/reference`) and indexer (`/lines/0/memo`) paths (translated to MVC `metadata.reference` / `lines[0].memo` on the wire by `Trellis.Asp`) | `Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersValidator.cs` |
 | AOT-friendly `AddTrellisFluentValidation()` + explicit `AddScoped<IValidator<T>, ...>` | `Showcase.MinimalApi/Program.cs` |
 | **IETF Idempotency-Key middleware** (opt-in `[Idempotent]` / `.WithMetadata(new IdempotentAttribute())` on POST — first call executes, retry replays the captured snapshot with `Idempotent-Replayed: true`, same key + mutated body is rejected as 422, missing key on an opted-in endpoint is rejected as 400) | `Showcase.{Mvc,MinimalApi}/Program.cs`, `Showcase.MinimalApi/Endpoints/TransferEndpoints.cs`, `Showcase.Mvc/Controllers/TransfersController.cs` |
 

--- a/Examples/Showcase/src/Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersCommand.cs
+++ b/Examples/Showcase/src/Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersCommand.cs
@@ -27,8 +27,8 @@ using Trellis.Showcase.Domain.ValueObjects;
 /// <see cref="ValidationBehavior{TMessage, TResponse}"/> aggregates every
 /// <see cref="Error.InvalidInput"/> failure into a single response with one combined
 /// <see cref="FieldViolation"/> list. Nested and indexer property names from FluentValidation
-/// are translated to RFC&#8239;6901 JSON Pointers (<c>/Metadata/Reference</c>,
-/// <c>/Lines/0/Memo</c>) by the FluentValidation adapter.
+/// are translated to RFC&#8239;6901 JSON Pointers (<c>/metadata/reference</c>,
+/// <c>/lines/0/memo</c>) by the FluentValidation adapter.
 /// </para>
 /// </summary>
 public sealed record SubmitBatchTransfersCommand(

--- a/Examples/Showcase/src/Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersValidator.cs
+++ b/Examples/Showcase/src/Showcase.Application/Features/SubmitBatchTransfers/SubmitBatchTransfersValidator.cs
@@ -8,9 +8,9 @@ using global::FluentValidation;
 /// <list type="bullet">
 ///   <item><description><c>RuleFor(c =&gt; c.Metadata.Reference)</c> produces the FluentValidation
 ///   property name <c>"Metadata.Reference"</c>, which the Trellis adapter translates to
-///   <c>/Metadata/Reference</c>.</description></item>
+///   <c>/metadata/reference</c>.</description></item>
 ///   <item><description><c>RuleForEach(c =&gt; c.Lines).ChildRules(...)</c> produces names like
-///   <c>"Lines[0].Memo"</c>, which the adapter translates to <c>/Lines/0/Memo</c>.</description></item>
+///   <c>"Lines[0].Memo"</c>, which the adapter translates to <c>/lines/0/memo</c>.</description></item>
 /// </list>
 /// </summary>
 public sealed class SubmitBatchTransfersValidator : AbstractValidator<SubmitBatchTransfersCommand>

--- a/Examples/Showcase/tests/Showcase.MinimalApi.Tests/BatchTransferEndpointTests.cs
+++ b/Examples/Showcase/tests/Showcase.MinimalApi.Tests/BatchTransferEndpointTests.cs
@@ -19,10 +19,10 @@ using Trellis.Showcase.MinimalApi.Endpoints;
 /// FluentValidation adapter on the same message and aggregates every violation into one
 /// 422 response. Internally, FluentValidation property names (e.g. <c>"Metadata.Reference"</c>,
 /// <c>"Lines[0].Memo"</c>) are normalized to RFC 6901 JSON Pointers
-/// (<c>/Metadata/Reference</c>, <c>/Lines/0/Memo</c>) and stored on
+/// (<c>/metadata/reference</c>, <c>/lines/0/memo</c>) and stored on
 /// <see cref="FieldViolation"/>. The ASP boundary then translates those pointers into the
 /// dot+bracket convention used by ASP.NET Core's default <c>ValidationProblemDetails</c>
-/// (<c>Metadata.Reference</c>, <c>Lines[0].Memo</c>) for the wire <c>errors</c> dict, so
+/// (<c>metadata.reference</c>, <c>lines[0].memo</c>) for the wire <c>errors</c> dict, so
 /// React form libraries (react-hook-form, Formik) and OpenAPI codegen consumers can lookup
 /// errors by the same field name they use client-side.
 /// </para>
@@ -98,14 +98,14 @@ public sealed class BatchTransferEndpointTests : IClassFixture<WebApplicationFac
         var body = await response.Content.ReadAsStringAsync(Ct);
 
         // Nested property: FluentValidation reports "Metadata.Reference" → adapter normalizes to
-        // RFC 6901 pointer "/Metadata/Reference" → ASP wire emits MVC convention "Metadata.Reference".
-        body.Should().Contain("Metadata.Reference");
+        // RFC 6901 pointer "/metadata/reference" → ASP wire emits MVC convention "metadata.reference".
+        body.Should().Contain("metadata.reference");
         // Indexer property: FluentValidation reports "Lines[0].Memo" → adapter normalizes to
-        // "/Lines/0/Memo" → ASP wire emits MVC convention "Lines[0].Memo".
-        body.Should().Contain("Lines[0].Memo");
+        // "/lines/0/memo" → ASP wire emits MVC convention "lines[0].memo".
+        body.Should().Contain("lines[0].memo");
         // Confirm the JSON Pointer slash form did NOT leak through to the wire.
-        body.Should().NotContain("Metadata/Reference");
-        body.Should().NotContain("Lines/0/Memo");
+        body.Should().NotContain("metadata/reference");
+        body.Should().NotContain("lines/0/memo");
     }
 
     [Fact]
@@ -128,9 +128,9 @@ public sealed class BatchTransferEndpointTests : IClassFixture<WebApplicationFac
         // From IValidate (uses InputPointer "/Lines/0/ToAccountId" → wire "Lines[0].ToAccountId")
         body.Should().Contain("Lines[0].ToAccountId");
         body.Should().Contain("A line may not target the source account.");
-        // From FluentValidation, normalized through "/Metadata/Reference" / "/Lines/0/Memo" then translated to MVC convention.
-        body.Should().Contain("Metadata.Reference");
-        body.Should().Contain("Lines[0].Memo");
+        // From FluentValidation, normalized through "/metadata/reference" / "/lines/0/memo" then translated to MVC convention.
+        body.Should().Contain("metadata.reference");
+        body.Should().Contain("lines[0].memo");
     }
 
     [Fact]

--- a/Examples/TestingPatterns/FluentValidationSamplesTests.cs
+++ b/Examples/TestingPatterns/FluentValidationSamplesTests.cs
@@ -196,7 +196,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Email" && e.Detail!.Contains("Email is already registered"));
+            e.Field.Path == "/email" && e.Detail!.Contains("Email is already registered"));
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Email" && e.Detail!.Contains("Email domain is not allowed"));
+            e.Field.Path == "/email" && e.Detail!.Contains("Email domain is not allowed"));
     }
 
     [Fact]
@@ -240,7 +240,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Username" && e.Detail!.Contains("Username is already taken"));
+            e.Field.Path == "/username" && e.Detail!.Contains("Username is already taken"));
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class FluentValidationSamplesTests
         // Assert
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path == "/Username");
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path == "/username");
     }
 
     [Fact]
@@ -573,7 +573,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/ShippingAddress" &&
+            e.Field.Path == "/shippingAddress" &&
             e.Detail!.Contains("Shipping address is required for physical orders"));
     }
 
@@ -620,7 +620,7 @@ public class FluentValidationSamplesTests
         var validationError = (Error.InvalidInput)result.UnwrapError();
         // FluentValidation's default message is "'Email' must not be empty."
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Email" &&
+            e.Field.Path == "/email" &&
             e.Detail!.Contains("must not be empty"));
     }
 
@@ -645,7 +645,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/TotalAmount" &&
+            e.Field.Path == "/totalAmount" &&
             e.Detail!.Contains("Express shipping not available for orders over $10,000"));
     }
 
@@ -691,7 +691,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/TaxId" &&
+            e.Field.Path == "/taxId" &&
             e.Detail!.Contains("Tax ID required for business orders"));
     }
 
@@ -745,7 +745,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Price" &&
+            e.Field.Path == "/price" &&
             e.Detail!.Contains("$-5") && e.Detail!.Contains("must be greater than $0"));
     }
 
@@ -763,7 +763,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Stock" &&
+            e.Field.Path == "/stock" &&
             e.Detail!.Contains("15000") && e.Detail!.Contains("exceeds maximum of 10,000"));
     }
 
@@ -781,7 +781,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Name" &&
+            e.Field.Path == "/name" &&
             e.Detail!.Contains("current: 2"));
     }
 
@@ -799,7 +799,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Discount" &&
+            e.Field.Path == "/discount" &&
             e.Detail!.Contains("$60") && e.Detail!.Contains("$100"));
     }
 
@@ -856,7 +856,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/OrderIds" &&
+            e.Field.Path == "/orderIds" &&
             e.Detail!.Contains("Batch must contain at least one order"));
     }
 
@@ -875,7 +875,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/OrderIds" &&
+            e.Field.Path == "/orderIds" &&
             e.Detail!.Contains("101") && e.Detail!.Contains("maximum is 100"));
     }
 
@@ -893,7 +893,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/OrderIds" &&
+            e.Field.Path == "/orderIds" &&
             e.Detail!.Contains("Batch contains duplicate order IDs"));
     }
 
@@ -1009,8 +1009,8 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         // Both Email and Phone should have validation errors
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("Email"));
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("Phone"));
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("email"));
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("phone"));
     }
 
     [Fact]
@@ -1029,9 +1029,9 @@ public class FluentValidationSamplesTests
         // Assert
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("Street"));
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("PostalCode"));
-        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("Country"));
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("street"));
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("postalCode"));
+        validationError.Fields.Items.Should().Contain(e => e.Field.Path.Contains("country"));
     }
 
     [Fact]
@@ -1051,7 +1051,7 @@ public class FluentValidationSamplesTests
         result.IsFailure.Should().BeTrue();
         var validationError = (Error.InvalidInput)result.UnwrapError();
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/ContactInfo" &&
+            e.Field.Path == "/contactInfo" &&
             e.Detail!.Contains("Contact information is required"));
     }
 
@@ -1100,7 +1100,7 @@ public class FluentValidationSamplesTests
         var validationError = (Error.InvalidInput)result.UnwrapError();
         // ValidateToResult uses custom paramName and message for null values
         validationError.Fields.Items.Should().Contain(e =>
-            e.Field.Path == "/Alias" &&
+            e.Field.Path == "/alias" &&
             e.Detail!.Contains("Hello There"));
     }
 

--- a/Trellis.FluentValidation/NUGET_README.md
+++ b/Trellis.FluentValidation/NUGET_README.md
@@ -39,7 +39,7 @@ builder.Services.AddTrellisFluentValidation();
 builder.Services.AddScoped<IValidator<MyCommand>, MyCommandValidator>();
 ```
 
-The adapter normalizes FluentValidation property names (`Metadata.Reference`, `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/Metadata/Reference`, `/Lines/0/Memo`) using `JsonPointerNormalizer`, which is now part of the public surface of `Trellis.FluentValidation`.
+The adapter normalizes FluentValidation property names (`Metadata.Reference`, `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/metadata/reference`, `/lines/0/memo`) using `JsonPointerNormalizer`, which is now part of the public surface of `Trellis.FluentValidation`.
 
 ## Key Features
 - Convert `ValidationResult` into `Result<T>` with Trellis validation errors.

--- a/Trellis.FluentValidation/README.md
+++ b/Trellis.FluentValidation/README.md
@@ -39,7 +39,7 @@ builder.Services.AddTrellisFluentValidation();
 builder.Services.AddScoped<IValidator<MyCommand>, MyCommandValidator>();
 ```
 
-The adapter normalizes FluentValidation property names (`Metadata.Reference`, `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/Metadata/Reference`, `/Lines/0/Memo`) using `JsonPointerNormalizer`, which is now part of the public surface of `Trellis.FluentValidation`.
+The adapter normalizes FluentValidation property names (`Metadata.Reference`, `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/metadata/reference`, `/lines/0/memo`) using `JsonPointerNormalizer`, which is now part of the public surface of `Trellis.FluentValidation`.
 
 ## Key Features
 - Convert `ValidationResult` into `Result<T>` with Trellis validation errors.

--- a/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
+++ b/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
@@ -148,8 +148,8 @@ public static class FluentValidationResultExtensions
     /// failure's <see cref="ValidationFailure.PropertyName"/> is normalized to an RFC 6901
     /// JSON Pointer before being placed on <see cref="FieldViolation.Field"/>: dotted member
     /// paths become path segments and array/list indexers become numeric segments
-    /// (e.g., <c>"Address.PostCode"</c> → <c>/Address/PostCode</c>,
-    /// <c>"Lines[0].Sku"</c> → <c>/Lines/0/Sku</c>). Special characters in segments are
+    /// (e.g., <c>"Address.PostCode"</c> → <c>/address/postCode</c>,
+    /// <c>"Lines[0].Sku"</c> → <c>/lines/0/sku</c>). Special characters in segments are
     /// escaped per RFC 6901 (<c>~</c> → <c>~0</c>, <c>/</c> → <c>~1</c>). Property names that
     /// already start with <c>/</c> are passed through unchanged. When
     /// <see cref="ValidationFailure.PropertyName"/> is empty, the caller-captured
@@ -186,8 +186,8 @@ public static class FluentValidationResultExtensions
     ///     }
     /// }
     /// // Output:
-    /// // /Name:  Name is required (validation.error)
-    /// // /Email: Email must be a valid email address (validation.error)
+    /// // /name:  Name is required (validation.error)
+    /// // /email: Email must be a valid email address (validation.error)
     /// </code>
     /// </example>
     /// <param name="paramName">

--- a/Trellis.FluentValidation/src/JsonPointerNormalizer.cs
+++ b/Trellis.FluentValidation/src/JsonPointerNormalizer.cs
@@ -1,12 +1,15 @@
 ﻿namespace Trellis.FluentValidation;
 
 using System.Text;
+using Trellis;
 
 /// <summary>
 /// Converts FluentValidation member-chain property names (e.g., <c>Address.PostCode</c>,
-/// <c>Items[0].Sku</c>) into RFC 6901 JSON Pointers (e.g., <c>/Address/PostCode</c>,
-/// <c>/Items/0/Sku</c>) so they can be carried through Trellis <see cref="InputPointer"/>
-/// values without losing structure.
+/// <c>Items[0].Sku</c>) into camelCase RFC 6901 JSON Pointers (e.g., <c>/address/postCode</c>,
+/// <c>/items/0/sku</c>) so they can be carried through Trellis <see cref="InputPointer"/> values.
+/// Each name segment's first character is lower-cased (via <see cref="StringExtensions.ToCamelCase"/>)
+/// so FluentValidation error keys match the camelCase JSON wire and the rest of Trellis's validation
+/// field names; indexer segments are left unchanged.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -48,7 +51,7 @@ public static class JsonPointerNormalizer
 
             i = propertyName[i] == '['
                 ? AppendIndexer(propertyName, i, sb)
-                : AppendSegment(propertyName, i, sb);
+                : AppendNameSegment(propertyName, i, sb);
 
             if (i < propertyName.Length && propertyName[i] == '.')
                 i++;
@@ -57,20 +60,13 @@ public static class JsonPointerNormalizer
         return sb.ToString();
     }
 
-    private static int AppendSegment(string source, int i, StringBuilder sb)
+    private static int AppendNameSegment(string source, int i, StringBuilder sb)
     {
+        var start = i;
         while (i < source.Length && source[i] != '.' && source[i] != '[')
-        {
-            var c = source[i];
-            if (c == '~')
-                sb.Append("~0");
-            else if (c == '/')
-                sb.Append("~1");
-            else
-                sb.Append(c);
             i++;
-        }
 
+        AppendEscaped(source.Substring(start, i - start).ToCamelCase(), sb);
         return i;
     }
 
@@ -81,8 +77,17 @@ public static class JsonPointerNormalizer
         while (i < source.Length && source[i] != ']')
             i++;
 
-        var indexContent = source.AsSpan(start, i - start);
-        foreach (var c in indexContent)
+        AppendEscaped(source.AsSpan(start, i - start), sb);
+
+        if (i < source.Length)
+            i++;
+
+        return i;
+    }
+
+    private static void AppendEscaped(ReadOnlySpan<char> segment, StringBuilder sb)
+    {
+        foreach (var c in segment)
         {
             if (c == '~')
                 sb.Append("~0");
@@ -91,10 +96,5 @@ public static class JsonPointerNormalizer
             else
                 sb.Append(c);
         }
-
-        if (i < source.Length)
-            i++;
-
-        return i;
     }
 }

--- a/Trellis.FluentValidation/tests/FluentTests.cs
+++ b/Trellis.FluentValidation/tests/FluentTests.cs
@@ -43,9 +43,9 @@ public class FluentTests
         rUser.Should().BeFailureOfType<Error.InvalidInput>()
             .Which.Should()
             .HaveFieldCount(3)
-            .And.HaveFieldError("FirstName")
-            .And.HaveFieldError("LastName")
-            .And.HaveFieldError("Email");
+            .And.HaveFieldError("firstName")
+            .And.HaveFieldError("lastName")
+            .And.HaveFieldError("email");
     }
 
     [Fact]
@@ -63,9 +63,9 @@ public class FluentTests
         rUser.Should().BeFailureOfType<Error.InvalidInput>()
             .Which.Should()
             .HaveFieldCount(3)
-            .And.HaveFieldError("FirstName")
-            .And.HaveFieldError("LastName")
-            .And.HaveFieldErrorWithDetail("Password", "Password must contain at least one number.");
+            .And.HaveFieldError("firstName")
+            .And.HaveFieldError("lastName")
+            .And.HaveFieldErrorWithDetail("password", "Password must contain at least one number.");
     }
 
     [Theory]
@@ -133,7 +133,7 @@ public class FluentTests
         // Assert
         result.Should().BeFailureOfType<Error.InvalidInput>()
             .Which.Should()
-            .HaveFieldErrorWithDetail("Alias", "Hello There");
+            .HaveFieldErrorWithDetail("alias", "Hello There");
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class FluentTests
         // Assert
         result.Should().BeFailureOfType<Error.InvalidInput>()
             .Which.Should()
-            .HaveFieldErrorWithDetail("CustomParam", "Custom error message");
+            .HaveFieldErrorWithDetail("customParam", "Custom error message");
     }
 
     [Fact]

--- a/Trellis.FluentValidation/tests/JsonPointerNormalizerTests.cs
+++ b/Trellis.FluentValidation/tests/JsonPointerNormalizerTests.cs
@@ -7,22 +7,25 @@ public class JsonPointerNormalizerTests
     [Theory]
     [InlineData(null, "")]
     [InlineData("", "")]
-    [InlineData("Email", "/Email")]
-    [InlineData("Address.PostCode", "/Address/PostCode")]
-    [InlineData("Address.Street.Line1", "/Address/Street/Line1")]
-    [InlineData("Items[0]", "/Items/0")]
-    [InlineData("Items[0].Sku", "/Items/0/Sku")]
-    [InlineData("Lines[12].Address.Zip", "/Lines/12/Address/Zip")]
-    [InlineData("Tags[abc]", "/Tags/abc")]
+    [InlineData("Email", "/email")]
+    [InlineData("Price.Amount", "/price/amount")]
+    [InlineData("Address.PostCode", "/address/postCode")]
+    [InlineData("Address.Street.Line1", "/address/street/line1")]
+    [InlineData("Items[0]", "/items/0")]
+    [InlineData("Items[0].Sku", "/items/0/sku")]
+    [InlineData("Lines[12].Address.Zip", "/lines/12/address/zip")]
+    [InlineData("Tags[abc]", "/tags/abc")]
     [InlineData("/already/a/pointer", "/already/a/pointer")]
-    public void ToJsonPointer_normalizes_property_paths(string? input, string expected)
+    public void ToJsonPointer_normalizes_property_paths_to_camel_case(string? input, string expected)
         => JsonPointerNormalizer.ToJsonPointer(input).Should().Be(expected);
 
     [Theory]
     [InlineData("a~b", "/a~0b")]
     [InlineData("a/b", "/a~1b")]
-    [InlineData("Items[a~b]", "/Items/a~0b")]
-    [InlineData("Items[a/b]", "/Items/a~1b")]
+    [InlineData("Field~Name", "/field~0Name")]
+    [InlineData("Path/With/Slash", "/path~1With~1Slash")]
+    [InlineData("Items[a~b]", "/items/a~0b")]
+    [InlineData("Items[a/b]", "/items/a~1b")]
     public void ToJsonPointer_escapes_reserved_characters_per_rfc6901(string input, string expected)
         => JsonPointerNormalizer.ToJsonPointer(input).Should().Be(expected);
 }

--- a/Trellis.Mediator.FluentValidation/NUGET_README.md
+++ b/Trellis.Mediator.FluentValidation/NUGET_README.md
@@ -29,7 +29,7 @@ builder.Services.AddTrellisFluentValidation();
 builder.Services.AddScoped<IValidator<MyCommand>, MyCommandValidator>();
 ```
 
-`AddTrellisFluentValidation()` registers `FluentValidationMessageValidatorAdapter<TMessage>` as the open-generic `IMessageValidator<TMessage>` implementation. Every `IValidator<T>` registered for the message in DI runs inside the existing `ValidationBehavior<TMessage, TResponse>` and contributes its failures to an aggregated `Error.InvalidInput` response. FluentValidation property names with member chains (`Address.City`) or indexers (`Items[0].Sku`) are translated to RFC 6901 JSON Pointers (`/Address/City`, `/Items/0/Sku`).
+`AddTrellisFluentValidation()` registers `FluentValidationMessageValidatorAdapter<TMessage>` as the open-generic `IMessageValidator<TMessage>` implementation. Every `IValidator<T>` registered for the message in DI runs inside the existing `ValidationBehavior<TMessage, TResponse>` and contributes its failures to an aggregated `Error.InvalidInput` response. FluentValidation property names with member chains (`Address.City`) or indexers (`Items[0].Sku`) are translated to camelCase RFC 6901 JSON Pointers (`/address/city`, `/items/0/sku`).
 
 ## AOT / trim story
 

--- a/Trellis.Mediator.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
+++ b/Trellis.Mediator.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
@@ -23,8 +23,8 @@ using Trellis.Mediator;
 /// </para>
 /// <para>
 /// FluentValidation property names that include member chains (<c>Address.PostCode</c>) or
-/// indexers (<c>Items[0].Sku</c>) are translated to RFC 6901 JSON Pointers
-/// (<c>/Address/PostCode</c>, <c>/Items/0/Sku</c>) via
+/// indexers (<c>Items[0].Sku</c>) are translated to camelCase RFC 6901 JSON Pointers
+/// (<c>/address/postCode</c>, <c>/items/0/sku</c>) via
 /// <see cref="JsonPointerNormalizer.ToJsonPointer(string?)"/> so they round-trip correctly
 /// through <see cref="InputPointer"/>. The normalizer lives in the sister
 /// <c>Trellis.FluentValidation</c> package so that domain-layer FluentValidation conversion

--- a/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
+++ b/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
@@ -64,7 +64,7 @@ public class FluentValidationMessageValidatorAdapterTests
 
         var error = ExtractError(result).Should().BeOfType<Error.InvalidInput>().Which;
         error.Fields.Items.Should().ContainSingle()
-            .Which.Field.Path.Should().Be("/Name");
+            .Which.Field.Path.Should().Be("/name");
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class FluentValidationMessageValidatorAdapterTests
 
         var error = ExtractError(result).Should().BeOfType<Error.InvalidInput>().Which;
         error.Fields.Items.Should().HaveCount(2);
-        error.Fields.Items.Should().Contain(fv => fv.Field.Path == "/Name");
-        error.Fields.Items.Should().Contain(fv => fv.Field.Path == "/Email");
+        error.Fields.Items.Should().Contain(fv => fv.Field.Path == "/name");
+        error.Fields.Items.Should().Contain(fv => fv.Field.Path == "/email");
     }
 
     [Fact]
@@ -107,8 +107,8 @@ public class FluentValidationMessageValidatorAdapterTests
 
         var error = ExtractError(result).Should().BeOfType<Error.InvalidInput>().Which;
         var paths = error.Fields.Items.Select(fv => fv.Field.Path).ToArray();
-        paths.Should().Contain("/Address/Zip");
-        paths.Should().Contain("/Lines/0/Sku");
+        paths.Should().Contain("/address/zip");
+        paths.Should().Contain("/lines/0/sku");
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class FluentValidationMessageValidatorAdapterTests
 
         var error = ExtractError(result).Should().BeOfType<Error.InvalidInput>().Which;
         error.Fields.Items.Should().ContainSingle()
-            .Which.Field.Path.Should().Be("/CreateUserCommand");
+            .Which.Field.Path.Should().Be("/createUserCommand");
     }
 
     #endregion

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -1482,7 +1482,7 @@ public sealed class CustomersController(ISender sender) : ControllerBase
 **What it shows.**
 
 - Keep DTOs transport-shaped and commands/domain methods value-object-shaped.
-- Pass field names into `TryCreate` so failures point at the request field (`/Email`, `/CustomerName` after pointer normalization at the ASP boundary).
+- Pass field names into `TryCreate` so failures point at the request field (`/email`, `/customerName` after pointer normalization at the ASP boundary).
 - Use `Result.Combine(...)` to aggregate per-field `Error.InvalidInput` failures into one validation response.
 - Stay on the ROP track: invalid input short-circuits before `sender.Send(...)`; valid input creates the command and continues.
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -14,7 +14,7 @@ audience: [llm]
 - **Namespace:** `Trellis.FluentValidation`
 - **Purpose:** Mediator-agnostic FluentValidation helpers for Trellis:
   1. **Standalone helpers** — `FluentValidationResultExtensions` converts a `ValidationResult` (or runs an `IValidator<T>` synchronously/asynchronously) into a `Result<T>` failure backed by `Error.InvalidInput`.
-  2. **Pointer normalization** — `JsonPointerNormalizer.ToJsonPointer(...)` projects FluentValidation member-chain property names (`Address.PostCode`, `Items[0].Sku`) into RFC 6901 JSON Pointers (`/Address/PostCode`, `/Items/0/Sku`) so they round-trip through Trellis `InputPointer` values.
+  2. **Pointer normalization** — `JsonPointerNormalizer.ToJsonPointer(...)` projects FluentValidation member-chain property names (`Address.PostCode`, `Items[0].Sku`) into camelCase RFC 6901 JSON Pointers (`/address/postCode`, `/items/0/sku`) so they round-trip through Trellis `InputPointer` values.
 
 > **v3 package split.** The Mediator integration (`AddTrellisFluentValidation()` + `FluentValidationMessageValidatorAdapter<TMessage>`) moved to the new `Trellis.Mediator.FluentValidation` package so consumers of these standalone helpers do not have to take a Mediator dependency. See [trellis-api-mediator-fluentvalidation.md](trellis-api-mediator-fluentvalidation.md#header) for the adapter API, and `MIGRATION_v3.md` for the migration recipe.
 
@@ -42,7 +42,7 @@ For wiring FluentValidation validators into the Trellis Mediator validation stag
 - Keep primitive-to-value-object parsing at the transport seam; validators should normally validate already-shaped command/value-object inputs.
 - `ToResult<T>` only null-checks `validationResult`; it does not independently reject a `null` `value`.
 - `ValidateToResultAsync<T>` observes `cancellationToken` BEFORE the null-value short-circuit, so a cancelled token always wins over the synchronous null-input fallback.
-- `JsonPointerNormalizer.ToJsonPointer` splits FluentValidation dotted chains (`Address.City` → `/Address/City`). The general-purpose `InputPointer.ForProperty(string)` does **not** split on `.` (it only escapes `~` → `~0` and `/` → `~1` per RFC 6901 §3). The dotted-chain normalization is FluentValidation-specific.
+- `JsonPointerNormalizer.ToJsonPointer` splits FluentValidation dotted chains (`Address.City` → `/address/city`). The general-purpose `InputPointer.ForProperty(string)` does **not** split on `.` (it only escapes `~` → `~0` and `/` → `~1` per RFC 6901 §3). The dotted-chain normalization is FluentValidation-specific.
 
 ## Types
 
@@ -84,19 +84,19 @@ public static class JsonPointerNormalizer
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static string ToJsonPointer(string? propertyName)` | `string` | Converts a FluentValidation `PropertyName` (e.g., `Address.PostCode`, `Items[0].Sku`) into an RFC 6901 JSON Pointer (`/Address/PostCode`, `/Items/0/Sku`). Returns `""` for `null` or empty input. Inputs that already start with `/` are assumed to already be pointers and are returned unchanged. Inside each segment, `~` is escaped to `~0` and `/` to `~1` per RFC 6901 §3. Indexer contents (`[...]`) are treated as standalone segments — `Items[0]` becomes `/Items/0`. |
+| `public static string ToJsonPointer(string? propertyName)` | `string` | Converts a FluentValidation `PropertyName` (e.g., `Address.PostCode`, `Items[0].Sku`) into a camelCase RFC 6901 JSON Pointer (`/address/postCode`, `/items/0/sku`) — each name segment's first character is lower-cased; indexer segments are unchanged. Returns `""` for `null` or empty input. Inputs that already start with `/` are assumed to already be pointers and are returned unchanged. Inside each segment, `~` is escaped to `~0` and `/` to `~1` per RFC 6901 §3. Indexer contents (`[...]`) are treated as standalone segments — `Items[0]` becomes `/items/0`. |
 
 **Pointer normalization (RFC 6901) — examples**
 
 | FluentValidation `PropertyName` | `ToJsonPointer` result |
 | --- | --- |
 | `""` or `null` | `""` |
-| `Email` | `/Email` |
-| `Address.PostCode` | `/Address/PostCode` |
-| `Items[0].Sku` | `/Items/0/Sku` |
+| `Email` | `/email` |
+| `Address.PostCode` | `/address/postCode` |
+| `Items[0].Sku` | `/items/0/sku` |
 | `/already/a/pointer` | `/already/a/pointer` (returned unchanged) |
-| `Field~Name` | `/Field~0Name` |
-| `Path/With/Slash` | `/Path~1With~1Slash` |
+| `Field~Name` | `/field~0Name` |
+| `Path/With/Slash` | `/path~1With~1Slash` |
 
 ## Extension methods
 
@@ -206,7 +206,7 @@ using Trellis.FluentValidation;
 // Custom FluentValidation projection that needs to build an InputPointer
 // without going through the Mediator adapter.
 var pointer = new InputPointer(JsonPointerNormalizer.ToJsonPointer("Items[0].Sku"));
-// pointer.RawValue == "/Items/0/Sku"
+// pointer.RawValue == "/items/0/sku"
 ```
 
 ## Cross-references

--- a/docs/docfx_project/api_reference/trellis-api-mediator-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator-fluentvalidation.md
@@ -81,9 +81,9 @@ FluentValidation property names are converted to JSON Pointers via [`JsonPointer
 
 | FluentValidation `PropertyName` | Resulting `InputPointer.RawValue` |
 | --- | --- |
-| `Email` | `/Email` |
-| `Address.PostCode` | `/Address/PostCode` |
-| `Items[0].Sku` | `/Items/0/Sku` |
+| `Email` | `/email` |
+| `Address.PostCode` | `/address/postCode` |
+| `Items[0].Sku` | `/items/0/sku` |
 
 Dotted FluentValidation paths split into separate JSON-pointer segments; bracketed indexers become numeric segments. Other producers (e.g., the ASP integration) build `InputPointer` values directly via `InputPointer.ForProperty(...)`, which does **not** split on `.`, so the normalizer is FluentValidation-specific.
 

--- a/docs/docfx_project/articles/integration-fluentvalidation.md
+++ b/docs/docfx_project/articles/integration-fluentvalidation.md
@@ -29,7 +29,7 @@ The Mediator-agnostic helpers in `Trellis.FluentValidation` convert standalone `
 
 - You already use FluentValidation and want failures to surface as `Error.InvalidInput` instead of exceptions or hand-rolled translations.
 - You send messages through `Trellis.Mediator` and want validators to run automatically inside `ValidationBehavior<TMessage,TResponse>` without per-handler boilerplate.
-- You need RFC 6901 JSON Pointer paths (`/Lines/0/Memo`) on validation failures so the ASP boundary renders them under the right field.
+- You need RFC 6901 JSON Pointer paths (`/lines/0/memo`) on validation failures so the ASP boundary renders them under the right field.
 
 ## Surface at a glance
 
@@ -319,10 +319,10 @@ The adapter and `ToResult` translate FluentValidation property names to RFC 6901
 
 | FluentValidation `PropertyName` | `FieldViolation.Field` |
 |---|---|
-| `Email` | `/Email` |
-| `Address.PostCode` | `/Address/PostCode` |
-| `Items[0].Sku` | `/Items/0/Sku` |
-| `Items[0].Tags[2]` | `/Items/0/Tags/2` |
+| `Email` | `/email` |
+| `Address.PostCode` | `/address/postCode` |
+| `Items[0].Sku` | `/items/0/sku` |
+| `Items[0].Tags[2]` | `/items/0/tags/2` |
 
 Special characters in segments are escaped per RFC 6901 (`~` → `~0`, `/` → `~1`). Names that already begin with `/` are passed through unchanged.
 

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -369,7 +369,7 @@ public static class Composition
 
 ### FluentValidation adapter
 
-Add the optional `Trellis.Mediator.FluentValidation` package and call `AddTrellisFluentValidation()` to surface every registered `IValidator<TMessage>` through `IMessageValidator<TMessage>`. The adapter normalizes FluentValidation property paths (e.g., `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/Lines/0/Memo`) so `Error.InvalidInput.Fields` has a consistent pointer shape regardless of which source produced each violation.
+Add the optional `Trellis.Mediator.FluentValidation` package and call `AddTrellisFluentValidation()` to surface every registered `IValidator<TMessage>` through `IMessageValidator<TMessage>`. The adapter normalizes FluentValidation property paths (e.g., `Lines[0].Memo`) into RFC 6901 JSON Pointers (`/lines/0/memo`) so `Error.InvalidInput.Fields` has a consistent pointer shape regardless of which source produced each violation.
 
 ```csharp
 using System.Collections.Generic;


### PR DESCRIPTION
## Problem
Validation error-key casing was inconsistent across sources. The seam
(`Required*.TryCreate(value, fieldName)` via `ToCamelCase`) and the ASP scalar-binding path emit
**camelCase** keys, but the FluentValidation path (`JsonPointerNormalizer.ToJsonPointer`) preserved
the C# PascalCase member name — so a client deserializing `errors` saw `Price.Amount` from
FluentValidation but `plan`/`currency` from the seam.

## Fix
`JsonPointerNormalizer.ToJsonPointer` now lower-camelCases each **name** segment (first character
only, via `Trellis.StringExtensions.ToCamelCase`) before RFC 6901 escaping. Indexer/array-index
segments are unchanged. Examples: `Address.PostCode -> /address/postCode`, `Items[0].Sku ->
/items/0/sku`. Both FluentValidation integration paths (`Trellis.FluentValidation.ValidateToResult`
and the `Trellis.Mediator.FluentValidation` adapter) share this normalizer, so both are unified.

`JsonPointerToMvc` and `InputPointer.ForProperty` are unchanged (case-agnostic).

## Tests (TDD: red -> green)
Flipped `JsonPointerNormalizerTests` to camelCase and added two escaped-uppercase cases
(`Field~Name -> /field~0Name`, `Path/With/Slash -> /path~1With~1Slash`). Updated every genuinely
FluentValidation-derived assertion across Mediator.FV, FluentValidation, Examples, and the Showcase
integration test. Scalar-binding/plain-Mediator tests are intentionally untouched — their
PascalCase keys come from actual wire property names, not the normalizer.

## Docs
Updated `trellis-api-fluentvalidation.md`, `trellis-api-mediator-fluentvalidation.md`,
`integration-fluentvalidation.md`, `integration-mediator.md`, both FluentValidation package READMEs,
the Showcase example src/README, src XML docs, and a CHANGELOG `[Unreleased]` entry. Historical
CHANGELOG/MIGRATION_v3 examples left as-is.

## Validation
Release build (warnings-as-errors), full suite 6977 passed / 0 failed, docfx clean, stale-docs audit
clean, Native AOT publish gate green. Reviewed by GPT-5.5 (two rounds; both findings addressed).
