### PR TITLE
Document ServiceLifetime.Scoped on AddMediator in the cookbook

### DIFF
--- a/Trellis.Mediator/src/ServiceCollectionExtensions.cs
+++ b/Trellis.Mediator/src/ServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class ServiceCollectionExtensions
     /// services.AddMediator(options =>
     /// {
     ///     options.Assemblies = [typeof(MyCommand).Assembly];
+    ///     options.ServiceLifetime = ServiceLifetime.Scoped;
     ///     options.PipelineBehaviors = ServiceCollectionExtensions.PipelineBehaviors.ToArray();
     /// });
     /// </code>

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -855,7 +855,11 @@ public static class CompositionRoot
             .UseSqlServer(connectionString)
             .AddTrellisInterceptors());
 
-        services.AddMediator(options => options.Assemblies = [typeof(PlaceOrderCommand).Assembly]);
+        services.AddMediator(options =>
+        {
+            options.Assemblies = [typeof(PlaceOrderCommand).Assembly];
+            options.ServiceLifetime = ServiceLifetime.Scoped;
+        });
 
         services.AddTrellis(options => options
             .UseAsp()
@@ -888,6 +892,8 @@ public static class CompositionRoot
 | `UseEntityFrameworkUnitOfWork<TContext>()` | `AddTrellisUnitOfWork<TContext>()` | Implies `UseMediator()` and is always applied last. |
 
 **Still app-owned.** `AddTrellis(...)` does **not** call `AddDbContext`, `AddMediator`, or route-constraint registration. Those choices depend on provider, connection string, source-generator setup, migrations, route template names, and hosting style.
+
+> **Set `options.ServiceLifetime = ServiceLifetime.Scoped` on `AddMediator(...)`** in any host that creates a request/execution scope (ASP.NET Core, workers). Mediator's default lifetime is `Singleton`, but the Trellis pipeline behaviors depend on per-request services (`IActorProvider`, `IUnitOfWork`, `IMessageValidator<>`), so a singleton handler/behavior fails the DI root-scope validation the moment it resolves a scoped dependency — a build-clean service that throws at startup. (Same guidance: `Trellis.Mediator` README and the [Mediator integration article](../articles/integration-mediator.md).)
 
 ---
 
@@ -2356,7 +2362,11 @@ public class HealthProbeWorkerTests
                 // composition root so the test exercises the same wiring the production
                 // host uses. Forgetting either registration would surface as
                 // GetRequiredService throwing at scope resolution.
-                s.AddMediator(options => options.Assemblies = [typeof(RunProbeCommand).Assembly]);
+                s.AddMediator(options =>
+                {
+                    options.Assemblies = [typeof(RunProbeCommand).Assembly];
+                    options.ServiceLifetime = ServiceLifetime.Scoped;
+                });
                 s.AddDomainEventDispatch();
                 s.AddSingleton<IHealthProbeRepository, FakeHealthProbeRepository>();
             });

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -68,7 +68,7 @@ using Trellis.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddMediator();
+builder.Services.AddMediator(opts => opts.ServiceLifetime = ServiceLifetime.Scoped);
 builder.Services.AddTrellis(options => options
     .UseAsp()
     .UseMediator());


### PR DESCRIPTION
## Problem
The cookbook (the primary AI-facing doc) showed `services.AddMediator(options => options.Assemblies
= [...])` without `options.ServiceLifetime = ServiceLifetime.Scoped`. Mediator handlers default to
`Singleton`, but the Trellis pipeline behaviors depend on per-request services (`IActorProvider`,
`IUnitOfWork`, `IMessageValidator<>`), so copying the cookbook produced a service that built cleanly
but threw at startup on DI root-scope validation. The correct guidance already existed in
`Trellis.Mediator`'s README/NUGET_README and `integration-mediator.md` (which even has an explanatory
note) — the cookbook and two other spots lagged.

## Fix
- Cookbook Recipe 12 (DI playbook) and Recipe 26 (WorkerHarness) `AddMediator(...)` calls now set
  `options.ServiceLifetime = ServiceLifetime.Scoped`.
- Added a callout to Recipe 12 explaining why (mirroring the Mediator README + integration article).
- `integration-observability.md` and the `Trellis.Mediator` XML-doc `<example>` now set Scoped.

## Validation
`Trellis.Mediator` Release build (warnings-as-errors), docfx, and stale-docs audit all clean.
Doc/XML-doc only (no behavior change); reviewed by GPT-5.5 — confirmed no remaining `AddMediator`
example omits Scoped.
