### PR TITLE
Update Showcase.Mvc to launch browser at /scalar by default

### DIFF
--- a/Examples/Showcase/src/Showcase.Mvc/Properties/launchSettings.json
+++ b/Examples/Showcase/src/Showcase.Mvc/Properties/launchSettings.json
@@ -1,10 +1,11 @@
-{
+﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "Showcase.Mvc": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "scalar",
       "applicationUrl": "https://localhost:61223",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
Changed launch profile to open the browser automatically on project start and set the default launch URL to "scalar". This improves developer experience by navigating directly to the intended page.