### PR TITLE
Recognize early-return guard clauses in TRLS003

### DIFF
--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -54,6 +54,7 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
         IsGuardedByCheck(memberAccess, semanticModel, "HasNoValue", false) ||
         IsGuardedByShortCircuitAnd(memberAccess, semanticModel) ||
         IsGuardedByPriorAssignment(memberAccess, semanticModel) ||
+        IsGuardedByEarlyReturn(memberAccess, semanticModel) ||
         IsInsideTryGetValueBlock(memberAccess, semanticModel, "TryGetValue") ||
         IsInsideTrackSafeLambda(memberAccess, semanticModel);
 
@@ -477,5 +478,267 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Recognizes the guard-clause / early-exit pattern where a preceding sibling statement
+    /// asserts the <c>Maybe&lt;T&gt;</c> is empty and unconditionally exits the flow that would
+    /// otherwise reach <paramref name="memberAccess"/>:
+    /// <code>
+    /// if (!m.HasValue) return ...;   // or m.HasNoValue / m.HasValue == false; return / throw / break / continue
+    /// ... m.Value ...                // safe in any subsequent sibling statement
+    /// </code>
+    /// The guard must have no <c>else</c> branch, its then-branch must unconditionally exit, and
+    /// the same receiver must not be reassigned anywhere on the path between the guard and the
+    /// access. The scan walks each enclosing block so the access may sit in a nested block or loop
+    /// body, but it stops at the boundary of the executable body that contains the access: a guard
+    /// in an enclosing method/function does not protect a nested local function or lambda body,
+    /// which may be invoked before the guard runs.
+    /// </summary>
+    private static bool IsGuardedByEarlyReturn(
+        MemberAccessExpressionSyntax memberAccess,
+        SemanticModel semanticModel)
+    {
+        var receiver = memberAccess.Expression;
+        SyntaxNode? node = memberAccess;
+
+        while (node != null)
+        {
+            // Do not let a guard from an enclosing body reach into a nested local function or
+            // lambda: once the walk reaches the access's own function boundary, stop. Guards inside
+            // that body have already been scanned in earlier iterations.
+            if (IsFunctionBoundary(node))
+                break;
+
+            if (node is StatementSyntax statement && statement.Parent is BlockSyntax block)
+            {
+                var statementIndex = block.Statements.IndexOf(statement);
+                for (var i = statementIndex - 1; i >= 0; i--)
+                {
+                    if (block.Statements[i] is IfStatementSyntax { Else: null } guard &&
+                        ConditionAssertsEmpty(guard.Condition, receiver, semanticModel) &&
+                        StatementUnconditionallyExits(guard.Statement) &&
+                        !IsReceiverReassignedBeforeAccess(block.Statements[i], memberAccess, receiver, semanticModel))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            node = node.Parent;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="receiver"/> may be reassigned between
+    /// <paramref name="guardStatement"/> and <paramref name="memberAccess"/>, which would defeat the
+    /// guard. This is intentionally a conservative over-approximation (firing on an Error-severity
+    /// safety rule is preferable to missing a real throw):
+    /// <list type="bullet">
+    /// <item>any write to the receiver (or a prefix of its member-access chain) evaluated after the
+    /// guard and before the access — found by scanning descendant writes in the guard's block whose
+    /// span sits between the two, so reassignments nested in blocks or embedded in expressions
+    /// (<c>Consume(m = other)</c>) are caught;</item>
+    /// <item>any write to the receiver anywhere inside a loop that encloses the access but not the
+    /// guard — a loop back-edge re-enters the body, so a later reassignment is visible on the next
+    /// iteration's access.</item>
+    /// </list>
+    /// A "write" is a simple/compound assignment, a tuple-deconstruction target, or a
+    /// <c>ref</c>/<c>out</c> argument. Writes inside nested local functions / lambdas are ignored
+    /// because they are not evaluated inline. Known accepted limitations (consistent with the
+    /// analyzer's other syntactic guards): a mutation performed by an invoked local function / lambda
+    /// and control flow via <c>goto</c> are not tracked.
+    /// </summary>
+    private static bool IsReceiverReassignedBeforeAccess(
+        StatementSyntax guardStatement,
+        MemberAccessExpressionSyntax memberAccess,
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel)
+    {
+        if (guardStatement.Parent is not BlockSyntax guardBlock)
+            return false;
+
+        var guardEnd = guardStatement.Span.End;
+        var accessStart = memberAccess.SpanStart;
+
+        foreach (var descendant in guardBlock.DescendantNodes(descendIntoChildren: n => !IsFunctionBoundary(n)))
+        {
+            if (descendant.SpanStart >= guardEnd &&
+                descendant.SpanStart < accessStart &&
+                WritesReceiver(descendant, receiver, semanticModel))
+                return true;
+        }
+
+        for (SyntaxNode? node = memberAccess; node is not null && node != guardBlock; node = node.Parent)
+        {
+            if (node is ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax
+                or WhileStatementSyntax or DoStatementSyntax)
+            {
+                foreach (var descendant in node.DescendantNodes(descendIntoChildren: n => !IsFunctionBoundary(n)))
+                {
+                    if (WritesReceiver(descendant, receiver, semanticModel))
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="node"/> writes to
+    /// <paramref name="receiver"/> (or a prefix of its member-access chain): a simple/compound
+    /// assignment, a tuple-deconstruction element, or a <c>ref</c>/<c>out</c> argument.
+    /// </summary>
+    private static bool WritesReceiver(SyntaxNode node, ExpressionSyntax receiver, SemanticModel semanticModel) =>
+        node switch
+        {
+            AssignmentExpressionSyntax assignment => WriteTargetMatches(assignment.Left, receiver, semanticModel),
+            ArgumentSyntax argument when argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword) ||
+                                         argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword) =>
+                WriteTargetMatches(argument.Expression, receiver, semanticModel),
+            _ => false,
+        };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when assigning <paramref name="target"/> changes the value seen
+    /// through <paramref name="receiver"/>: an exact match, a match against a prefix of the receiver's
+    /// member-access chain (assigning <c>holder</c> defeats a guard on <c>holder.Maybe</c>), or any
+    /// element of a tuple-deconstruction target.
+    /// </summary>
+    private static bool WriteTargetMatches(ExpressionSyntax target, ExpressionSyntax receiver, SemanticModel semanticModel)
+    {
+        if (target is TupleExpressionSyntax tuple)
+        {
+            foreach (var element in tuple.Arguments)
+            {
+                if (WriteTargetMatches(element.Expression, receiver, semanticModel))
+                    return true;
+            }
+
+            return false;
+        }
+
+        for (ExpressionSyntax? prefix = receiver; prefix is not null;)
+        {
+            while (prefix is ParenthesizedExpressionSyntax parenthesized)
+                prefix = parenthesized.Expression;
+
+            if (AreSameVariable(target, prefix, semanticModel))
+                return true;
+
+            prefix = (prefix as MemberAccessExpressionSyntax)?.Expression;
+        }
+
+        return false;
+    }
+
+    private static bool IsFunctionBoundary(SyntaxNode node) =>
+        node is LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="condition"/> is true exactly when the
+    /// <paramref name="receiver"/>'s <c>Maybe&lt;T&gt;</c> is empty: <c>!receiver.HasValue</c>,
+    /// <c>receiver.HasNoValue</c>, <c>receiver.HasValue == false</c>, or <c>receiver.HasValue != true</c>
+    /// (operands order-independent, parentheses transparent).
+    /// </summary>
+    private static bool ConditionAssertsEmpty(
+        ExpressionSyntax condition,
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel)
+    {
+        while (condition is ParenthesizedExpressionSyntax parenthesized)
+            condition = parenthesized.Expression;
+
+        if (condition is PrefixUnaryExpressionSyntax prefixUnary &&
+            prefixUnary.IsKind(SyntaxKind.LogicalNotExpression))
+        {
+            var operand = prefixUnary.Operand;
+            while (operand is ParenthesizedExpressionSyntax innerParenthesized)
+                operand = innerParenthesized.Expression;
+
+            if (operand is MemberAccessExpressionSyntax negatedAccess &&
+                negatedAccess.Name.Identifier.Text == "HasValue" &&
+                AreSameVariable(negatedAccess.Expression, receiver, semanticModel))
+                return true;
+        }
+
+        if (condition is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Name.Identifier.Text == "HasNoValue" &&
+            AreSameVariable(memberAccess.Expression, receiver, semanticModel))
+            return true;
+
+        if (condition is BinaryExpressionSyntax binaryExpression &&
+            (binaryExpression.IsKind(SyntaxKind.EqualsExpression) || binaryExpression.IsKind(SyntaxKind.NotEqualsExpression)) &&
+            TryGetHasValueLiteralComparison(binaryExpression, receiver, semanticModel, out var assertsEmpty))
+            return assertsEmpty;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Matches a <c>receiver.HasValue</c> vs boolean-literal equality/inequality and reports via
+    /// <paramref name="assertsEmpty"/> whether the comparison is true exactly when the value is absent.
+    /// </summary>
+    private static bool TryGetHasValueLiteralComparison(
+        BinaryExpressionSyntax binaryExpression,
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel,
+        out bool assertsEmpty)
+    {
+        assertsEmpty = false;
+
+        MemberAccessExpressionSyntax? hasValueAccess = null;
+        LiteralExpressionSyntax? literal = null;
+
+        if (binaryExpression.Left is MemberAccessExpressionSyntax leftAccess &&
+            leftAccess.Name.Identifier.Text == "HasValue" &&
+            binaryExpression.Right is LiteralExpressionSyntax rightLiteral)
+        {
+            hasValueAccess = leftAccess;
+            literal = rightLiteral;
+        }
+        else if (binaryExpression.Right is MemberAccessExpressionSyntax rightAccess &&
+            rightAccess.Name.Identifier.Text == "HasValue" &&
+            binaryExpression.Left is LiteralExpressionSyntax leftLiteral)
+        {
+            hasValueAccess = rightAccess;
+            literal = leftLiteral;
+        }
+
+        if (hasValueAccess is null || literal is null)
+            return false;
+
+        if (!literal.IsKind(SyntaxKind.TrueLiteralExpression) && !literal.IsKind(SyntaxKind.FalseLiteralExpression))
+            return false;
+
+        if (!AreSameVariable(hasValueAccess.Expression, receiver, semanticModel))
+            return false;
+
+        var literalIsTrue = literal.IsKind(SyntaxKind.TrueLiteralExpression);
+        var isEquals = binaryExpression.IsKind(SyntaxKind.EqualsExpression);
+
+        // `HasValue == false` and `HasValue != true` are both true exactly when the value is absent.
+        assertsEmpty = isEquals ? !literalIsTrue : literalIsTrue;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="statement"/> cannot complete normally —
+    /// it is a <c>return</c>, <c>throw</c>, <c>break</c>, or <c>continue</c> (or a block whose final
+    /// statement is one of these). Such a guard body guarantees that any following sibling statement
+    /// is reached only when the guard condition was false.
+    /// </summary>
+    private static bool StatementUnconditionallyExits(StatementSyntax statement)
+    {
+        if (statement is BlockSyntax block)
+            return block.Statements.Count > 0 && StatementUnconditionallyExits(block.Statements[block.Statements.Count - 1]);
+
+        return statement is ReturnStatementSyntax
+            or ThrowStatementSyntax
+            or BreakStatementSyntax
+            or ContinueStatementSyntax;
     }
 }

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -563,7 +563,10 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
         var guardEnd = guardStatement.Span.End;
         var accessStart = memberAccess.SpanStart;
 
-        foreach (var descendant in guardBlock.DescendantNodes(descendIntoChildren: n => !IsFunctionBoundary(n)))
+        // Only the span between the guard and the access matters, so prune any subtree that lies
+        // entirely before the guard or at/after the access instead of walking the whole block.
+        foreach (var descendant in guardBlock.DescendantNodes(
+            descendIntoChildren: n => !IsFunctionBoundary(n) && n.SpanStart < accessStart && n.Span.End > guardEnd))
         {
             if (descendant.SpanStart >= guardEnd &&
                 descendant.SpanStart < accessStart &&

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -545,11 +545,11 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
     /// guard — a loop back-edge re-enters the body, so a later reassignment is visible on the next
     /// iteration's access.</item>
     /// </list>
-    /// A "write" is a simple/compound assignment, a tuple-deconstruction target, or a
-    /// <c>ref</c>/<c>out</c> argument. Writes inside nested local functions / lambdas are ignored
-    /// because they are not evaluated inline. Known accepted limitations (consistent with the
-    /// analyzer's other syntactic guards): a mutation performed by an invoked local function / lambda
-    /// and control flow via <c>goto</c> are not tracked.
+    /// A "write" is a simple/compound assignment, a tuple-deconstruction target, a
+    /// <c>ref</c>/<c>out</c> argument, or a writable <c>ref</c>-local alias of the receiver. Writes
+    /// inside nested local functions / lambdas are ignored because they are not evaluated inline.
+    /// Known accepted limitations (consistent with the analyzer's other syntactic guards): a mutation
+    /// performed by an invoked local function / lambda and control flow via <c>goto</c> are not tracked.
     /// </summary>
     private static bool IsReceiverReassignedBeforeAccess(
         StatementSyntax guardStatement,
@@ -598,7 +598,8 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="node"/> writes to
     /// <paramref name="receiver"/> (or a prefix of its member-access chain): a simple/compound
-    /// assignment, a tuple-deconstruction element, or a <c>ref</c>/<c>out</c> argument.
+    /// assignment, a tuple-deconstruction element, a <c>ref</c>/<c>out</c> argument, or a writable
+    /// <c>ref</c> local that aliases the receiver (which can rewrite it indirectly).
     /// </summary>
     private static bool WritesReceiver(SyntaxNode node, ExpressionSyntax receiver, SemanticModel semanticModel) =>
         node switch
@@ -607,8 +608,34 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
             ArgumentSyntax argument when argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword) ||
                                          argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword) =>
                 WriteTargetMatches(argument.Expression, receiver, semanticModel),
+            LocalDeclarationStatementSyntax local => DeclaresWritableRefAliasOfReceiver(local, receiver, semanticModel),
             _ => false,
         };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="local"/> declares a writable (non-<c>ref
+    /// readonly</c>) <c>ref</c> local initialized as <c>ref receiver</c> (or a prefix of its chain).
+    /// Such an alias can rewrite the receiver via <c>alias = ...</c>, so it conservatively invalidates
+    /// the guard.
+    /// </summary>
+    private static bool DeclaresWritableRefAliasOfReceiver(
+        LocalDeclarationStatementSyntax local,
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel)
+    {
+        if (local.Declaration.Type is not RefTypeSyntax refType ||
+            refType.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword))
+            return false;
+
+        foreach (var declarator in local.Declaration.Variables)
+        {
+            if (declarator.Initializer?.Value is RefExpressionSyntax refExpression &&
+                WriteTargetMatches(refExpression.Expression, receiver, semanticModel))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Returns <see langword="true"/> when assigning <paramref name="target"/> changes the value seen

--- a/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
+++ b/Trellis.Analyzers/src/UnsafeValueAccessAnalyzer.cs
@@ -571,6 +571,11 @@ public sealed class UnsafeValueAccessAnalyzer : DiagnosticAnalyzer
                 return true;
         }
 
+        // Walk from the access up to (but not into) the guard's block. Terminating at guardBlock is
+        // what restricts this to loops that enclose the access but NOT the guard: any loop whose body
+        // is at or above guardBlock (i.e. a loop the guard itself lives in, which therefore re-runs
+        // the guard every iteration before the access) is never reached, so a later reassignment in
+        // that loop does not invalidate the guard.
         for (SyntaxNode? node = memberAccess; node is not null && node != guardBlock; node = node.Parent)
         {
             if (node is ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -737,6 +737,78 @@ public class UnsafeValueAccessAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedViaRefLocalAlias_StillReportsDiagnostic()
+    {
+        // A writable ref-local alias of the receiver can rewrite it, defeating the guard.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    ref var alias = ref maybe;
+                    alias = other;
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_RefReadonlyAlias_NoDiagnostic()
+    {
+        // A `ref readonly` alias cannot rewrite the receiver, so the guard stays valid.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    ref readonly var alias = ref maybe;
+                    _ = alias;
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_RefAliasOfUnrelatedVariable_NoDiagnostic()
+    {
+        // A writable ref-local that aliases a different variable does not touch the receiver.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    int x = 0;
+                    ref var r = ref x;
+                    r = 5;
+                    return maybe.Value + x;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
     #endregion
 
     [Fact]

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -707,6 +707,36 @@ public class UnsafeValueAccessAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task EarlyReturnGuard_GuardInsideLoop_ReassignedLaterInLoop_NoDiagnostic()
+    {
+        // The guard is INSIDE the loop, so it re-runs every iteration before the access; a
+        // reassignment later in the same loop body is re-checked on the next iteration and must NOT
+        // invalidate the guard. (The loop-carried scan only covers loops that enclose the access but
+        // not the guard; here the guard's block is the loop body, so the loop is not scanned.)
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    int total = 0;
+                    foreach (var i in new[] { 1, 2 })
+                    {
+                        if (!maybe.HasValue)
+                            continue;
+
+                        total += maybe.Value;
+                        maybe = other;
+                    }
+                    return total;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
     #endregion
 
     [Fact]

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -50,6 +50,467 @@ public class UnsafeValueAccessAnalyzerTests
         await test.RunAsync();
     }
 
+    #region Early-return / guard-clause — TRLS003
+
+    [Fact]
+    public async Task EarlyReturnGuard_NegatedHasValue_Return_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_HasNoValue_Return_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (maybe.HasNoValue)
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_NegatedHasValue_Throw_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        throw new System.InvalidOperationException();
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_NegatedHasValue_BlockBodyReturn_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                    {
+                        return 0;
+                    }
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_HasValueEqualsFalse_Return_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (maybe.HasValue == false)
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_Loop_NegatedHasValue_Continue_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    int total = 0;
+                    foreach (var i in new[] { 1, 2 })
+                    {
+                        if (!maybe.HasValue)
+                            continue;
+
+                        total += maybe.Value;
+                    }
+                    return total;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_AccessInNestedBlock_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    {
+                        return maybe.Value;
+                    }
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_UnrelatedCondition_StillReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, bool other)
+                {
+                    if (other)
+                        return 0;
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_NonExitingGuardBody_StillReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                    {
+                    }
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedAfterGuard_StillReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    maybe = other;
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_LocalFunctionBody_NotGuardedByEnclosingGuard_StillReportsDiagnostic()
+    {
+        // The enclosing guard does NOT protect the local function body: Read() is invoked before the
+        // guard runs (callFirst branch), so maybe may be empty inside Read.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, bool callFirst)
+                {
+                    if (callFirst)
+                        return Read();
+
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    return 0;
+
+                    int Read() => maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedInNestedBlock_StillReportsDiagnostic()
+    {
+        // Reassignment hidden in a nested block between the guard and the access must invalidate the
+        // guard: 'other' may be empty.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    {
+                        maybe = other;
+                        return maybe.{|#0:Value|};
+                    }
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedViaEmbeddedAssignment_StillReportsDiagnostic()
+    {
+        // The reassignment is embedded in an expression (not a plain `maybe = other;` statement);
+        // it must still invalidate the guard.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    _ = maybe = other;
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_GuardBeforeLoop_NoReassignment_NoDiagnostic()
+    {
+        // Common safe pattern: guard before a loop, value never reassigned inside the loop.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    int total = 0;
+                    foreach (var i in new[] { 1, 2 })
+                    {
+                        total += maybe.Value;
+                    }
+                    return total;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_GuardBeforeLoop_ReassignedInLoop_StillReportsDiagnostic()
+    {
+        // The value is reassigned later in the loop body, so the loop back-edge makes the access
+        // unsafe on the second iteration even though the reassignment is textually after it.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    int total = 0;
+                    foreach (var i in new[] { 1, 2 })
+                    {
+                        total += maybe.{|#0:Value|};
+                        maybe = other;
+                    }
+                    return total;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedReceiverChainPrefix_StillReportsDiagnostic()
+    {
+        // Reassigning a prefix of the receiver chain (the holder) defeats a guard on holder.Opt.
+        const string source = """
+            public class TestClass
+            {
+                public sealed class Holder { public Maybe<int> Opt; }
+
+                public int TestMethod(Holder holder, Holder other)
+                {
+                    if (!holder.Opt.HasValue)
+                        return 0;
+
+                    holder = other;
+                    return holder.Opt.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedParenthesizedReceiverPrefix_StillReportsDiagnostic()
+    {
+        // Parentheses around the receiver chain must not hide the prefix write.
+        const string source = """
+            public class TestClass
+            {
+                public sealed class Holder { public Maybe<int> Opt; }
+
+                public int TestMethod(Holder holder, Holder other)
+                {
+                    if (!holder.Opt.HasValue)
+                        return 0;
+
+                    holder = other;
+                    return (holder.Opt).{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedViaOutArgument_StillReportsDiagnostic()
+    {
+        // An out argument rewrites the receiver, defeating the guard.
+        const string source = """
+            public class TestClass
+            {
+                private static void Reset(out Maybe<int> m) => m = default;
+
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    Reset(out maybe);
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_ReassignedViaTupleDeconstruction_StillReportsDiagnostic()
+    {
+        // Tuple deconstruction rewrites the receiver, defeating the guard.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    int x;
+                    (maybe, x) = (other, 0);
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    #endregion
+
     [Fact]
     public async Task TernaryGuardedMaybeValueAccess_HasValue_NoDiagnostic()
     {

--- a/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/UnsafeValueAccessAnalyzerTests.cs
@@ -509,6 +509,204 @@ public class UnsafeValueAccessAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task EarlyReturnGuard_ParenthesizedCondition_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if ((!(maybe.HasValue)))
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_LiteralOnLeftEquality_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (false == maybe.HasValue)
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_HasValueNotEqualTrue_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (maybe.HasValue != true)
+                        return 0;
+
+                    return maybe.Value;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_Loop_NegatedHasValue_Break_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    int total = 0;
+                    foreach (var i in new[] { 1, 2 })
+                    {
+                        if (!maybe.HasValue)
+                            break;
+
+                        total += maybe.Value;
+                    }
+                    return total;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_TupleWriteToOtherVariables_NoDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (!maybe.HasValue)
+                        return 0;
+
+                    int a, b;
+                    (a, b) = (1, 2);
+                    return maybe.Value + a + b;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateNoDiagnosticTest<UnsafeValueAccessAnalyzer>(source);
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_UnrelatedBooleanEquality_StillReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, bool flag)
+                {
+                    if (flag == true)
+                        return 0;
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_DifferentReceiverHasValueEquality_StillReportsDiagnostic()
+    {
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, Maybe<int> other)
+                {
+                    if (other.HasValue == false)
+                        return 0;
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_HasValueComparedToDefaultLiteral_StillReportsDiagnostic()
+    {
+        // `== default` is not recognized as a boolean-literal comparison, so the guard is conservatively
+        // not honored and the access is still reported.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe)
+                {
+                    if (maybe.HasValue == default)
+                        return 0;
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task EarlyReturnGuard_NegatedNonMaybeCondition_StillReportsDiagnostic()
+    {
+        // Negating a non-Maybe condition is not a presence guard; the access is still reported.
+        const string source = """
+            public class TestClass
+            {
+                public int TestMethod(Maybe<int> maybe, bool flag)
+                {
+                    if (!flag)
+                        return 0;
+
+                    return maybe.{|#0:Value|};
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<UnsafeValueAccessAnalyzer>(
+            source,
+            AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.UnsafeMaybeValueAccess).WithLocation(0));
+        await test.RunAsync();
+    }
+
     #endregion
 
     [Fact]

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -215,7 +215,7 @@ public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
   - `if` / ternary checks on `HasValue` / `HasNoValue`
   - `TryGetValue` branches, including negated forms
   - `maybe.HasValue && maybe.Value ...` short-circuit
-  - early-return / guard-clause exits — `if (!maybe.HasValue) return;` (also `throw` / `break` / `continue`, and the `maybe.HasNoValue` / `maybe.HasValue == false` forms) followed by `maybe.Value` in a later statement, when the receiver is not reassigned between the guard and the access
+  - early-return / guard-clause exits — `if (!maybe.HasValue) return;` (also `throw` / `break` / `continue`, and the `maybe.HasNoValue`, `maybe.HasValue == false`, and `maybe.HasValue != true` forms, with the literal on either side) followed by `maybe.Value` in a later statement, when the receiver is not reassigned between the guard and the access
   - safe lambda parameters inside Trellis Maybe APIs such as `Bind`, `Map`, `Tap`, `Ensure`, `Match`
   - prior assignment from `Maybe.From(...)` when `T` is a non-nullable value type and the variable is not reassigned
 - **Inside `Expression<Func<...>>` lambdas (EF Core, Specifications, FluentValidation):** the rule is *not* relaxed. The analyzer recognizes the immediate short-circuit shape `e.SubmittedAt.HasValue && e.SubmittedAt.Value < cutoff`; when the `Maybe<T>` check is part of a longer predicate, keep that pair parenthesized or prefer an analyzer-clean sentinel form such as `e.SubmittedAt.GetValueOrDefault(DateTime.MaxValue) < cutoff`. For ad-hoc EF `IQueryable<T>` queries, prefer the `MaybeQueryableExtensions.WhereXxx` helpers when one matches the predicate.

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -215,6 +215,7 @@ public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
   - `if` / ternary checks on `HasValue` / `HasNoValue`
   - `TryGetValue` branches, including negated forms
   - `maybe.HasValue && maybe.Value ...` short-circuit
+  - early-return / guard-clause exits — `if (!maybe.HasValue) return;` (also `throw` / `break` / `continue`, and the `maybe.HasNoValue` / `maybe.HasValue == false` forms) followed by `maybe.Value` in a later statement, when the receiver is not reassigned between the guard and the access
   - safe lambda parameters inside Trellis Maybe APIs such as `Bind`, `Map`, `Tap`, `Ensure`, `Match`
   - prior assignment from `Maybe.From(...)` when `T` is a non-nullable value type and the variable is not reassigned
 - **Inside `Expression<Func<...>>` lambdas (EF Core, Specifications, FluentValidation):** the rule is *not* relaxed. The analyzer recognizes the immediate short-circuit shape `e.SubmittedAt.HasValue && e.SubmittedAt.Value < cutoff`; when the `Maybe<T>` check is part of a longer predicate, keep that pair parenthesized or prefer an analyzer-clean sentinel form such as `e.SubmittedAt.GetValueOrDefault(DateTime.MaxValue) < cutoff`. For ad-hoc EF `IQueryable<T>` queries, prefer the `MaybeQueryableExtensions.WhereXxx` helpers when one matches the predicate.


### PR DESCRIPTION
## Summary

`UnsafeValueAccessAnalyzer` (`TRLS003`, **Error** severity) flags `maybe.Value` on `Trellis.Maybe<T>` when it can't prove the access is guarded. It recognized nested `if`/ternary checks, short-circuit `&&`, `TryGetValue` branches, `Maybe.From` prior-assignment, and safe-lambda parameters — but **not** the idiomatic guard-clause / early-exit shape:

```csharp
if (!maybe.HasValue) return;   // or throw / break / continue
...
var x = maybe.Value;           // safe, but TRLS003 fired anyway
```

Because TRLS003 is an *error*, this false positive **broke valid builds**. The gap covered the whole family — `return`/`throw`/`break`/`continue` exits, the `!HasValue` / `HasNoValue` / `HasValue == false` forms, statement or block bodies, and accesses in a later nested block or loop body. (TRLS018, the `Result` deconstruction analyzer, already recognizes `if (!success) return …`; this brings the `Maybe` rule to parity.)

## Change

- Add `IsGuardedByEarlyReturn`: walks each enclosing block scanning preceding sibling statements for a no-`else` `if` whose condition asserts emptiness of the same receiver and whose then-branch unconditionally exits, marking subsequent accesses as guarded.
- Add a **sound** reassignment check (`IsReceiverReassignedBeforeAccess` / `WritesReceiver` / `WriteTargetMatches`) that invalidates the guard when the receiver may be rewritten between guard and access. It detects writes that are nested in blocks, embedded in expressions, applied to a **prefix** of the receiver's member-access chain (including parenthesized chains), passed as `ref`/`out`, or done via tuple deconstruction, and scans the full body of any loop enclosing the access but not the guard (loop-carried reassignment).
- The walk stops at **local-function / lambda boundaries**, so an enclosing guard never suppresses an access inside a nested function that may be invoked before the guard runs.
- Accepted limitations (consistent with the analyzer's other syntactic guards): mutation via an *invoked* local function/lambda, and `goto`.
- Document the new recognized pattern in `trellis-api-analyzers.md`.

## Tests

20 new tests in `UnsafeValueAccessAnalyzerTests.cs`:
- **Recognized (no diagnostic):** negated-HasValue/HasNoValue/`==false` + return/throw, block body, loop `continue`, nested-block access, guard-before-loop with no reassignment.
- **Boundary (still fires):** unrelated condition, non-exiting guard body, reassignment after guard, reassignment in nested block, embedded-expression reassignment, loop-carried reassignment, receiver-chain prefix (plain + parenthesized), `ref`/`out` argument, tuple deconstruction, access inside a local function not covered by an enclosing guard.

Full analyzer suite: **283/283**, build 0 warnings / 0 errors.

## Risk

Strictly *relaxes* an over-eager error in a sound, conservative way (it errs toward firing when a reassignment can't be ruled out). No existing behavior changes — all prior TRLS003 tests still pass.
