### PR TITLE
docs: surface transactional outbox + integration events in overview docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,7 @@ For any non-trivial Trellis work, load these **before** writing the first line o
 | Ready-to-use value objects and primitive attributes | `docs/docfx_project/api_reference/trellis-api-primitives.md` |
 | ASP.NET Core response mapping, validation, ETags, Prefer handling | `docs/docfx_project/api_reference/trellis-api-asp.md` |
 | EF Core integration | `docs/docfx_project/api_reference/trellis-api-efcore.md` |
+| Transactional outbox and domain/integration event publishing | `docs/docfx_project/api_reference/trellis-api-efcore-outbox.md` |
 | Authorization | `docs/docfx_project/api_reference/trellis-api-authorization.md` |
 | FluentValidation integration | `docs/docfx_project/api_reference/trellis-api-fluentvalidation.md` |
 | HttpClient extensions | `docs/docfx_project/api_reference/trellis-api-http.md` |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ return EmailAddress.TryCreate(request.Email)
 
 - `Result<T>` and `Maybe<T>` pipelines that make failures explicit.
 - Strongly typed value objects that remove primitive obsession.
-- DDD building blocks: `Aggregate`, `Entity`, `ValueObject`, `Specification`, and domain events.
+- DDD building blocks: `Aggregate`, `Entity`, `ValueObject`, `Specification`, and domain & integration events.
+- Reliable, crash-safe event delivery via a transactional outbox—events persist atomically with state and are relayed after commit.
 - ASP.NET Core, EF Core, Mediator, HttpClient, FluentValidation, and Stateless integrations.
 - Roslyn analyzers and test helpers that keep teams on the happy path.
 - AOT-friendly, allocation-conscious APIs built for modern .NET. (Per-package APIs are AOT- and trim-safe; the optional `Trellis.ServiceDefaults` composition builder exposes both AOT-safe per-type overloads — e.g. `UseFluentValidation<TValidator, TMessage>()` — and assembly-scanning overloads annotated with `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` so the AOT analyzer surfaces the choice at the consumer's call site. `Trellis.EntityFrameworkCore` follows EF Core's own AOT policy and is intentionally excluded from the AOT publish gate.)
@@ -88,6 +89,7 @@ var result = Result.Ok("ada@example.com")
 | [Trellis.Mediator](https://www.nuget.org/packages/Trellis.Mediator) | Result-aware pipeline behaviors for [Mediator](https://github.com/martinothamar/Mediator) |
 | [Trellis.FluentValidation](https://www.nuget.org/packages/Trellis.FluentValidation) | FluentValidation output converted into Trellis results |
 | [Trellis.EntityFrameworkCore](https://www.nuget.org/packages/Trellis.EntityFrameworkCore) | EF Core conventions, converters, Maybe queries, and safe save helpers (bundles the `Maybe<T>` / owned value-object source generator) |
+| [Trellis.EntityFrameworkCore.Outbox](https://www.nuget.org/packages/Trellis.EntityFrameworkCore.Outbox) | Transactional outbox that captures domain events in the same transaction and relays them after commit, with domain/integration-event routing |
 | [Trellis.ServiceDefaults](https://www.nuget.org/packages/Trellis.ServiceDefaults) | Opinionated composition builder for wiring Trellis web-service modules in the canonical order |
 | [Trellis.StateMachine](https://www.nuget.org/packages/Trellis.StateMachine) | Stateless transitions that return `Result<TState>` |
 | [Trellis.Testing](https://www.nuget.org/packages/Trellis.Testing) | FluentAssertions extensions for `Result<T>` and `Maybe<T>` |

--- a/docs/docfx_project/index.md
+++ b/docs/docfx_project/index.md
@@ -124,6 +124,7 @@ string message = orderNumber.Match(
 | **`Result<T>` and `Maybe<T>`** | Make success and failure explicit instead of hiding them in exceptions and nulls | [Basics](articles/basics.md) |
 | **Generated value objects** | Turn raw primitives into domain language the compiler understands | [Introduction](articles/intro.md) |
 | **DDD building blocks** | Model aggregates, entities, value objects, and specifications directly | [Aggregate Factory Pattern](articles/aggregate-factory-pattern.md) |
+| **Durable event publishing** | Publish domain and integration events reliably via a transactional outbox—atomic with the state change, relayed after commit | [Transactional Outbox](articles/integration-outbox.md) |
 | **Structured error types** | Return meaningful failures with default HTTP mappings | [Error Handling](articles/error-handling.md) |
 | **ASP.NET integration** | Convert results to MVC or Minimal API responses without repetitive switch logic | [ASP.NET Core Integration](articles/integration-aspnet.md) |
 | **Roslyn analyzers** | Catch unsafe `.Value` access and other ROP mistakes during development | [Analyzers](articles/analyzers/index.md) |


### PR DESCRIPTION
The per-package docs were updated by #605 / #606, but the cross-cutting **overview** surfaces still omitted the new `Trellis.EntityFrameworkCore.Outbox` package and the durable-events capability. This PR closes that gap (docs-only).

## Changes
- **`README.md`** — add `Trellis.EntityFrameworkCore.Outbox` to the Integration package table; "What You Get" now mentions domain & integration events + crash-safe outbox delivery.
- **`docs/docfx_project/index.md`** — add a "Durable event publishing" row to the landing-page capability table (links to the Transactional Outbox guide).
- **`.github/copilot-instructions.md`** — add an area-table row pointing outbox/integration-event work to `trellis-api-efcore-outbox.md`.

## Already current (no change needed)
Per-package API references, the outbox article + its TOC entry, cookbook Recipe 35/36 + task-lookup table, CHANGELOG, and the outbox package README/NUGET_README.

Docs-only: no build/test impact. BOM preserved on all three files.