### PR TITLE
Fix confirmed accuracy bugs in the cross-package cookbook

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -4,7 +4,7 @@ namespaces: [Trellis, Trellis.Asp, Trellis.EntityFrameworkCore, Trellis.Mediator
 types: [recipes]
 related_docs: [trellis-api-core.md, trellis-api-asp.md, trellis-api-efcore.md, trellis-api-mediator.md]
 version: v3
-last_verified: 2026-06-05
+last_verified: 2026-06-17
 audience: [llm]
 ---
 # Trellis Cross-Package Cookbook
@@ -466,6 +466,7 @@ app.MapGet("/blobs/{id:guid}", async (Guid id, IBlobRepository repo, Cancellatio
 using Trellis;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
+using Trellis.Mediator;
 using Trellis.Primitives;
 
 // CANONICAL OWNER CHECK — the 90% case. Implement IAuthorizeResource<TResource> for the
@@ -814,7 +815,7 @@ public class PlaceOrderHandlerTests
         var result = await sut.Handle(command, CancellationToken.None);
 
         result.Should().BeSuccess();
-        result.Should().HaveValue(repo.Last().Id);                  // structural equality on Result<T>
+        result.Should().HaveValue(repo.Last().Id);                  // asserts the Result<T> value equals
     }
 
     [Fact]
@@ -830,7 +831,7 @@ public class PlaceOrderHandlerTests
 }
 ```
 
-**What it shows.** `ResultAssertions<TValue>.HaveValue(...)` does structural comparison; `UnwrapError()` is the safe accessor that *only* returns the error and is intended for use after `Should().BeFailure...`. Calling `.Should()` on an `Error.InvalidInput` returns the specialized `ValidationErrorAssertions` (with `HaveFieldError`, `HaveFieldErrorWithDetail`, `HaveFieldCount`). Async assertions have two valid shapes: await the pipeline first and assert the resulting `Result<T>`, or call `BeSuccessAsync` / `BeFailureAsync` directly on `Task<Result<T>>` or `ValueTask<Result<T>>`. The unsupported shape is `await result.Should().BeSuccessAsync()` because `.Should()` returns synchronous `ResultAssertions<TValue>`.
+**What it shows.** `ResultAssertions<TValue>.HaveValue(expected)` asserts the success value **equals** `expected` (use `HaveValueEquivalentTo` for member-wise structural equivalence); `UnwrapError()` is the safe accessor that *only* returns the error and is intended for use after `Should().BeFailure...`. Calling `.Should()` on an `Error.InvalidInput` returns the specialized `ValidationErrorAssertions` (with `HaveFieldError`, `HaveFieldErrorWithDetail`, `HaveFieldCount`). Async assertions have two valid shapes: await the pipeline first and assert the resulting `Result<T>`, or call `BeSuccessAsync` / `BeFailureAsync` directly on `Task<Result<T>>` or `ValueTask<Result<T>>`. The unsupported shape is `await result.Should().BeSuccessAsync()` because `.Should()` returns synchronous `ResultAssertions<TValue>`.
 
 ---
 
@@ -853,6 +854,7 @@ If you are looking up a specific analyzer by ID, the standalone file is faster t
 ```csharp
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Trellis.EntityFrameworkCore;
 using Trellis.ServiceDefaults;
 
 public static class CompositionRoot
@@ -918,6 +920,7 @@ The unobvious bits this recipe pins down:
 
 ```csharp
 using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
 using Trellis;
 using Trellis.EntityFrameworkCore;
 using Trellis.Primitives;
@@ -988,8 +991,8 @@ public sealed partial class Customer : Aggregate<CustomerId>
 }
 
 // CONFIGURATION — note the absence of OwnsOne(c => c.ShippingAddress).
-// CompositeValueObjectConvention picks up [OwnedEntity] types automatically
-// through the source-generated ApplyTrellisConventionsFor<TContext>() entry point.
+// CompositeValueObjectConvention picks up composite ValueObject types (the ones you mark
+// [OwnedEntity]) automatically through the source-generated ApplyTrellisConventionsFor<TContext>().
 internal sealed class CustomerConfiguration : IEntityTypeConfiguration<Customer>
 {
     public void Configure(EntityTypeBuilder<Customer> builder)
@@ -1016,7 +1019,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 **What it shows.**
 
 - `[OwnedEntity]` + `partial` + `ValueObject` + private ctor is the contract. The three diagnostics (`TRLS036`/`037`/`038`) catch each violation at compile time.
-- `CompositeValueObjectJsonConverter<T>` makes JSON deserialization round-trip through `TryCreate`, so an API request body with a missing `state` produces the same `Error.InvalidInput` shape the domain emits.
+- `CompositeValueObjectJsonConverter<T>` makes JSON deserialization round-trip through `TryCreate`, so an API request body with an **invalid** `state` (one that fails the VO's rule) produces the same `Error.InvalidInput` shape the domain emits. A **missing** required inner field is caught earlier as a `TrellisJsonValidationException` ("required property missing") *before* `TryCreate` runs.
 - `ApplyTrellisConventions` removes the boilerplate `OwnsOne` call. You only need `OwnsOne` when you want to **override** the convention (custom column names, table splitting, indexes on inner properties).
 
 **Storage shape.**
@@ -1024,7 +1027,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 | Aggregate property | Storage |
 |---|---|
 | Required `ShippingAddress` (non-nullable) | Table-split: 5 columns on the `Customers` table — `ShippingAddress_Street`, `ShippingAddress_City`, `ShippingAddress_State`, `ShippingAddress_PostalCode`, `ShippingAddress_Country` (all `NOT NULL`). |
-| Optional `Maybe<ShippingAddress>` | Because the inner properties are non-nullable, `CompositeValueObjectConvention` switches to a **separate table** named `{Owner}_{Property}` (e.g., `Customer_BillingAddress`) with a `1:0..1` FK back to `Customers`. See the storage rules in [trellis-api-efcore.md](trellis-api-efcore.md#maybet-storage-owned-types-and-migrations) for the full decision matrix. |
+| Optional `Maybe<ShippingAddress>` | `CompositeValueObjectConvention` **table-splits** it into the `Customers` table as **nullable** columns (`BillingAddress_Street`, …, all `NULL`-able); absence is encoded as all-null. It uses a **separate table** `{Owner}_{Property}` when the composite has **nested owned navigations** *or* a **non-nullable value-type inner property** — table-splitting can't represent either for an optional dependent (all-null columns would make existence ambiguous, and EF Core rejects making a non-nullable value-type column optional), so row existence encodes presence instead. See the storage rules in [trellis-api-efcore.md](trellis-api-efcore.md#maybet-storage-owned-types-and-migrations) for the full decision matrix. |
 
 **JSON wire shape.**
 
@@ -1032,9 +1035,9 @@ The `[JsonConverter(typeof(CompositeValueObjectJsonConverter<T>))]` attribute on
 
 | C# property | JSON request/response shape |
 |---|---|
-| `ShippingAddress ShippingAddress { get; private set; }` (required composite VO) | `"shippingAddress": { "street": "1 Main St", "city": "Redmond", "state": "WA", "postalCode": "98052", "country": "US" }` — every field present; missing inner field → `Error.InvalidInput` with field path `/shippingAddress/<field>`. |
+| `ShippingAddress ShippingAddress { get; private set; }` (required composite VO) | `"shippingAddress": { "street": "1 Main St", "city": "Redmond", "state": "WA", "postalCode": "98052", "country": "US" }` — every field present; an **invalid** inner field (fails `TryCreate`) → `Error.InvalidInput` with field path `/shippingAddress/<field>`; a **missing** inner field → a "required property missing" `TrellisJsonValidationException`. |
 | `partial Maybe<ShippingAddress> BillingAddress { get; set; }` (optional composite VO on a domain model — **not** used directly on a request DTO; see Recipe 14) | Domain model only. On the wire, request DTOs use a **nullable transport** (`ShippingAddress?`) and the controller adapts via `Maybe.From(...)`. Response DTOs project to `ShippingAddress?` for the same reason. |
-| `Money Total { get; private set; }` (required composite VO with scalar inner properties — `decimal Amount`, `Currency Currency`) | `"total": { "amount": 49.99, "currency": "USD" }` — the property casing comes from System.Text.Json's `PropertyNamingPolicy.CamelCase` (set by `AddTrellisAsp()`). Inner scalar VOs (e.g., `Currency : RequiredString<Currency>`) serialize as their underlying primitive (`"USD"`, not `{"value":"USD"}`). |
+| `Money Total { get; private set; }` (required composite VO with scalar inner properties — `decimal Amount`, `Currency Currency`) | `"total": { "amount": 49.99, "currency": "USD" }` — the inner field casing is camelCase (the `CompositeValueObjectJsonConverter` emits camelCase property names). Inner scalar VOs (e.g., `Currency : RequiredString<Currency>`) serialize as their underlying primitive (`"USD"`, not `{"value":"USD"}`). |
 | Scalar VO (`OrderId : RequiredGuid<OrderId>`, `EmailAddress : RequiredString<EmailAddress>`) | Always serializes as the underlying primitive (`"550e8400-..."`, `"a@b.com"`). Never wrapped in `{ "value": ... }`. This is automatic via the source-generated `IScalarValue<T,P>` JSON converter. |
 
 **Anti-pattern → fix.**
@@ -1225,8 +1228,9 @@ The answer depends on whether the inner type is a **scalar** (single-primitive) 
 using Trellis;
 using Trellis.Primitives;
 
-public sealed partial class EmailAddress : RequiredString<EmailAddress>;
-public sealed partial class PhoneNumber  : RequiredString<PhoneNumber>;
+// EmailAddress and PhoneNumber are the shipped, validating value objects from Trellis.Primitives
+// (PhoneNumber validates E.164, EmailAddress validates format). Use them — do NOT redeclare bare
+// RequiredString subclasses, which are lenient (reject null only) and would skip format validation.
 
 public sealed record CreateCustomerRequest(
     EmailAddress         Email,           // required
@@ -1240,7 +1244,7 @@ public sealed class CustomersController(ISender sender) : ControllerBase
     public ValueTask<ActionResult<CustomerResponse>> Create(
         [FromBody] CreateCustomerRequest request, CancellationToken ct) =>
         sender.Send(new CreateCustomerCommand(request.Email, request.PhoneNumber), ct)
-              .ToHttpResponseAsync(CustomerResponse.From, /* … */)
+              .ToHttpResponseAsync(CustomerResponse.From)
               .AsActionResultAsync<CustomerResponse>();
 }
 ```
@@ -1272,7 +1276,7 @@ public sealed class CustomersController(ISender sender) : ControllerBase
             : Maybe.From(request.ShippingAddress);
 
         return sender.Send(new CreateCustomerCommand(request.Email, shipping), ct)
-                     .ToHttpResponseAsync(CustomerResponse.From, /* … */)
+                     .ToHttpResponseAsync(CustomerResponse.From)
                      .AsActionResultAsync<CustomerResponse>();
     }
 }
@@ -1341,11 +1345,11 @@ public sealed class CreateOrderHandler(IOrderRepository repo)
 
 > `repo.Add(entity)` stages the aggregate for insertion via EF Core; `TransactionalCommandBehavior`, registered by `services.AddTrellisUnitOfWork<TContext>()` in your ACL composition root, automatically calls `SaveChangesAsync` after every successful handler — no explicit save call is needed in the handler.
 
-**What it shows.** Handlers in Trellis follow a strict separation: the handler shapes domain state and the pipeline owns the commit boundary. `IRepository.Add` returns `void` precisely to signal "staged, not yet persisted" — the `void` return makes it impossible to write the (wrong) `await repo.Add(...).Should().BeSuccess()`. The mediator pipeline wraps the handler; from innermost (closest to the handler) outward it is: `TransactionalCommandBehavior` → `ValidationBehavior` → `AuthorizationBehavior` → `LoggingBehavior` → `TracingBehavior` → `ExceptionBehavior` (the opt-in `ResourceAuthorizationBehavior` sits just outside `ValidationBehavior`). When the handler returns a successful `Result<T>`, the transactional behavior calls `SaveChangesAsync` and only then surfaces the result; on failure or exception, nothing is committed.
+**What it shows.** Handlers in Trellis follow a strict separation: the handler shapes domain state and the pipeline owns the commit boundary. `RepositoryBase.Add` (the base behind your `IOrderRepository`) returns `void` precisely to signal "staged, not yet persisted" — the `void` return makes it impossible to write the (wrong) `await repo.Add(...).Should().BeSuccess()`. The mediator pipeline wraps the handler; from innermost (closest to the handler) outward it is: `TransactionalCommandBehavior` → `ValidationBehavior` → `AuthorizationBehavior` → `LoggingBehavior` → `TracingBehavior` → `ExceptionBehavior` (the opt-in `ResourceAuthorizationBehavior` sits just outside `ValidationBehavior`). When the handler returns a successful `Result<T>`, the transactional behavior calls `SaveChangesAsync` and only then surfaces the result; on failure or exception, nothing is committed (unless the command opts into `IPersistOnFailure`, which deliberately commits the failure path).
 
 | Method | Signature | Saves immediately? | When to use |
 |---|---|---|---|
-| `IRepository.Add(T)` (and `Remove(T)`, `RemoveByIdAsync(TId)`) | `void` / `Task<Result<Unit>>` for not-found | **No** — staged for the UoW | Handlers and any production-shaped repository contract |
+| `RepositoryBase.Add(T)` (and `Remove(T)`, `RemoveByIdAsync(TId)`) | `void` / `Task<Result<Unit>>` for not-found | **No** — staged for the UoW | Handlers and any production-shaped repository contract |
 | `FakeRepository.Add(T)` | `void` | n/a (in-memory; visible immediately) | **Test setup** — "put this in the store so the handler can find it" |
 | `FakeRepository.SaveAsync(T)` | `Task<Result<Unit>>` | n/a (in-memory; visible immediately) | Tests that explicitly assert on the `Result` shape, e.g., conflict-result handling |
 
@@ -1882,7 +1886,7 @@ foreach (var li in order.LineItems)
     product.ReleaseStock(li.Quantity);
 }
 
-// ✅ Fail-loud with full preflight — same shape as the worked example above.
+// ✅ Fail-loud with full preflight — same two-pass shape as the worked example above.
 // Compute the missing set BEFORE any side effect; only enter the release loop
 // when every related aggregate is reachable.
 var missing = order.LineItems.Select(li => li.ProductId).Distinct()
@@ -1894,13 +1898,19 @@ if (missing.Length > 0)
         : new Error.Aggregate(missing.Select(id =>
             (Error)new Error.NotFound(ResourceRef.For<Product>(id))).ToArray()));
 
+// Preflight the per-aggregate domain invariants (Recipe 25) BEFORE any mutation.
+// Releasing stock on Product A then failing on Product B would leave A partially
+// released — TransactionalCommandBehavior cannot roll back the in-memory aggregate
+// graph within the request. Never mutate-and-bail in the loop.
+var preflight = order.LineItems
+    .Select(li => byId[li.ProductId].CanReleaseStock(li.Quantity))
+    .SequenceAll();
+if (preflight.IsFailure)
+    return Result.Fail<Order>(preflight.Error);
+
+// Pass 2: every mutation has a matching Can* that just returned Ok — provably non-failing.
 foreach (var li in order.LineItems)
-{
-    var product = byId[li.ProductId];
-    var release = product.ReleaseStock(li.Quantity);
-    if (release.Error is { } err)
-        return Result.Fail<Order>(err);
-}
+    byId[li.ProductId].ReleaseStock(li.Quantity).Discard();
 ```
 
 ---
@@ -1950,7 +1960,7 @@ app.MapPut("/orders/{id:guid}", (OrderId id, ReplaceOrderRequest request, OrderD
 
 ## Cross-cutting tips
 
-- **Run analyzers in CI.** `Trellis.Analyzers` ships in the framework and runs as part of every `dotnet build`. Treat warnings as errors for `TRLS00x` once your codebase is clean.
+- **Run analyzers in CI.** `Trellis.Analyzers` ships with the Trellis ASP template and runs on every build of a project that references it. Treat warnings as errors for `TRLS00x` once your codebase is clean.
 - **Two independent `await` calls in a handler?** `Result.ParallelAsync` + `WhenAllAsync` is the framework idiom — **but only when the loads hit different resources**. Two repository reads against the same scoped `DbContext` (the typical Trellis setup with `AddTrellisUnitOfWork<TContext>()`) race EF Core and throw `InvalidOperationException`; keep those sequential. The recipe spells out the safe shapes (HTTP + DB, two distinct upstream services, factory-created `DbContext`s via `IDbContextFactory<T>`) and the anti-pattern. See [Recipe 21](#recipe-21--parallel-independent-loads-in-handlers-resultparallelasync--whenallasync). The rule for "independent": the second factory's body does not reference any value produced by the first **and** the two factories hit distinct underlying resources.
 - **Do not mix sync chain methods with async lambdas.** `result.Map(async v => …)` triggers `TRLS009`; use `MapAsync`. The fix provider can apply this rewrite automatically.
 - **Construct errors via the closed ADT.** `new Error.NotFound(ResourceRef.For<Order>(id))` — never `new Error("not_found", "...")`, which won't compile against the abstract base record.
@@ -1989,6 +1999,7 @@ The naive workaround is a per-handler ownership guard (e.g. cricket's old `Match
 ### Cricket fan-out — end to end
 
 ```csharp
+using Mediator;
 using Trellis;
 using Trellis.Authorization;
 
@@ -2621,11 +2632,11 @@ public sealed class PaymentsController : ControllerBase
 app.MapPost("/payments", CreatePaymentAsync).WithMetadata(new IdempotentAttribute());
 ```
 
-**What it shows.** The middleware reads the configured header (default `Idempotency-Key`), rejects raw header values above the parser's 4 KiB defensive cap, parses accepted values as the [RFC 8941](https://www.rfc-editor.org/rfc/rfc8941) `sf-string` subset, buffers the request body up to `MaxRequestBodyBytes`, computes a SHA-256 fingerprint over `(method, path, normalized headers, body)`, resolves a tenant/actor scope through `IIdempotencyScopeResolver` (default: per-actor via `IActorProvider`, falling back to anonymous when no actor is established), and calls `IIdempotencyStore.TryReserveAsync(scope, key, fingerprint, ct)`. The store either issues a `Reserved` outcome (carrying an opaque CAS reservation token), reports `AlreadyInFlight` (concurrent reservation still open — the middleware responds `409 Conflict` with `Retry-After`), `Replay` (a completed snapshot — the middleware writes the captured status code, headers, and body verbatim), or `BodyHashMismatch` (same key, different fingerprint — the middleware responds `422 Unprocessable Entity` so the client knows the key was reused with a mutated request). When the reservation is `Reserved`, the middleware decorates `IHttpResponseBodyFeature` with `CapturingResponseBodyFeature` (a tee — bytes still flow to the client while a bounded copy is captured) and registers an `OnStarting` callback that snapshots the final status code and response headers before the first byte flushes. On a successful flush within `MaxResponseBodyBytes`, the middleware calls `IIdempotencyStore.CompleteAsync(reservationId, snapshot, ct)` against a bounded 5-second cancellation token (NOT `HttpContext.RequestAborted`, so finalisation still runs if the client disconnected). On any failure path — exception, response-too-large, `SendFileAsync` (uncapturable), middleware abort, **5xx response status** (treated as transient per the IETF Idempotency-Key draft), or **response trailers** (cannot be replayed by the snapshot writer) — the middleware calls `AbandonAsync(reservationId, ct)` so the next retry can re-reserve. Reservation tokens are opaque `string` GUIDs the store uses for CAS so a stale completer cannot finalise a reservation the store already abandoned via the reservation-timeout sweeper.
+**What it shows.** The middleware reads the configured header (default `Idempotency-Key`), rejects raw header values above the parser's 4 KiB defensive cap, parses accepted values as the [RFC 8941](https://www.rfc-editor.org/rfc/rfc8941) `sf-string` subset, buffers the request body up to `MaxRequestBodyBytes`, computes a SHA-256 fingerprint over `(method, path, normalized headers, body)`, resolves a tenant/actor scope through `IIdempotencyScopeResolver` (default: per-actor via `IActorProvider`, falling back to anonymous when no actor is established), and calls `IIdempotencyStore.TryReserveAsync(scope, key, fingerprint, ct)`. The store either issues a `Reserved` outcome (carrying an opaque CAS reservation token), reports `AlreadyInFlight` (concurrent reservation still open — the middleware responds `409 Conflict` with `Retry-After`), `Replay` (a completed snapshot — the middleware writes the captured status code, headers, and body verbatim), or `BodyHashMismatch` (same key, different fingerprint — the middleware responds `422 Unprocessable Entity` so the client knows the key was reused with a mutated request). When the reservation is `Reserved`, the middleware decorates `IHttpResponseBodyFeature` with `CapturingResponseBodyFeature` (a tee — bytes still flow to the client while a bounded copy is captured) and registers an `OnStarting` callback that snapshots the final status code and response headers before the first byte flushes. On a successful flush within `MaxResponseBodyBytes`, the middleware calls `IIdempotencyStore.CompleteAsync(scope, key, reservationId, snapshot, ct)` against a bounded 5-second cancellation token (NOT `HttpContext.RequestAborted`, so finalisation still runs if the client disconnected). On any failure path — exception, response-too-large, `SendFileAsync` (uncapturable), middleware abort, **5xx response status** (treated as transient per the IETF Idempotency-Key draft), or **response trailers** (cannot be replayed by the snapshot writer) — the middleware calls `AbandonAsync(scope, key, reservationId, ct)` so the next retry can re-reserve. Reservation tokens are opaque `string` GUIDs the store uses for CAS so a stale completer cannot finalise a reservation the store already took over after the reservation timeout elapsed (a later same-key request re-reserves; there is no background sweeper).
 
 **Composition rules.** `services.AddTrellisIdempotency(...)` (or the builder slot `t.UseIdempotency(...)`) registers options + scope resolver + an internal marker; `services.AddInMemoryIdempotencyStore()` is a separate, explicit call so a dev-only in-memory store is never silently inherited into production. `app.UseTrellisIdempotency()` throws at startup if `AddTrellisIdempotency(...)` was not called. The `IIdempotencyStore` registration is also validated at startup when the container exposes `IServiceProviderIsService` (the default Microsoft.Extensions.DependencyInjection container does); on containers that do not expose it the missing-store failure surfaces as a per-request resolution error on the first opted-in request. The in-memory store is single-process only; multi-instance hosts need an EF-backed store (per-tenant table or shared with `Scope` as a discriminator column) that implements the same CAS contract. `MaxRequestBodyBytes` and `MaxResponseBodyBytes` are hard caps: exceeding the request cap returns `413 Payload Too Large` before any handler runs; exceeding the response cap aborts capture and records no snapshot (the next retry re-executes), so the cap should be set high enough to envelop the largest legitimate response from any opted-in endpoint. Endpoints that stream via `SendFileAsync` cannot be captured and are equivalent to exceeding the response cap — model those as non-idempotent or convert them to a buffered response.
 
-**Tests.** Use `Microsoft.AspNetCore.TestHost.TestServer` (the same harness pattern as Recipe 26) plus an `IIdempotencyStore` registered as a singleton (`InMemoryIdempotencyStore`) plus `TimeProvider` swapped for `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (from the `Microsoft.Extensions.TimeProvider.Testing` NuGet package). Drive the same `(key, body)` twice — assert the second call returns the captured status code, headers, and body byte-for-byte. Drive `(key, mutated-body)` — assert `422` and the original snapshot is still replayable. Advance `FakeTimeProvider` past `ReservationTimeout` to exercise the sweep + re-reserve path. The NuGet package is `Microsoft.Extensions.TimeProvider.Testing` (the namespace containing `FakeTimeProvider` is `Microsoft.Extensions.Time.Testing`); the test project should reference the package the same way `Trellis.Testing.Worker`'s harness does.
+**Tests.** Use `Microsoft.AspNetCore.TestHost.TestServer` (the same harness pattern as Recipe 26) plus an `IIdempotencyStore` registered as a singleton (`InMemoryIdempotencyStore`) plus `TimeProvider` swapped for `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (from the `Microsoft.Extensions.TimeProvider.Testing` NuGet package). Drive the same `(key, body)` twice — assert the second call returns the captured status code, headers, and body byte-for-byte. Drive `(key, mutated-body)` — assert `422` and the original snapshot is still replayable. Advance `FakeTimeProvider` past `ReservationTimeout` to exercise the reservation-timeout takeover path (a later same-key request re-reserves the stale entry). The NuGet package is `Microsoft.Extensions.TimeProvider.Testing` (the namespace containing `FakeTimeProvider` is `Microsoft.Extensions.Time.Testing`); the test project should reference the package the same way `Trellis.Testing.Worker`'s harness does.
 
 ---
 
@@ -2924,9 +2935,7 @@ The pipeline extracts the ID from `IIdentifyResource<Incident, IncidentId>` firs
 ```csharp
 endpoints.MapGet("/incidents/{id}", async (...) =>
     (await mediator.Send(new GetIncidentQuery(...)))
-        .Build()
-        .WithCacheControl(CacheControl.NoStore())   // safe under HideAsNotFound
-        .ToHttpResponse());
+        .ToHttpResponse(o => o.WithCacheControl(CacheControl.NoStore())));   // safe under HideAsNotFound
 ```
 
 **Observability.** Every translation emits a structured log at `Information`:

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -463,6 +463,7 @@ app.MapGet("/blobs/{id:guid}", async (Guid id, IBlobRepository repo, Cancellatio
 **Problem.** Resource-based ownership check on an update command (the 90% case) plus a static permission gate on a delete command, all via the mediator pipeline.
 
 ```csharp
+using Mediator;
 using Trellis;
 using Trellis.Asp.Authorization;
 using Trellis.Authorization;
@@ -991,8 +992,9 @@ public sealed partial class Customer : Aggregate<CustomerId>
 }
 
 // CONFIGURATION — note the absence of OwnsOne(c => c.ShippingAddress).
-// CompositeValueObjectConvention picks up composite ValueObject types (the ones you mark
-// [OwnedEntity]) automatically through the source-generated ApplyTrellisConventionsFor<TContext>().
+// CompositeValueObjectConvention discovers composite ValueObject types by their inheritance
+// from ValueObject (NOT the [OwnedEntity] attribute) through the source-generated
+// ApplyTrellisConventionsFor<TContext>().
 internal sealed class CustomerConfiguration : IEntityTypeConfiguration<Customer>
 {
     public void Configure(EntityTypeBuilder<Customer> builder)
@@ -2002,6 +2004,7 @@ The naive workaround is a per-handler ownership guard (e.g. cricket's old `Match
 using Mediator;
 using Trellis;
 using Trellis.Authorization;
+using Trellis.Mediator;
 
 public sealed partial class MatchId : RequiredGuid<MatchId>;
 public sealed partial class TeamId  : RequiredGuid<TeamId>;


### PR DESCRIPTION
## What

Fixes confirmed accuracy bugs in `trellis-api-cookbook.md` found during a two-pass pre-publish review of the LLM-facing recipes. The high-risk recipes have **no compiled demonstrator** in `Examples/CookbookSnippets/`, so these drifted from source. Every fix was verified against framework source (and a gpt-5.5 review of the diff).

## Fixes

| Recipe | Fix |
|---|---|
| **R32** | Remove phantom `.Build()` result extension → `.ToHttpResponse(o => o.WithCacheControl(CacheControl.NoStore()))`. |
| **R29** | Correct `IIdempotencyStore.CompleteAsync`/`AbandonAsync` signatures (`scope, key, reservationId, …`); stale reservations are taken over lazily on a same-key retry after the timeout — **no background sweeper**. |
| **R22** | Replace the mutate-and-bail loop with the two-pass `Can*(…).SequenceAll()` preflight → `Op(…).Discard()` shape (`TransactionalCommandBehavior` cannot roll back an in-memory aggregate graph within a request). |
| **R14** | Drop the bare lenient `EmailAddress`/`PhoneNumber : RequiredString` that shadow the **shipped** validating `Trellis.Primitives` VOs; fix two dangling-comment args. |
| **R13** | Correct `Maybe<composite>` storage (nullable table-split unless nested owned navs **or** a non-nullable value-type inner property), discovery wording (by `ValueObject` inheritance), JSON error path (missing field → `TrellisJsonValidationException`), camelCase attribution. |
| **R10** | `HaveValue(expected)` is equality; `HaveValueEquivalentTo` is structural. |
| **R16** | `RepositoryBase.Add` (no framework `IRepository`); `IPersistOnFailure` caveat. |
| **R7/R12/R13/R24** | Add missing `using` directives. |
| cross-cut | Clarify analyzers ship with the Trellis ASP template; bump `last_verified`. |

## Validation

- API-reference lint ✅ · stale-docs audit ✅ (exit 0) · UTF-8 BOM preserved ✅
- gpt-5.5 diff review: 1 finding (R13 separate-table condition) — fixed.

Docs-only; no source changes.