### PR TITLE
Add WriteOutcome static factory helpers (cast-free case construction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `WriteOutcome` static factory helpers (cast-free case construction)
+
+A non-generic `static class WriteOutcome` (in `Trellis.Http.Abstractions`, namespace `Trellis`) now
+provides `Created<T>`, `Updated<T>`, `UpdatedNoContent<T>`, `Accepted<T>`, and `AcceptedNoContent<T>`
+helpers that build each `WriteOutcome<T>` case but **return the base `WriteOutcome<T>`**. Previously,
+`new WriteOutcome<T>.Updated(...)` had the nested case type, and because `Result<T>` is invariant the
+result could not implicitly upcast to `Result<WriteOutcome<T>>` — so pipelines had to widen it with an
+explicit `(WriteOutcome<T>)` cast (e.g. `.Map(p => (WriteOutcome<Order>)new WriteOutcome<Order>.Updated(p, meta))`).
+The helpers remove that cast: `.Map(p => WriteOutcome.Updated(p, meta))` now infers `T` from the value
+and flows straight into `ToHttpResponse(...)`. (Forgetting the cast was usually a compile error, but the
+no-body-projector path could silently bind the plain-`Result<T>` overload and skip outcome translation —
+the helpers close that gap too.) Mirrors the existing non-generic `Result` / generic `Result<T>` pairing.
+Purely additive; the nested-record construction still works.
+
 ### Added — `Error.InvariantViolation` resource factories (`For` / `ForReason`)
 
 `Error.InvariantViolation` now exposes the same case-scoped convenience factories as the other

--- a/Trellis.Http.Abstractions/NUGET_README.md
+++ b/Trellis.Http.Abstractions/NUGET_README.md
@@ -8,7 +8,7 @@ HTTP-aware abstractions for Trellis boundary code.
 
 - `HttpError` — closed union of HTTP transport failures (`405`, `406`, `412`, `413`, `415`, `416`, `428`).
 - `AuthChallenge`, `EntityTagValue`, `PreconditionKind`, `RetryAfterValue` — reusable HTTP payload/value types.
-- `AggregateETagExtensions`, `RepresentationMetadata`, `WriteOutcome<T>` — conditional-request and response-shaping helpers shared by server/client packages.
+- `AggregateETagExtensions`, `RepresentationMetadata`, `WriteOutcome<T>` — conditional-request and response-shaping helpers shared by server/client packages. The static `WriteOutcome` factory (`WriteOutcome.Updated(value, metadata)`, `Created(...)`, …) returns the base `WriteOutcome<T>`, so write results bind the `Result<WriteOutcome<T>>` response overloads without a cast.
 - `Error.TransportFault(ITransportFault)` integration via `HttpError : ITransportFault`.
 
 ## Quick example

--- a/Trellis.Http.Abstractions/README.md
+++ b/Trellis.Http.Abstractions/README.md
@@ -26,7 +26,7 @@ dotnet add package Trellis.Http.Abstractions
 | `AggregateETagExtensions` | `OptionalETag` / `RequireETag` pipeline operators that lift `HttpError.PreconditionFailed` / `PreconditionRequired` into `Error.TransportFault` for `Result<T>` of an `IAggregate`. |
 | `AuthChallenge` | Boundary representation of a `WWW-Authenticate` challenge. |
 | `RetryAfterValue` | HTTP wire representation of `Retry-After` (delay-seconds or HTTP-date). Use `RetryAdvice` in the domain; the boundary translates one to the other. |
-| `RepresentationMetadata`, `WriteOutcome<T>` | Conditional-request and response-shaping helpers shared by server/client packages. |
+| `RepresentationMetadata`, `WriteOutcome<T>` | Conditional-request and response-shaping helpers shared by server/client packages. The static `WriteOutcome` factory (`Updated<T>`, `Created<T>`, `UpdatedNoContent<T>`, `Accepted<T>`, `AcceptedNoContent<T>`) builds each case but returns the base `WriteOutcome<T>`, so results flow through `Result.Map(...)` / `ToHttpResponse(...)` without a `(WriteOutcome<T>)` cast — e.g. `WriteOutcome.Updated(value, metadata)`. |
 
 ## Quick example
 

--- a/Trellis.Http.Abstractions/src/WriteOutcome.cs
+++ b/Trellis.Http.Abstractions/src/WriteOutcome.cs
@@ -40,3 +40,54 @@ public abstract record WriteOutcome<T>
     /// <param name="RetryAfter">Optional hint for when to poll next.</param>
     public sealed record AcceptedNoContent(string? MonitorUri = null, RetryAfterValue? RetryAfter = null) : WriteOutcome<T>;
 }
+
+/// <summary>
+/// Factory helpers that build a <see cref="WriteOutcome{T}"/> case but return the
+/// <em>base</em> type, so call sites flow through generic pipelines (for example
+/// <c>Result.Map</c> / <c>ToHttpResponse</c>) without an explicit <c>(WriteOutcome&lt;T&gt;)</c>
+/// cast to widen the nested case. Mirrors the non-generic <c>Result</c> / generic
+/// <c>Result&lt;T&gt;</c> pairing.
+/// </summary>
+public static class WriteOutcome
+{
+    /// <summary>Builds the <c>Created</c> case (HTTP <c>201</c>), returned as the base <see cref="WriteOutcome{T}"/>.</summary>
+    /// <typeparam name="T">The representation/body type.</typeparam>
+    /// <param name="value">The created entity.</param>
+    /// <param name="location">An address that identifies the newly created resource.</param>
+    /// <param name="metadata">Optional representation metadata (ETag, Last-Modified, …).</param>
+    /// <returns>The created outcome typed as <see cref="WriteOutcome{T}"/>.</returns>
+    public static WriteOutcome<T> Created<T>(T value, string location, RepresentationMetadata? metadata = null)
+        => new WriteOutcome<T>.Created(value, location, metadata);
+
+    /// <summary>Builds the <c>Updated</c> case (HTTP <c>200</c>), returned as the base <see cref="WriteOutcome{T}"/>.</summary>
+    /// <typeparam name="T">The representation/body type.</typeparam>
+    /// <param name="value">The updated entity.</param>
+    /// <param name="metadata">Optional representation metadata for the updated resource.</param>
+    /// <returns>The updated outcome typed as <see cref="WriteOutcome{T}"/>.</returns>
+    public static WriteOutcome<T> Updated<T>(T value, RepresentationMetadata? metadata = null)
+        => new WriteOutcome<T>.Updated(value, metadata);
+
+    /// <summary>Builds the <c>UpdatedNoContent</c> case (HTTP <c>204</c>), returned as the base <see cref="WriteOutcome{T}"/>. <typeparamref name="T"/> must be specified explicitly.</summary>
+    /// <typeparam name="T">The representation/body type the surrounding pipeline carries.</typeparam>
+    /// <param name="metadata">Optional representation metadata for the updated resource.</param>
+    /// <returns>The no-content updated outcome typed as <see cref="WriteOutcome{T}"/>.</returns>
+    public static WriteOutcome<T> UpdatedNoContent<T>(RepresentationMetadata? metadata = null)
+        => new WriteOutcome<T>.UpdatedNoContent(metadata);
+
+    /// <summary>Builds the <c>Accepted</c> case (HTTP <c>202</c>), returned as the base <see cref="WriteOutcome{T}"/>.</summary>
+    /// <typeparam name="T">The status-body type.</typeparam>
+    /// <param name="statusBody">A status body describing the in-flight operation.</param>
+    /// <param name="monitorUri">Optional address where progress can be polled.</param>
+    /// <param name="retryAfter">Optional hint for when to poll next.</param>
+    /// <returns>The accepted outcome typed as <see cref="WriteOutcome{T}"/>.</returns>
+    public static WriteOutcome<T> Accepted<T>(T statusBody, string? monitorUri = null, RetryAfterValue? retryAfter = null)
+        => new WriteOutcome<T>.Accepted(statusBody, monitorUri, retryAfter);
+
+    /// <summary>Builds the <c>AcceptedNoContent</c> case (HTTP <c>202</c>), returned as the base <see cref="WriteOutcome{T}"/>. <typeparamref name="T"/> must be specified explicitly.</summary>
+    /// <typeparam name="T">The representation/body type the surrounding pipeline carries.</typeparam>
+    /// <param name="monitorUri">Optional address where progress can be polled.</param>
+    /// <param name="retryAfter">Optional hint for when to poll next.</param>
+    /// <returns>The no-content accepted outcome typed as <see cref="WriteOutcome{T}"/>.</returns>
+    public static WriteOutcome<T> AcceptedNoContent<T>(string? monitorUri = null, RetryAfterValue? retryAfter = null)
+        => new WriteOutcome<T>.AcceptedNoContent(monitorUri, retryAfter);
+}

--- a/Trellis.Http.Abstractions/tests/WriteOutcomeTests.cs
+++ b/Trellis.Http.Abstractions/tests/WriteOutcomeTests.cs
@@ -1,0 +1,84 @@
+﻿namespace Trellis.Http.Abstractions.Tests;
+
+using Trellis.Testing;
+
+/// <summary>
+/// Tests for the <see cref="WriteOutcome"/> factory helpers. The defining behavior is that each
+/// helper returns the <em>base</em> <see cref="WriteOutcome{T}"/> (not the nested case), so the
+/// results assign to a <c>WriteOutcome&lt;Doc&gt;</c> local with no cast and flow through generic
+/// pipelines that bind on <c>Result&lt;WriteOutcome&lt;T&gt;&gt;</c>.
+/// </summary>
+public class WriteOutcomeTests
+{
+    private sealed record Doc(int Id);
+
+    [Fact]
+    public void Created_returns_base_typed_case_with_payload()
+    {
+        var doc = new Doc(1);
+        var meta = RepresentationMetadata.WithStrongETag("etag-c");
+
+        WriteOutcome<Doc> outcome = WriteOutcome.Created(doc, "/docs/1", meta);
+
+        var created = outcome.Should().BeOfType<WriteOutcome<Doc>.Created>().Subject;
+        created.Value.Should().Be(doc);
+        created.Location.Should().Be("/docs/1");
+        created.Metadata.Should().Be(meta);
+    }
+
+    [Fact]
+    public void Updated_returns_base_typed_case_with_payload()
+    {
+        var doc = new Doc(2);
+        var meta = RepresentationMetadata.WithStrongETag("etag-u");
+
+        WriteOutcome<Doc> outcome = WriteOutcome.Updated(doc, meta);
+
+        var updated = outcome.Should().BeOfType<WriteOutcome<Doc>.Updated>().Subject;
+        updated.Value.Should().Be(doc);
+        updated.Metadata.Should().Be(meta);
+    }
+
+    [Fact]
+    public void Updated_metadata_is_optional()
+    {
+        WriteOutcome<Doc> outcome = WriteOutcome.Updated(new Doc(3));
+
+        outcome.Should().BeOfType<WriteOutcome<Doc>.Updated>()
+            .Which.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdatedNoContent_returns_base_typed_case_with_metadata()
+    {
+        var meta = RepresentationMetadata.WithStrongETag("etag-unc");
+
+        WriteOutcome<Doc> outcome = WriteOutcome.UpdatedNoContent<Doc>(meta);
+
+        outcome.Should().BeOfType<WriteOutcome<Doc>.UpdatedNoContent>()
+            .Which.Metadata.Should().Be(meta);
+    }
+
+    [Fact]
+    public void Accepted_returns_base_typed_case_with_payload()
+    {
+        var doc = new Doc(4);
+        var retry = RetryAfterValue.FromSeconds(30);
+
+        WriteOutcome<Doc> outcome = WriteOutcome.Accepted(doc, "/status/4", retry);
+
+        var accepted = outcome.Should().BeOfType<WriteOutcome<Doc>.Accepted>().Subject;
+        accepted.StatusBody.Should().Be(doc);
+        accepted.MonitorUri.Should().Be("/status/4");
+        accepted.RetryAfter.Should().Be(retry);
+    }
+
+    [Fact]
+    public void AcceptedNoContent_returns_base_typed_case()
+    {
+        WriteOutcome<Doc> outcome = WriteOutcome.AcceptedNoContent<Doc>("/status/5");
+
+        outcome.Should().BeOfType<WriteOutcome<Doc>.AcceptedNoContent>()
+            .Which.MonitorUri.Should().Be("/status/5");
+    }
+}

--- a/docs/docfx_project/api_reference/trellis-api-http-abstractions.md
+++ b/docs/docfx_project/api_reference/trellis-api-http-abstractions.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Http.Abstractions
 namespaces: [Trellis]
-types: [HttpError, AuthChallenge, EntityTagValue, RetryAfterValue, PreconditionKind, RepresentationMetadata, "WriteOutcome<T>", AggregateETagExtensions]
+types: [HttpError, AuthChallenge, EntityTagValue, RetryAfterValue, PreconditionKind, RepresentationMetadata, "WriteOutcome<T>", WriteOutcome, AggregateETagExtensions]
 version: v3
 last_verified: 2026-06-03
 audience: [llm]
@@ -66,7 +66,8 @@ Construct it only in HTTP-aware boundaries and wrap it in `new Error.TransportFa
 | Type | Purpose |
 | --- | --- |
 | `RepresentationMetadata` | Response metadata bag for `ETag`, `Last-Modified`, `Vary`, `Content-Language`, and `Content-Location`. Build with `RepresentationMetadata.Create()` or the convenience helpers `WithETag(...)` / `WithStrongETag(...)`. |
-| `WriteOutcome<T>` | Closed union for HTTP-shaped write results: `Created`, `Updated`, `UpdatedNoContent`, `Accepted`, and `AcceptedNoContent`. The `Accepted*` cases can still carry `RetryAfterValue`. |
+| `WriteOutcome<T>` | Closed union for HTTP-shaped write results: `Created`, `Updated`, `UpdatedNoContent`, `Accepted`, and `AcceptedNoContent`. The `Accepted*` cases can still carry `RetryAfterValue`. Construct via the nested records (`new WriteOutcome<T>.Updated(...)`) or — to recover the base type without a cast — the static `WriteOutcome` factory helpers below. |
+| `WriteOutcome` (static) | Factory helpers — `Created<T>`, `Updated<T>`, `UpdatedNoContent<T>`, `Accepted<T>`, `AcceptedNoContent<T>` — that build each case but **return the base `WriteOutcome<T>`**. This lets results flow through generic pipelines such as `Result.Map(...)` / `ToHttpResponse(...)` (which bind on `Result<WriteOutcome<T>>`) **without an explicit `(WriteOutcome<T>)` cast**: `new WriteOutcome<T>.Updated(...)` has the nested case type, and `Result<T>` invariance then blocks the implicit upcast. Mirrors the non-generic `Result` / generic `Result<T>` pairing. `T` is inferred from the value for `Created`/`Updated`/`Accepted`; specify it explicitly for the no-content cases. |
 
 ## `AggregateETagExtensions`
 

--- a/docs/docfx_project/api_reference/trellis-api-http-abstractions.md
+++ b/docs/docfx_project/api_reference/trellis-api-http-abstractions.md
@@ -3,7 +3,7 @@ package: Trellis.Http.Abstractions
 namespaces: [Trellis]
 types: [HttpError, AuthChallenge, EntityTagValue, RetryAfterValue, PreconditionKind, RepresentationMetadata, "WriteOutcome<T>", WriteOutcome, AggregateETagExtensions]
 version: v3
-last_verified: 2026-06-03
+last_verified: 2026-06-19
 audience: [llm]
 ---
 # Trellis.Http.Abstractions &mdash; API Reference


### PR DESCRIPTION
## Why

The S3-era write pipeline has to widen a write outcome with an explicit cast:

```csharp
.MapAsync(p => (WriteOutcome<Order>)new WriteOutcome<Order>.Updated(p, RepresentationMetadata.WithStrongETag(p.ETag)))
.ToHttpResponseAsync(OrderResponse.From);
```

`new WriteOutcome<Order>.Updated(...)` has the **nested case** type `WriteOutcome<Order>.Updated`. `Map` infers that exact type, so it produces `Result<WriteOutcome<Order>.Updated>`. Because `Result<T>` is an invariant `readonly struct`, that does **not** implicitly upcast to `Result<WriteOutcome<Order>>` — the shape the `ToHttpResponse` write-outcome overload binds on. Hence the `(WriteOutcome<Order>)` cast.

Forgetting the cast is *usually* a compile error (CS1503) — but the no-body-projector path (`.ToHttpResponseAsync()`) silently binds the plain `Result<T>` overload with `T = WriteOutcome<Order>.Updated` and serializes the raw outcome envelope, skipping the status/header translation. So the underlying ergonomics deserve a fix.

## What

A non-generic `static class WriteOutcome` (in `Trellis.Http.Abstractions`, namespace `Trellis`) with helpers that build each case but **return the base `WriteOutcome<T>`**:

```csharp
public static WriteOutcome<T> Created<T>(T value, string location, RepresentationMetadata? metadata = null);
public static WriteOutcome<T> Updated<T>(T value, RepresentationMetadata? metadata = null);
public static WriteOutcome<T> UpdatedNoContent<T>(RepresentationMetadata? metadata = null);
public static WriteOutcome<T> Accepted<T>(T statusBody, string? monitorUri = null, RetryAfterValue? retryAfter = null);
public static WriteOutcome<T> AcceptedNoContent<T>(string? monitorUri = null, RetryAfterValue? retryAfter = null);
```

Now the call site is cast-free, with `T` inferred from the value:

```csharp
.MapAsync(p => WriteOutcome.Updated(p, RepresentationMetadata.WithStrongETag(p.ETag)))
.ToHttpResponseAsync(OrderResponse.From);
```

Because the helpers return the base type, the WriteOutcome overload binds even without a body projector — closing the silent-degradation gap too.

This mirrors the framework's existing non-generic `Result` / generic `Result<T>` pairing (and `Task`/`Task<T>`). Purely additive — the nested-record construction still works.

**Parameter naming:** camelCase (`value`, `metadata`, `statusBody`, …), matching every other static factory in the framework — `Result.Ok(value)`, `RepresentationMetadata.WithStrongETag(opaqueTag)`, `RetryAfterValue.FromSeconds(seconds)` — and the .NET method-parameter convention, rather than the records' PascalCase positional parameters.

## Tests & gates

- 6 `WriteOutcomeTests` — one per case plus the optional-metadata path — each **assigns the result to a `WriteOutcome<Doc>` local with no cast**, which is the whole guarantee, then asserts the nested case + payload.
- Http.Abstractions suite **81 pass / 0 fail**; Release build **0 warn / 0 err** (XML-doc crefs resolve under warnings-as-errors); DocsLint **0/0**; stale-docs audit **0**.
- gpt-5.5 review: flagged the param-name casing; kept camelCase as the deliberate, framework-consistent choice (see above).

(Follow-up, not in this PR: once this ships in a published package, the S3E3 teaching slide can drop the cast.)
