### PR TITLE
Document handling Trellis analyzers in test code

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -54,6 +54,8 @@ The analyzers ship as a **separate NuGet package, `Trellis.Analyzers`**. Install
 
 Prefer fixing the code over suppressing diagnostics. When a suppression is genuinely intentional, use `TrellisDiagnosticIds` constants instead of string literals and include a justification.
 
+In test projects, `TRLS001` and `TRLS015` are the rules most likely to need tuning — intentional fire-and-forget calls in *arrange*, and `DbContext.SaveChangesAsync()` used for seeding. Idiomatic assertions and explicit discards (`_ = ...`) already satisfy `TRLS001`, so reach for a scoped `.editorconfig` severity override rather than a project-wide `<NoWarn>`. See [test-context guidance](trellis-api-testing-reference.md#common-traps).
+
 ## Diagnostics
 
 | ID | Severity | Title | Description |

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -54,7 +54,7 @@ The analyzers ship as a **separate NuGet package, `Trellis.Analyzers`**. Install
 
 Prefer fixing the code over suppressing diagnostics. When a suppression is genuinely intentional, use `TrellisDiagnosticIds` constants instead of string literals and include a justification.
 
-In test projects, `TRLS001` and `TRLS015` are the rules most likely to need tuning — intentional fire-and-forget calls in *arrange*, and `DbContext.SaveChangesAsync()` used for seeding. Idiomatic assertions and explicit discards (`_ = ...`) already satisfy `TRLS001`, so reach for a scoped `.editorconfig` severity override rather than a project-wide `<NoWarn>`. See [test-context guidance](trellis-api-testing-reference.md#common-traps).
+In test projects, `TRLS001` and `TRLS015` are the rules most likely to need tuning — intentional fire-and-forget calls in *arrange*, and `DbContext.SaveChangesAsync()` used for seeding. Idiomatic assertions and explicit discards (`_ = ...`) already satisfy `TRLS001`. To relax a rule across scattered test projects, apply a shared global analyzer config (`is_global = true`) to every `*.Tests` project from the root `Directory.Build.props` rather than a project-wide `<NoWarn>`. See [test-context guidance](trellis-api-testing-reference.md#common-traps).
 
 ## Diagnostics
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -3,7 +3,7 @@ package: Trellis.Testing
 namespaces: [Trellis.Testing]
 types: ["FakeRepository<TAggregate, TId>", "FakeSharedResourceLoader<TResource, TId>", TestActorProvider, TestActorScope, "ResultAssertions<TValue>", ResultAssertionsExtensions, ResultAssertionsAsyncExtensions, IResultAssertions, IResultAssertionsExtensions, "MaybeAssertions<T>", MaybeAssertionsExtensions, ErrorAssertions, ErrorAssertionsExtensions, ValidationErrorAssertions, ValidationErrorAssertionsExtensions, UnwrapExtensions, UnwrapFailedException, AggregateTestMutator]
 version: v3
-last_verified: 2026-06-03
+last_verified: 2026-06-17
 audience: [llm]
 ---
 # Trellis.Testing — API Reference
@@ -40,6 +40,15 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-10--test-hand
 - `Unwrap()` and `UnwrapError()` are test helpers. Do not copy them into production code or documentation snippets for application logic.
 - Test both the success path and the expected error branch; a compiling handler that never asserts failure semantics can still miss Trellis behavior.
 - ASP.NET Core integration helpers are in [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#use-this-file-when), not this package.
+- **Trellis analyzers in test code.** Idiomatic assertions already satisfy `TRLS001` (Result not handled): a FluentAssertions chain (`result.Should().BeSuccess()`) and an explicit discard (`_ = await repo.AddAsync(...)`) both count as *handled*. For a deliberate fire-and-forget call in *arrange*/seeding, prefer the discard (`_ = ...`) over a blanket `<NoWarn>TRLS001</NoWarn>` so the rule keeps protecting the rest of the project. Seeding through `DbContext.SaveChangesAsync()` trips `TRLS015`; call `SaveChangesResultAsync()` (then assert or discard it), or relax just that one rule in the test project if you intentionally seed with the raw EF method.
+- **Relax a rule per test project with `.editorconfig`, not `<NoWarn>`.** A scoped severity override keeps the rule visible as guidance instead of silently disabling it:
+
+  ```ini
+  # tests/.editorconfig
+  [*.cs]
+  dotnet_diagnostic.TRLS001.severity = suggestion
+  dotnet_diagnostic.TRLS015.severity = none
+  ```
 
 ## Types
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-reference.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-reference.md
@@ -41,13 +41,20 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-10--test-hand
 - Test both the success path and the expected error branch; a compiling handler that never asserts failure semantics can still miss Trellis behavior.
 - ASP.NET Core integration helpers are in [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#use-this-file-when), not this package.
 - **Trellis analyzers in test code.** Idiomatic assertions already satisfy `TRLS001` (Result not handled): a FluentAssertions chain (`result.Should().BeSuccess()`) and an explicit discard (`_ = await repo.AddAsync(...)`) both count as *handled*. For a deliberate fire-and-forget call in *arrange*/seeding, prefer the discard (`_ = ...`) over a blanket `<NoWarn>TRLS001</NoWarn>` so the rule keeps protecting the rest of the project. Seeding through `DbContext.SaveChangesAsync()` trips `TRLS015`; call `SaveChangesResultAsync()` (then assert or discard it), or relax just that one rule in the test project if you intentionally seed with the raw EF method.
-- **Relax a rule per test project with `.editorconfig`, not `<NoWarn>`.** A scoped severity override keeps the rule visible as guidance instead of silently disabling it:
+- **Relax a rule across test projects with one shared file, not a per-project `<NoWarn>`.** In a Clean Architecture layout the test projects are scattered (`Domain/tests/`, `Application/tests/`, …) with no common folder, so a per-directory `.editorconfig` is awkward. Keep a single global analyzer config and apply it to every `*.Tests` project from the root `Directory.Build.props`; a severity override (rather than `<NoWarn>`) keeps the rule visible as guidance:
 
   ```ini
-  # tests/.editorconfig
-  [*.cs]
+  # eng/Trellis.Tests.globalconfig
+  is_global = true
   dotnet_diagnostic.TRLS001.severity = suggestion
   dotnet_diagnostic.TRLS015.severity = none
+  ```
+
+  ```xml
+  <!-- Directory.Build.props (repo root) — auto-applies to *.Tests projects, no per-project edits -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)eng/Trellis.Tests.globalconfig" />
+  </ItemGroup>
   ```
 
 ## Types


### PR DESCRIPTION
## Summary

Adds guidance on handling Trellis analyzers in **test code**, the one analyzer-related gap surfaced while stress-testing the framework against a generated app (whose test projects had resorted to a blunt `<NoWarn>$(NoWarn);TRLS001</NoWarn>`).

## Why

In test projects, `TRLS001` (Result not handled) fires on intentional fire-and-forget calls in *arrange*/seeding, and `TRLS015` (use `SaveChangesResultAsync`) fires when seeding data via `DbContext.SaveChangesAsync()`. The docs didn't say how to handle this idiomatically, so the path of least resistance was a project-wide `<NoWarn>`.

Importantly, **the analyzers are already test-friendly**: `TRLS001` treats both a FluentAssertions `.Should()…` chain and an explicit discard (`_ = ...`) as *handled* (verified by existing analyzer tests). So most idiomatic test code never trips it — this is purely a discoverability/guidance gap, not an analyzer bug. No analyzer behavior changes.

## Change

- **`trellis-api-testing-reference.md` → "Common traps":** idiomatic assertions/discards satisfy `TRLS001`; prefer `_ = ...` for deliberate arrange ignores over a blanket `<NoWarn>`; `SaveChangesResultAsync()` vs raw `SaveChangesAsync()` for seeding (`TRLS015`); and a scoped `.editorconfig` severity example for per-test-project relaxation. `last_verified` bumped.
- **`trellis-api-analyzers.md` → "Suppression guidance":** a short note that `TRLS001`/`TRLS015` are the rules most likely to need per-test-project tuning, linking to the test-context guidance.

## Scope

Documentation only. API-reference lint passes.
