### PR TITLE
Surface the opt-in Trellis.Analyzers package in docs and dogfood Showcase

### DIFF
--- a/Examples/Showcase/src/Showcase.Application/Showcase.Application.csproj
+++ b/Examples/Showcase/src/Showcase.Application/Showcase.Application.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\Trellis.Core\src\Trellis.Core.csproj" />
     <ProjectReference Include="..\..\..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
     <ProjectReference Include="..\..\..\..\Trellis.Mediator\src\Trellis.Mediator.csproj" />
+    <ProjectReference Include="..\..\..\..\Trellis.Analyzers\src\Trellis.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/Examples/Showcase/src/Showcase.Application/Workflows/BankingWorkflow.cs
+++ b/Examples/Showcase/src/Showcase.Application/Workflows/BankingWorkflow.cs
@@ -88,12 +88,11 @@ public class BankingWorkflow
         string description,
         CancellationToken cancellationToken = default)
     {
-        var fromCheck = _fraud.AnalyzeTransactionAsync(fromAccount, amount, "transfer-out", cancellationToken);
-        var toCheck = _fraud.AnalyzeTransactionAsync(toAccount, amount, "transfer-in", cancellationToken);
-        await Task.WhenAll(fromCheck, toCheck);
-
-        var combined = fromCheck.Result.Combine(toCheck.Result);
-        if (combined.TryGetError(out var combinedError))
+        var fraudCheck = await (
+            _fraud.AnalyzeTransactionAsync(fromAccount, amount, "transfer-out", cancellationToken),
+            _fraud.AnalyzeTransactionAsync(toAccount, amount, "transfer-in", cancellationToken)
+        ).WhenAllAsync();
+        if (fraudCheck.TryGetError(out var combinedError))
             return Result.Fail<(BankAccount From, BankAccount To)>(combinedError);
 
         return await fromAccount.TransferTo(toAccount, amount, description)

--- a/Examples/Showcase/src/Showcase.Domain/Showcase.Domain.csproj
+++ b/Examples/Showcase/src/Showcase.Domain/Showcase.Domain.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\..\..\Trellis.Core\src\Trellis.Core.csproj" />
     <ProjectReference Include="..\..\..\..\Trellis.StateMachine\src\Trellis.StateMachine.csproj" />
     <ProjectReference Include="..\..\..\..\Trellis.Core\generator\Trellis.Core.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\..\Trellis.Analyzers\src\Trellis.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
   </ItemGroup>
 

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -5,9 +5,22 @@
 Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
 ## Installation
+
+The analyzers are **opt-in** and ship separately — installing `Trellis.Core` does not include them.
+
 ```bash
 dotnet add package Trellis.Analyzers
 ```
+
+Mark the reference analyzer-only so it does not flow to consumers of your library:
+
+```xml
+<PackageReference Include="Trellis.Analyzers" Version="...">
+  <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+```
+
+Tune any rule's severity per project via `.editorconfig`, e.g. `dotnet_diagnostic.TRLS001.severity = error`.
 
 ## Quick Example
 ```csharp

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -12,7 +12,7 @@ The analyzers are **opt-in** and ship separately — installing `Trellis.Core` d
 dotnet add package Trellis.Analyzers
 ```
 
-Mark the reference analyzer-only so it does not flow to consumers of your library:
+Prevent the package from flowing transitively to consumers of your library (analyzers are a build-time-only concern):
 
 ```xml
 <PackageReference Include="Trellis.Analyzers" Version="...">

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -5,9 +5,22 @@
 Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
 ## Installation
+
+The analyzers are **opt-in** and ship separately — installing `Trellis.Core` does not include them.
+
 ```bash
 dotnet add package Trellis.Analyzers
 ```
+
+Mark the reference analyzer-only so it does not flow to consumers of your library:
+
+```xml
+<PackageReference Include="Trellis.Analyzers" Version="...">
+  <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+```
+
+Tune any rule's severity per project via `.editorconfig`, e.g. `dotnet_diagnostic.TRLS001.severity = error`.
 
 ## Quick Example
 ```csharp

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -12,7 +12,7 @@ The analyzers are **opt-in** and ship separately — installing `Trellis.Core` d
 dotnet add package Trellis.Analyzers
 ```
 
-Mark the reference analyzer-only so it does not flow to consumers of your library:
+Prevent the package from flowing transitively to consumers of your library (analyzers are a build-time-only concern):
 
 ```xml
 <PackageReference Include="Trellis.Analyzers" Version="...">

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -51,4 +51,21 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
   </ItemGroup>
 
+  <!--
+      Force-disable PublishAot/PublishTrimmed inherited from a parent AOT-publishing project.
+      Analyzers target netstandard2.0 (mandated by Roslyn) and cannot satisfy the AOT/Trim gate
+      (NETSDK1207). Source-tree consumers that reference this project as an analyzer
+      (OutputItemType="Analyzer") inside an AOT-published app graph would otherwise fail. This
+      target runs before ProcessFrameworkReferences, which is gated on _RequiresILLinkPack=true
+      (set by PublishAot/PublishTrimmed). Mirrors Trellis.Core.Generator.csproj.
+   -->
+  <Target Name="_TrellisDisablePublishAotForAnalyzer"
+          BeforeTargets="ProcessFrameworkReferences;_CheckForUnsupportedNETCoreSdkVersion;CollectPackageReferences;Restore">
+    <PropertyGroup>
+      <PublishAot>false</PublishAot>
+      <PublishTrimmed>false</PublishTrimmed>
+      <_RequiresILLinkPack>false</_RequiresILLinkPack>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -14,6 +14,20 @@ audience: [llm]
 
 See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) — recipes using this package.
 
+## Installation — the analyzers are opt-in
+
+The analyzers ship as a **separate NuGet package, `Trellis.Analyzers`**. Installing `Trellis.Core` (or any other Trellis package) does **not** include them — every `TRLS###` diagnostic stays silent until you add this package. Enable it on each project that uses Trellis `Result<T>`, `Maybe<T>`, value objects, or the EF Core integration:
+
+```xml
+<PackageReference Include="Trellis.Analyzers" Version="...">
+  <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+```
+
+- `PrivateAssets="all"` keeps the package a build-time-only concern so the analyzers do not flow to downstream consumers of your library.
+- Tune any rule's severity per project through `.editorconfig`, e.g. `dotnet_diagnostic.TRLS001.severity = error`. Default severities are in the [Diagnostics](#diagnostics) table.
+- In this repository's own source tree, examples reference the analyzer project directly with `OutputItemType="Analyzer" ReferenceOutputAssembly="false"` (see `Examples/Showcase/src/Showcase.Application`); published-package consumers use the `PackageReference` above.
+
 ## Use this file when
 
 - A build emits a `TRLS###` diagnostic and you need the exact meaning, likely fix, or suppression constant.

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -834,6 +834,8 @@ The anti-pattern catalog moved to its own file so that AI sessions and human rea
 
 If you are looking up a specific analyzer by ID, the standalone file is faster than scanning this cookbook. The cookbook recipes still link to the relevant sections of that file where they apply.
 
+> **Enabling these analyzers.** They are **opt-in**: the diagnostics ship in a separate `Trellis.Analyzers` package that `Trellis.Core` does not pull in. Add `<PackageReference Include="Trellis.Analyzers" PrivateAssets="all" />` to every project that uses Trellis `Result`/`Maybe`/value objects so the gallery below is enforced at build time. See [trellis-api-analyzers.md](trellis-api-analyzers.md#installation--the-analyzers-are-opt-in) for the install snippet and `.editorconfig` severity control.
+
 ---
 
 ## Recipe 12 — DI wiring playbook: `AddTrellis` composition builder

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -834,7 +834,7 @@ The anti-pattern catalog moved to its own file so that AI sessions and human rea
 
 If you are looking up a specific analyzer by ID, the standalone file is faster than scanning this cookbook. The cookbook recipes still link to the relevant sections of that file where they apply.
 
-> **Enabling these analyzers.** They are **opt-in**: the diagnostics ship in a separate `Trellis.Analyzers` package that `Trellis.Core` does not pull in. Add `<PackageReference Include="Trellis.Analyzers" PrivateAssets="all" />` to every project that uses Trellis `Result`/`Maybe`/value objects so the gallery below is enforced at build time. See [trellis-api-analyzers.md](trellis-api-analyzers.md#installation--the-analyzers-are-opt-in) for the install snippet and `.editorconfig` severity control.
+> **Enabling these analyzers.** They are **opt-in**: the diagnostics ship in a separate `Trellis.Analyzers` package that `Trellis.Core` does not pull in. Add `<PackageReference Include="Trellis.Analyzers" PrivateAssets="all" />` to every project that uses Trellis `Result`/`Maybe`/value objects so the analyzer diagnostics (`TRLS###`) are enforced at build time. See [trellis-api-analyzers.md](trellis-api-analyzers.md#installation--the-analyzers-are-opt-in) for the install snippet and `.editorconfig` severity control.
 
 ---
 


### PR DESCRIPTION
## Problem

The Trellis `Result` / `Maybe` / value-object / EF-Core diagnostic analyzers ship as a **separate, opt-in NuGet package, `Trellis.Analyzers`**. Installing `Trellis.Core` does **not** include them — `Trellis.Core` bundles only its source *generator* under `analyzers/dotnet/cs`, not the diagnostic analyzers. Yet:

- No example project enabled the analyzers (nothing dogfooded them outside the analyzer's own tests).
- The AI-facing `trellis-api-analyzers.md` reference had **no installation / opt-in section**, so adopters (and AI agents) had no way to discover that the safety net exists or how to turn it on.

## Changes

**Documentation**
- `trellis-api-analyzers.md` — new **"Installation — the analyzers are opt-in"** section: explains the package is separate from `Trellis.Core`, shows the `PackageReference` with `PrivateAssets="all"`, and notes `.editorconfig` per-rule severity control.
- `trellis-api-cookbook.md` — Recipe 11 ("the analyzers in action") gets an **"Enabling these analyzers"** callout linking to the install section.
- `Trellis.Analyzers/README.md` + `NUGET_README.md` — enhanced Installation section (opt-in note, `PrivateAssets`, severity tuning).

**Dogfood (flagship Showcase library projects)**
- Enabled `Trellis.Analyzers` in `Showcase.Domain` + `Showcase.Application` via `OutputItemType="Analyzer"`.
- Fixed the 2 surfaced `TRLS005` (sync-over-async `.Result`) sites in `BankingWorkflow.TransferAsync` by switching the manual *start-tasks → `Task.WhenAll` → `.Result` → `Combine`* pattern to the framework's own **`(taskA, taskB).WhenAllAsync()`** combinator. This is **behavior-preserving** — `WhenAllAsync` internally does exactly `await Task.WhenAll(...)` then `Result.Combine(...)`.
- Added the missing UTF-8 BOM to `Showcase.Application.csproj` (repo encoding standard).

> Scope was confirmed with the maintainer: document the opt-in **and** dogfood the Showcase *library* projects (Domain + Application). The console-demo examples (e.g. EfCoreExample) and the Showcase host projects (MinimalApi/Mvc) are intentionally out of scope here.

## Validation

- `Showcase.Domain` + `Showcase.Application` build clean with the analyzers (Debug 0/0; Release via the full suite).
- `dotnet test Trellis.slnx -c Release --filter-not-trait "Category=Integration"`: **6964 passed, 0 failed, 15 skipped**.
- `Showcase.Tests` 44 pass; `Showcase.MinimalApi.Tests` 21 pass (transfer path preserved).
- docfx: **0 errors** (only benign `FailedToLoadAnalyzer` warnings); the new cross-doc anchor link validated. stale-docs audit clean. All changed files UTF-8 BOM.
- Reviewed by a `gpt-5.5` code-review agent: no significant issues.