### PR TITLE
Align cookbook Recipe 2/10 snippets to the VO-at-seam pattern

### DIFF
--- a/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
+++ b/Examples/CookbookSnippets/Recipe02_CommandHandler.cs
@@ -14,32 +14,39 @@ using Trellis.EntityFrameworkCore;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
 using Trellis.Mediator.FluentValidation;
+using MonetaryAmount = Trellis.Primitives.MonetaryAmount;
 
-public sealed record PlaceOrderCommand(System.Guid OrderId, decimal Amount, string Currency, string OwnerId)
-    : ICommand<Result<OrderId>>;
+public sealed record PlaceOrderRequest(System.Guid OrderId, decimal Amount, string Currency, string OwnerId);
+
+public sealed record PlaceOrderCommand(OrderId OrderId, Money Total, ActorId OwnerId)
+    : ICommand<Result<OrderId>>
+{
+    public static Result<PlaceOrderCommand> TryCreate(PlaceOrderRequest request) =>
+        Result.Combine(
+                OrderId.TryCreate(request.OrderId, nameof(request.OrderId)),
+                MonetaryAmount.TryCreate(request.Amount, nameof(request.Amount)),
+                CurrencyCode.TryCreate(request.Currency, nameof(request.Currency)),
+                ActorId.TryCreate(request.OwnerId, nameof(request.OwnerId)))
+            .Map((orderId, amount, currency, ownerId) =>
+                new PlaceOrderCommand(orderId, new Money(amount.Value, currency), ownerId));
+}
 
 public sealed class PlaceOrderValidator : AbstractValidator<PlaceOrderCommand>
 {
-    public PlaceOrderValidator()
-    {
-        RuleFor(x => x.OrderId).NotEmpty();
-        RuleFor(x => x.Amount).GreaterThan(0);
-        RuleFor(x => x.Currency).Length(3);
-        RuleFor(x => x.OwnerId).NotEmpty();
-    }
+    public PlaceOrderValidator() =>
+        RuleFor(x => x.Total.Amount)
+            .LessThanOrEqualTo(10_000m)
+            .WithMessage("Orders over 10,000 require manual approval.");
 }
 
 public sealed class PlaceOrderHandler(IOrderRepository repo)
     : ICommandHandler<PlaceOrderCommand, Result<OrderId>>
 {
-    public ValueTask<Result<OrderId>> Handle(PlaceOrderCommand command, CancellationToken cancellationToken) =>
-        new(Result.Combine(
-                OrderId.TryCreate(command.OrderId),
-                CurrencyCode.TryCreate(command.Currency).Map(c => new Money(command.Amount, c)),
-                ActorId.TryCreate(command.OwnerId))
-            .Bind((id, money, ownerId) => Order.TryCreate(id, money, ownerId))
+    public ValueTask<Result<OrderId>> Handle(PlaceOrderCommand cmd, CancellationToken cancellationToken) =>
+        Order.TryCreate(cmd.OrderId, cmd.Total, cmd.OwnerId)
             .Tap(repo.Add)
-            .Map(o => o.Id));
+            .Map(o => o.Id)
+            .AsValueTask();
 }
 
 // Composition root

--- a/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
+++ b/Examples/CookbookSnippets/Recipe10_HandlerTest.cs
@@ -4,10 +4,12 @@ namespace CookbookSnippets.Recipe10;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using CookbookSnippets.Recipe01;
 using CookbookSnippets.Recipe02;
 using CookbookSnippets.Stubs;
 using FluentAssertions;
 using Trellis;
+using Trellis.Authorization;
 using Trellis.Testing;
 using Xunit;
 
@@ -20,27 +22,26 @@ public class PlaceOrderHandlerTests
         var repo = new InMemoryOrderRepository();
         var sut = new PlaceOrderHandler(repo);
 
-        var result = await sut.Handle(
-            new PlaceOrderCommand(Guid.NewGuid(), 100m, "USD", "alice"),
-            CancellationToken.None);
+        var command = new PlaceOrderCommand(
+            OrderId.TryCreate(Guid.NewGuid()).Unwrap(),
+            new Money(100m, CurrencyCode.TryCreate("USD").Unwrap()),
+            ActorId.TryCreate("alice").Unwrap());
+
+        var result = await sut.Handle(command, CancellationToken.None);
 
         result.Should().BeSuccess();
         result.Should().HaveValue(repo.Last().Id);
     }
 
     [Fact]
-    public async Task PlaceOrder_fails_with_validation_when_currency_invalid()
+    public void PlaceOrder_request_adapter_fails_when_currency_invalid()
     {
-        var sut = new PlaceOrderHandler(new InMemoryOrderRepository());
+        var request = new PlaceOrderRequest(Guid.NewGuid(), 100m, "US", "alice"); // 2 chars, not 3
 
-        var result = await sut.Handle(
-            new PlaceOrderCommand(Guid.NewGuid(), 100m, "US", "alice"),
-            CancellationToken.None);
+        var result = PlaceOrderCommand.TryCreate(request);
 
-        var error = result.Should().BeFailureOfType<Error.InvalidInput>().Which;
-        var unwrapped = result.UnwrapError();
-        unwrapped.Should().BeOfType<Error.InvalidInput>();
-        error.Should().HaveFieldError("currency");
+        result.Should().BeFailureOfType<Error.InvalidInput>()
+            .Which.Should().HaveFieldError("currency");
     }
 #pragma warning restore CA1707
 }
@@ -60,6 +61,7 @@ internal static class Recipe10TestingSurface
             .And.HaveFieldCount(1);
 
         _ = assertions;
+        _ = Result.Fail<int>(error).UnwrapError();
     }
 
     public static async Task AsyncResultAssertionSurface()

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -788,7 +788,7 @@ unproc.Rules.Should().ContainSingle().Which.ReasonCode.Should().Be("state.machin
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis;
-using Trellis.Primitives;
+using Trellis.Authorization;
 using Trellis.Testing;
 using Xunit;
 
@@ -802,7 +802,8 @@ public class PlaceOrderHandlerTests
 
         var command = new PlaceOrderCommand(
             OrderId.TryCreate(Guid.NewGuid()).Unwrap(),
-            Money.TryCreate(100m, "USD").Unwrap());
+            new Money(100m, CurrencyCode.TryCreate("USD").Unwrap()),
+            ActorId.TryCreate("alice").Unwrap());
 
         var result = await sut.Handle(command, CancellationToken.None);
 
@@ -813,7 +814,7 @@ public class PlaceOrderHandlerTests
     [Fact]
     public void PlaceOrder_request_adapter_fails_when_currency_invalid()
     {
-        var request = new PlaceOrderRequest(Guid.NewGuid(), 100m, "US"); // 2 chars, not 3
+        var request = new PlaceOrderRequest(Guid.NewGuid(), 100m, "US", "alice"); // 2 chars, not 3
 
         var result = PlaceOrderCommand.TryCreate(request);
 


### PR DESCRIPTION
## Problem

The cookbook's **Recipe 2** prose and markdown teach the canonical **VO-at-seam** pattern:

- a primitive transport DTO (`PlaceOrderRequest`),
- a value-object-shaped command `PlaceOrderCommand(OrderId, Money, ActorId)` with a static `TryCreate(PlaceOrderRequest)` seam adapter that parses primitives into value objects, and
- a **pure** handler that does *not* parse primitives ("Handlers receive value-object-shaped commands and must not parse primitives").

But the **compiled** snippets contradicted that prose:

- `Recipe02_CommandHandler.cs` defined a **primitive** command `PlaceOrderCommand(Guid, decimal, string, string)` and parsed primitives **inside the handler** — the opposite of the prose.
- `Recipe10_HandlerTest.cs` and the **Recipe 10 markdown** constructed the command with the wrong arity and called a non-existent `Money.TryCreate(...)` on the example domain's user-defined `Money` (which has only a public ctor, no `TryCreate`).

## Fix (VO-at-seam everywhere)

- **`Recipe02_CommandHandler.cs`** — primitive command → VO command with a `TryCreate(PlaceOrderRequest)` seam adapter (`Result.Combine(OrderId, MonetaryAmount, CurrencyCode, ActorId).Map(...)`); validator now targets `x.Total.Amount`; handler is pure (`Order.TryCreate(...).Tap(repo.Add).Map(o => o.Id).AsValueTask()`). `MonetaryAmount` is aliased to avoid a `Money`/`CurrencyCode` ambiguity (the file imports the example domain's `Recipe01` types).
- **`Recipe10_HandlerTest.cs`** — VO-command construction for the success test; the currency-invalid test now exercises the **seam adapter** (`PlaceOrderCommand.TryCreate(request)`) instead of parsing in the handler. `UnwrapError` stays compile-pinned in the surface helper since the recipe advertises it.
- **`trellis-api-cookbook.md` (Recipe 10 only)** — fixed the command/request arities and imports to match. **Recipe 2 markdown is unchanged** — it is the source of truth.

## Validation

- TDD red→green: refactoring Recipe02 first broke Recipe10's compile (`CS1729`), then the Recipe10 refactor restored it.
- `dotnet build Examples/CookbookSnippets`: **0 warnings, 0 errors**.
- `dotnet test Trellis.slnx -c Release --filter-not-trait "Category=Integration"`: **6964 passed, 0 failed, 15 skipped**.
- docfx: **0 errors** (only benign `FailedToLoadAnalyzer` warnings); stale-docs audit: clean.
- Empirically verified the seam yields validation field path `/currency`, matching `HaveFieldError("currency")`.
- Reviewed by a `gpt-5.5` code-review agent: no significant issues.

> CookbookSnippets is a compile-verification project (no test SDK), so its `[Fact]` methods are compile-checked, not executed in CI; the runtime field-name behavior was verified separately.