### PR TITLE
Add resource-error convenience factories to NotFound/Gone/Conflict/Forbidden

### DIFF
--- a/Trellis.Core/src/Errors/Error.cs
+++ b/Trellis.Core/src/Errors/Error.cs
@@ -395,7 +395,7 @@ public abstract record Error
         /// <param name="detail">Optional human-readable detail.</param>
         /// <returns>A resourceless <see cref="Conflict"/>.</returns>
         public static Conflict ForReason(string reasonCode, string? detail = null) =>
-            new(Resource: null, reasonCode) { Detail = detail };
+            new(Resource: null, ReasonCode: reasonCode) { Detail = detail };
     }
 
     // ───────────────────────────────────────────────────────────────────────────

--- a/Trellis.Core/src/Errors/Error.cs
+++ b/Trellis.Core/src/Errors/Error.cs
@@ -266,6 +266,28 @@ public abstract record Error
     {
         /// <inheritdoc />
         public override string Kind => "not-found";
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="NotFound"/> for the resource type
+        /// <typeparamref name="TResource"/> (its CLR name becomes the resource name).
+        /// </summary>
+        /// <typeparam name="TResource">The resource type whose name identifies the resource.</typeparam>
+        /// <param name="id">Optional identifier of the specific instance; omit for a collection-level lookup.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="NotFound"/> wrapping the resource reference.</returns>
+        public static NotFound For<TResource>(object? id = null, string? detail = null) =>
+            new(ResourceRef.For<TResource>(id)) { Detail = detail };
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="NotFound"/> from an explicit resource
+        /// type name and optional identifier.
+        /// </summary>
+        /// <param name="resourceType">The resource type name (e.g. <c>"Season"</c>).</param>
+        /// <param name="id">Optional identifier of the specific instance.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="NotFound"/> wrapping the resource reference.</returns>
+        public static NotFound For(string resourceType, object? id = null, string? detail = null) =>
+            new(ResourceRef.For(resourceType, id)) { Detail = detail };
     }
 
     /// <summary>The resource was previously known but has been permanently removed (tombstone).</summary>
@@ -274,6 +296,28 @@ public abstract record Error
     {
         /// <inheritdoc />
         public override string Kind => "gone";
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="Gone"/> for the resource type
+        /// <typeparamref name="TResource"/> (its CLR name becomes the resource name).
+        /// </summary>
+        /// <typeparam name="TResource">The resource type whose name identifies the resource.</typeparam>
+        /// <param name="id">Optional identifier of the specific instance.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="Gone"/> wrapping the resource reference.</returns>
+        public static Gone For<TResource>(object? id = null, string? detail = null) =>
+            new(ResourceRef.For<TResource>(id)) { Detail = detail };
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="Gone"/> from an explicit resource
+        /// type name and optional identifier.
+        /// </summary>
+        /// <param name="resourceType">The resource type name (e.g. <c>"Season"</c>).</param>
+        /// <param name="id">Optional identifier of the specific instance.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="Gone"/> wrapping the resource reference.</returns>
+        public static Gone For(string resourceType, object? id = null, string? detail = null) =>
+            new(ResourceRef.For(resourceType, id)) { Detail = detail };
     }
 
     /// <summary>The request conflicts with the current state of the resource.</summary>
@@ -318,6 +362,40 @@ public abstract record Error
         /// </remarks>
         [JsonIgnore]
         public string? ConstraintTableName { get; init; }
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="Conflict"/> against the resource type
+        /// <typeparamref name="TResource"/> (its CLR name becomes the resource name).
+        /// </summary>
+        /// <typeparam name="TResource">The conflicting resource type.</typeparam>
+        /// <param name="id">Identifier of the conflicting instance; pass <see langword="null"/> for a collection-level conflict, or use <see cref="ForReason(string, string?)"/>.</param>
+        /// <param name="reasonCode">Machine-readable code describing the kind of conflict.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="Conflict"/> for the resource.</returns>
+        public static Conflict For<TResource>(object? id, string reasonCode, string? detail = null) =>
+            new(ResourceRef.For<TResource>(id), reasonCode) { Detail = detail };
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="Conflict"/> from an explicit resource
+        /// type name and identifier.
+        /// </summary>
+        /// <param name="resourceType">The conflicting resource type name.</param>
+        /// <param name="id">Identifier of the conflicting instance.</param>
+        /// <param name="reasonCode">Machine-readable code describing the kind of conflict.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="Conflict"/> for the resource.</returns>
+        public static Conflict For(string resourceType, object? id, string reasonCode, string? detail = null) =>
+            new(ResourceRef.For(resourceType, id), reasonCode) { Detail = detail };
+
+        /// <summary>
+        /// Convenience factory for a stateless conflict with no identifiable resource (e.g. a
+        /// workflow / state-machine guard, or library code with no aggregate context).
+        /// </summary>
+        /// <param name="reasonCode">Machine-readable code describing the kind of conflict.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A resourceless <see cref="Conflict"/>.</returns>
+        public static Conflict ForReason(string reasonCode, string? detail = null) =>
+            new(Resource: null, reasonCode) { Detail = detail };
     }
 
     // ───────────────────────────────────────────────────────────────────────────
@@ -352,6 +430,27 @@ public abstract record Error
 
         /// <inheritdoc />
         public override string Code => PolicyId;
+
+        /// <summary>
+        /// Convenience factory that builds a <see cref="Forbidden"/> for <paramref name="policyId"/>
+        /// against the resource type <typeparamref name="TResource"/> (its CLR name becomes the resource name).
+        /// </summary>
+        /// <typeparam name="TResource">The resource the policy was evaluated against.</typeparam>
+        /// <param name="policyId">Identifier of the policy that denied access.</param>
+        /// <param name="id">Optional identifier of the specific instance.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A <see cref="Forbidden"/> carrying the policy and resource.</returns>
+        public static Forbidden For<TResource>(string policyId, object? id = null, string? detail = null) =>
+            new(policyId, ResourceRef.For<TResource>(id)) { Detail = detail };
+
+        /// <summary>
+        /// Convenience factory for a policy denial with no specific resource context.
+        /// </summary>
+        /// <param name="policyId">Identifier of the policy that denied access.</param>
+        /// <param name="detail">Optional human-readable detail.</param>
+        /// <returns>A resourceless <see cref="Forbidden"/>.</returns>
+        public static Forbidden ForPolicy(string policyId, string? detail = null) =>
+            new(policyId) { Detail = detail };
     }
 
     // ───────────────────────────────────────────────────────────────────────────

--- a/Trellis.Core/tests/Errors/ErrorFactoryTests.cs
+++ b/Trellis.Core/tests/Errors/ErrorFactoryTests.cs
@@ -1,0 +1,137 @@
+﻿namespace Trellis.Core.Tests.Errors;
+
+/// <summary>
+/// Tests for the resource-error convenience factories on <see cref="Error.NotFound"/>,
+/// <see cref="Error.Gone"/>, <see cref="Error.Conflict"/>, and <see cref="Error.Forbidden"/>,
+/// which mirror the existing <see cref="Error.InvalidInput.ForField(string, string, string?)"/> /
+/// <see cref="Error.InvalidInput.ForRule(string, string?)"/> style (trailing optional detail).
+/// </summary>
+public class ErrorFactoryTests
+{
+    private sealed class Team;
+
+    // ── NotFound ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NotFound_For_Generic_BuildsResourceAndDetail()
+    {
+        var error = Error.NotFound.For<Team>(42, "Team not found.");
+
+        error.Resource.Type.Should().Be("Team");
+        error.Resource.Id.Should().Be("42");
+        error.Detail.Should().Be("Team not found.");
+    }
+
+    [Fact]
+    public void NotFound_For_Generic_NoArguments_DefaultsNull()
+    {
+        var error = Error.NotFound.For<Team>();
+
+        error.Resource.Type.Should().Be("Team");
+        error.Resource.Id.Should().BeNull();
+        error.Detail.Should().BeNull();
+    }
+
+    [Fact]
+    public void NotFound_For_StringType_BuildsResource()
+    {
+        var error = Error.NotFound.For("Season", 7, "Season not found.");
+
+        error.Resource.Type.Should().Be("Season");
+        error.Resource.Id.Should().Be("7");
+        error.Detail.Should().Be("Season not found.");
+    }
+
+    // ── Gone ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Gone_For_Generic_BuildsResourceAndDetail()
+    {
+        var error = Error.Gone.For<Team>(1, "gone");
+
+        error.Resource.Type.Should().Be("Team");
+        error.Resource.Id.Should().Be("1");
+        error.Detail.Should().Be("gone");
+    }
+
+    [Fact]
+    public void Gone_For_StringType_BuildsResource()
+    {
+        var error = Error.Gone.For("Season", 7);
+
+        error.Resource.Type.Should().Be("Season");
+        error.Resource.Id.Should().Be("7");
+        error.Detail.Should().BeNull();
+    }
+
+    // ── Conflict ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Conflict_For_Generic_BuildsResourceReasonDetail()
+    {
+        var error = Error.Conflict.For<Team>(5, "team.unresolved_penalties", "has penalties");
+
+        error.Resource.Should().NotBeNull();
+        error.Resource!.Value.Type.Should().Be("Team");
+        error.Resource.Value.Id.Should().Be("5");
+        error.ReasonCode.Should().Be("team.unresolved_penalties");
+        error.Code.Should().Be("team.unresolved_penalties");
+        error.Detail.Should().Be("has penalties");
+    }
+
+    [Fact]
+    public void Conflict_For_StringType_BuildsResourceReason()
+    {
+        var error = Error.Conflict.For("Team", 5, "x.y", "d");
+
+        error.Resource!.Value.Type.Should().Be("Team");
+        error.Resource.Value.Id.Should().Be("5");
+        error.ReasonCode.Should().Be("x.y");
+        error.Detail.Should().Be("d");
+    }
+
+    [Fact]
+    public void Conflict_ForReason_ResourcelessConflict()
+    {
+        var error = Error.Conflict.ForReason("registration.pending_exists", "pending");
+
+        error.Resource.Should().BeNull();
+        error.ReasonCode.Should().Be("registration.pending_exists");
+        error.Detail.Should().Be("pending");
+    }
+
+    // ── Forbidden ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Forbidden_For_Generic_BuildsPolicyResourceDetail()
+    {
+        var error = Error.Forbidden.For<Team>("team.owner-only", 9, "owner only");
+
+        error.PolicyId.Should().Be("team.owner-only");
+        error.Code.Should().Be("team.owner-only");
+        error.Resource.Should().NotBeNull();
+        error.Resource!.Value.Type.Should().Be("Team");
+        error.Resource.Value.Id.Should().Be("9");
+        error.Detail.Should().Be("owner only");
+    }
+
+    [Fact]
+    public void Forbidden_For_Generic_NoIdNoDetail_DefaultsNull()
+    {
+        var error = Error.Forbidden.For<Team>("team.owner-only");
+
+        error.PolicyId.Should().Be("team.owner-only");
+        error.Resource!.Value.Id.Should().BeNull();
+        error.Detail.Should().BeNull();
+    }
+
+    [Fact]
+    public void Forbidden_ForPolicy_ResourcelessForbidden()
+    {
+        var error = Error.Forbidden.ForPolicy("team.owner-only", "denied");
+
+        error.PolicyId.Should().Be("team.owner-only");
+        error.Resource.Should().BeNull();
+        error.Detail.Should().Be("denied");
+    }
+}

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -521,9 +521,9 @@ Closed discriminated union of domain error values. Each case is a nested `sealed
 | `public override bool Equals(object? obj)` / `Equals(Error? other)` | Value equality over discriminator + typed payload + `Detail`. **`Cause` is excluded** so two errors with identical surface payload compare equal regardless of how deeply they were wrapped (mirrors `System.Exception` precedent). Collection-bearing payloads use `EquatableArray<T>` for sequence equality. |
 | `public override int GetHashCode()` | Hash matches `Equals`. |
 
-#### Construction (no static factory methods)
+#### Construction and case-scoped factories
 
-Construct cases directly: `new Error.NotFound(payload) { Detail = "..." }`. The base type intentionally exposes no static `Error.Validation(...)` / `Error.NotFound(...)` helpers — every call site names the case it produces. <!-- v1-stale-ok: explanatory note about removed v1 factory helpers -->
+Construct cases directly: `new Error.NotFound(payload) { Detail = "..." }`. The base `Error` type intentionally exposes no static `Error.Validation(...)` / `Error.NotFound(...)` helpers — every call site names the case it produces. <!-- v1-stale-ok: explanatory note about removed v1 factory helpers --> For the common single-payload shapes, the resource-oriented cases (`NotFound`, `Gone`, `Conflict`, `Forbidden`) and `InvalidInput` expose **case-scoped** convenience factories (e.g. `Error.NotFound.For<Order>(id, detail)`) that bundle the typed payload and an optional trailing `detail` argument while still naming the case — see each case row below.
 
 ---
 
@@ -535,10 +535,10 @@ Nested `sealed record` cases under `Error`. The base constructor is `private`, s
 | --- | --- | --- |
 | `Error.InvalidInput` | `(EquatableArray<FieldViolation> Fields, EquatableArray<RuleViolation> Rules = default)` | Request input failed semantic validation. Use `ForField(...)` / `ForRule(...)` for the common single-violation shapes. |
 | `Error.InvariantViolation` | `(string ReasonCode, ResourceRef? Resource = null)` | Domain rule failed outside field-bound request validation; use for cross-aggregate invariants or internal preconditions. |
-| `Error.NotFound` | `(ResourceRef Resource)` | The addressed resource does not exist. |
-| `Error.Forbidden` | `(string PolicyId, ResourceRef? Resource = null)` | The caller is authenticated but not allowed by the named policy. |
-| `Error.Conflict` | `(ResourceRef? Resource, string ReasonCode)` | The request collides with current state (for example duplicate keys or concurrent modification). |
-| `Error.Gone` | `(ResourceRef Resource)` | The resource previously existed but has been permanently removed (tombstone). |
+| `Error.NotFound` | `(ResourceRef Resource)` | The addressed resource does not exist. Use `For<TResource>(id, detail)` / `For(type, id, detail)` for the common shape. |
+| `Error.Forbidden` | `(string PolicyId, ResourceRef? Resource = null)` | The caller is authenticated but not allowed by the named policy. Use `For<TResource>(policyId, id, detail)` or `ForPolicy(policyId, detail)` (resourceless). |
+| `Error.Conflict` | `(ResourceRef? Resource, string ReasonCode)` | The request collides with current state (for example duplicate keys or concurrent modification). Use `For<TResource>(id, reasonCode, detail)` / `For(type, id, reasonCode, detail)` / `ForReason(reasonCode, detail)` (resourceless). |
+| `Error.Gone` | `(ResourceRef Resource)` | The resource previously existed but has been permanently removed (tombstone). Use `For<TResource>(id, detail)` / `For(type, id, detail)` for the common shape. |
 | `Error.AuthenticationRequired` | `(string? Scheme = null, string? ReasonCode = null)` | Authentication is missing or could not be established. `ReasonCode` (when supplied) distinguishes causes that share the 401 surface — e.g. `"Authentication.InvalidCredentials"` vs `"Authentication.MissingCredentials"` vs `"Authentication.TokenExpired"` — so telemetry, dashboards, and client branching don't have to parse `Detail`. |
 | `Error.Unavailable` | `(string? ReasonCode = null, RetryAdvice? Retry = null)` | A dependency or subsystem is temporarily unavailable; retry may succeed later. |
 | `Error.RateLimited` | `(RetryAdvice? Retry = null)` | The caller exceeded a quota or rate limit. |


### PR DESCRIPTION
## Summary

`Error.InvalidInput` already exposes convenience factories (`ForField(...)`, `ForRule(...)`), but the resource-oriented error cases (`NotFound`, `Gone`, `Conflict`, `Forbidden`) had only their record constructors. Call sites therefore had to write the verbose form repeatedly:

```csharp
new Error.NotFound(ResourceRef.For<Team>(id)) { Detail = "Team not found." }
```

This adds **case-scoped** static factories that bundle the `ResourceRef` and take an optional trailing `detail` argument, mirroring `InvalidInput.ForField`'s signature:

```csharp
Error.NotFound.For<Team>(id, "Team not found.")
```

## Motivation

Surfaced while using a large real-world app (cricket-league backend) as a Trellis stress test. `new Error.Conflict(...)` alone appeared ~59 times across the Application layer, every one carrying a hand-built `ResourceRef.For<T>(...)` and a `{ Detail = ... }` initializer — friction the framework can remove.

## API added (purely additive)

| Case | Factories |
|---|---|
| `NotFound` | `For<TResource>(object? id = null, string? detail = null)`, `For(string resourceType, object? id = null, string? detail = null)` |
| `Gone` | `For<TResource>(...)`, `For(string, ...)` — same shape |
| `Conflict` | `For<TResource>(object? id, string reasonCode, string? detail = null)`, `For(string resourceType, object? id, string reasonCode, string? detail = null)`, `ForReason(string reasonCode, string? detail = null)` (resourceless) |
| `Forbidden` | `For<TResource>(string policyId, object? id = null, string? detail = null)`, `ForPolicy(string policyId, string? detail = null)` (resourceless) |

Each delegates to the existing `ResourceRef.For<T>(id)` / `ResourceRef.For(type, id)` helpers and sets `{ Detail = detail }`. `Conflict.For<T>` cannot default `id` because a required `reasonCode` follows; collection-level conflicts use `ForReason`.

## Before / after

```csharp
// NotFound
- new Error.NotFound(ResourceRef.For<Team>(command.TeamId)) { Detail = "Team not found." }
+ Error.NotFound.For<Team>(command.TeamId, "Team not found.")

// Conflict (resourceless)
- new Error.Conflict(null, "registration.pending_exists") { Detail = "A pending registration exists." }
+ Error.Conflict.ForReason("registration.pending_exists", "A pending registration exists.")

// Forbidden
- new Error.Forbidden("team.owner-only", ResourceRef.For<Team>(resource.Id)) { Detail = "Only the owner may manage this team." }
+ Error.Forbidden.For<Team>("team.owner-only", resource.Id, "Only the owner may manage this team.")
```

## Tests & validation

- 11 new tests in `Trellis.Core/tests/Errors/ErrorFactoryTests.cs` (happy paths + resourceless variants + default-null args).
- Full solution build: 0 warnings / 0 errors (warnings-as-errors enabled).
- Full `Trellis.Core` suite: 2241 passed / 0 failed.
- Docs updated: `trellis-api-core.md` construction note + the four case rows.

No breaking changes — existing constructors are untouched.
