### PR TITLE
Reject a malformed X-Test-Actor header by default in DevelopmentActor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `DevelopmentActorProvider` rejects a malformed `X-Test-Actor` header by default
+
+`DevelopmentActorOptions.ThrowOnMalformedHeader` now defaults to `true`. A malformed `X-Test-Actor`
+header (invalid JSON, missing/empty/whitespace `Id`, or non-string permission entries) is a developer
+error and is now **rejected** with an `InvalidOperationException` instead of silently falling back to
+the configured default actor — which was a silent privilege elevation when `DefaultPermissions` is
+non-empty. An **absent** or empty header is unchanged: it still yields the configured default actor
+(intentional dev convenience). Set `ThrowOnMalformedHeader = false` to restore the previous lenient
+fall-back-to-default behavior. Development-only — the provider already throws outside Development.
+
 ### Changed — binder/JSON value-validation status honors `MapError<Error.InvalidInput>`
 
 Scalar- and composite-value-object validation failures raised during request binding and JSON body

--- a/Trellis.Asp/src/Authorization/DevelopmentActorOptions.cs
+++ b/Trellis.Asp/src/Authorization/DevelopmentActorOptions.cs
@@ -34,9 +34,15 @@ public sealed class DevelopmentActorOptions
     public IReadOnlySet<string> DefaultPermissions { get; set; } = new HashSet<string>();
 
     /// <summary>
-    /// When <see langword="true"/>, a malformed <c>X-Test-Actor</c> header throws
+    /// When <see langword="true"/> (the default), a malformed <c>X-Test-Actor</c> header throws
     /// <see cref="InvalidOperationException"/> instead of falling back to the default actor.
-    /// Defaults to <see langword="false"/>.
     /// </summary>
-    public bool ThrowOnMalformedHeader { get; set; }
+    /// <remarks>
+    /// A malformed header is a developer error and is treated distinctly from an <em>absent</em>
+    /// header (which intentionally yields the configured default actor). Rejecting it by default
+    /// avoids silently granting the default actor's permissions — a privilege elevation when
+    /// <see cref="DefaultPermissions"/> is non-empty. Set to <see langword="false"/> to restore the
+    /// lenient fall-back-to-default behavior.
+    /// </remarks>
+    public bool ThrowOnMalformedHeader { get; set; } = true;
 }

--- a/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Authorization/ServiceCollectionExtensions.cs
@@ -179,8 +179,9 @@ public static class ServiceCollectionExtensions
     /// <param name="configure">
     /// Optional delegate to customize <see cref="DevelopmentActorOptions"/>.
     /// Set <see cref="DevelopmentActorOptions.DefaultPermissions"/> to grant permissions
-    /// when no header is present, or <see cref="DevelopmentActorOptions.ThrowOnMalformedHeader"/>
-    /// to reject invalid headers instead of falling back.
+    /// when no header is present, or set <see cref="DevelopmentActorOptions.ThrowOnMalformedHeader"/>
+    /// to <see langword="false"/> to fall back to the default actor on a malformed header
+    /// instead of rejecting it (rejection is the default).
     /// </param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>

--- a/Trellis.Asp/tests/Authorization/DevelopmentActorProviderTests.cs
+++ b/Trellis.Asp/tests/Authorization/DevelopmentActorProviderTests.cs
@@ -243,10 +243,27 @@ public class DevelopmentActorProviderTests
     #region Development — Malformed header
 
     [Fact]
-    public async Task GetCurrentActor_Development_MalformedJson_FallsBackToDefault()
+    public async Task GetCurrentActor_Development_MalformedJson_ByDefault_Throws()
     {
+        // Security: a MALFORMED header is a developer error, distinct from an ABSENT header
+        // (which intentionally yields the default actor). By default the provider now rejects it
+        // rather than silently falling back to the configured default actor — which would be a
+        // silent privilege elevation when DefaultPermissions is non-empty.
         var context = CreateHttpContextWithHeader("not valid json {{{");
         var provider = CreateProvider(context);
+
+        Func<Task> act = async () => await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Malformed*");
+    }
+
+    [Fact]
+    public async Task GetCurrentActor_Development_MalformedJson_FallsBackToDefault()
+    {
+        // Opt-out: with ThrowOnMalformedHeader=false the legacy lenient behavior is preserved.
+        var context = CreateHttpContextWithHeader("not valid json {{{");
+        var provider = CreateProvider(context, options: new DevelopmentActorOptions { ThrowOnMalformedHeader = false });
 
         var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
@@ -257,7 +274,7 @@ public class DevelopmentActorProviderTests
     public async Task GetCurrentActor_Development_MissingId_FallsBackToDefault()
     {
         var context = CreateHttpContextWithHeader("""{"Permissions":["orders:read"]}""");
-        var provider = CreateProvider(context);
+        var provider = CreateProvider(context, options: new DevelopmentActorOptions { ThrowOnMalformedHeader = false });
 
         var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
@@ -268,7 +285,7 @@ public class DevelopmentActorProviderTests
     public async Task GetCurrentActor_Development_EmptyId_FallsBackToDefault()
     {
         var context = CreateHttpContextWithHeader("""{"Id":"","Permissions":["orders:read"]}""");
-        var provider = CreateProvider(context);
+        var provider = CreateProvider(context, options: new DevelopmentActorOptions { ThrowOnMalformedHeader = false });
 
         var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
@@ -282,7 +299,7 @@ public class DevelopmentActorProviderTests
         // Without this guard, ActorId.TryCreate would reject the value and Actor.Create
         // would throw ArgumentException instead of producing the configured default actor.
         var context = CreateHttpContextWithHeader("""{"Id":"   ","Permissions":["orders:read"]}""");
-        var provider = CreateProvider(context);
+        var provider = CreateProvider(context, options: new DevelopmentActorOptions { ThrowOnMalformedHeader = false });
 
         var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 
@@ -337,7 +354,7 @@ public class DevelopmentActorProviderTests
     public async Task GetCurrentActor_Development_NonStringPermissionValues_FallsBackToDefault()
     {
         var context = CreateHttpContextWithHeader("""{"Id":"user-1","Permissions":[123,true]}""");
-        var provider = CreateProvider(context);
+        var provider = CreateProvider(context, options: new DevelopmentActorOptions { ThrowOnMalformedHeader = false });
 
         var actor = (await provider.GetCurrentActorAsync(TestContext.Current.CancellationToken)).Unwrap();
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -709,7 +709,7 @@ public sealed class DevelopmentActorOptions
 | --- | --- | --- |
 | `DefaultActorId` | `string` | Default fallback actor ID. Default: `"development"`. |
 | `DefaultPermissions` | `IReadOnlySet<string>` | Default fallback permissions when no header is supplied. Default: empty `HashSet<string>`. |
-| `ThrowOnMalformedHeader` | `bool` | When `true`, malformed `X-Test-Actor` JSON throws instead of falling back to the default actor. Default: `false`. |
+| `ThrowOnMalformedHeader` | `bool` | When `true` (the **default**), a malformed `X-Test-Actor` header throws instead of falling back to the default actor — a malformed header is a developer error, distinct from an absent header. Set to `false` to restore the lenient fall-back-to-default behavior. Default: `true`. |
 
 ### `DevelopmentActorProvider`
 
@@ -727,7 +727,7 @@ Reads the `X-Test-Actor` header (JSON: `{ "Id": ..., "Permissions": [...], "Forb
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Throws `InvalidOperationException` whenever `!hostEnvironment.IsDevelopment()`, regardless of header presence. In Development, always returns `Maybe.From(actor)` — never `Maybe.None` — so dev workflows are unaffected by the 401 contract: `Maybe.From(Actor.Create(DefaultActorId, DefaultPermissions))` when `HttpContext` is null or the header is missing/empty, otherwise the parsed actor wrapped via `Maybe.From`. Malformed JSON logs a warning and falls back unless `ThrowOnMalformedHeader` is `true`. |
+| `public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default)` | `Task<Maybe<Actor>>` | Throws `InvalidOperationException` whenever `!hostEnvironment.IsDevelopment()`, regardless of header presence. In Development, always returns `Maybe.From(actor)` — never `Maybe.None` — so dev workflows are unaffected by the 401 contract: `Maybe.From(Actor.Create(DefaultActorId, DefaultPermissions))` when `HttpContext` is null or the header is missing/empty, otherwise the parsed actor wrapped via `Maybe.From`. Malformed JSON throws `InvalidOperationException` by default (`ThrowOnMalformedHeader` defaults to `true`); set it to `false` to instead log a warning and fall back to the default actor. |
 
 ### `CachingActorProvider`
 

--- a/docs/docfx_project/articles/integration-asp-authorization.md
+++ b/docs/docfx_project/articles/integration-asp-authorization.md
@@ -216,7 +216,7 @@ See [Cache partitioning across actors (`VaryForActor()`)](#cache-partitioning-ac
 | `AddTrellisWorkerActor(this IServiceCollection, Actor)` | DI extension | Scoped `IActorProvider` → `WorkerComposedActorProvider` wrapping the prior slot | Returns the supplied system actor when `IHttpContextAccessor.HttpContext` is null; delegates to the inner provider otherwise. |
 | `ClaimsActorProvider` | Class | Scoped, virtual `GetCurrentActorAsync` | Subclass for custom flat-claim providers. Permissions resolved via literal `FindAll(PermissionsClaim)` plus the well-known short↔long counterpart from the JWT inbound claim-name map; matches are merged into a deduplicated `FrozenSet<string>`. |
 | `EntraActorProvider` | Class | Scoped, sealed | Falls back to short `oid` when `IdClaimType` is the default; rewraps mapper exceptions in `InvalidOperationException`. |
-| `DevelopmentActorProvider` | Class | Scoped, sealed partial | Logs a warning and falls back when the header is malformed (unless `ThrowOnMalformedHeader = true`). |
+| `DevelopmentActorProvider` | Class | Scoped, sealed partial | Throws on a malformed header by default (`ThrowOnMalformedHeader = true`); set it to `false` to log a warning and fall back to the default actor. |
 | `CachingActorProvider` | Class | Scoped, sealed | Uses `LazyInitializer.EnsureInitialized` + `HttpContext.RequestAborted`; honors per-call `CancellationToken` via `Task.WaitAsync`. |
 | `EntraActorOptions` / `ClaimsActorOptions` / `DevelopmentActorOptions` | Options | — | Mapping delegates / claim-type strings / dev defaults. |
 
@@ -346,7 +346,7 @@ For local development and integration tests only. The provider reads an `X-Test-
 |---|---|---|
 | `DevelopmentActorOptions.DefaultActorId` | `"development"` | Used when the header is missing or empty. |
 | `DevelopmentActorOptions.DefaultPermissions` | empty `HashSet<string>` | Used when the header is missing or empty. |
-| `DevelopmentActorOptions.ThrowOnMalformedHeader` | `false` | When `true`, malformed JSON throws instead of logging a warning and falling back. |
+| `DevelopmentActorOptions.ThrowOnMalformedHeader` | `true` | When `true` (the default), a malformed header throws; set to `false` to log a warning and fall back to the default actor. |
 
 ```csharp
 using System.Collections.Generic;

--- a/docs/docfx_project/articles/integration-sso.md
+++ b/docs/docfx_project/articles/integration-sso.md
@@ -871,7 +871,6 @@ if (builder.Environment.IsDevelopment())
     {
         options.DefaultActorId         = "developer@local";
         options.DefaultPermissions     = new HashSet<string> { "todos:read", "todos:create" };
-        options.ThrowOnMalformedHeader = false;
     });
 }
 else


### PR DESCRIPTION
…Provider

DevelopmentActorOptions.ThrowOnMalformedHeader now defaults to true. A malformed X-Test-Actor header (invalid JSON, missing/empty/whitespace Id, or non-string permission entries) is a developer error and is now rejected with an InvalidOperationException instead of silently falling back to the configured default actor -- which was a silent privilege elevation when DefaultPermissions is non-empty (the ARCL benchmark surfaced this with DefaultPermissions = All).

An absent or empty header is unchanged: it still yields the configured default actor (intentional dev convenience; that path never reaches HandleMalformedHeader). Set ThrowOnMalformedHeader = false to restore the previous lenient behavior. Development-only -- the provider already throws outside Development.

TDD: new MalformedJson_ByDefault_Throws test (red before the flip, green after); the five *_FallsBackToDefault tests now set ThrowOnMalformedHeader = false to keep the opt-out path covered. Docs (api-ref + integration articles) and CHANGELOG updated.

Build 0/0, 7002 tests pass, docfx clean, stale-docs audit clean.