### PR TITLE
Qualify Microsoft.AspNetCore.Http.IResult in the asp.md DELETE example comment

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -1185,7 +1185,7 @@ public sealed class WidgetsController(ISender sender) : ControllerBase
 
     // DELETE — 204 No Content. Body-less, so return IResult directly (no AsActionResultAsync).
     // Fully-qualify Microsoft.AspNetCore.Http.IResult — it clashes with Trellis.IResult under `using Trellis;`.
-    // ToHttpResponseAsync() returns ValueTask<IResult>, so await it and return Task<IResult>.
+    // ToHttpResponseAsync() returns ValueTask<Microsoft.AspNetCore.Http.IResult>, so await it and return Task<Microsoft.AspNetCore.Http.IResult>.
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]


### PR DESCRIPTION
## What

Fully-qualifies `Microsoft.AspNetCore.Http.IResult` in the DELETE controller example comment in `trellis-api-asp.md`.

## Why

The example deliberately uses the fully-qualified `Microsoft.AspNetCore.Http.IResult` (line 1193) to avoid clashing with `Trellis.IResult` under `using Trellis;` — and the comment immediately above even says *"Fully-qualify Microsoft.AspNetCore.Http.IResult — it clashes with Trellis.IResult"*. But the very next line then described the return types with a bare `IResult` (`ValueTask<IResult>` / `Task<IResult>`), which is ambiguous and could mislead a reader into thinking Trellis `IResult` is involved.

Surfaced by a Copilot review comment on the `TrellisAspTemplate` 3.0.0-alpha.394 bump PR (whose synced copy of this doc carries the same text — fixed there in lockstep so the next `TrellisSyncApiReference` stays consistent).

Docs-only; `lint-api-reference.ps1` and the stale-docs audit pass.