### PR TITLE
Fix TRLS020 false positive on server-built Mediator commands

### DIFF
--- a/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
+++ b/Trellis.Analyzers/src/CompositeValueObjectDtoConverterAnalyzer.cs
@@ -29,10 +29,6 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
                 symbolContext => AnalyzeMethod(symbolContext, reportedProperties),
                 SymbolKind.Method);
 
-            compilationContext.RegisterSymbolAction(
-                symbolContext => AnalyzeMessageType(symbolContext, reportedProperties),
-                SymbolKind.NamedType);
-
             compilationContext.RegisterOperationAction(
                 operationContext => AnalyzeEndpointMappingInvocation(operationContext, reportedProperties),
                 OperationKind.Invocation);
@@ -62,14 +58,6 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
         }
     }
 
-    private static void AnalyzeMessageType(SymbolAnalysisContext context, ISet<ISymbol> reportedProperties)
-    {
-        if (context.Symbol is not INamedTypeSymbol type || !IsMediatorMessageType(type))
-            return;
-
-        AnalyzeDtoType(type, context.ReportDiagnostic, reportedProperties);
-    }
-
     private static void AnalyzeEndpointMappingInvocation(OperationAnalysisContext context, ISet<ISymbol> reportedProperties)
     {
         var invocation = (IInvocationOperation)context.Operation;
@@ -97,6 +85,10 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
             IMethodReferenceOperation methodReference => methodReference.Method,
             IDelegateCreationOperation { Target: var target } => GetEndpointHandlerMethod(target),
             IConversionOperation { Operand: var operand } => GetEndpointHandlerMethod(operand),
+            // A delegate-typed value (e.g. a local/field/parameter holding the handler) is not a
+            // lambda or method group, so fall back to the delegate's Invoke signature to recover
+            // the handler parameters that are bound from the request.
+            { Type: INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: { } invoke } } => invoke,
             _ => null,
         };
 
@@ -207,24 +199,6 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
         (InheritsFrom(method.ContainingType, "ControllerBase", "Microsoft.AspNetCore.Mvc") ||
          HasAttribute(method.ContainingType, "ApiControllerAttribute", "Microsoft.AspNetCore.Mvc"));
 
-    private static bool IsMediatorMessageType(INamedTypeSymbol type)
-    {
-        foreach (var interfaceType in type.AllInterfaces)
-        {
-            if (interfaceType.Name is "IRequest" or "ICommand" or "IQuery" &&
-                IsMediatorNamespace(interfaceType.ContainingNamespace))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsMediatorNamespace(INamespaceSymbol? namespaceSymbol)
-    {
-        var namespaceName = namespaceSymbol?.ToDisplayString();
-        return namespaceName == "Mediator" || namespaceName?.EndsWith(".Mediator", StringComparison.Ordinal) == true;
-    }
-
     private static bool IsEndpointMappingMethod(IMethodSymbol method)
     {
         var endpointMethod = method.ReducedFrom ?? method;
@@ -252,8 +226,6 @@ public sealed class CompositeValueObjectDtoConverterAnalyzer : DiagnosticAnalyze
         // shim via `namespace Microsoft.AspNetCore.Builder { ... }` resolves to the nested
         // namespace `TestNamespace.Microsoft.AspNetCore.Builder`. Without this suffix branch the
         // analyzer's MapPost/MapPut/MapPatch/MapDelete detection cannot fire from analyzer tests.
-        // (Compare to `IsMediatorNamespace`, where the suffix branch ALSO accommodates real
-        // forks like `Foo.Mediator`; here the suffix branch is purely a test-support concession.)
         var namespaceName = namespaceSymbol?.ToDisplayString();
         return namespaceName == "Microsoft.AspNetCore.Builder" ||
                namespaceName?.EndsWith(".Microsoft.AspNetCore.Builder", StringComparison.Ordinal) == true;

--- a/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/CompositeValueObjectDtoConverterAnalyzerTests.cs
@@ -229,8 +229,13 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
     }
 
     [Fact]
-    public async Task MediatorRequestDto_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    public async Task ServerBuiltMediatorCommand_WithOwnedValueObject_NoDiagnostic()
     {
+        // A Mediator command constructed server-side (mapped from a separate request DTO, never
+        // deserialized from the HTTP body) must NOT be flagged: System.Text.Json never touches it,
+        // so there is no TryCreate-bypass risk and [JsonConverter] would be dead weight. TRLS020
+        // only fires at real binding seams ([FromBody]/controller return, Minimal API handler params),
+        // not on every Mediator message type.
         const string source = """
             using Mediator;
             using Trellis;
@@ -255,7 +260,125 @@ public class CompositeValueObjectDtoConverterAnalyzerTests
             }
 
             // Result<int> is a placeholder because the analyzer test stubs do not include Unit.
+            public sealed record CreateCustomerCommand(ShippingAddress ShippingAddress) : ICommand<Result<int>>;
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(source);
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MediatorCommandAsMinimalApiBody_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        // Coverage retained after dropping the blanket Mediator-message rule: a command bound DIRECTLY
+        // as a Minimal API request body is still flagged via the endpoint-mapping seam.
+        const string source = """
+            using Microsoft.AspNetCore.Builder;
+            using Mediator;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            namespace Mediator
+            {
+                public interface ICommand<TResponse> { }
+            }
+
+            namespace Microsoft.AspNetCore.Builder
+            {
+                public delegate void CreateCustomerCommandHandler(global::TestNamespace.CreateCustomerCommand command);
+
+                public static class EndpointRouteBuilderExtensions
+                {
+                    public static void MapPost(this object builder, string pattern, CreateCustomerCommandHandler handler) { }
+                }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            // Result<int> is a placeholder because the analyzer test stubs do not include Unit.
             public sealed record CreateCustomerCommand(ShippingAddress {|#0:ShippingAddress|}) : ICommand<Result<int>>;
+
+            public static class CustomerEndpoints
+            {
+                public static void Map(object app) =>
+                    app.MapPost("/customers", (CreateCustomerCommand command) => { });
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.CompositeValueObjectDtoMissingJsonConverter)
+                .WithLocation(0)
+                .WithArguments("ShippingAddress", "CreateCustomerCommand.ShippingAddress"));
+        test.TestState.Sources.Add(("AspAndTrellisStubs.cs", AspAndTrellisStubSource));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MediatorCommandViaDelegateLocalMinimalApiBody_WithOwnedValueObjectMissingConverter_ReportsDiagnostic()
+    {
+        // Coverage retention for the delegate-valued handler shape: the command is bound as the
+        // Minimal API body, but the handler is passed as a delegate local (not an inline lambda or
+        // method group). The endpoint seam must still resolve the delegate's Invoke signature.
+        const string source = """
+            using Microsoft.AspNetCore.Builder;
+            using Mediator;
+            using Trellis;
+            using Trellis.EntityFrameworkCore;
+
+            namespace Mediator
+            {
+                public interface ICommand<TResponse> { }
+            }
+
+            namespace Microsoft.AspNetCore.Builder
+            {
+                public delegate void CreateCustomerCommandHandler(global::TestNamespace.CreateCustomerCommand command);
+
+                public static class EndpointRouteBuilderExtensions
+                {
+                    public static void MapPost(this object builder, string pattern, CreateCustomerCommandHandler handler) { }
+                }
+            }
+
+            [OwnedEntity]
+            public partial class ShippingAddress : ValueObject
+            {
+                public string Street { get; }
+                public string City { get; }
+
+                protected override System.Collections.Generic.IEnumerable<System.IComparable?> GetEqualityComponents()
+                {
+                    yield return Street;
+                    yield return City;
+                }
+            }
+
+            // Result<int> is a placeholder because the analyzer test stubs do not include Unit.
+            public sealed record CreateCustomerCommand(ShippingAddress {|#0:ShippingAddress|}) : ICommand<Result<int>>;
+
+            public static class CustomerEndpoints
+            {
+                public static void Map(object app)
+                {
+                    CreateCustomerCommandHandler handler = (CreateCustomerCommand command) => { };
+                    app.MapPost("/customers", handler);
+                }
+            }
             """;
 
         var test = AnalyzerTestHelper.CreateDiagnosticTest<CompositeValueObjectDtoConverterAnalyzer>(

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -3,7 +3,7 @@ package: Trellis.Analyzers
 namespaces: [Trellis, Trellis.Analyzers]
 types: [TrellisDiagnosticIds, DiagnosticDescriptors, ResultNotHandledAnalyzer, UseBindInsteadOfMapAnalyzer, UnsafeValueAccessAnalyzer, ResultDoubleWrappingAnalyzer, AsyncResultMisuseAnalyzer, MaybeDoubleWrappingAnalyzer, UseResultCombineAnalyzer, AsyncLambdaWithSyncMethodAnalyzer, ThrowInResultChainAnalyzer, UnsafeValueInLinqAnalyzer, CombineLimitAnalyzer, UseSaveChangesResultAnalyzer, HasIndexMaybePropertyAnalyzer, UnsafeResultDeconstructionAnalyzer, DefaultResultOrMaybeAnalyzer, CompositeValueObjectDtoConverterAnalyzer, RedundantEfConfigurationAnalyzer, OwnedEntityInitOnlyPropertyAnalyzer, AddResultGuardCodeFixProvider, UseBindInsteadOfMapCodeFixProvider, UseAsyncMethodVariantCodeFixProvider, UseSaveChangesResultCodeFixProvider, TRLS043, TRLS044, TRLS045, TRLS054, TRLS055, TRLS057, TRLS058]
 version: v3
-last_verified: 2026-06-03
+last_verified: 2026-06-17
 audience: [llm]
 ---
 # Trellis.Analyzers — API Reference
@@ -341,7 +341,7 @@ public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 - No code fix (the appropriate replacement depends on intent — success vs. failure for `Result`, value vs. None for `Maybe`).
 
 #### `CompositeValueObjectDtoConverterAnalyzer` — `TRLS020`
-- Flags ASP.NET controller request/response DTOs, Minimal API handler request DTOs, and Mediator `IRequest<T>`/`ICommand<T>`/`IQuery<T>` message DTOs with properties whose type is an `[OwnedEntity]` Trellis `ValueObject` missing `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]`.
+- Flags ASP.NET controller request/response DTOs and Minimal API handler request DTOs with properties whose type is an `[OwnedEntity]` Trellis `ValueObject` missing `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]`. A Mediator `ICommand<T>`/`IRequest<T>`/`IQuery<T>` is flagged only when it is itself bound as the request body at one of those seams (e.g. a Minimal API handler parameter); a command constructed server-side and never deserialized from JSON is not flagged.
 - Also flags properties typed `Maybe<TComposite>` where `TComposite` is an `[OwnedEntity]` `ValueObject`. **`Maybe<TComposite>` is always flagged**, even when the inner `TComposite` carries `[JsonConverter(typeof(CompositeValueObjectJsonConverter<TComposite>))]`: that converter operates on `TComposite`, not on `Maybe<TComposite>`. Trellis ships no `MaybeCompositeValueObjectJsonConverterFactory`, so STJ falls back to default construction of the inner type and wraps it in `Maybe.From`, silently bypassing `TryCreate`. The supported DTO transport per cookbook Recipe 14 is `TComposite?` plus `Maybe.From(...)` at the endpoint/API seam — applicable to controller actions, Minimal API handlers, and Mediator message-construction sites.
 - This catches the silent JSON-binding failure where System.Text.Json can default-construct the composite value object and bypass `TryCreate` validation.
 - Does not flag domain model properties that are not exposed through DTO surfaces.

--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -4,7 +4,7 @@ namespaces: [Trellis, Trellis.Analyzers]
 types: [TRLS001, TRLS003, TRLS010, TRLS013, TRLS015, TRLS016, TRLS018, TRLS019, TRLS020, TRLS035, TRLS036, TRLS037, TRLS038, TRLS039, TRLS054, TRLS055, TRLS056]
 related_docs: [trellis-api-analyzers.md, trellis-api-cookbook.md]
 version: v4
-last_verified: 2026-06-03
+last_verified: 2026-06-17
 audience: [llm]
 ---
 # Trellis Anti-Pattern → Fix Gallery
@@ -202,7 +202,7 @@ return await db.SaveChangesResultAsync(ct);       // Result<int> carries the aff
 
 ## TRLS020 — Composite value object DTO property is not safely deserializable
 
-Composite value objects exposed through request/response DTOs need a supported JSON transport so binding round-trips through `TryCreate`. A bare composite DTO property must use `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` on the value-object type. A `Maybe<TComposite>` DTO property is not analyzer-clean even when the inner composite type has that converter; use a nullable transport (`TComposite?`) plus `Maybe.From(...)` at the endpoint/API seam instead. The analyzer only inspects DTOs that are visible through a controller `[FromBody]` parameter or response type, a minimal API endpoint handler parameter, or a Mediator message type — the DTO type alone is not enough to trip the rule.
+Composite value objects exposed through request/response DTOs need a supported JSON transport so binding round-trips through `TryCreate`. A bare composite DTO property must use `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` on the value-object type. A `Maybe<TComposite>` DTO property is not analyzer-clean even when the inner composite type has that converter; use a nullable transport (`TComposite?`) plus `Maybe.From(...)` at the endpoint/API seam instead. The analyzer only inspects DTOs that are actually bound from the wire: a controller `[FromBody]` parameter or response type, or a minimal API endpoint handler parameter. A Mediator command is flagged only when it is itself the bound request body at one of those seams; a command constructed server-side (mapped from a separate request DTO and never deserialized from JSON) is not flagged, because System.Text.Json never touches it. The DTO type alone is not enough to trip the rule.
 
 ```csharp
 // WRONG — bare composite [OwnedEntity] value object exposed as a [FromBody] DTO property without the converter


### PR DESCRIPTION
## Summary

`TRLS020` (`CompositeValueObjectDtoConverterAnalyzer`) warns that a composite `[OwnedEntity]` value-object property exposed by a request/response DTO needs `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` (or, for `Maybe<TComposite>`, a nullable transport) so System.Text.Json binding routes through `TryCreate`.

It also had a **blanket** detection path (`AnalyzeMessageType`, `SymbolKind.NamedType`) that flagged **every** Mediator `ICommand`/`IRequest`/`IQuery` carrying such a property — on the assumption that all messages are deserialized from the request body. That produced a **false positive on server-built commands**: a command constructed server-side (the controller maps a separate request DTO into the command) is never JSON-bound, so System.Text.Json never touches it and the suggested `[JsonConverter]` is dead weight. In a real generation run this led to **9 dead `[JsonConverter]` attributes** being added to satisfy a warning that did not apply.

## Change

- **Remove** the blanket `AnalyzeMessageType` path and the now-unused `IsMediatorMessageType` / `IsMediatorNamespace` helpers (plus a stale comment that referenced them).
- Rely on the **real binding seams** that were already covered:
  - `AnalyzeMethod` — controller `[FromBody]` parameters and controller return types.
  - `AnalyzeEndpointMappingInvocation` — Minimal API `MapPost/Put/Patch/Delete` handler parameters.
- A command that genuinely **is** the request body is still caught at its endpoint seam (including the cross-assembly case, where the warning is emitted in the compilation that maps the endpoint).
- **Coverage completeness:** teach `GetEndpointHandlerMethod` to resolve a delegate-typed handler value (a local/field holding the handler) via `DelegateInvokeMethod`, so `Handler h = ...; app.MapPost("/x", h);` is still analyzed. (Caught by review — this shape was previously masked by the blanket path.)

## Tests

- `MediatorRequestDto_..._ReportsDiagnostic` → renamed/flipped to `ServerBuiltMediatorCommand_..._NoDiagnostic` (asserts a server-built command is **not** flagged).
- Add `MediatorCommandAsMinimalApiBody_..._ReportsDiagnostic` — a command used directly as a Minimal API body **is** still flagged.
- Add `MediatorCommandViaDelegateLocalMinimalApiBody_..._ReportsDiagnostic` — a command bound via a delegate local **is** still flagged.
- Full analyzer suite: **264/264 pass.**

## Docs

- `trellis-api-analyzers.md` and `trellis-api-anti-patterns.md`: drop the "Mediator message type" scope claim; note that server-built commands are exempt and the rule fires only at real binding seams. `last_verified` bumped.

## Risk

`TRLS020` is **unshipped** (`Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md`), so this behavior change does not affect any released analyzer version.
