### PR TITLE
Document exact-match permission semantics (no check-time wildcards)

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -3,7 +3,7 @@ package: Trellis.Authorization
 namespaces: [Trellis.Authorization]
 types: [Actor, ActorAttributes, ActorId, IActorProvider, IAuthorize, "IAuthorizeResource<TResource>", "IAuthorizeResourceVia<TOwner>", "IIdentifyResource<TResource,TId>", "IIdentifyRelatedResource<TRelated,TId>", "IIdentifyRelatedResources<TRelated,TId>", "IResourceLoader<TMessage,TResource>", "ResourceLoaderById<TMessage,TResource,TId>", "SharedResourceLoaderById<TResource,TId>"]
 version: v3
-last_verified: 2026-06-03
+last_verified: 2026-06-17
 audience: [llm]
 ---
 # Trellis.Authorization — API Reference
@@ -392,6 +392,7 @@ See [Recipe 31](trellis-api-cookbook.md#recipe-31--avoid-duplicate-load-with-iau
 - **Ordinal comparison everywhere.** Permission lookups, attribute lookups, and `IsOwner` use `StringComparison.Ordinal`. Hydrate permissions and attributes with consistent casing.
 - **Permissions snapshot to frozen collections.** Mutating a collection passed into `Actor` after construction has no effect; the actor exposes a `FrozenSet<string>` / `FrozenDictionary<string, string>` snapshot for O(1) lookups.
 - **Scoped permissions** use the `"Permission:Scope"` convention (`Document.Edit:Tenant_A`). Add scoped entries directly to `Permissions` and check via `HasPermission(string, string)` — no separate scope collection.
+- **Exact match only — no check-time wildcards.** `HasPermission` is a set lookup, so a granted `"seasons:*"` does **not** match a `HasPermission("seasons:read")` check, and a granted unscoped `"seasons"` does **not** satisfy `HasPermission("seasons", scope)`. Expand any `entity:*`-style authoring shorthand into a concrete permission catalog when hydrating the `Actor` (e.g. a static `Permissions` constants class plus a role→permissions map), consistent with the pre-flatten guidance above. This keeps every check O(1) and avoids the privilege-escalation surface of pattern matching at authorization time.
 - **Pipeline ordering.** When a command implements both `IAuthorize` (static) and `IAuthorizeResource<TResource>` (resource), the mediator behavior runs static checks first; resource loading and `Authorize(actor, resource)` only execute if the static check passes. A loader failure short-circuits before `Authorize` is called.
 
 ## Code examples


### PR DESCRIPTION
## Summary

Clarify in the `Trellis.Authorization` API reference that permission matching is **exact** — there is no check-time wildcard expansion — and document the idiomatic way to handle `entity:*`-style "all actions" shorthands.

## Why

`Actor.HasPermission` is a frozen-set lookup (ordinal), chosen so every authorization check stays O(1) and there is no pattern-matching surface at authorization time. The reference documented deny-overrides-allow, ordinal comparison, and the `Permission:Scope` convention, but never stated the exact-match rule outright. That left a real ambiguity: an `entity:*` shorthand (e.g. an admin granted `seasons:*`) silently fails if passed literally as a permission string — a granted `"seasons:*"` does not match `HasPermission("seasons:read")`, and a granted unscoped `"seasons"` does not satisfy `HasPermission("seasons", scope)`.

This surfaced as friction while stress-testing the framework against a real generated app whose spec used `seasons:*` / `teams:*` shorthand. The generated code handled it correctly — it expanded the shorthand into a concrete `Permissions` catalog plus a role→permissions map (the documented "pre-flatten at hydration" pattern) and never stored a literal `*` — but the framework should state the rule explicitly so the idiom is unambiguous.

## Change

One bullet added to **Behavioral notes** in `docs/docfx_project/api_reference/trellis-api-authorization.md`:

> **Exact match only — no check-time wildcards.** `HasPermission` is a set lookup, so a granted `"seasons:*"` does not match a `HasPermission("seasons:read")` check, and a granted unscoped `"seasons"` does not satisfy `HasPermission("seasons", scope)`. Expand any `entity:*`-style authoring shorthand into a concrete permission catalog when hydrating the `Actor` … This keeps every check O(1) and avoids the privilege-escalation surface of pattern matching at authorization time.

`last_verified` bumped to 2026-06-17.

## Scope

Documentation only — no behavior change. The exact-match + pre-flatten design is intentional and unchanged; this PR only makes it explicit. API-reference lint passes.
